### PR TITLE
feat: accept a stable agent identity for leases

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,10 @@ Configure an MCP client to spawn it with this generic configuration:
   "mcpServers": {
     "pitlane": {
       "command": "pitlane",
-      "args": ["mcp"]
+      "args": ["mcp"],
+      "env": {
+        "PITLANE_AGENT_ID": "agent-1"
+      }
     }
   }
 }
@@ -86,6 +89,14 @@ Configure an MCP client to spawn it with this generic configuration:
 
 GUI-launched MCP clients may not inherit your shell `PATH`; in that case,
 replace `pitlane` with its absolute path.
+
+`PITLANE_AGENT_ID` sets this server's stable requester identity — Pitlane
+allows at most one active lease per identity, so **give each agent session a
+distinct, stable id** (falling back to a pid-derived value otherwise, which
+does not survive a process restart). This is also the id shown as the
+requester in `pitlane status` / `pitlane list --leases`; see
+[docs/CLI.md](docs/CLI.md#agent-identity) for the full precedence, including
+the CLI's `--agent-id` flag.
 
 The server provides exactly two tools:
 
@@ -101,7 +112,8 @@ Both tools return structured results as well as JSON text content, so MCP
 clients can reliably consume the leased device details or release confirmation.
 An MCP lease is held by the server process's daemon connection: release it
 explicitly when work is done; it is also released when that MCP process
-disconnects. Run one MCP server process per agent session.
+disconnects. Run one MCP server process per agent session, each with its own
+`PITLANE_AGENT_ID`.
 
 ## Configuration
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -19,6 +19,26 @@ progress/diagnostics go to **stderr** as JSON lines; results go to **stdout**.
 
 ---
 
+## Agent identity
+
+Leases are keyed by requester: at most one active lease (held or detached)
+per agent id, enforced by the daemon. Give each agent session a **stable**
+id so this actually constrains anything — a fresh id on every CLI invocation
+(the default) makes the constraint a no-op, since every invocation looks
+like a different requester.
+
+Resolution order, first match wins:
+
+1. `--agent-id <id>` on `pitlane lease`.
+2. the `PITLANE_AGENT_ID` environment variable.
+3. a pid-derived value (today's behavior; not stable across invocations).
+
+Reuse the same id across an agent's own invocations (e.g. export
+`PITLANE_AGENT_ID` once per agent session) and use a distinct id per agent so
+they don't collide with each other. The id shows up as the requester in
+`pitlane status` and `pitlane list --leases`, so an operator can tell which
+agent holds what.
+
 ## `pitlane lease`
 
 Acquire a device. Blocks while waiting for capacity, then while provisioning
@@ -26,12 +46,15 @@ and booting, then — in held mode — keeps running to hold the lease.
 
 ```
 pitlane lease --platform <ios|android> --device <model> [--os <version>]
-              [--timeout <duration>] [--no-wait] [--detach]
+              [--agent-id <id>] [--timeout <duration>] [--no-wait] [--detach]
               [--allow-download] [--json]
 ```
 
 - `--platform`, `--device` — required. `--os` defaults to the newest runtime
   already installed for that platform.
+- `--agent-id` — this invocation's requester identity; see
+  [Agent identity](#agent-identity). Defaults to `PITLANE_AGENT_ID`, then a
+  pid-derived value.
 - `--timeout` — max time to wait in the queue (exit 10 on expiry).
 - `--no-wait` — fail immediately with exit 11 instead of queueing.
 - `--allow-download` — permit downloading a missing runtime / system image
@@ -78,6 +101,12 @@ is reserved for MCP JSON-RPC; fatal diagnostics are written to stderr. The
 server auto-starts the daemon when needed and exposes the focused
 `lease_simulator` and `release_simulator` tool surface for one agent session.
 
+The requester identity for leases made through this server is
+`PITLANE_AGENT_ID`, falling back to a pid-derived value — see
+[Agent identity](#agent-identity). Set a distinct `PITLANE_AGENT_ID` per MCP
+server process (one per agent session) so the one-lease-per-agent rule is
+meaningful.
+
 ## `pitlane status`
 
 Human and JSON status include derived warm counts globally and per platform.
@@ -86,15 +115,17 @@ visible as busy running capacity and never contribute to warm inventory.
 
 Human-oriented overview: daemon health, managed capacity (used/limit per
 platform), running and reserved capacity (globally and per platform), every
-managed device with its state, current leases (who, since when), and queue
-depth. `--json` for the structured equivalent. `overLimit` is true when a
-lowered limit cannot yet be met, for example because active leases consume
-all running slots.
+managed device with its state, current leases (who — the agent id, see
+[Agent identity](#agent-identity) — since when), and queue depth. `--json`
+for the structured equivalent. `overLimit` is true when a lowered limit
+cannot yet be met, for example because active leases consume all running
+slots.
 
 ## `pitlane list [--devices|--leases|--rules]`
 
 Scriptable listings of managed devices, active leases, or registered cleanup
-rules. Defaults to `--devices`.
+rules. Defaults to `--devices`. Each lease record's `requesterId` is the
+agent id (see [Agent identity](#agent-identity)) that holds it.
 
 ## `pitlane cleanup [--dry-run] [--rule <name>]`
 

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -20,6 +20,7 @@ import { connectExistingDaemon } from "../daemon-client/client.js";
 import {
   DaemonClientError,
   errorExitCode,
+  fallbackRequesterId,
   parseDuration,
   runCli,
   type CliEnvironment,
@@ -59,6 +60,11 @@ describe("CLI boundary", () => {
     expect(parseDuration("90s")).toBe(90_000);
     expect(parseDuration("10m")).toBe(600_000);
     expect(parseDuration("250")).toBe(250);
+  });
+
+  it("resolves the fallback requester id from PITLANE_AGENT_ID, else the process pid", () => {
+    expect(fallbackRequesterId({ PITLANE_AGENT_ID: "agent-from-env" })).toBe("agent-from-env");
+    expect(fallbackRequesterId({})).toBe(String(process.pid));
   });
 
   it("reports missing lease arguments as usage errors", async () => {
@@ -234,6 +240,158 @@ describe("CLI boundary", () => {
         .split("\n")
         .map((line) => JSON.parse(line)),
     ).toEqual([{ event: "queued", queue_position: 1 }]);
+  });
+
+  it("--agent-id overrides the environment's fallback requester id", async () => {
+    const output = outputCapture();
+    const connection = new StubConnection();
+    connection.response("lease.request", {
+      device: {
+        driverDeviceId: "ABCD",
+        spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
+        state: "leased",
+      },
+      lease: { id: "lse_1", mode: "detached", ttlDeadline: 1_000 },
+      timing: {
+        estimatedBootMs: 1,
+        estimatedProvisionMs: 1,
+        estimatedReclaimMs: 0,
+        estimatedReadyMs: 2,
+      },
+    });
+
+    await expect(
+      runCli(
+        [
+          "lease",
+          "--platform",
+          "ios",
+          "--device",
+          "iPhone 17 Pro",
+          "--detach",
+          "--agent-id",
+          "agent-x",
+        ],
+        output.environmentWith({ connect: async () => connection, requesterId: "fallback-id" }),
+      ),
+    ).resolves.toBe(0);
+
+    expect(connection.calls).toEqual([
+      expect.objectContaining({
+        payload: expect.objectContaining({ requesterId: "agent-x" }),
+        type: "lease.request",
+      }),
+    ]);
+  });
+
+  it("falls back to the environment's requester id when --agent-id is omitted", async () => {
+    const output = outputCapture();
+    const connection = new StubConnection();
+    connection.response("lease.request", {
+      device: {
+        driverDeviceId: "ABCD",
+        spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
+        state: "leased",
+      },
+      lease: { id: "lse_1", mode: "detached", ttlDeadline: 1_000 },
+      timing: {
+        estimatedBootMs: 1,
+        estimatedProvisionMs: 1,
+        estimatedReclaimMs: 0,
+        estimatedReadyMs: 2,
+      },
+    });
+
+    await expect(
+      runCli(
+        ["lease", "--platform", "ios", "--device", "iPhone 17 Pro", "--detach"],
+        output.environmentWith({ connect: async () => connection, requesterId: "fallback-id" }),
+      ),
+    ).resolves.toBe(0);
+
+    expect(connection.calls).toEqual([
+      expect.objectContaining({
+        payload: expect.objectContaining({ requesterId: "fallback-id" }),
+        type: "lease.request",
+      }),
+    ]);
+  });
+
+  it("rejects an empty --agent-id as a usage error", async () => {
+    const output = outputCapture();
+
+    await expect(
+      runCli(
+        ["lease", "--platform", "ios", "--device", "iPhone 17 Pro", "--agent-id", ""],
+        output.environment,
+      ),
+    ).resolves.toBe(2);
+    expect(output.stderr).toContain("--agent-id");
+  });
+
+  it("enforces one lease per --agent-id: same id collides, distinct ids do not", async () => {
+    const harness = await createHarness();
+    const first = outputCapture();
+
+    await expect(
+      runCli(
+        [
+          "lease",
+          "--platform",
+          "ios",
+          "--device",
+          "iPhone 16",
+          "--detach",
+          "--agent-id",
+          "dup-agent",
+        ],
+        first.environmentWith({
+          connect: () => connectExistingDaemon(harness.socketPath, new NodeIpcTransport()),
+        }),
+      ),
+    ).resolves.toBe(0);
+
+    const second = outputCapture();
+    await expect(
+      runCli(
+        [
+          "lease",
+          "--platform",
+          "ios",
+          "--device",
+          "iPhone 16",
+          "--detach",
+          "--agent-id",
+          "dup-agent",
+        ],
+        second.environmentWith({
+          connect: () => connectExistingDaemon(harness.socketPath, new NodeIpcTransport()),
+        }),
+      ),
+    ).resolves.toBe(1);
+    expect(second.stderr).toContain("dup-agent");
+    expect(second.stderr).toContain("already");
+
+    const third = outputCapture();
+    await expect(
+      runCli(
+        [
+          "lease",
+          "--platform",
+          "ios",
+          "--device",
+          "iPhone 16",
+          "--detach",
+          "--agent-id",
+          "other-agent",
+          "--no-wait",
+        ],
+        third.environmentWith({
+          connect: () => connectExistingDaemon(harness.socketPath, new NodeIpcTransport()),
+        }),
+      ),
+    ).resolves.toBe(11);
+    expect(third.stderr).not.toContain("already");
   });
 
   it("prints a detached token, exits, and renews it", async () => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -68,7 +68,17 @@ export interface CliEnvironment {
   readonly writeConfigFile: (contents: Record<string, unknown>) => Promise<void>;
 }
 
-function defaultCliEnvironment(): CliEnvironment {
+/**
+ * Resolves the fallback requester identity from the environment: `PITLANE_AGENT_ID`
+ * when set, else a pid-derived value so callers that never configure a stable id
+ * keep today's behavior. The per-invocation `--agent-id` flag on `lease` (parsed at
+ * that command's own boundary) takes precedence over this default.
+ */
+export function fallbackRequesterId(env: NodeJS.ProcessEnv): string {
+  return env.PITLANE_AGENT_ID ?? String(process.pid);
+}
+
+function defaultCliEnvironment(env: NodeJS.ProcessEnv = process.env): CliEnvironment {
   const dataDirectory = join(homedir(), ".pitlane");
   const filesystem = new NodeFilesystem();
   const clock = new SystemClock();
@@ -91,7 +101,7 @@ function defaultCliEnvironment(): CliEnvironment {
       }),
     connectExisting: () => connectExistingDaemon(socketPath, ipc),
     now: () => clock.now(),
-    requesterId: String(process.pid),
+    requesterId: fallbackRequesterId(env),
     readConfigFile: async () => {
       if (!(await filesystem.exists(configPath))) return {};
       return requireObject(JSON.parse(await filesystem.readFile(configPath)) as unknown);
@@ -188,6 +198,7 @@ export function parseDuration(value: string): number {
 async function runLease(argv: readonly string[], environment: CliEnvironment): Promise<number> {
   if (argv[0] === "renew") return runRenew(argv.slice(1), environment);
   const values = commandArgs(argv, {
+    "agent-id": { type: "string" },
     "allow-download": { type: "boolean" },
     detach: { type: "boolean" },
     device: { type: "string" },
@@ -200,7 +211,9 @@ async function runLease(argv: readonly string[], environment: CliEnvironment): P
   });
   if (values.help) {
     environment.stdout.write(
-      "Usage: pitlane lease --platform <ios|android> --device <model> [--os <version>]\n",
+      "Usage: pitlane lease --platform <ios|android> --device <model> [--os <version>]\n" +
+        "                     [--agent-id <id>] [--timeout <duration>] [--no-wait] [--detach]\n" +
+        "                     [--allow-download] [--json]\n",
     );
     return 0;
   }
@@ -208,6 +221,8 @@ async function runLease(argv: readonly string[], environment: CliEnvironment): P
     throw new UsageError("lease requires --platform <ios|android>");
   if (typeof values.device !== "string" || values.device === "")
     throw new UsageError("lease requires --device <model>");
+  if (values["agent-id"] === "") throw new UsageError("lease --agent-id must not be empty");
+  const requesterId = values["agent-id"] ?? environment.requesterId;
   const detached = values.detach ?? false;
   const timeoutMs = typeof values.timeout === "string" ? parseDuration(values.timeout) : undefined;
   const termination = detached ? undefined : waitForTermination(environment.signals);
@@ -220,7 +235,7 @@ async function runLease(argv: readonly string[], environment: CliEnvironment): P
       allowDownload: values["allow-download"] ?? false,
       mode: detached ? "detached" : "held",
       noWait: values["no-wait"] ?? false,
-      requesterId: environment.requesterId,
+      requesterId,
       request: {
         model: values.device,
         ...(typeof values.os === "string" ? { osVersion: values.os } : {}),

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -99,7 +99,8 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
     capacity: leaseEngine,
     config,
     doctor,
-    defaultRequesterId: options.defaultRequesterId ?? String(process.pid),
+    defaultRequesterId:
+      options.defaultRequesterId ?? process.env.PITLANE_AGENT_ID ?? String(process.pid),
     eventBus,
     host: new DaemonEndpointHost({
       connector: ipc,

--- a/src/mcp/main.test.ts
+++ b/src/mcp/main.test.ts
@@ -66,6 +66,55 @@ describe("MCP stdio lifecycle", () => {
     await client.close();
   });
 
+  it("sources the requester id from PITLANE_AGENT_ID when none is given explicitly", async () => {
+    const connection = new LeaseConnection();
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const runner = await startMcpStdio({
+      connect: async () => connection,
+      createTransport: () => serverTransport,
+      env: { PITLANE_AGENT_ID: "agent-from-env" },
+      signals: new FakeSignals(),
+    });
+    const client = new Client({ name: "test", version: "1.0.0" });
+    await client.connect(clientTransport);
+    await client.request(
+      {
+        method: "tools/call",
+        params: { arguments: { device: "iPhone", platform: "ios" }, name: "lease_simulator" },
+      },
+      CallToolResultSchema,
+    );
+
+    expect(connection.lastRequesterId).toBe("agent-from-env");
+    await runner.shutdown();
+    await client.close();
+  });
+
+  it("prefers an explicit requesterId over PITLANE_AGENT_ID", async () => {
+    const connection = new LeaseConnection();
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const runner = await startMcpStdio({
+      connect: async () => connection,
+      createTransport: () => serverTransport,
+      env: { PITLANE_AGENT_ID: "agent-from-env" },
+      requesterId: "explicit-agent",
+      signals: new FakeSignals(),
+    });
+    const client = new Client({ name: "test", version: "1.0.0" });
+    await client.connect(clientTransport);
+    await client.request(
+      {
+        method: "tools/call",
+        params: { arguments: { device: "iPhone", platform: "ios" }, name: "lease_simulator" },
+      },
+      CallToolResultSchema,
+    );
+
+    expect(connection.lastRequesterId).toBe("explicit-agent");
+    await runner.shutdown();
+    await client.close();
+  });
+
   it("closes once when stdin reaches EOF", async () => {
     const transport = new FakeTransport();
     const server = new FakeServer();
@@ -156,13 +205,15 @@ class FakeSignals {
 
 class LeaseConnection implements DaemonConnection {
   closeCalls = 0;
+  lastRequesterId: unknown;
   async close(): Promise<void> {
     this.closeCalls += 1;
   }
   onPush(): () => void {
     return () => undefined;
   }
-  async request(): Promise<unknown> {
+  async request(_type: string, payload: unknown): Promise<unknown> {
+    this.lastRequesterId = (payload as { readonly requesterId?: unknown }).requesterId;
     return {
       device: {
         driverDeviceId: "SIM-1",

--- a/src/mcp/main.ts
+++ b/src/mcp/main.ts
@@ -31,6 +31,8 @@ export interface McpStdioEnvironment {
   readonly connect?: () => Promise<DaemonConnection>;
   readonly createServer?: (session: McpSession) => McpServer;
   readonly createTransport?: () => McpTransport;
+  /** Source for `PITLANE_AGENT_ID` when `requesterId` is not given explicitly. */
+  readonly env?: NodeJS.ProcessEnv;
   readonly requesterId?: string;
   readonly signals?: Signals;
   /** The stdio transport currently does not surface stdin EOF as onclose. */
@@ -57,9 +59,10 @@ export async function startMcpStdio(
   environment: McpStdioEnvironment = {},
 ): Promise<McpStdioRunner> {
   const defaults = defaultEnvironment();
+  const env = environment.env ?? process.env;
   const session = new McpSession({
     connect: environment.connect ?? defaults.connect,
-    requesterId: environment.requesterId ?? `mcp:${process.pid}`,
+    requesterId: environment.requesterId ?? env.PITLANE_AGENT_ID ?? `mcp:${process.pid}`,
   });
   const server = (environment.createServer ?? createMcpServer)(session);
   const transport = (environment.createTransport ?? defaults.createTransport)();


### PR DESCRIPTION
## What changed

The lease requester identity was a process pid (`String(process.pid)` in the CLI, `` `mcp:${process.pid}` `` in the MCP server, `String(process.pid)` as the daemon's default). Since every CLI invocation is a new process, the "one lease per agent" rule in `LeaseAcquisitionCoordinator` / `WaitQueue` (`RequesterAlreadyLeasedError`) was effectively unenforceable for CLI users.

This adds a stable identity, resolved in this order:

1. `--agent-id <id>` on `pitlane lease`.
2. the `PITLANE_AGENT_ID` environment variable.
3. a pid-derived value (today's behavior, unchanged when neither of the above is set).

Threaded through:
- **CLI** (`src/cli/index.ts`): `defaultCliEnvironment` now resolves the fallback id from `PITLANE_AGENT_ID` (injectable `env` param, read from `process.env` only at the composition boundary); `runLease` accepts `--agent-id` and it takes precedence over the environment default.
- **MCP server** (`src/mcp/main.ts`): `startMcpStdio` resolves `requesterId` from an explicit override, else `PITLANE_AGENT_ID` (via an injectable `env` field), else the existing `mcp:<pid>` fallback.
- **Daemon** (`src/daemon/main.ts`): `defaultRequesterId` (the fallback for a raw protocol client that omits `requesterId`) now also honors `PITLANE_AGENT_ID` before falling back to pid, for consistency — in practice both real callers above always send `requesterId` explicitly, so this path is rarely hit.

No core/`lease-acquisition-coordinator.ts`/`wait-queue.ts` changes were needed — the one-lease-per-requester check and the `RequesterAlreadyLeasedError` message already key off whatever `requesterId` string they're given. `status` and `list --leases` already render `LeaseRecord.requesterId`, so they now show the stable id automatically once callers pass one in — no rendering code changed.

Docs: added an "Agent identity" section to `docs/CLI.md` (referenced from the `lease`, `mcp`, `status`, and `list` sections) and updated the README's MCP integration section with the `PITLANE_AGENT_ID` env var and the recommendation that each agent session use a distinct, stable id.

## Explicitly out of scope

Per the issue, this does **not** touch:
- Structured CLI errors / exit codes for `REQUESTER_ALREADY_LEASED` (issue #18) — exit-code mapping and error rendering are unchanged.
- Lease TTL, heartbeat, catalog, or MCP tool-surface work.

## Decisions made where the issue was silent

- `pitlane mcp` does **not** gain its own `--agent-id` CLI flag; the MCP server sources its identity solely from `PITLANE_AGENT_ID` (or an explicit override for tests), matching how MCP client configs typically pass environment variables to a spawned server, and keeping `runMcp`'s "no arguments" CLI parsing untouched.
- Extended `daemon/main.ts`'s `defaultRequesterId` to also honor `PITLANE_AGENT_ID` for completeness (it was named in the issue's problem statement), even though it's effectively dead code today since both real clients always send `requesterId` explicitly.
- An empty `--agent-id ""` is rejected as a usage error (exit 2), consistent with how `--device ""` is already rejected.

## How I verified this

- `pnpm check` (typecheck, lint, format:check, vitest) — green, 340 passed / 2 skipped.
- `pnpm fallow --ci` — green, no new findings against the changed files.
- Added tests:
  - `src/cli/index.test.ts`: `fallbackRequesterId` precedence (env var vs. pid); `--agent-id` overriding the environment default and being omittable; empty `--agent-id` rejected; an integration test against a real in-process daemon proving two detached leases with the same `--agent-id` hit `REQUESTER_ALREADY_LEASED` (exit 1, message contains the id) while a distinct id proceeds past that check (hits `NO_CAPACITY`/exit 11 instead, since it isn't rejected as already-leased).
  - `src/mcp/main.test.ts`: `startMcpStdio` resolves `requesterId` from `PITLANE_AGENT_ID` when not given explicitly, and prefers an explicit `requesterId` over the env var.

Closes #19

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJpxZonwJvftcpNpk6CLFK)_