### PR TITLE
Add MCP server for agent-held device leases

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -2,6 +2,12 @@
   // This file is JSONC: fallow reads these comments; generic JSON tools may not.
   "$schema": "./node_modules/fallow/schema.json",
   "entry": ["src/index.ts", "src/cli/main.ts", "src/daemon/main.ts"],
+  "ignoreDependencyOverrides": [
+    // MCP SDK 1.29 transitively requires vulnerable node-server 1.x; lockfile/audit verify this patched override.
+    { "package": "@hono/node-server", "source": "pnpm-workspace.yaml" },
+    // MCP SDK 1.29 transitively requires vulnerable ip-address <=10.3.0; lockfile/audit verify this patched override.
+    { "package": "ip-address", "source": "pnpm-workspace.yaml" }
+  ],
   "duplicates": {
     // Hide pair-only clones; focus on widespread copy-paste
     // worth refactoring. Lower to 2 to report every duplicate pair.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ other exists.
 
 ## The solution
 
-Pitlane is a single CLI (backed by a local daemon) that works the same way
-for both platforms and gives agents one primitive: **lease a device**.
+Pitlane is a CLI-first control plane (backed by a local daemon) that works the
+same way for both platforms and gives agents one primitive: **lease a device**.
+Agents that support the Model Context Protocol (MCP) can optionally use the
+same lease workflow through a local stdio server.
 
 ## Features
 
@@ -35,9 +37,11 @@ for both platforms and gives agents one primitive: **lease a device**.
 - **Managed-device registry.** Pitlane only ever shuts down, erases, or
   deletes devices it created itself. Everything else on the machine is
   read-only to it.
-- **Agent-first output.** Machine-readable JSON everywhere: the lease
-  result is one JSON line on stdout, progress (e.g. provisioning ETAs)
-  streams as JSON lines on stderr.
+- **Agent-first output.** CLI lease results are one JSON line on stdout;
+  progress (e.g. provisioning ETAs) streams as JSON lines on stderr. The
+  optional MCP server reserves stdout for MCP JSON-RPC.
+- **Optional MCP integration.** A local stdio MCP server gives agent clients
+  the lease and release workflow without replacing the CLI operator interface.
 
 ## Getting started
 
@@ -54,6 +58,50 @@ The daemon starts on demand — no separate setup step is needed. Use
 Pitlane-managed devices.
 
 See [docs/CLI.md](docs/CLI.md) for the full command reference.
+
+## MCP integration (optional)
+
+The CLI remains Pitlane's primary, full operator interface. MCP is a focused
+agent integration: it intentionally exposes neither status, configuration,
+events, lease renewal, nor destructive or other operator commands.
+
+Start the local stdio server with:
+
+```sh
+pitlane mcp
+```
+
+Configure an MCP client to spawn it with this generic configuration:
+
+```json
+{
+  "mcpServers": {
+    "pitlane": {
+      "command": "pitlane",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+GUI-launched MCP clients may not inherit your shell `PATH`; in that case,
+replace `pitlane` with its absolute path.
+
+The server provides exactly two tools:
+
+- `lease_simulator` requires `platform` (`ios` or `android`) and `device`.
+  `os` is optional and otherwise selects the newest installed runtime.
+  `no_wait` defaults to `false`; `timeout_seconds` optionally limits queue
+  waiting. `allow_download` defaults to `false` and must be explicitly `true`
+  before a missing runtime or system image may be downloaded.
+- `release_simulator` requires the `lease_id` returned by the lease tool and
+  releases only that MCP session's lease.
+
+Both tools return structured results as well as JSON text content, so MCP
+clients can reliably consume the leased device details or release confirmation.
+An MCP lease is held by the server process's daemon connection: release it
+explicitly when work is done; it is also released when that MCP process
+disconnects. Run one MCP server process per agent session.
 
 ## Configuration
 

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -11,8 +11,11 @@ and installing over each other — without ever knowing the other exists.
 
 ## The solution
 
-Pitlane is a higher-order CLI (backed by a local daemon) that is the same for
-both platforms and gives agents one primitive: **lease a device**.
+Pitlane is a CLI-first control plane (backed by a local daemon) that is the
+same for both platforms and gives agents one primitive: **lease a device**.
+An optional local stdio MCP integration exposes the focused lease/release
+workflow to compatible agent clients; the CLI remains the full operator
+interface.
 
 - `pitlane lease` returns a *ready* device — booted and health-checked — that
   no other agent will touch for the duration of the lease.
@@ -35,9 +38,9 @@ both platforms and gives agents one primitive: **lease a device**.
 - **Managed-device registry.** Pitlane only ever shuts down, erases, or
   deletes devices it created itself. Everything else on the machine is
   read-only to it.
-- **Agent-first output.** Machine-readable JSON everywhere: the lease result
-  is one JSON line on stdout, progress (e.g. provisioning ETAs) streams as
-  JSON lines on stderr.
+- **Agent-first output.** CLI lease results are one JSON line on stdout;
+  progress (e.g. provisioning ETAs) streams as JSON lines on stderr. The
+  optional MCP server reserves stdout for MCP JSON-RPC.
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for how it's built, [CLI.md](CLI.md)
 for the command surface, and [known-pitfalls.md](known-pitfalls.md) for

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,28 +3,39 @@
 ## Topology
 
 ```
-agent ──spawns──> pitlane CLI ──unix socket──> pitlane daemon
-                                                   │
-                                     ┌─────────────┼─────────────┐
-                                     │        core (platform-    │
-                                     │        agnostic)          │
-                                     │  lease table · wait queue │
-                                     │  registry · capacity      │
-                                     │  state machine · reaper   │
-                                     │  event bus · warm-pool    │
-                                     │  policy                   │
-                                     └──────┬───────────┬────────┘
-                                            │  driver   │  driver
-                                            ▼ interface ▼ interface
-                                       iOS driver   Android driver
-                                       (simctl)     (avdmanager/
-                                                     emulator/adb)
+agent ──spawns──> pitlane CLI ──┐
+                                ├─ shared daemon client ──unix socket──> pitlane daemon
+MCP client ──spawns──> stdio MCP ┘                                      │
+                                                                     ┌───┼─────────────┐
+                                                                     │ core (platform-│
+                                                                     │ agnostic)      │
+                                                                     │ lease table ·  │
+                                                                     │ wait queue ·   │
+                                                                     │ registry ·     │
+                                                                     │ capacity ·     │
+                                                                     │ state machine ·│
+                                                                     │ reaper · event │
+                                                                     │ bus · warm-pool│
+                                                                     │ policy         │
+                                                                     └─┬─────────┬────┘
+                                                                       │ driver  │ driver
+                                                                       ▼ interface ▼ interface
+                                                                  iOS driver   Android driver
+                                                                  (simctl)     (avdmanager/
+                                                                                emulator/adb)
 ```
 
-- **CLI**: thin client. In the default *held* mode it acquires a lease, prints
-  one JSON result line on stdout, then stays alive holding the daemon
-  connection; the connection is the lease heartbeat. Progress streams as JSON
-  lines on stderr.
+- **CLI and stdio MCP server**: sibling thin frontends over the shared daemon
+  client and unix socket. The core never knows which frontend made a request.
+  The CLI is the full operator interface; the MCP server intentionally limits
+  its tool surface to leasing and releasing for an agent session.
+- **CLI**: in the default *held* mode it acquires a lease, prints one JSON
+  result line on stdout, then stays alive holding the daemon connection; the
+  connection is the lease heartbeat. Progress streams as JSON lines on stderr.
+- **stdio MCP server**: its process owns one agent session and exposes MCP over
+  stdin/stdout. A lease is held by that process's daemon connection until the
+  session explicitly releases it or the MCP transport disconnects, at which
+  point the connection closes and releases the lease.
 - **Daemon**: owns all state, serializes all decisions. Started on demand,
   reachable over a unix socket.
 
@@ -116,8 +127,10 @@ Conclusions baked into the drivers:
 
 ## Leases
 
-- **Held mode (default)**: lease lives as long as the CLI process; connection
-  close = release. Known gap: orphaned holders when the agent dies — see
+- **Held mode (default)**: lease lives as long as its holding frontend's daemon
+  connection. For the CLI, that is the CLI process; for MCP, it is the MCP
+  server process for that agent session. Connection close = release. Known
+  gap: orphaned holders when the agent dies — see
   [known-pitfalls.md](known-pitfalls.md).
 - **Detached mode (`--detach`)**: returns a token, daemon enforces a TTL, the
   agent must `pitlane renew` periodically.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,9 +1,10 @@
 # CLI reference
 
 Part of the user manual: every command the pitlane CLI is expected to
-implement. All commands accept `--json` for machine-readable output (agents
-are the primary audience). Progress/diagnostics go to **stderr** as JSON
-lines; results go to **stdout**.
+implement. Except for `pitlane mcp`, commands accept `--json` for
+machine-readable output (agents are the primary audience). Their
+progress/diagnostics go to **stderr** as JSON lines; results go to **stdout**.
+`pitlane mcp` instead reserves stdout for MCP JSON-RPC framing.
 
 ## Global exit codes
 
@@ -69,6 +70,13 @@ already expired.
 Explicitly release a lease (primarily for detached mode or operator
 intervention). `--all` force-releases every lease — confirmation required
 unless `--yes`.
+
+## `pitlane mcp`
+
+Start Pitlane's local stdio MCP server. It accepts no flags. Standard output
+is reserved for MCP JSON-RPC; fatal diagnostics are written to stderr. The
+server auto-starts the daemon when needed and exposes the focused
+`lease_simulator` and `release_simulator` tool surface for one agent session.
 
 ## `pitlane status`
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     "check": "pnpm run typecheck && pnpm run lint && pnpm run format:check && pnpm run test",
     "release": "release-it"
   },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.29.0",
+    "zod": "^3.25.76"
+  },
   "devDependencies": {
     "@release-it/conventional-changelog": "^11.0.1",
     "@types/node": "^26.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,211 +1,23 @@
----
-lockfileVersion: '9.0'
-
-importers:
-
-  .:
-    configDependencies: {}
-    packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: 11.9.0
-        version: 11.9.0
-      pnpm:
-        specifier: 11.9.0
-        version: 11.9.0
-
-packages:
-
-  '@pnpm/exe@11.9.0':
-    resolution: {integrity: sha512-pPPOpR79qW3nsNhlyDIdfstli4Bi78mk8r22ySxpFRwMbO8KXSjGrVzGmJBsVX39NnJTh7/WADj527nZhG9H9g==}
-    hasBin: true
-
-  '@pnpm/linux-arm64@11.9.0':
-    resolution: {integrity: sha512-XYmY2qadHauBA3QaHi2R7fI6kt5Flje0WHz9MVrbH0kVH/XLpfOLnwPeE1+EX6K/nDa2CBvzp35VjYCNGFJa9A==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@pnpm/linux-x64@11.9.0':
-    resolution: {integrity: sha512-fl7W5imnSmmgXIqMQFZ/rPaVvk9OkKF8/anqHZE3XEDfWcn3BlWGndyOEas/JN7u2BXWYjs63DJZ3rnG6WOhLA==}
-    cpu: [x64]
-    os: [linux]
-
-  '@pnpm/linuxstatic-arm64@11.9.0':
-    resolution: {integrity: sha512-fif8xbnzVEAIlvaU4yIgWKXeXYb4Kj6WMEl/KvM2x1Rp3AKAjBW/53SGzxO4cZP9doAqUzOIpMRGFVbHGeMDRw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@pnpm/linuxstatic-x64@11.9.0':
-    resolution: {integrity: sha512-9dKu3QdShqOpnWrjW9owARpIJeP0ul8UgIIbBUv8VDGEYibt+g49zQsNaD7SdMD3WeRSjExPQ1zIhplzr5cwvQ==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@pnpm/macos-arm64@11.9.0':
-    resolution: {integrity: sha512-MWzBTgeI5p3odjdVltYvFXaSWAjF2Xk5YaxiP/u2RmW8N6PHsLyIyj37Ds992CrXgFM8fO1RpvsEirozhsD6KA==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@pnpm/win-arm64@11.9.0':
-    resolution: {integrity: sha512-u/QxEcbKJZxC1t3zUYCZiHzu7TaZ/iXc6EGZoQjkeVT0LXmEVR6ypcK3ByjhIqbxQ3HGX75gnpIpR+VjRjubfw==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@pnpm/win-x64@11.9.0':
-    resolution: {integrity: sha512-HqJVHmZG5UKfLi38AjMl2azVmq87TlWRhwSW+f4q9LLaZeAkFyIZ7LY/pN6mh4VlH9yWj90C+tsb1yKiy7OKnw==}
-    cpu: [x64]
-    os: [win32]
-
-  '@reflink/reflink-darwin-arm64@0.1.19':
-    resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@reflink/reflink-darwin-x64@0.1.19':
-    resolution: {integrity: sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@reflink/reflink-linux-arm64-gnu@0.1.19':
-    resolution: {integrity: sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@reflink/reflink-linux-arm64-musl@0.1.19':
-    resolution: {integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@reflink/reflink-linux-x64-gnu@0.1.19':
-    resolution: {integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@reflink/reflink-linux-x64-musl@0.1.19':
-    resolution: {integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@reflink/reflink-win32-arm64-msvc@0.1.19':
-    resolution: {integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@reflink/reflink-win32-x64-msvc@0.1.19':
-    resolution: {integrity: sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@reflink/reflink@0.1.19':
-    resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
-    engines: {node: '>= 10'}
-
-  detect-libc@2.1.2:
-    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
-    engines: {node: '>=8'}
-
-  pnpm@11.9.0:
-    resolution: {integrity: sha512-vWgtXQP+Ul73yf1ngMaITR51asTJyf4AxTh4KCQxDc+Q493E9Tg18G3669UIXkGFXgvLs7YN4qxburieUDbwOw==}
-    engines: {node: '>=22.13'}
-    hasBin: true
-
-snapshots:
-
-  '@pnpm/exe@11.9.0':
-    dependencies:
-      '@reflink/reflink': 0.1.19
-      detect-libc: 2.1.2
-    optionalDependencies:
-      '@pnpm/linux-arm64': 11.9.0
-      '@pnpm/linux-x64': 11.9.0
-      '@pnpm/linuxstatic-arm64': 11.9.0
-      '@pnpm/linuxstatic-x64': 11.9.0
-      '@pnpm/macos-arm64': 11.9.0
-      '@pnpm/win-arm64': 11.9.0
-      '@pnpm/win-x64': 11.9.0
-
-  '@pnpm/linux-arm64@11.9.0':
-    optional: true
-
-  '@pnpm/linux-x64@11.9.0':
-    optional: true
-
-  '@pnpm/linuxstatic-arm64@11.9.0':
-    optional: true
-
-  '@pnpm/linuxstatic-x64@11.9.0':
-    optional: true
-
-  '@pnpm/macos-arm64@11.9.0':
-    optional: true
-
-  '@pnpm/win-arm64@11.9.0':
-    optional: true
-
-  '@pnpm/win-x64@11.9.0':
-    optional: true
-
-  '@reflink/reflink-darwin-arm64@0.1.19':
-    optional: true
-
-  '@reflink/reflink-darwin-x64@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-arm64-gnu@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-arm64-musl@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-x64-gnu@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-x64-musl@0.1.19':
-    optional: true
-
-  '@reflink/reflink-win32-arm64-msvc@0.1.19':
-    optional: true
-
-  '@reflink/reflink-win32-x64-msvc@0.1.19':
-    optional: true
-
-  '@reflink/reflink@0.1.19':
-    optionalDependencies:
-      '@reflink/reflink-darwin-arm64': 0.1.19
-      '@reflink/reflink-darwin-x64': 0.1.19
-      '@reflink/reflink-linux-arm64-gnu': 0.1.19
-      '@reflink/reflink-linux-arm64-musl': 0.1.19
-      '@reflink/reflink-linux-x64-gnu': 0.1.19
-      '@reflink/reflink-linux-x64-musl': 0.1.19
-      '@reflink/reflink-win32-arm64-msvc': 0.1.19
-      '@reflink/reflink-win32-x64-msvc': 0.1.19
-
-  detect-libc@2.1.2: {}
-
-  pnpm@11.9.0: {}
-
----
 lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@hono/node-server': 2.0.10
+  ip-address: '>=10.3.1'
+
 importers:
 
   .:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 1.29.0
+        version: 1.29.0(zod@3.25.76)
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@release-it/conventional-changelog':
         specifier: ^11.0.1
@@ -297,6 +109,12 @@ packages:
     resolution: {integrity: sha512-piMKRxPWev6T4hUFlUJ2dD2sMm5Wc62jm4El/yY2SAmHiwychGcyzYsWh4qQg5r8zPWIkE8wIfXlWXsLKtU7nw==}
     cpu: [x64]
     os: [win32]
+
+  '@hono/node-server@2.0.10':
+    resolution: {integrity: sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
 
   '@inquirer/ansi@2.0.7':
     resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
@@ -434,6 +252,16 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -1034,9 +862,24 @@ packages:
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   agent-base@8.0.0:
     resolution: {integrity: sha512-QT8i0hCz6C/KQ+KTAbSNwCHDGdmUJl2tp2ZpNlGSWCfhUNVbYG2WLE3MdZGBAgXPV4GAvjGMxo+C1hroyxmZEg==}
     engines: {node: '>= 14'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
@@ -1063,12 +906,20 @@ packages:
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   c12@3.3.3:
     resolution: {integrity: sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q==}
@@ -1077,6 +928,14 @@ packages:
     peerDependenciesMeta:
       magicast:
         optional: true
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1129,6 +988,14 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   content-type@2.0.0:
     resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
     engines: {node: '>=18'}
@@ -1172,6 +1039,22 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   data-uri-to-buffer@7.0.0:
     resolution: {integrity: sha512-CuRUx0TXGSbbWdEci3VK/XOZGP3n0P4pIKpsqpVtBqaIIuj3GKK8H45oAqA4Rg8FHipc+CzRdUzmD4YQXxv66Q==}
     engines: {node: '>= 14'}
@@ -1206,6 +1089,10 @@ packages:
     peerDependencies:
       quickjs-wasi: ^0.0.1
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
@@ -1221,8 +1108,34 @@ packages:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escodegen@2.1.0:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
@@ -1249,9 +1162,31 @@ packages:
     resolution: {integrity: sha512-EaNCGm+8XEIU7YNcc+THptWAO5NfKBHHARxt+wxZljj9bTr/+arRoOm9/MpGt4n6xn9fLnPFRSoLD0WFYGFUxQ==}
     engines: {node: '>=20'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.6.2:
+    resolution: {integrity: sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   exsolve@1.1.0:
     resolution: {integrity: sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==}
@@ -1261,11 +1196,17 @@ packages:
     engines: {node: '>=22'}
     hasBin: true
 
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
 
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -1282,14 +1223,37 @@ packages:
       picomatch:
         optional: true
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-uri@7.0.0:
     resolution: {integrity: sha512-ZsC7KQxm1Hra8yO0RvMZ4lGJT7vnBtSNpEHKq39MPN7vjuvCiu1aQ8rkXUaIXG1y/TSDez97Gmv04ibnYqCp/A==}
@@ -1305,14 +1269,34 @@ packages:
   git-url-parse@16.1.0:
     resolution: {integrity: sha512-cPLz4HuK86wClEW7iDdeAKcCVlWXmrLpb2L+G9goW0Z1dtpNS6BXXSOckUTlJT/LDQViE1QZKstNORzHsLnobw==}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   handlebars@4.7.9:
     resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.13.3:
+    resolution: {integrity: sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@8.1.0:
     resolution: {integrity: sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   http-proxy-agent@8.0.0:
     resolution: {integrity: sha512-7pose0uGgrCJeH2Qh4JcNhWZp3u/oNrWjNYDK4ydOLxOpTw8V8ogHFAmkz0VWq96JBFj4umVJpvmQi287rSYLg==}
@@ -1329,9 +1313,13 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.5.0:
+    resolution: {integrity: sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==}
     engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -1355,6 +1343,9 @@ packages:
     resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
     engines: {node: '>=8'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-ssh@1.4.1:
     resolution: {integrity: sha512-JNeu1wQsHjyHgn9NcWTaXq6zWSR6hqE0++zhfZlkFBbScNkyvxCdeV8sRkSBaeLKxmbpR21brail63ACNxJ0Tg==}
 
@@ -1366,6 +1357,9 @@ packages:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
   issue-parser@7.0.1:
     resolution: {integrity: sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==}
     engines: {node: ^18.17 || >=20.6.1}
@@ -1373,6 +1367,15 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  jose@6.2.9:
+    resolution: {integrity: sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-with-bigint@3.5.10:
     resolution: {integrity: sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w==}
@@ -1541,8 +1544,20 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.1:
+    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
+    engines: {node: '>= 0.8'}
+
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
+    engines: {node: '>=18'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
   mime-db@1.54.0:
@@ -1572,6 +1587,10 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
@@ -1595,12 +1614,27 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
 
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
@@ -1661,6 +1695,17 @@ packages:
     resolution: {integrity: sha512-bCgsFI+GeGWPAvAiUv63ZorMeif3/U0zaXABGJbOWt5OH2KCaPHF6S+0ok4aqM9RuIPGyZdx9tR9l13PsW4AYQ==}
     engines: {node: '>=14.13.0'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -1673,6 +1718,10 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
@@ -1692,6 +1741,10 @@ packages:
   protocols@2.0.2:
     resolution: {integrity: sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   proxy-agent@7.0.0:
     resolution: {integrity: sha512-okTgt79rHTvMHkr/Ney5rZpgCHh3g1g3tI5uhkgN5b7OeI3n0Q/ui1uv9OdrnZNJM9WIZJqZPh/UJs+YtO/TMQ==}
     engines: {node: '>= 14'}
@@ -1699,8 +1752,20 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
   quickjs-wasi@0.0.1:
     resolution: {integrity: sha512-fBWNLTBkxkLAhe1AzF1hyXEvuA+N+vV1WMP2D6iiMUblvmOt8Pp5t8zUcgvz7aYA1ldUdxDlgUse15dmcKjkNg==}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
@@ -1718,6 +1783,10 @@ packages:
     engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
     hasBin: true
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
@@ -1730,6 +1799,10 @@ packages:
     resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
 
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
@@ -1750,6 +1823,41 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1793,6 +1901,10 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
@@ -1834,12 +1946,20 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   type-fest@2.19.0:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
     engines: {node: '>=12.20'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
@@ -1864,6 +1984,10 @@ packages:
   universal-user-agent@7.0.3:
     resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   url-join@5.0.0:
     resolution: {integrity: sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1873,6 +1997,10 @@ packages:
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite@8.1.4:
     resolution: {integrity: sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==}
@@ -1962,6 +2090,11 @@ packages:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
     engines: {node: 20 || >=22}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -1977,6 +2110,9 @@ packages:
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
@@ -1988,6 +2124,14 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
 
@@ -2039,6 +2183,10 @@ snapshots:
 
   '@fallow-cli/win32-x64-msvc@3.6.0':
     optional: true
+
+  '@hono/node-server@2.0.10(hono@4.13.3)':
+    dependencies:
+      hono: 4.13.3
 
   '@inquirer/ansi@2.0.7': {}
 
@@ -2160,6 +2308,28 @@ snapshots:
       '@types/node': 26.1.1
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 2.0.10(hono@4.13.3)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.1
+      express: 5.2.1
+      express-rate-limit: 8.6.2(express@5.2.1)
+      hono: 4.13.3
+      jose: 6.2.9
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
@@ -2549,7 +2719,23 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   agent-base@8.0.0: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.5
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-regex@6.2.2: {}
 
@@ -2569,11 +2755,27 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   buffer-from@1.1.2: {}
 
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
+
+  bytes@3.1.2: {}
 
   c12@3.3.3:
     dependencies:
@@ -2589,6 +2791,16 @@ snapshots:
       perfect-debounce: 2.1.0
       pkg-types: 2.3.1
       rc9: 2.1.2
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   chai@6.2.2: {}
 
@@ -2631,6 +2843,10 @@ snapshots:
   confbox@0.2.4: {}
 
   consola@3.4.2: {}
+
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
 
   content-type@2.0.0: {}
 
@@ -2683,6 +2899,21 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   data-uri-to-buffer@7.0.0: {}
 
   debug@4.4.3:
@@ -2707,6 +2938,8 @@ snapshots:
       esprima: 4.0.1
       quickjs-wasi: 0.0.1
 
+  depd@2.0.0: {}
+
   destr@2.0.5: {}
 
   detect-libc@2.1.2: {}
@@ -2717,7 +2950,27 @@ snapshots:
 
   dotenv@17.4.2: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  encodeurl@2.0.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.3.1: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  escape-html@1.0.3: {}
 
   escodegen@2.1.0:
     dependencies:
@@ -2739,7 +2992,56 @@ snapshots:
 
   eta@4.5.1: {}
 
+  etag@1.8.1: {}
+
+  eventsource-parser@3.1.1: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.1
+
   expect-type@1.4.0: {}
+
+  express-rate-limit@8.6.2(express@5.2.1):
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   exsolve@1.1.0: {}
 
@@ -2756,11 +3058,15 @@ snapshots:
       '@fallow-cli/win32-arm64-msvc': 3.6.0
       '@fallow-cli/win32-x64-msvc': 3.6.0
 
+  fast-deep-equal@3.1.3: {}
+
   fast-string-truncated-width@3.0.3: {}
 
   fast-string-width@3.0.2:
     dependencies:
       fast-string-truncated-width: 3.0.3
+
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -2774,10 +3080,45 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   get-east-asian-width@1.6.0: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   get-uri@7.0.0:
     dependencies:
@@ -2805,6 +3146,8 @@ snapshots:
     dependencies:
       git-up: 8.1.1
 
+  gopd@1.2.0: {}
+
   handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
@@ -2814,9 +3157,25 @@ snapshots:
     optionalDependencies:
       uglify-js: 3.19.3
 
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.13.3: {}
+
   hosted-git-info@8.1.0:
     dependencies:
       lru-cache: 10.4.3
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   http-proxy-agent@8.0.0:
     dependencies:
@@ -2838,7 +3197,9 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ip-address@10.2.0: {}
+  ip-address@10.5.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-docker@3.0.0: {}
 
@@ -2852,6 +3213,8 @@ snapshots:
 
   is-obj@2.0.0: {}
 
+  is-promise@4.0.0: {}
+
   is-ssh@1.4.1:
     dependencies:
       protocols: 2.0.2
@@ -2862,6 +3225,8 @@ snapshots:
     dependencies:
       is-inside-container: 1.0.0
 
+  isexe@2.0.0: {}
+
   issue-parser@7.0.1:
     dependencies:
       lodash.capitalize: 4.2.1
@@ -2871,6 +3236,12 @@ snapshots:
       lodash.uniqby: 4.7.0
 
   jiti@2.7.0: {}
+
+  jose@6.2.9: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-with-bigint@3.5.10: {}
 
@@ -2993,7 +3364,13 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.1: {}
+
   meow@13.2.0: {}
+
+  merge-descriptors@2.0.0: {}
 
   mime-db@1.54.0: {}
 
@@ -3010,6 +3387,8 @@ snapshots:
   mute-stream@3.0.0: {}
 
   nanoid@3.3.16: {}
+
+  negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
 
@@ -3033,9 +3412,21 @@ snapshots:
       pathe: 2.0.3
       tinyexec: 1.2.4
 
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
   obug@2.1.3: {}
 
   ohash@2.0.11: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   onetime@7.0.0:
     dependencies:
@@ -3140,6 +3531,12 @@ snapshots:
       '@types/parse-path': 7.1.0
       parse-path: 7.1.0
 
+  parseurl@1.3.3: {}
+
+  path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
+
   pathe@2.0.3: {}
 
   perfect-debounce@2.1.0: {}
@@ -3147,6 +3544,8 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.5: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@2.3.1:
     dependencies:
@@ -3166,6 +3565,11 @@ snapshots:
 
   protocols@2.0.2: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   proxy-agent@7.0.0:
     dependencies:
       agent-base: 8.0.0
@@ -3181,7 +3585,21 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
   quickjs-wasi@0.0.1: {}
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
 
   rc9@2.1.2:
     dependencies:
@@ -3226,6 +3644,8 @@ snapshots:
       - magicast
       - supports-color
 
+  require-from-string@2.0.2: {}
+
   restore-cursor@5.1.0:
     dependencies:
       onetime: 7.0.0
@@ -3254,6 +3674,16 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.5
       '@rolldown/binding-win32-x64-msvc': 1.1.5
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   run-applescript@7.1.0: {}
 
   safe-buffer@5.2.1: {}
@@ -3263,6 +3693,67 @@ snapshots:
   semver@7.7.4: {}
 
   semver@7.8.5: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -3280,7 +3771,7 @@ snapshots:
 
   socks@2.8.9:
     dependencies:
-      ip-address: 10.2.0
+      ip-address: 10.5.0
       smart-buffer: 4.2.0
 
   source-map-js@1.2.1: {}
@@ -3302,6 +3793,8 @@ snapshots:
   spdx-license-ids@3.0.23: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@4.2.0: {}
 
@@ -3338,9 +3831,17 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  toidentifier@1.0.1: {}
+
   tslib@2.8.1: {}
 
   type-fest@2.19.0: {}
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.1
+      mime-types: 3.0.2
 
   typedarray@0.0.6: {}
 
@@ -3376,6 +3877,8 @@ snapshots:
 
   universal-user-agent@7.0.3: {}
 
+  unpipe@1.0.0: {}
+
   url-join@5.0.0: {}
 
   util-deprecate@1.0.2: {}
@@ -3384,6 +3887,8 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  vary@1.1.2: {}
 
   vite@8.1.4(@types/node@26.1.1)(jiti@2.7.0):
     dependencies:
@@ -3426,6 +3931,10 @@ snapshots:
 
   walk-up-path@4.0.0: {}
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -3439,6 +3948,8 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
+  wrappy@1.0.2: {}
+
   wsl-utils@0.3.1:
     dependencies:
       is-wsl: 3.1.1
@@ -3447,3 +3958,9 @@ snapshots:
   yargs-parser@22.0.0: {}
 
   yoctocolors@2.1.2: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod@3.25.76: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
 allowBuilds:
   lefthook: true
+overrides:
+  "@hono/node-server": 2.0.10
+  ip-address: ">=10.3.1"

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -70,6 +70,88 @@ describe("CLI boundary", () => {
     expect(output.stderr).toContain("Usage:");
   });
 
+  it("lists the MCP server in root help", async () => {
+    const output = outputCapture();
+
+    await expect(runCli([], output.environment)).resolves.toBe(0);
+    expect(output.stdout).toContain("mcp");
+    expect(output.stdout).toContain("Start the stdio MCP server");
+  });
+
+  it("does not load the MCP runner for non-MCP commands", async () => {
+    const output = outputCapture();
+    const loadMcpStdio = vi.fn(async () => vi.fn(async () => undefined));
+    const connection = new StubConnection();
+    connection.response("status.get", {});
+
+    await expect(
+      runCli(
+        ["status", "--json"],
+        output.environmentWith({ connect: async () => connection, loadMcpStdio }),
+      ),
+    ).resolves.toBe(0);
+    expect(loadMcpStdio).not.toHaveBeenCalled();
+  });
+
+  it.each([["--help"], ["-h"]])("prints MCP help without starting it: %s", async (help) => {
+    const output = outputCapture();
+    const runner = vi.fn(async () => undefined);
+
+    await expect(
+      runCli(["mcp", help], output.environmentWith({ runMcpStdio: runner })),
+    ).resolves.toBe(0);
+    expect(output.stdout).toBe("Usage: pitlane mcp\n");
+    expect(output.stderr).toBe("");
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it("waits for the MCP runner without writing before it completes", async () => {
+    const output = outputCapture();
+    let complete!: () => void;
+    const runner = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          complete = resolve;
+        }),
+    );
+    const run = runCli(["mcp"], output.environmentWith({ runMcpStdio: runner }));
+
+    await vi.waitFor(() => expect(runner).toHaveBeenCalledTimes(1));
+    expect(output.stdout).toBe("");
+    expect(output.stderr).toBe("");
+    complete();
+    await expect(run).resolves.toBe(0);
+    expect(output.stdout).toBe("");
+    expect(output.stderr).toBe("");
+  });
+
+  it.each([["--json"], ["unexpected"], ["--help=true"]])(
+    "rejects unexpected MCP input: %s",
+    async (argument) => {
+      const output = outputCapture();
+      const runner = vi.fn(async () => undefined);
+
+      await expect(
+        runCli(["mcp", argument], output.environmentWith({ runMcpStdio: runner })),
+      ).resolves.toBe(2);
+      expect(output.stdout).toBe("");
+      expect(output.stderr).toContain("Usage:");
+      expect(runner).not.toHaveBeenCalled();
+    },
+  );
+
+  it("reports MCP startup failures safely on stderr", async () => {
+    const output = outputCapture();
+    const runner = vi.fn(async () => {
+      throw new Error("MCP startup failed");
+    });
+
+    await expect(runCli(["mcp"], output.environmentWith({ runMcpStdio: runner }))).resolves.toBe(1);
+    expect(output.stdout).toBe("");
+    expect(output.stderr).toBe("MCP startup failed\n");
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps held lease stdout pure, renders progress to stderr, and releases on SIGTERM", async () => {
     const harness = await createHarness();
     const output = outputCapture();
@@ -163,7 +245,13 @@ describe("CLI boundary", () => {
         spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
         state: "leased",
       },
-      lease: { id: "lse_9f2c" },
+      lease: { id: "lse_9f2c", mode: "detached", ttlDeadline: 61_000 },
+      timing: {
+        estimatedBootMs: 20,
+        estimatedProvisionMs: 10,
+        estimatedReclaimMs: 0,
+        estimatedReadyMs: 30,
+      },
     });
 
     await expect(
@@ -172,7 +260,9 @@ describe("CLI boundary", () => {
         detached.environmentWith({ connect: async () => connection }),
       ),
     ).resolves.toBe(0);
-    expect(JSON.parse(detached.stdout)).toMatchObject({ lease: "lse_9f2c" });
+    expect(detached.stdout).toBe(
+      '{"device":"iPhone 17 Pro","lease":"lse_9f2c","os":"26.5","platform":"ios","state":"leased","udid":"ABCD"}\n',
+    );
     expect(connection.closed).toBe(true);
 
     const renew = outputCapture();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,6 +10,7 @@ import {
   SystemClock,
 } from "../ports/index.js";
 import { connectDaemon, connectExistingDaemon } from "../daemon-client/client.js";
+import { parseRawLeaseGrant } from "../daemon-client/contracts.js";
 import { DaemonClientError, type DaemonConnection } from "../daemon-client/protocol.js";
 
 export { DaemonClientError, type DaemonConnection } from "../daemon-client/protocol.js";
@@ -18,6 +19,7 @@ const USAGE = `Usage: pitlane <command> [options]
 
 Commands:
   lease, release, status, list, cleanup, doctor, nuke, events, daemon, config
+  mcp                         Start the stdio MCP server
 Run 'pitlane <command> --help' for command usage.`;
 
 const DAEMON_ERROR_EXIT_CODES: Readonly<Record<string, number>> = {
@@ -46,6 +48,8 @@ interface Signals {
   off(signal: "SIGINT" | "SIGTERM", listener: () => void): unknown;
 }
 
+type McpStdioRunner = () => Promise<void>;
+
 export interface CliEnvironment {
   readonly configPath: string;
   readonly connect: () => Promise<DaemonConnection>;
@@ -54,6 +58,9 @@ export interface CliEnvironment {
   readonly requesterId: string;
   readonly readConfigFile: () => Promise<Record<string, unknown>>;
   readonly readLogFile?: () => Promise<string>;
+  /** Loads the MCP frontend only when the `mcp` command is dispatched. */
+  readonly loadMcpStdio?: () => Promise<McpStdioRunner>;
+  readonly runMcpStdio?: () => Promise<void>;
   readonly signals: Signals;
   readonly stderr: Output;
   readonly stdout: Output;
@@ -101,6 +108,10 @@ function defaultCliEnvironment(): CliEnvironment {
   };
 }
 
+async function loadDefaultMcpStdio(): Promise<McpStdioRunner> {
+  return (await import("../mcp/main.js")).runMcpStdio;
+}
+
 export async function runCli(
   argv: readonly string[],
   environment: CliEnvironment = defaultCliEnvironment(),
@@ -131,6 +142,8 @@ export async function runCli(
         return await runDaemon(argv.slice(1), environment);
       case "config":
         return await runConfig(argv.slice(1), environment);
+      case "mcp":
+        return await runMcp(argv.slice(1), environment);
       default:
         throw new UsageError(`Unknown command: ${argv[0]}`);
     }
@@ -139,6 +152,18 @@ export async function runCli(
     if (error instanceof UsageError) environment.stderr.write(`${USAGE}\n`);
     return errorExitCode(error);
   }
+}
+
+async function runMcp(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+  if (argv.length === 1 && isHelp(argv[0])) {
+    environment.stdout.write("Usage: pitlane mcp\n");
+    return 0;
+  }
+  if (argv.length > 0) throw new UsageError("mcp accepts no arguments");
+  const runMcpStdio =
+    environment.runMcpStdio ?? (await (environment.loadMcpStdio ?? loadDefaultMcpStdio)());
+  await runMcpStdio();
+  return 0;
 }
 
 export function errorExitCode(error: unknown): number {
@@ -518,25 +543,14 @@ function commandArgs(
 }
 
 function leaseResult(value: unknown): Record<string, unknown> & { readonly lease: string } {
-  const grant = requireObject(value);
-  const lease = requireObject(grant.lease);
-  const device = requireObject(grant.device);
-  const spec = requireObject(device.spec);
-  if (
-    typeof lease.id !== "string" ||
-    typeof device.driverDeviceId !== "string" ||
-    typeof spec.model !== "string" ||
-    typeof spec.osVersion !== "string" ||
-    (spec.platform !== "ios" && spec.platform !== "android")
-  )
-    throw new Error("Daemon returned an invalid lease grant");
+  const grant = parseRawLeaseGrant(value);
   return {
-    device: spec.model,
-    lease: lease.id,
-    os: spec.osVersion,
-    platform: spec.platform,
+    device: grant.device.spec.model,
+    lease: grant.lease.id,
+    os: grant.device.spec.osVersion,
+    platform: grant.device.spec.platform,
     state: "leased",
-    udid: device.driverDeviceId,
+    udid: grant.device.driverDeviceId,
   };
 }
 

--- a/src/daemon-client/contracts.test.ts
+++ b/src/daemon-client/contracts.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { parseRawLeaseGrant } from "./contracts.js";
+
+const leaseGrant = {
+  device: {
+    driverDeviceId: "ABCD",
+    spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
+  },
+  lease: { id: "lse_9f2c", mode: "held", ttlDeadline: 61_000 },
+  timing: {
+    estimatedBootMs: 20,
+    estimatedProvisionMs: 10,
+    estimatedReclaimMs: 0,
+    estimatedReadyMs: 30,
+  },
+};
+
+describe("parseRawLeaseGrant", () => {
+  it("parses the lease fields shared by daemon frontends", () => {
+    expect(parseRawLeaseGrant(leaseGrant)).toEqual(leaseGrant);
+  });
+
+  it.each([
+    [{ ...leaseGrant, device: { ...leaseGrant.device, driverDeviceId: 42 } }],
+    [
+      {
+        ...leaseGrant,
+        device: { ...leaseGrant.device, spec: { ...leaseGrant.device.spec, platform: "web" } },
+      },
+    ],
+    [{ ...leaseGrant, lease: { ...leaseGrant.lease, mode: "forever" } }],
+    [{ ...leaseGrant, lease: { id: "lse_9f2c", mode: "held" } }],
+    [{ ...leaseGrant, timing: { ...leaseGrant.timing, estimatedReadyMs: "30" } }],
+    [null],
+  ])("rejects malformed daemon payloads", (value) => {
+    expect(() => parseRawLeaseGrant(value)).toThrow("Daemon returned an invalid lease grant");
+  });
+});

--- a/src/daemon-client/contracts.ts
+++ b/src/daemon-client/contracts.ts
@@ -1,0 +1,64 @@
+export interface RawLeaseGrant {
+  readonly device: {
+    readonly driverDeviceId: string;
+    readonly spec: {
+      readonly model: string;
+      readonly osVersion: string;
+      readonly platform: "android" | "ios";
+    };
+  };
+  readonly lease: {
+    readonly id: string;
+    readonly mode: "detached" | "held";
+    readonly ttlDeadline: number;
+  };
+  readonly timing: {
+    readonly estimatedBootMs: number;
+    readonly estimatedProvisionMs: number;
+    readonly estimatedReclaimMs: number;
+    readonly estimatedReadyMs: number;
+  };
+}
+
+export function parseRawLeaseGrant(value: unknown): RawLeaseGrant {
+  const grant = requireObject(value);
+  const device = requireObject(grant.device);
+  const spec = requireObject(device.spec);
+  const lease = requireObject(grant.lease);
+  const timing = requireObject(grant.timing);
+  if (
+    typeof device.driverDeviceId !== "string" ||
+    typeof spec.model !== "string" ||
+    typeof spec.osVersion !== "string" ||
+    (spec.platform !== "ios" && spec.platform !== "android") ||
+    typeof lease.id !== "string" ||
+    (lease.mode !== "held" && lease.mode !== "detached") ||
+    typeof lease.ttlDeadline !== "number" ||
+    typeof timing.estimatedProvisionMs !== "number" ||
+    typeof timing.estimatedBootMs !== "number" ||
+    typeof timing.estimatedReclaimMs !== "number" ||
+    typeof timing.estimatedReadyMs !== "number"
+  ) {
+    throw new Error("Daemon returned an invalid lease grant");
+  }
+  return {
+    device: {
+      driverDeviceId: device.driverDeviceId,
+      spec: { model: spec.model, osVersion: spec.osVersion, platform: spec.platform },
+    },
+    lease: { id: lease.id, mode: lease.mode, ttlDeadline: lease.ttlDeadline },
+    timing: {
+      estimatedBootMs: timing.estimatedBootMs,
+      estimatedProvisionMs: timing.estimatedProvisionMs,
+      estimatedReclaimMs: timing.estimatedReclaimMs,
+      estimatedReadyMs: timing.estimatedReadyMs,
+    },
+  };
+}
+
+function requireObject(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("Daemon returned an invalid lease grant");
+  }
+  return value as Record<string, unknown>;
+}

--- a/src/mcp/contracts.test.ts
+++ b/src/mcp/contracts.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  leaseSimulatorInputSchema,
+  leaseSimulatorOutputSchema,
+  MAX_TIMEOUT_SECONDS,
+  releaseSimulatorInputSchema,
+  releaseSimulatorOutputSchema,
+} from "./contracts.js";
+
+describe("MCP contracts", () => {
+  it("applies safe lease input defaults", () => {
+    expect(leaseSimulatorInputSchema.parse({ device: "iPhone 17 Pro", platform: "ios" })).toEqual({
+      allow_download: false,
+      device: "iPhone 17 Pro",
+      no_wait: false,
+      platform: "ios",
+    });
+  });
+
+  it.each([
+    [{ device: "", platform: "ios" }],
+    [{ device: "Pixel", os: "", platform: "android" }],
+    [{ device: "Pixel", platform: "android", timeout_seconds: -1 }],
+    [{ device: "Pixel", platform: "android", timeout_seconds: Number.POSITIVE_INFINITY }],
+    [{ device: "Pixel", platform: "android", timeout_seconds: MAX_TIMEOUT_SECONDS + 1 }],
+  ])("rejects invalid lease inputs", (input) => {
+    expect(() => leaseSimulatorInputSchema.parse(input)).toThrow();
+  });
+
+  it("validates public success results", () => {
+    expect(
+      leaseSimulatorOutputSchema.parse({
+        device: "iPhone 17 Pro",
+        device_id: "ABCD",
+        expires_at_ms: 61_000,
+        lease_id: "lse_9f2c",
+        mode: "held",
+        os: "26.5",
+        platform: "ios",
+        state: "leased",
+        timing: {
+          estimated_boot_ms: 20,
+          estimated_provision_ms: 10,
+          estimated_reclaim_ms: 0,
+          estimated_ready_ms: 30,
+        },
+      }),
+    ).toMatchObject({ lease_id: "lse_9f2c", state: "leased" });
+    expect(releaseSimulatorInputSchema.parse({ lease_id: "lse_9f2c" })).toEqual({
+      lease_id: "lse_9f2c",
+    });
+    expect(releaseSimulatorOutputSchema.parse({ lease_id: "lse_9f2c", released: true })).toEqual({
+      lease_id: "lse_9f2c",
+      released: true,
+    });
+  });
+});

--- a/src/mcp/contracts.ts
+++ b/src/mcp/contracts.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+const nonEmptyString = z.string().min(1);
+const finiteNumber = z.number().finite();
+export const MAX_TIMEOUT_SECONDS = Number.MAX_SAFE_INTEGER / 1_000;
+
+export const leaseSimulatorInputSchema = z.object({
+  allow_download: z.boolean().default(false),
+  device: nonEmptyString,
+  no_wait: z.boolean().default(false),
+  os: nonEmptyString.optional(),
+  platform: z.enum(["ios", "android"]),
+  timeout_seconds: finiteNumber
+    .nonnegative()
+    .max(MAX_TIMEOUT_SECONDS, "timeout_seconds is too large to convert safely to milliseconds")
+    .optional(),
+});
+
+export const leaseSimulatorOutputSchema = z.object({
+  device: nonEmptyString,
+  device_id: nonEmptyString,
+  expires_at_ms: finiteNumber,
+  lease_id: nonEmptyString,
+  mode: z.literal("held"),
+  os: nonEmptyString,
+  platform: z.enum(["ios", "android"]),
+  state: z.literal("leased"),
+  timing: z.object({
+    estimated_boot_ms: finiteNumber,
+    estimated_provision_ms: finiteNumber,
+    estimated_reclaim_ms: finiteNumber,
+    estimated_ready_ms: finiteNumber,
+  }),
+});
+
+export const releaseSimulatorInputSchema = z.object({
+  lease_id: nonEmptyString,
+});
+
+export const releaseSimulatorOutputSchema = z.object({
+  lease_id: nonEmptyString,
+  released: z.literal(true),
+});
+
+export type LeaseSimulatorInput = z.infer<typeof leaseSimulatorInputSchema>;
+export type LeaseSimulatorOutput = z.infer<typeof leaseSimulatorOutputSchema>;
+export type ReleaseSimulatorInput = z.infer<typeof releaseSimulatorInputSchema>;
+export type ReleaseSimulatorOutput = z.infer<typeof releaseSimulatorOutputSchema>;

--- a/src/mcp/main.test.ts
+++ b/src/mcp/main.test.ts
@@ -1,0 +1,194 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it } from "vitest";
+
+import type { DaemonConnection } from "../daemon-client/protocol.js";
+import { startMcpStdio, type McpTransport } from "./main.js";
+
+describe("MCP stdio lifecycle", () => {
+  it.each(["transport", "SIGINT", "SIGTERM"])("closes once on %s", async (cause) => {
+    const transport = new FakeTransport();
+    const server = new FakeServer();
+    const signals = new FakeSignals();
+    const runner = await startMcpStdio({
+      createServer: () => server as unknown as McpServer,
+      createTransport: () => transport,
+      signals,
+    });
+
+    if (cause === "transport") transport.onclose?.();
+    else signals.emit(cause);
+    await runner.finished;
+    await runner.shutdown();
+
+    expect(server.closeCalls).toBe(1);
+    expect(transport.closeCalls).toBe(1);
+    expect(signals.listeners.size).toBe(0);
+  });
+
+  it("cleans up after startup failure", async () => {
+    const transport = new FakeTransport();
+    const server = new FakeServer(new Error("startup failed"));
+    await expect(
+      startMcpStdio({
+        createServer: () => server as unknown as McpServer,
+        createTransport: () => transport,
+      }),
+    ).rejects.toThrow("startup failed");
+    expect(server.closeCalls).toBe(1);
+    expect(transport.closeCalls).toBe(1);
+  });
+
+  it("closes the lease-owning session when its transport ends", async () => {
+    const connection = new LeaseConnection();
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const runner = await startMcpStdio({
+      connect: async () => connection,
+      createTransport: () => serverTransport,
+      requesterId: "mcp-test",
+      signals: new FakeSignals(),
+    });
+    const client = new Client({ name: "test", version: "1.0.0" });
+    await client.connect(clientTransport);
+    await client.request(
+      {
+        method: "tools/call",
+        params: { arguments: { device: "iPhone", platform: "ios" }, name: "lease_simulator" },
+      },
+      CallToolResultSchema,
+    );
+
+    serverTransport.onclose?.();
+    await runner.finished;
+    expect(connection.closeCalls).toBe(1);
+    await client.close();
+  });
+
+  it("closes once when stdin reaches EOF", async () => {
+    const transport = new FakeTransport();
+    const server = new FakeServer();
+    const stdin = new FakeStdin();
+    const runner = await startMcpStdio({
+      createServer: () => server as unknown as McpServer,
+      createTransport: () => transport,
+      stdin,
+    });
+
+    stdin.end();
+    await runner.finished;
+    expect(server.closeCalls).toBe(1);
+    expect(transport.closeCalls).toBe(1);
+    expect(stdin.listener).toBeUndefined();
+  });
+
+  it("finishes when the transport closes during server connection", async () => {
+    const transport = new FakeTransport();
+    const server = new FakeServer(undefined, () => transport.onclose?.());
+    const runner = await startMcpStdio({
+      createServer: () => server as unknown as McpServer,
+      createTransport: () => transport,
+    });
+
+    await runner.finished;
+    expect(server.closeCalls).toBe(1);
+    expect(transport.closeCalls).toBe(1);
+  });
+
+  it("does not connect when stdin had already ended", async () => {
+    const transport = new FakeTransport();
+    const server = new FakeServer();
+    const stdin = new FakeStdin(true);
+    const runner = await startMcpStdio({
+      createServer: () => server as unknown as McpServer,
+      createTransport: () => transport,
+      stdin,
+    });
+
+    await runner.finished;
+    expect(server.connectCalls).toBe(0);
+    expect(server.closeCalls).toBe(1);
+    expect(transport.closeCalls).toBe(1);
+  });
+});
+
+class FakeServer {
+  closeCalls = 0;
+  connectCalls = 0;
+  private transport: McpTransport | undefined;
+  constructor(
+    private readonly connectError?: Error,
+    private readonly duringConnect?: () => void,
+  ) {}
+  async close(): Promise<void> {
+    this.closeCalls += 1;
+    await this.transport?.close();
+  }
+  async connect(transport: McpTransport): Promise<void> {
+    this.connectCalls += 1;
+    this.transport = transport;
+    this.duringConnect?.();
+    if (this.connectError !== undefined) throw this.connectError;
+  }
+}
+
+class FakeTransport implements McpTransport {
+  closeCalls = 0;
+  onclose?: () => void;
+  async close(): Promise<void> {
+    this.closeCalls += 1;
+  }
+}
+
+class FakeSignals {
+  readonly listeners = new Map<string, () => void>();
+  on(signal: string, listener: () => void): void {
+    this.listeners.set(signal, listener);
+  }
+  off(signal: string): void {
+    this.listeners.delete(signal);
+  }
+  emit(signal: string): void {
+    this.listeners.get(signal)?.();
+  }
+}
+
+class LeaseConnection implements DaemonConnection {
+  closeCalls = 0;
+  async close(): Promise<void> {
+    this.closeCalls += 1;
+  }
+  onPush(): () => void {
+    return () => undefined;
+  }
+  async request(): Promise<unknown> {
+    return {
+      device: {
+        driverDeviceId: "SIM-1",
+        spec: { model: "iPhone", osVersion: "26", platform: "ios" },
+      },
+      lease: { id: "lease-1", mode: "held", ttlDeadline: 10 },
+      timing: {
+        estimatedBootMs: 1,
+        estimatedProvisionMs: 1,
+        estimatedReclaimMs: 0,
+        estimatedReadyMs: 2,
+      },
+    };
+  }
+}
+
+class FakeStdin {
+  listener: (() => void) | undefined;
+  constructor(readonly readableEnded = false) {}
+  off(): void {
+    this.listener = undefined;
+  }
+  once(_event: "end", listener: () => void): void {
+    this.listener = listener;
+  }
+  end(): void {
+    this.listener?.();
+  }
+}

--- a/src/mcp/main.ts
+++ b/src/mcp/main.ts
@@ -1,0 +1,141 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { NodeDaemonLauncher, NodeIpcTransport, SystemClock } from "../ports/index.js";
+import { connectDaemon } from "../daemon-client/client.js";
+import type { DaemonConnection } from "../daemon-client/protocol.js";
+import { McpSession } from "./session.js";
+import { createMcpServer } from "./server.js";
+
+interface Signals {
+  on(signal: "SIGINT" | "SIGTERM", listener: () => void): unknown;
+  off(signal: "SIGINT" | "SIGTERM", listener: () => void): unknown;
+}
+
+interface StdinLifecycle {
+  off(event: "end", listener: () => void): unknown;
+  once(event: "end", listener: () => void): unknown;
+  readonly readableEnded?: boolean;
+}
+
+/** The runner needs only the lifecycle portion of the SDK transport contract. */
+export interface McpTransport {
+  close(): Promise<void>;
+  onclose?: () => void;
+}
+
+export interface McpStdioEnvironment {
+  readonly connect?: () => Promise<DaemonConnection>;
+  readonly createServer?: (session: McpSession) => McpServer;
+  readonly createTransport?: () => McpTransport;
+  readonly requesterId?: string;
+  readonly signals?: Signals;
+  /** The stdio transport currently does not surface stdin EOF as onclose. */
+  readonly stdin?: StdinLifecycle;
+}
+
+export interface McpStdioRunner {
+  readonly shutdown: () => Promise<void>;
+  readonly finished: Promise<void>;
+}
+
+/**
+ * Connects the MCP server to stdio and remains pending until the connection closes.
+ * The caller owns process exit status and any fatal diagnostic rendering.
+ */
+// fallow-ignore-next-line unused-export -- CLI routing invokes this public frontend entrypoint.
+export async function runMcpStdio(environment: McpStdioEnvironment = {}): Promise<void> {
+  const runner = await startMcpStdio(environment);
+  await runner.finished;
+}
+
+/** Starts an injectable MCP stdio lifecycle; primarily useful to integration-test shutdown. */
+export async function startMcpStdio(
+  environment: McpStdioEnvironment = {},
+): Promise<McpStdioRunner> {
+  const defaults = defaultEnvironment();
+  const session = new McpSession({
+    connect: environment.connect ?? defaults.connect,
+    requesterId: environment.requesterId ?? `mcp:${process.pid}`,
+  });
+  const server = (environment.createServer ?? createMcpServer)(session);
+  const transport = (environment.createTransport ?? defaults.createTransport)();
+  const signals = environment.signals ?? process;
+  const stdin = environment.stdin ?? process.stdin;
+  let resolveFinished!: () => void;
+  const finished = new Promise<void>((resolve) => {
+    resolveFinished = resolve;
+  });
+  let shutdownPromise: Promise<void> | undefined;
+  let serverConnectStarted = false;
+
+  const onSignal = () => {
+    void shutdown();
+  };
+  const onStdinEnd = () => {
+    void shutdown();
+  };
+  const previousTransportOnClose = transport.onclose;
+  transport.onclose = () => {
+    previousTransportOnClose?.();
+    void shutdown();
+  };
+  const shutdown = (): Promise<void> => {
+    shutdownPromise ??= (async () => {
+      signals.off("SIGINT", onSignal);
+      signals.off("SIGTERM", onSignal);
+      stdin.off("end", onStdinEnd);
+      // McpServer owns its transport once connect starts; its close() closes the
+      // transport and fires onclose. Close a never-connected transport ourselves.
+      await Promise.allSettled([
+        session.close(),
+        server.close(),
+        ...(serverConnectStarted ? [] : [transport.close()]),
+      ]);
+      resolveFinished();
+    })();
+    return shutdownPromise;
+  };
+
+  signals.on("SIGINT", onSignal);
+  signals.on("SIGTERM", onSignal);
+  stdin.once("end", onStdinEnd);
+  if (stdin.readableEnded) {
+    await shutdown();
+    return { finished, shutdown };
+  }
+  try {
+    serverConnectStarted = true;
+    await server.connect(transport as never);
+  } catch (error: unknown) {
+    await shutdown();
+    throw error;
+  }
+
+  return { finished, shutdown };
+}
+
+function defaultEnvironment(): Required<Pick<McpStdioEnvironment, "connect" | "createTransport">> {
+  const dataDirectory = join(homedir(), ".pitlane");
+  const clock = new SystemClock();
+  const ipc = new NodeIpcTransport();
+  const socketPath = join(dataDirectory, "daemon.sock");
+  const logPath = join(dataDirectory, "daemon.log");
+  return {
+    connect: () =>
+      connectDaemon({
+        clock,
+        ipc,
+        launcher: new NodeDaemonLauncher({
+          args: [join(dirname(fileURLToPath(import.meta.url)), "../daemon/main.js")],
+          command: process.execPath,
+          logPath,
+        }),
+        socketPath,
+      }),
+    createTransport: () => new StdioServerTransport(),
+  };
+}

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -1,0 +1,146 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { CallToolResultSchema, ListToolsResultSchema } from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it } from "vitest";
+
+import { DaemonClientError, type DaemonConnection } from "../daemon-client/protocol.js";
+import { leaseSimulatorOutputSchema, releaseSimulatorOutputSchema } from "./contracts.js";
+import { McpSession } from "./session.js";
+import { createMcpServer } from "./server.js";
+
+const grant = {
+  device: {
+    driverDeviceId: "SIM-1",
+    spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" as const },
+  },
+  lease: { id: "lease-1", mode: "held" as const, ttlDeadline: 12_345 },
+  timing: {
+    estimatedBootMs: 3,
+    estimatedProvisionMs: 2,
+    estimatedReclaimMs: 1,
+    estimatedReadyMs: 6,
+  },
+};
+
+describe("MCP server", () => {
+  it("advertises exactly the lease tools and returns dual schema-valid results", async () => {
+    const connection = new StubConnection([grant, { leaseId: "lease-1" }]);
+    const { client, close } = await connectedServer(connection);
+    try {
+      const listed = await client.request({ method: "tools/list" }, ListToolsResultSchema);
+      expect(listed.tools.map((tool) => tool.name)).toEqual([
+        "lease_simulator",
+        "release_simulator",
+      ]);
+      for (const tool of listed.tools) {
+        expect(tool.title).toEqual(expect.any(String));
+        expect(tool.description).toEqual(expect.any(String));
+        expect(tool.inputSchema).toEqual(expect.any(Object));
+        expect(tool.outputSchema).toEqual(expect.any(Object));
+      }
+
+      const lease = await call(client, "lease_simulator", {
+        device: "iPhone 17 Pro",
+        platform: "ios",
+      });
+      expect(lease.isError).not.toBe(true);
+      leaseSimulatorOutputSchema.parse(lease.structuredContent);
+      expect(lease.structuredContent).toMatchObject({ lease_id: "lease-1", mode: "held" });
+      expect(JSON.parse(text(lease))).toEqual(lease.structuredContent);
+
+      const release = await call(client, "release_simulator", { lease_id: "lease-1" });
+      expect(release.isError).not.toBe(true);
+      releaseSimulatorOutputSchema.parse(release.structuredContent);
+      expect(release.structuredContent).toEqual({ lease_id: "lease-1", released: true });
+      expect(JSON.parse(text(release))).toEqual(release.structuredContent);
+    } finally {
+      await close();
+    }
+  });
+
+  it("returns stable, sanitized errors without invalid structured output", async () => {
+    const connection = new StubConnection([
+      new DaemonClientError("NO_CAPACITY", "No matching devices are available"),
+      new Error("/private/secret-stack-path"),
+    ]);
+    const { client, close } = await connectedServer(connection);
+    try {
+      const expected = await call(client, "lease_simulator", {
+        device: "iPhone 17 Pro",
+        platform: "ios",
+      });
+      expect(expected).toMatchObject({ isError: true });
+      expect(JSON.parse(text(expected))).toEqual({
+        code: "NO_CAPACITY",
+        message: "No matching devices are available",
+      });
+      expect(expected.structuredContent).toBeUndefined();
+
+      const unexpected = await call(client, "lease_simulator", {
+        device: "iPhone 17 Pro",
+        platform: "ios",
+      });
+      expect(JSON.parse(text(unexpected))).toEqual({
+        code: "INTERNAL",
+        message: "Pitlane could not complete the request",
+      });
+      expect(text(unexpected)).not.toContain("private");
+    } finally {
+      await close();
+    }
+  });
+
+  it("rejects invalid tool arguments through the registered schema", async () => {
+    const { client, close } = await connectedServer(new StubConnection([]));
+    try {
+      const result = await call(client, "lease_simulator", { device: "", platform: "desktop" });
+      expect(result.isError).toBe(true);
+      expect(text(result)).toContain("Input validation error");
+    } finally {
+      await close();
+    }
+  });
+});
+
+async function connectedServer(connection: StubConnection) {
+  const session = new McpSession({ connect: async () => connection, requesterId: "mcp-test" });
+  const server = createMcpServer(session);
+  const client = new Client({ name: "mcp-test-client", version: "1.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+  return {
+    client,
+    close: async () => {
+      await Promise.all([client.close(), server.close(), session.close()]);
+    },
+  };
+}
+
+function call(client: Client, name: string, arguments_: Record<string, unknown>) {
+  return client.request(
+    { method: "tools/call", params: { arguments: arguments_, name } },
+    CallToolResultSchema,
+  );
+}
+
+function text(result: { content: Array<{ type: string; text?: string }> }): string {
+  const first = result.content[0];
+  if (first?.type !== "text" || first.text === undefined) throw new Error("Expected text result");
+  return first.text;
+}
+
+class StubConnection implements DaemonConnection {
+  closeCalls = 0;
+  constructor(private readonly responses: unknown[]) {}
+  async close(): Promise<void> {
+    this.closeCalls += 1;
+  }
+  onPush(): () => void {
+    return () => undefined;
+  }
+  async request(): Promise<unknown> {
+    const response = this.responses.shift();
+    if (response instanceof Error) throw response;
+    return response;
+  }
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,71 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import {
+  leaseSimulatorInputSchema,
+  leaseSimulatorOutputSchema,
+  releaseSimulatorInputSchema,
+  releaseSimulatorOutputSchema,
+} from "./contracts.js";
+import { McpSession, toMcpErrorResult } from "./session.js";
+
+const SERVER_INFO = { name: "pitlane", version: "1.0.0" };
+
+/** Creates the MCP tool surface for one lease-owning session. */
+export function createMcpServer(session: McpSession): McpServer {
+  const server = new McpServer(SERVER_INFO);
+
+  server.registerTool(
+    "lease_simulator",
+    {
+      title: "Lease simulator",
+      description:
+        "Lease one simulator or emulator for this MCP session. The lease is held until released or this MCP connection closes; provisioning can block unless no_wait is true. Downloads are disabled by default and require allow_download: true.",
+      inputSchema: leaseSimulatorInputSchema,
+      outputSchema: leaseSimulatorOutputSchema,
+    },
+    async (input, extra) => {
+      try {
+        const output = await session.lease(input, extra.signal);
+        return success(output);
+      } catch (error: unknown) {
+        return failure(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    "release_simulator",
+    {
+      title: "Release simulator",
+      description:
+        "Release the simulator lease owned by this MCP session. A session can release only its own held lease.",
+      inputSchema: releaseSimulatorInputSchema,
+      outputSchema: releaseSimulatorOutputSchema,
+    },
+    async (input) => {
+      try {
+        const output = await session.release(input);
+        return success(output);
+      } catch (error: unknown) {
+        return failure(error);
+      }
+    },
+  );
+
+  return server;
+}
+
+function success(structuredContent: Record<string, unknown>) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(structuredContent) }],
+    structuredContent,
+  };
+}
+
+function failure(error: unknown) {
+  const result = toMcpErrorResult(error);
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(result) }],
+    isError: true,
+  };
+}

--- a/src/mcp/session.test.ts
+++ b/src/mcp/session.test.ts
@@ -1,0 +1,351 @@
+import { describe, expect, it } from "vitest";
+
+import { DaemonClientError, type DaemonConnection } from "../daemon-client/protocol.js";
+import { leaseSimulatorInputSchema } from "./contracts.js";
+import { McpSession, toMcpErrorResult } from "./session.js";
+
+const input = leaseSimulatorInputSchema.parse({ device: "iPhone 17 Pro", platform: "ios" });
+const rawGrant = {
+  device: {
+    driverDeviceId: "ABCD",
+    spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" as const },
+  },
+  lease: { id: "lse_9f2c", mode: "held" as const, ttlDeadline: 61_000 },
+  timing: {
+    estimatedBootMs: 20,
+    estimatedProvisionMs: 10,
+    estimatedReclaimMs: 0,
+    estimatedReadyMs: 30,
+  },
+};
+
+describe("McpSession", () => {
+  it("maps safe defaults and grants to the public result", async () => {
+    const connection = new StubConnection();
+    connection.responses.push(rawGrant);
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+
+    await expect(session.lease(input)).resolves.toEqual({
+      device: "iPhone 17 Pro",
+      device_id: "ABCD",
+      expires_at_ms: 61_000,
+      lease_id: "lse_9f2c",
+      mode: "held",
+      os: "26.5",
+      platform: "ios",
+      state: "leased",
+      timing: {
+        estimated_boot_ms: 20,
+        estimated_provision_ms: 10,
+        estimated_reclaim_ms: 0,
+        estimated_ready_ms: 30,
+      },
+    });
+    expect(connection.requests).toEqual([
+      {
+        payload: {
+          allowDownload: false,
+          mode: "held",
+          noWait: false,
+          requesterId: "mcp-session-1",
+          request: { model: "iPhone 17 Pro", platform: "ios" },
+        },
+        type: "lease.request",
+      },
+    ]);
+  });
+
+  it("converts timeout seconds and optional fields for the daemon", async () => {
+    const connection = new StubConnection();
+    connection.responses.push(rawGrant);
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+    await session.lease(
+      leaseSimulatorInputSchema.parse({
+        allow_download: true,
+        device: "iPhone 17 Pro",
+        no_wait: true,
+        os: "26.5",
+        platform: "ios",
+        timeout_seconds: 1.25,
+      }),
+    );
+    expect(connection.requests[0]?.payload).toEqual({
+      allowDownload: true,
+      mode: "held",
+      noWait: true,
+      requesterId: "mcp-session-1",
+      request: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
+      timeoutMs: 1_250,
+    });
+  });
+
+  it("rejects timeout values that would overflow milliseconds before requesting the daemon", async () => {
+    const connection = new StubConnection();
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+
+    await expect(
+      session.lease({ ...input, timeout_seconds: Number.MAX_VALUE }),
+    ).rejects.toMatchObject({ code: "INVALID_TIMEOUT" });
+    expect(connection.requests).toEqual([]);
+  });
+
+  it("rejects releases that this session does not own without calling the daemon", async () => {
+    const connection = new StubConnection();
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+    await expect(session.release({ lease_id: "other" })).rejects.toMatchObject({
+      code: "LEASE_NOT_OWNED",
+    });
+    expect(connection.requests).toEqual([]);
+  });
+
+  it("preserves expected daemon errors and sanitizes unexpected ones", async () => {
+    const connection = new StubConnection();
+    connection.responses.push(
+      new DaemonClientError("NO_CAPACITY", "No matching devices are available"),
+    );
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+    await expect(session.lease(input)).rejects.toBeInstanceOf(DaemonClientError);
+    expect(
+      toMcpErrorResult(new DaemonClientError("NO_CAPACITY", "No matching devices are available")),
+    ).toEqual({
+      code: "NO_CAPACITY",
+      message: "No matching devices are available",
+    });
+    expect(toMcpErrorResult(new Error("/private/secret"))).toEqual({
+      code: "INTERNAL",
+      message: "Pitlane could not complete the request",
+    });
+  });
+
+  it("defers repeat lease ownership decisions to the daemon and replaces stale local ownership", async () => {
+    const connection = new StubConnection();
+    const activeError = new DaemonClientError("REQUESTER_ALREADY_LEASED", "Lease is active");
+    const replacementGrant = {
+      ...rawGrant,
+      lease: { ...rawGrant.lease, id: "lse_replacement" },
+    };
+    connection.responses.push(rawGrant, activeError, replacementGrant, {
+      leaseId: "lse_replacement",
+    });
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+
+    await session.lease(input);
+    await expect(session.lease(input)).rejects.toBe(activeError);
+    await expect(session.lease(input)).resolves.toMatchObject({ lease_id: "lse_replacement" });
+    await session.release({ lease_id: "lse_replacement" });
+    expect(connection.requests.map((request) => request.type)).toEqual([
+      "lease.request",
+      "lease.request",
+      "lease.request",
+      "lease.release",
+    ]);
+  });
+
+  it("rejects malformed and non-held daemon grants", async () => {
+    const malformed = new StubConnection();
+    malformed.responses.push({ nope: true });
+    await expect(
+      new McpSession({ connect: async () => malformed, requesterId: "mcp-session-1" }).lease(input),
+    ).rejects.toThrow("Daemon returned an invalid lease grant");
+    expect(malformed.closeCalls).toBe(1);
+
+    const detached = new StubConnection();
+    detached.responses.push(
+      { ...rawGrant, lease: { ...rawGrant.lease, mode: "detached" } },
+      new DaemonClientError("UNKNOWN_LEASE", "Lease was already gone"),
+    );
+    await expect(
+      new McpSession({ connect: async () => detached, requesterId: "mcp-session-1" }).lease(input),
+    ).rejects.toMatchObject({ code: "INVALID_LEASE_GRANT" });
+    expect(detached.requests).toEqual([
+      expect.objectContaining({ type: "lease.request" }),
+      { payload: { leaseId: "lse_9f2c" }, type: "lease.release" },
+    ]);
+    expect(detached.closeCalls).toBe(1);
+  });
+
+  it("closes the active connection when cancelled so a late grant cannot be orphaned", async () => {
+    const connection = new StubConnection();
+    const lateGrant = deferred<unknown>();
+    connection.responses.push(lateGrant.promise);
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+    const controller = new AbortController();
+    const unhandled: unknown[] = [];
+    const recordUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on("unhandledRejection", recordUnhandled);
+    try {
+      const lease = session.lease(input, controller.signal);
+      await waitFor(() => connection.requests.length === 1);
+      controller.abort();
+      await expect(lease).rejects.toMatchObject({ code: "CANCELLED" });
+      expect(connection.closeCalls).toBe(1);
+      lateGrant.resolve(rawGrant);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(connection.closeCalls).toBe(1);
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", recordUnhandled);
+    }
+  });
+
+  it("closes promptly during a pending lease and makes the session terminal", async () => {
+    const connection = new StubConnection();
+    const lateGrant = deferred<unknown>();
+    connection.responses.push(lateGrant.promise);
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+    const unhandled: unknown[] = [];
+    const recordUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on("unhandledRejection", recordUnhandled);
+    try {
+      const lease = session.lease(input);
+      await waitFor(() => connection.requests.length === 1);
+      await session.close();
+      expect(connection.closeCalls).toBe(1);
+      await expect(lease).rejects.toMatchObject({ code: "SESSION_CLOSED" });
+      await expect(session.lease(input)).rejects.toMatchObject({ code: "SESSION_CLOSED" });
+      await expect(session.release({ lease_id: "lse_9f2c" })).rejects.toMatchObject({
+        code: "SESSION_CLOSED",
+      });
+      lateGrant.resolve(rawGrant);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", recordUnhandled);
+    }
+  });
+
+  it("closes a connection that finishes establishing after session shutdown", async () => {
+    const connection = new StubConnection();
+    const connectionDeferred = deferred<DaemonConnection>();
+    let connectCalls = 0;
+    const session = new McpSession({
+      connect: async () => {
+        connectCalls += 1;
+        return connectionDeferred.promise;
+      },
+      requesterId: "mcp-session-1",
+    });
+    const lease = session.lease(input);
+
+    await waitFor(() => connectCalls === 1);
+    await session.close();
+    connectionDeferred.resolve(connection);
+    await expect(lease).rejects.toMatchObject({ code: "SESSION_CLOSED" });
+    await waitFor(() => connection.closeCalls === 1);
+    expect(connection.requests).toEqual([]);
+  });
+
+  it("serializes lease and release mutations", async () => {
+    const connection = new StubConnection();
+    const grant = deferred<unknown>();
+    connection.responses.push(grant.promise, { leaseId: "lse_9f2c" });
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+    const lease = session.lease(input);
+    const release = session.release({ lease_id: "lse_9f2c" });
+
+    await waitFor(() => connection.requests.length === 1);
+    expect(connection.requests).toHaveLength(1);
+    grant.resolve(rawGrant);
+    await lease;
+    await release;
+    expect(connection.requests.map((request) => request.type)).toEqual([
+      "lease.request",
+      "lease.release",
+    ]);
+  });
+
+  it("releases explicitly, clears expired ownership, and closes idempotently", async () => {
+    const connection = new StubConnection();
+    connection.responses.push(rawGrant, { leaseId: "lse_9f2c" });
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+    await session.lease(input);
+    await expect(session.release({ lease_id: "lse_9f2c" })).resolves.toEqual({
+      lease_id: "lse_9f2c",
+      released: true,
+    });
+    await expect(session.release({ lease_id: "lse_9f2c" })).rejects.toMatchObject({
+      code: "LEASE_NOT_OWNED",
+    });
+    await Promise.all([session.close(), session.close(), session.close()]);
+    expect(connection.closeCalls).toBe(1);
+  });
+
+  it("forgets ownership when the daemon says a lease is unknown or expired", async () => {
+    const connection = new StubConnection();
+    connection.responses.push(rawGrant, new DaemonClientError("UNKNOWN_LEASE", "Lease expired"));
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+    await session.lease(input);
+    await expect(session.release({ lease_id: "lse_9f2c" })).rejects.toMatchObject({
+      code: "UNKNOWN_LEASE",
+    });
+    await expect(session.release({ lease_id: "lse_9f2c" })).rejects.toMatchObject({
+      code: "LEASE_NOT_OWNED",
+    });
+  });
+});
+
+class StubConnection implements DaemonConnection {
+  readonly requests: Array<{ readonly payload: unknown; readonly type: string }> = [];
+  readonly responses: unknown[] = [];
+  closeCalls = 0;
+
+  async request(type: string, payload: unknown): Promise<unknown> {
+    this.requests.push({ payload, type });
+    const response = this.responses.shift();
+    if (response instanceof Error) throw response;
+    return response instanceof Promise ? response : response;
+  }
+
+  onPush(): () => void {
+    return () => undefined;
+  }
+
+  async close(): Promise<void> {
+    this.closeCalls += 1;
+  }
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  while (!predicate()) await new Promise((resolve) => setTimeout(resolve, 0));
+}

--- a/src/mcp/session.ts
+++ b/src/mcp/session.ts
@@ -1,0 +1,316 @@
+import { parseRawLeaseGrant, type RawLeaseGrant } from "../daemon-client/contracts.js";
+import { DaemonClientError, type DaemonConnection } from "../daemon-client/protocol.js";
+import type {
+  LeaseSimulatorInput,
+  LeaseSimulatorOutput,
+  ReleaseSimulatorInput,
+  ReleaseSimulatorOutput,
+} from "./contracts.js";
+import { leaseSimulatorOutputSchema, MAX_TIMEOUT_SECONDS } from "./contracts.js";
+
+export interface McpSessionOptions {
+  readonly connect: () => Promise<DaemonConnection>;
+  readonly requesterId: string;
+}
+
+export interface McpErrorResult {
+  readonly code: string;
+  readonly message: string;
+}
+
+interface LeaseAbortWatch {
+  readonly cancelled: Promise<never>;
+  cleanup(): Promise<void> | undefined;
+  dispose(): void;
+}
+
+class McpSessionError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "McpSessionError";
+  }
+}
+
+export function toMcpErrorResult(error: unknown): McpErrorResult {
+  if (error instanceof DaemonClientError || error instanceof McpSessionError) {
+    return { code: error.code, message: error.message };
+  }
+  return { code: "INTERNAL", message: "Pitlane could not complete the request" };
+}
+
+export class McpSession {
+  readonly #connect: () => Promise<DaemonConnection>;
+  readonly #requesterId: string;
+  #connection: DaemonConnection | undefined;
+  #connecting: Promise<DaemonConnection> | undefined;
+  #closed = false;
+  #closedConnections = new Set<DaemonConnection>();
+  #closePromise: Promise<void> | undefined;
+  #rejectClosed!: (reason: McpSessionError) => void;
+  #sessionClosed: Promise<never>;
+  #ownedLeaseId: string | undefined;
+  #mutations: Promise<void> = Promise.resolve();
+
+  constructor(options: McpSessionOptions) {
+    this.#connect = options.connect;
+    this.#requesterId = options.requesterId;
+    this.#sessionClosed = new Promise<never>((_resolve, reject) => {
+      this.#rejectClosed = reject;
+    });
+    void this.#sessionClosed.catch(() => undefined);
+  }
+
+  lease(input: LeaseSimulatorInput, signal?: AbortSignal): Promise<LeaseSimulatorOutput> {
+    return this.#mutate(() => {
+      this.#throwIfClosed();
+      return this.#lease(input, signal);
+    });
+  }
+
+  release(input: ReleaseSimulatorInput): Promise<ReleaseSimulatorOutput> {
+    return this.#mutate(async () => {
+      this.#throwIfClosed();
+      if (this.#ownedLeaseId !== input.lease_id) {
+        throw new McpSessionError("LEASE_NOT_OWNED", "This session does not own that lease");
+      }
+      const connection = await this.#connectionForUse();
+      try {
+        await Promise.race([
+          connection.request("lease.release", { leaseId: input.lease_id }),
+          this.#sessionClosed,
+        ]);
+      } catch (error: unknown) {
+        if (isNoLongerActiveLease(error)) this.#ownedLeaseId = undefined;
+        throw error;
+      }
+      this.#ownedLeaseId = undefined;
+      return { lease_id: input.lease_id, released: true };
+    });
+  }
+
+  close(): Promise<void> {
+    if (this.#closePromise !== undefined) return this.#closePromise;
+    this.#closed = true;
+    this.#ownedLeaseId = undefined;
+    this.#rejectClosed(new McpSessionError("SESSION_CLOSED", "MCP session is closed"));
+    const connection = this.#connection;
+    this.#connection = undefined;
+    if (this.#connecting !== undefined) {
+      void this.#connecting
+        .then((nextConnection) => this.#closeDaemonConnection(nextConnection))
+        .catch(noop);
+    }
+    this.#closePromise =
+      connection === undefined ? Promise.resolve() : this.#closeDaemonConnection(connection);
+    return this.#closePromise;
+  }
+
+  async #lease(input: LeaseSimulatorInput, signal?: AbortSignal): Promise<LeaseSimulatorOutput> {
+    throwIfAborted(signal);
+
+    const abortWatch = this.#watchLeaseAbort(signal);
+    let responseReceived = false;
+    try {
+      const connection = await this.#connectionForUse();
+      await this.#throwIfCancelledBeforeRequest(signal);
+      const response = await this.#requestLease(connection, input, abortWatch.cancelled);
+      responseReceived = true;
+      return await this.#mapLeaseResponse(connection, response, signal, abortWatch);
+    } catch (error: unknown) {
+      await this.#cleanupFailedLease(responseReceived, abortWatch.cleanup());
+      throw error;
+    } finally {
+      abortWatch.dispose();
+    }
+  }
+
+  #watchLeaseAbort(signal: AbortSignal | undefined): LeaseAbortWatch {
+    let cleanup: Promise<void> | undefined;
+    let reject: ((reason: McpSessionError) => void) | undefined;
+    const cancelled = new Promise<never>((_resolve, nextReject) => {
+      reject = nextReject;
+    });
+    void cancelled.catch(() => undefined);
+    const abort = () => {
+      cleanup ??= this.#closeConnection().catch(() => undefined);
+      reject?.(new McpSessionError("CANCELLED", "Lease request cancelled"));
+    };
+    signal?.addEventListener("abort", abort, { once: true });
+    return {
+      cancelled,
+      cleanup: () => cleanup,
+      dispose: () => signal?.removeEventListener("abort", abort),
+    };
+  }
+
+  async #throwIfCancelledBeforeRequest(signal: AbortSignal | undefined): Promise<void> {
+    if (!signal?.aborted) return;
+    await this.#closeConnection().catch(() => undefined);
+    throw new McpSessionError("CANCELLED", "Lease request cancelled");
+  }
+
+  #requestLease(
+    connection: DaemonConnection,
+    input: LeaseSimulatorInput,
+    cancelled: Promise<never>,
+  ): Promise<unknown> {
+    return Promise.race([
+      connection.request("lease.request", daemonLeaseRequest(input, this.#requesterId)),
+      cancelled,
+      this.#sessionClosed,
+    ]);
+  }
+
+  async #mapLeaseResponse(
+    connection: DaemonConnection,
+    response: unknown,
+    signal: AbortSignal | undefined,
+    abortWatch: LeaseAbortWatch,
+  ): Promise<LeaseSimulatorOutput> {
+    const grant = parseRawLeaseGrant(response);
+    this.#throwIfClosed();
+    if (signal?.aborted) {
+      await abortWatch.cleanup();
+      throw new McpSessionError("CANCELLED", "Lease request cancelled");
+    }
+    if (grant.lease.mode !== "held") {
+      await this.#releaseUnexpectedLease(connection, grant.lease.id);
+      throw new McpSessionError("INVALID_LEASE_GRANT", "Daemon returned a non-held lease grant");
+    }
+    const output = leaseSimulatorOutputSchema.parse(leaseSimulatorOutput(grant));
+    this.#ownedLeaseId = grant.lease.id;
+    return output;
+  }
+
+  async #releaseUnexpectedLease(connection: DaemonConnection, leaseId: string): Promise<void> {
+    try {
+      await connection.request("lease.release", { leaseId });
+    } catch {
+      // The connection close below remains the daemon-side held-lease cleanup fallback.
+    } finally {
+      await this.#closeConnection().catch(() => undefined);
+    }
+  }
+
+  async #cleanupFailedLease(
+    responseReceived: boolean,
+    abortCleanup: Promise<void> | undefined,
+  ): Promise<void> {
+    if (abortCleanup !== undefined) await abortCleanup;
+    else if (responseReceived) await this.#closeConnection().catch(() => undefined);
+  }
+
+  async #connectionForUse(): Promise<DaemonConnection> {
+    if (this.#connection !== undefined) return this.#connection;
+    this.#connecting ??= this.#connect();
+    const connecting = this.#connecting;
+    try {
+      const connection = await connecting;
+      if (this.#closed) {
+        await this.#closeDaemonConnection(connection);
+        this.#throwIfClosed();
+      }
+      this.#connection = connection;
+      return connection;
+    } catch (error: unknown) {
+      this.#throwIfClosed();
+      throw error;
+    } finally {
+      if (this.#connecting === connecting) this.#connecting = undefined;
+    }
+  }
+
+  async #closeConnection(): Promise<void> {
+    const connection = this.#connection;
+    this.#connection = undefined;
+    if (connection !== undefined) await this.#closeDaemonConnection(connection);
+  }
+
+  async #closeDaemonConnection(connection: DaemonConnection): Promise<void> {
+    if (this.#closedConnections.has(connection)) return;
+    this.#closedConnections.add(connection);
+    await connection.close();
+  }
+
+  #throwIfClosed(): void {
+    if (this.#closed) throw new McpSessionError("SESSION_CLOSED", "MCP session is closed");
+  }
+
+  #mutate<T>(mutation: () => Promise<T>): Promise<T> {
+    const result = this.#mutations.then(mutation, mutation);
+    this.#mutations = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+}
+
+function isNoLongerActiveLease(error: unknown): boolean {
+  return (
+    error instanceof DaemonClientError &&
+    (error.code === "UNKNOWN_LEASE" || error.code === "LEASE_EXPIRED")
+  );
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw new McpSessionError("CANCELLED", "Lease request cancelled");
+}
+
+function noop(): void {}
+
+function daemonLeaseRequest(
+  input: LeaseSimulatorInput,
+  requesterId: string,
+): Record<string, unknown> {
+  return {
+    allowDownload: input.allow_download,
+    mode: "held",
+    noWait: input.no_wait,
+    requesterId,
+    request: {
+      model: input.device,
+      ...(input.os === undefined ? {} : { osVersion: input.os }),
+      platform: input.platform,
+    },
+    ...(input.timeout_seconds === undefined
+      ? {}
+      : { timeoutMs: timeoutMilliseconds(input.timeout_seconds) }),
+  };
+}
+
+function timeoutMilliseconds(timeoutSeconds: number): number {
+  if (
+    !Number.isFinite(timeoutSeconds) ||
+    timeoutSeconds < 0 ||
+    timeoutSeconds > MAX_TIMEOUT_SECONDS
+  ) {
+    throw new McpSessionError(
+      "INVALID_TIMEOUT",
+      "timeout_seconds is too large to convert safely to milliseconds",
+    );
+  }
+  return timeoutSeconds * 1_000;
+}
+
+function leaseSimulatorOutput(grant: RawLeaseGrant): LeaseSimulatorOutput {
+  return {
+    device: grant.device.spec.model,
+    device_id: grant.device.driverDeviceId,
+    expires_at_ms: grant.lease.ttlDeadline,
+    lease_id: grant.lease.id,
+    mode: "held",
+    os: grant.device.spec.osVersion,
+    platform: grant.device.spec.platform,
+    state: "leased",
+    timing: {
+      estimated_boot_ms: grant.timing.estimatedBootMs,
+      estimated_provision_ms: grant.timing.estimatedProvisionMs,
+      estimated_reclaim_ms: grant.timing.estimatedReclaimMs,
+      estimated_ready_ms: grant.timing.estimatedReadyMs,
+    },
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2023",
-    "lib": ["ES2023"],
+    "lib": ["ES2023", "DOM"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "strict": true,


### PR DESCRIPTION
## What is this?

Supersedes #7, recreated on top of #9 (daemon transport decomposition), which landed after #7 was opened and left it unmergeable. The MCP server's own logic (`session.ts`, `server.ts`, `contracts.ts`) is carried over unchanged — the `DaemonConnection` interface it depends on didn't change shape. Only the connection bootstrap (`src/mcp/main.ts`) and the CLI's `mcp` command wiring (`src/cli/index.ts`) were adapted to the new ports-based `connectDaemon({ clock, ipc, launcher, socketPath })`, matching the pattern the CLI itself now uses.

## Summary

- add `pitlane mcp`, a local stdio MCP server backed by the shared daemon-client connection
- expose exactly two agent-facing tools: `lease_simulator` and `release_simulator`
- return schema-validated structured output with equivalent JSON text fallback
- keep held leases tied to the MCP session's daemon connection and release them on explicit release, cancellation, EOF, signal, or transport shutdown
- share lease-grant parsing between the CLI and MCP frontends via a new `daemon-client/contracts.ts`
- document generic MCP client setup, lifecycle, safe download defaults, and the intentionally limited MCP surface
- pin the stable MCP TypeScript SDK v1.29 and override two vulnerable transitive dependencies surfaced by `pnpm audit`: `@hono/node-server` (patched to 2.0.10, carried over from #7) and `ip-address` (patched to >=10.3.1, a new advisory disclosed since #7 was opened)

## Why

Agents can already consume Pitlane's JSON CLI output, but MCP structured tool contracts avoid CLI-output parsing for clients that support Model Context Protocol. The daemon remains the single owner of state, queueing, platform decisions, and safety invariants; the core does not know which frontend initiated a request.

## Validation

- `pnpm run check` — 333 passed, 2 skipped (typecheck, lint, format, test)
- `pnpm run build`
- `pnpm audit --prod` — no known vulnerabilities
- `pnpm exec fallow audit --base origin/main --format compact` — no new gated findings
- real spawned-stdio smoke test discovered exactly `lease_simulator` and `release_simulator`

## Notes

The CLI remains the primary/full operator interface. MCP intentionally omits status, configuration, events, renewal/detached mode, and destructive/operator commands.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FzZpprSzW1puA1h15x5RV5)_