### PR TITLE
chore: gate commits on fallow audit

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,3 +9,7 @@ pre-commit:
       glob: "*.{ts,js,mts,cts}"
       run: pnpm exec oxlint {staged_files}
       fail_text: "Run 'pnpm lint' to fix lint errors."
+    fallow:
+      glob: "*.{ts,js,mts,cts}"
+      run: pnpm exec fallow audit --base HEAD --format compact
+      fail_text: "Fallow found issues in your changes. Run 'pnpm fallow' to see details."


### PR DESCRIPTION
## Summary
- Fallow was already wired into the repo (`.fallowrc.json`, `pnpm fallow` script, CI job in #1/#2/#3) but wasn't part of the local pre-commit hook, so violations only surfaced after a PR was opened.
- Adds a `fallow` pre-commit command to `lefthook.yml`, scoped to `*.{ts,js,mts,cts}` staged files, running `fallow audit --base HEAD` — the same audit-and-gate command CI uses, scoped to the commit's changes.

## Test plan
- [x] `pnpm exec fallow audit --base HEAD --format compact` runs clean on this branch
- [x] Committed this change through the actual lefthook pre-commit hook to confirm it fires/skips correctly