### PR TITLE
Add lease_status MCP tool and lease-lost notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Configure an MCP client to spawn it with this generic configuration:
 GUI-launched MCP clients may not inherit your shell `PATH`; in that case,
 replace `pitlane` with its absolute path.
 
-The server provides exactly two tools:
+The server provides exactly three tools:
 
 - `lease_simulator` requires `platform` (`ios` or `android`) and `device`.
   `os` is optional and otherwise selects the newest installed runtime.
@@ -96,12 +96,27 @@ The server provides exactly two tools:
   before a missing runtime or system image may be downloaded.
 - `release_simulator` requires the `lease_id` returned by the lease tool and
   releases only that MCP session's lease.
+- `lease_status` is read-only and takes no input. It reports this session's
+  current lease (`lease_id`, `device`, `os`, `platform`, `device_id`,
+  `expires_at_ms`, `state`), or `{ "held": false }` if the session holds
+  nothing. It is cheap, local, and safe to call repeatedly — e.g. after a
+  context compaction, to check whether a device is still held.
 
-Both tools return structured results as well as JSON text content, so MCP
-clients can reliably consume the leased device details or release confirmation.
-An MCP lease is held by the server process's daemon connection: release it
-explicitly when work is done; it is also released when that MCP process
-disconnects. Run one MCP server process per agent session.
+All three tools return structured results as well as JSON text content, so
+MCP clients can reliably consume the leased device details, release
+confirmation, or status. An MCP lease is held by the server process's daemon
+connection: release it explicitly when work is done; it is also released when
+that MCP process disconnects. Run one MCP server process per agent session.
+
+If a held lease ends elsewhere — it expires, or is force-released by
+`pitlane release --all`, `pitlane nuke`, or doctor expiry — the daemon pushes
+a lease-ended fact to this session, which forgets that lease and relays it to
+the MCP client as a `notifications/message` logging notification (level
+`warning`, `logger: "pitlane"`) carrying `lease_id`, `device_id`, and
+`reason`. A well-behaved agent should treat this as "the device is gone" and
+call `lease_simulator` again rather than keep operating on it; a subsequent
+`release_simulator` for that lease id fails with `LEASE_NOT_OWNED` instead of
+succeeding.
 
 ## Configuration
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -76,7 +76,10 @@ unless `--yes`.
 Start Pitlane's local stdio MCP server. It accepts no flags. Standard output
 is reserved for MCP JSON-RPC; fatal diagnostics are written to stderr. The
 server auto-starts the daemon when needed and exposes the focused
-`lease_simulator` and `release_simulator` tool surface for one agent session.
+`lease_simulator`, `release_simulator`, and `lease_status` tool surface for
+one agent session. If that session's held lease ends elsewhere (expiry or a
+force-release), the server relays it as an MCP logging notification. See
+[../README.md](../README.md#mcp-integration-optional) for details.
 
 ## `pitlane status`
 

--- a/src/daemon-client/contracts.ts
+++ b/src/daemon-client/contracts.ts
@@ -20,12 +20,18 @@ export interface RawLeaseGrant {
   };
 }
 
+export interface RawLeaseLost {
+  readonly deviceId: string;
+  readonly leaseId: string;
+  readonly reason: string;
+}
+
 export function parseRawLeaseGrant(value: unknown): RawLeaseGrant {
-  const grant = requireObject(value);
-  const device = requireObject(grant.device);
-  const spec = requireObject(device.spec);
-  const lease = requireObject(grant.lease);
-  const timing = requireObject(grant.timing);
+  const grant = requireObject(value, "Daemon returned an invalid lease grant");
+  const device = requireObject(grant.device, "Daemon returned an invalid lease grant");
+  const spec = requireObject(device.spec, "Daemon returned an invalid lease grant");
+  const lease = requireObject(grant.lease, "Daemon returned an invalid lease grant");
+  const timing = requireObject(grant.timing, "Daemon returned an invalid lease grant");
   if (
     typeof device.driverDeviceId !== "string" ||
     typeof spec.model !== "string" ||
@@ -56,9 +62,22 @@ export function parseRawLeaseGrant(value: unknown): RawLeaseGrant {
   };
 }
 
-function requireObject(value: unknown): Record<string, unknown> {
+/** Parses the lease-lost push notification body pushed to the lease's holding connection. */
+export function parseRawLeaseLost(value: unknown): RawLeaseLost {
+  const payload = requireObject(value, "Daemon sent an invalid lease-lost notification");
+  if (
+    typeof payload.leaseId !== "string" ||
+    typeof payload.deviceId !== "string" ||
+    typeof payload.reason !== "string"
+  ) {
+    throw new Error("Daemon sent an invalid lease-lost notification");
+  }
+  return { deviceId: payload.deviceId, leaseId: payload.leaseId, reason: payload.reason };
+}
+
+function requireObject(value: unknown, message: string): Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new Error("Daemon returned an invalid lease grant");
+    throw new Error(message);
   }
   return value as Record<string, unknown>;
 }

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -32,7 +32,7 @@ interface ServerFrame {
   readonly id?: string | null;
   readonly ok?: boolean;
   readonly payload?: unknown;
-  readonly push?: "event" | "progress";
+  readonly push?: "event" | "lease-lost" | "progress";
 }
 
 const runningDaemons: DaemonServer[] = [];
@@ -317,6 +317,103 @@ describe("DaemonServer", () => {
     await expect(harness.stateFilesystem.readFile("/state.json")).resolves.toContain('"leases":[]');
     expect(harness.eventBus.replay().map((event) => event.event)).toContain("daemon.stopping");
   });
+
+  it("pushes a lease-lost notification to the holding connection when its lease's TTL backstop expires", async () => {
+    const harness = await createHarness();
+    const holder = await createClient(harness.socketPath);
+    await hello(holder);
+    const grant = await holder.request("lease.request", {
+      mode: "held",
+      requesterId: "holder",
+      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+    });
+    const leaseId = leaseIdOf(grant);
+    const deviceId = harness.registry.snapshot.leases.find(
+      (lease) => lease.id === leaseId,
+    )?.deviceId;
+
+    harness.clock.advance(60_000);
+    await expect(holder.nextFrame((frame) => frame.push === "lease-lost")).resolves.toMatchObject({
+      payload: { deviceId, leaseId, reason: "expired" },
+      push: "lease-lost",
+    });
+    await expect.poll(() => harness.registry.snapshot.leases).toEqual([]);
+
+    // The connection no longer believes it holds the expired lease, so closing it
+    // (which releases any still-held leases) must not error or hang the daemon.
+    await holder.close();
+    const observer = await createClient(harness.socketPath);
+    await hello(observer);
+    await expect(observer.request("status.get", {})).resolves.toMatchObject({ ok: true });
+    await observer.close();
+  });
+
+  it("pushes a lease-lost notification to the actual holding connection when another connection force-releases its lease", async () => {
+    const harness = await createHarness();
+    const holder = await createClient(harness.socketPath);
+    const releaser = await createClient(harness.socketPath);
+    await Promise.all([hello(holder), hello(releaser)]);
+    const grant = await holder.request("lease.request", {
+      mode: "held",
+      requesterId: "holder",
+      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+    });
+    const leaseId = leaseIdOf(grant);
+
+    await expect(releaser.request("lease.release", { leaseId })).resolves.toMatchObject({
+      ok: true,
+    });
+    await expect(holder.nextFrame((frame) => frame.push === "lease-lost")).resolves.toMatchObject({
+      payload: { leaseId, reason: "explicit" },
+      push: "lease-lost",
+    });
+
+    // Acceptance criterion: the (now stale) holder's own release attempt is rejected
+    // by the daemon rather than causing a transport error; the MCP layer maps this
+    // local-ownership loss to LEASE_NOT_OWNED without even asking the daemon.
+    await expect(holder.request("lease.release", { leaseId })).resolves.toMatchObject({
+      error: { code: "UNKNOWN_LEASE" },
+      ok: false,
+    });
+    await holder.close();
+    await releaser.close();
+  });
+
+  it("does not push a redundant lease-lost notification back to a connection that explicitly released its own lease", async () => {
+    const harness = await createHarness();
+    const holder = await createClient(harness.socketPath);
+    await hello(holder);
+    const grant = await holder.request("lease.request", {
+      mode: "held",
+      requesterId: "holder",
+      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+    });
+    const leaseId = leaseIdOf(grant);
+
+    await expect(holder.request("lease.release", { leaseId })).resolves.toMatchObject({
+      ok: true,
+    });
+    // A subsequent request on the same connection lets us assert, by frame order, that
+    // no lease-lost push arrived for the release this connection asked for itself.
+    await expect(holder.request("status.get", {})).resolves.toMatchObject({ ok: true });
+    expect(holder.frames().filter((frame) => frame.push === "lease-lost")).toEqual([]);
+    await holder.close();
+  });
+
+  it("ignores lease-lost facts for leases with no currently connected holder without breaking the daemon", async () => {
+    const harness = await createHarness();
+    harness.eventBus.emit("lease.expired", { deviceId: "device-x", leaseId: "lease-x" }, "test");
+    harness.eventBus.emit(
+      "lease.released",
+      { deviceId: "device-y", leaseId: "lease-y", reason: "killed" },
+      "test",
+    );
+
+    const client = await createClient(harness.socketPath);
+    await hello(client);
+    await expect(client.request("status.get", {})).resolves.toMatchObject({ ok: true });
+    await client.close();
+  });
 });
 
 async function createHarness(
@@ -469,6 +566,10 @@ async function hello(client: Client): Promise<void> {
   ).resolves.toMatchObject({
     ok: true,
   });
+}
+
+function leaseIdOf(frame: ServerFrame): string {
+  return (frame.payload as { readonly lease: { readonly id: string } }).lease.id;
 }
 
 async function flush(): Promise<void> {

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -59,6 +59,7 @@ export interface DaemonServerOptions {
 export class DaemonServer {
   readonly #connections = new Set<Connection>();
   readonly #protocolVersion: number;
+  readonly #unsubscribeLeaseLost: Array<() => void> = [];
   #stopping = false;
   #stopPromise: Promise<void> | undefined;
 
@@ -73,6 +74,18 @@ export class DaemonServer {
 
   async start(): Promise<void> {
     await this.options.host.start((connection) => this.#accept(connection));
+    this.#unsubscribeLeaseLost.push(
+      this.options.eventBus.subscribe("lease.expired", (envelope) =>
+        this.#notifyLeaseLost(envelope.payload.leaseId, envelope.payload.deviceId, "expired"),
+      ),
+      this.options.eventBus.subscribe("lease.released", (envelope) =>
+        this.#notifyLeaseLost(
+          envelope.payload.leaseId,
+          envelope.payload.deviceId,
+          envelope.payload.reason,
+        ),
+      ),
+    );
 
     this.options.eventBus.emit(
       "daemon.started",
@@ -92,6 +105,7 @@ export class DaemonServer {
 
   async #stop(reason: string): Promise<void> {
     this.options.eventBus.emit("daemon.stopping", { reason }, "daemon");
+    for (const unsubscribe of this.#unsubscribeLeaseLost.splice(0)) unsubscribe();
     this.options.reaper.dispose();
     await Promise.all([...this.#connections].map((connection) => this.#releaseHeld(connection)));
     for (const connection of this.#connections) {
@@ -232,14 +246,28 @@ export class DaemonServer {
         return this.#requestLease(connection, frame.payload);
       case "lease.release": {
         const leaseId = requiredString(objectPayload(frame.payload), "leaseId");
-        await this.options.leases.release(leaseId, "explicit");
-        connection.heldLeaseIds.delete(leaseId);
+        // Clear before the request commits so a lease-lost push (triggered by the
+        // resulting lease.released event) does not also fire back at this same
+        // connection for the release it just asked for itself.
+        const wasHeld = connection.heldLeaseIds.delete(leaseId);
+        try {
+          await this.options.leases.release(leaseId, "explicit");
+        } catch (error: unknown) {
+          if (wasHeld) connection.heldLeaseIds.add(leaseId);
+          throw error;
+        }
         return { leaseId };
       }
       case "lease.release-all": {
-        const leaseIds = await this.options.leases.releaseAll("explicit");
+        const previouslyHeld = [...connection.heldLeaseIds];
         connection.heldLeaseIds.clear();
-        return { leaseIds };
+        try {
+          const leaseIds = await this.options.leases.releaseAll("explicit");
+          return { leaseIds };
+        } catch (error: unknown) {
+          for (const leaseId of previouslyHeld) connection.heldLeaseIds.add(leaseId);
+          throw error;
+        }
       }
       case "lease.renew": {
         const payload = objectPayload(frame.payload);
@@ -392,6 +420,27 @@ export class DaemonServer {
 
   async #pushEvent(socket: IpcConnection, event: EventEnvelope): Promise<void> {
     await writeFrame(socket, { push: "event", payload: event });
+  }
+
+  /**
+   * Pushes a lease-ended fact to the connection currently holding `leaseId`, if any,
+   * and stops tracking that lease as held so a later connection close does not try
+   * to release it again. Reacts to the existing post-commit lease.expired /
+   * lease.released facts (observer-only; no transaction waits on this).
+   */
+  #notifyLeaseLost(leaseId: string, deviceId: string, reason: string): void {
+    for (const connection of this.#connections) {
+      if (!connection.heldLeaseIds.delete(leaseId)) continue;
+      void this.#pushLeaseLost(connection.socket, { deviceId, leaseId, reason });
+      return;
+    }
+  }
+
+  async #pushLeaseLost(
+    socket: IpcConnection,
+    payload: { readonly deviceId: string; readonly leaseId: string; readonly reason: string },
+  ): Promise<void> {
+    await writeFrame(socket, { push: "lease-lost", payload });
   }
 
   async #respondError(

--- a/src/mcp/contracts.ts
+++ b/src/mcp/contracts.ts
@@ -42,7 +42,40 @@ export const releaseSimulatorOutputSchema = z.object({
   released: z.literal(true),
 });
 
+export const leaseStatusInputSchema = z.object({});
+
+// Flat and all-optional (rather than a discriminated union) because the MCP SDK
+// validates structuredContent against outputSchema as a plain object shape.
+export const leaseStatusOutputSchema = z.object({
+  device: nonEmptyString.optional(),
+  device_id: nonEmptyString.optional(),
+  expires_at_ms: finiteNumber.optional(),
+  held: z.boolean(),
+  lease_id: nonEmptyString.optional(),
+  os: nonEmptyString.optional(),
+  platform: z.enum(["ios", "android"]).optional(),
+  state: z.literal("leased").optional(),
+});
+
 export type LeaseSimulatorInput = z.infer<typeof leaseSimulatorInputSchema>;
 export type LeaseSimulatorOutput = z.infer<typeof leaseSimulatorOutputSchema>;
 export type ReleaseSimulatorInput = z.infer<typeof releaseSimulatorInputSchema>;
 export type ReleaseSimulatorOutput = z.infer<typeof releaseSimulatorOutputSchema>;
+export type LeaseStatusOutput = z.infer<typeof leaseStatusOutputSchema>;
+
+/** The `lease_status` result when this session currently holds a lease. */
+export interface HeldLeaseStatus {
+  readonly device: string;
+  readonly device_id: string;
+  readonly expires_at_ms: number;
+  readonly held: true;
+  readonly lease_id: string;
+  readonly os: string;
+  readonly platform: "android" | "ios";
+  readonly state: "leased";
+}
+
+/** The `lease_status` result when this session holds nothing. */
+export interface NoLeaseStatus {
+  readonly held: false;
+}

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -1,10 +1,18 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { CallToolResultSchema, ListToolsResultSchema } from "@modelcontextprotocol/sdk/types.js";
+import {
+  CallToolResultSchema,
+  ListToolsResultSchema,
+  LoggingMessageNotificationSchema,
+} from "@modelcontextprotocol/sdk/types.js";
 import { describe, expect, it } from "vitest";
 
 import { DaemonClientError, type DaemonConnection } from "../daemon-client/protocol.js";
-import { leaseSimulatorOutputSchema, releaseSimulatorOutputSchema } from "./contracts.js";
+import {
+  leaseSimulatorOutputSchema,
+  leaseStatusOutputSchema,
+  releaseSimulatorOutputSchema,
+} from "./contracts.js";
 import { McpSession } from "./session.js";
 import { createMcpServer } from "./server.js";
 
@@ -31,6 +39,7 @@ describe("MCP server", () => {
       expect(listed.tools.map((tool) => tool.name)).toEqual([
         "lease_simulator",
         "release_simulator",
+        "lease_status",
       ]);
       for (const tool of listed.tools) {
         expect(tool.title).toEqual(expect.any(String));
@@ -38,6 +47,11 @@ describe("MCP server", () => {
         expect(tool.inputSchema).toEqual(expect.any(Object));
         expect(tool.outputSchema).toEqual(expect.any(Object));
       }
+
+      const noLease = await call(client, "lease_status", {});
+      expect(noLease.isError).not.toBe(true);
+      leaseStatusOutputSchema.parse(noLease.structuredContent);
+      expect(noLease.structuredContent).toEqual({ held: false });
 
       const lease = await call(client, "lease_simulator", {
         device: "iPhone 17 Pro",
@@ -48,11 +62,71 @@ describe("MCP server", () => {
       expect(lease.structuredContent).toMatchObject({ lease_id: "lease-1", mode: "held" });
       expect(JSON.parse(text(lease))).toEqual(lease.structuredContent);
 
+      const held = await call(client, "lease_status", {});
+      expect(held.isError).not.toBe(true);
+      leaseStatusOutputSchema.parse(held.structuredContent);
+      expect(held.structuredContent).toEqual({
+        device: "iPhone 17 Pro",
+        device_id: "SIM-1",
+        expires_at_ms: 12_345,
+        held: true,
+        lease_id: "lease-1",
+        os: "26.5",
+        platform: "ios",
+        state: "leased",
+      });
+
       const release = await call(client, "release_simulator", { lease_id: "lease-1" });
       expect(release.isError).not.toBe(true);
       releaseSimulatorOutputSchema.parse(release.structuredContent);
       expect(release.structuredContent).toEqual({ lease_id: "lease-1", released: true });
       expect(JSON.parse(text(release))).toEqual(release.structuredContent);
+
+      const afterRelease = await call(client, "lease_status", {});
+      expect(afterRelease.structuredContent).toEqual({ held: false });
+    } finally {
+      await close();
+    }
+  });
+
+  it("relays a daemon lease-lost push as an MCP logging notification and forgets the lease", async () => {
+    const connection = new StubConnection([grant]);
+    const { client, close, session } = await connectedServer(connection);
+    try {
+      const notifications: unknown[] = [];
+      client.setNotificationHandler(LoggingMessageNotificationSchema, (notification) => {
+        notifications.push(notification.params);
+      });
+
+      const lease = await call(client, "lease_simulator", {
+        device: "iPhone 17 Pro",
+        platform: "ios",
+      });
+      expect(lease.isError).not.toBe(true);
+
+      connection.pushLeaseLost({ deviceId: "SIM-1", leaseId: "lease-1", reason: "expired" });
+      await expect
+        .poll(() => notifications)
+        .toEqual([
+          {
+            data: {
+              device_id: "SIM-1",
+              lease_id: "lease-1",
+              message: "Pitlane lease ended; this session no longer holds the device.",
+              reason: "expired",
+            },
+            level: "warning",
+            logger: "pitlane",
+          },
+        ]);
+
+      expect(session.status()).toEqual({ held: false });
+      const releaseAfterLost = await call(client, "release_simulator", { lease_id: "lease-1" });
+      expect(releaseAfterLost.isError).toBe(true);
+      expect(JSON.parse(text(releaseAfterLost))).toEqual({
+        code: "LEASE_NOT_OWNED",
+        message: "This session does not own that lease",
+      });
     } finally {
       await close();
     }
@@ -113,6 +187,7 @@ async function connectedServer(connection: StubConnection) {
     close: async () => {
       await Promise.all([client.close(), server.close(), session.close()]);
     },
+    session,
   };
 }
 
@@ -131,12 +206,21 @@ function text(result: { content: Array<{ type: string; text?: string }> }): stri
 
 class StubConnection implements DaemonConnection {
   closeCalls = 0;
+  readonly #listeners = new Set<(kind: string, payload: unknown) => void>();
   constructor(private readonly responses: unknown[]) {}
   async close(): Promise<void> {
     this.closeCalls += 1;
   }
-  onPush(): () => void {
-    return () => undefined;
+  onPush(listener: (kind: string, payload: unknown) => void): () => void {
+    this.#listeners.add(listener);
+    return () => this.#listeners.delete(listener);
+  }
+  pushLeaseLost(payload: {
+    readonly deviceId: string;
+    readonly leaseId: string;
+    readonly reason: string;
+  }): void {
+    for (const listener of this.#listeners) listener("lease-lost", payload);
   }
   async request(): Promise<unknown> {
     const response = this.responses.shift();

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -3,6 +3,8 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   leaseSimulatorInputSchema,
   leaseSimulatorOutputSchema,
+  leaseStatusInputSchema,
+  leaseStatusOutputSchema,
   releaseSimulatorInputSchema,
   releaseSimulatorOutputSchema,
 } from "./contracts.js";
@@ -12,7 +14,7 @@ const SERVER_INFO = { name: "pitlane", version: "1.0.0" };
 
 /** Creates the MCP tool surface for one lease-owning session. */
 export function createMcpServer(session: McpSession): McpServer {
-  const server = new McpServer(SERVER_INFO);
+  const server = new McpServer(SERVER_INFO, { capabilities: { logging: {} } });
 
   server.registerTool(
     "lease_simulator",
@@ -51,6 +53,37 @@ export function createMcpServer(session: McpSession): McpServer {
       }
     },
   );
+
+  server.registerTool(
+    "lease_status",
+    {
+      title: "Lease status",
+      description:
+        "Report this MCP session's current lease, or an explicit no-lease result if it holds nothing. Read-only, small, and safe to call repeatedly (e.g. after a context compaction).",
+      inputSchema: leaseStatusInputSchema,
+      outputSchema: leaseStatusOutputSchema,
+    },
+    () => {
+      try {
+        return success(session.status());
+      } catch (error: unknown) {
+        return failure(error);
+      }
+    },
+  );
+
+  session.onLeaseLost((notice) => {
+    void server.server.sendLoggingMessage({
+      data: {
+        device_id: notice.deviceId,
+        lease_id: notice.leaseId,
+        message: "Pitlane lease ended; this session no longer holds the device.",
+        reason: notice.reason,
+      },
+      level: "warning",
+      logger: "pitlane",
+    });
+  });
 
   return server;
 }

--- a/src/mcp/session.test.ts
+++ b/src/mcp/session.test.ts
@@ -315,12 +315,122 @@ describe("McpSession", () => {
       code: "LEASE_NOT_OWNED",
     });
   });
+
+  it("reports no lease held until a lease is granted, and the held lease's details after", async () => {
+    const connection = new StubConnection();
+    connection.responses.push(rawGrant, { leaseId: "lse_9f2c" });
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+    expect(session.status()).toEqual({ held: false });
+
+    await session.lease(input);
+    expect(session.status()).toEqual({
+      device: "iPhone 17 Pro",
+      device_id: "ABCD",
+      expires_at_ms: 61_000,
+      held: true,
+      lease_id: "lse_9f2c",
+      os: "26.5",
+      platform: "ios",
+      state: "leased",
+    });
+
+    await session.release({ lease_id: "lse_9f2c" });
+    expect(session.status()).toEqual({ held: false });
+  });
+
+  it("throws when status is queried on a closed session", async () => {
+    const connection = new StubConnection();
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+    await session.close();
+    expect(() => session.status()).toThrowError(
+      expect.objectContaining({ code: "SESSION_CLOSED" }),
+    );
+  });
+
+  it("clears ownership and notifies listeners when the daemon pushes a lease-lost fact", async () => {
+    const connection = new StubConnection();
+    connection.responses.push(rawGrant);
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+    await session.lease(input);
+
+    const notices: unknown[] = [];
+    session.onLeaseLost((notice) => notices.push(notice));
+    connection.pushLeaseLost({ deviceId: "ABCD", leaseId: "lse_9f2c", reason: "expired" });
+
+    expect(session.status()).toEqual({ held: false });
+    expect(notices).toEqual([{ deviceId: "ABCD", leaseId: "lse_9f2c", reason: "expired" }]);
+    await expect(session.release({ lease_id: "lse_9f2c" })).rejects.toMatchObject({
+      code: "LEASE_NOT_OWNED",
+    });
+  });
+
+  it("ignores a lease-lost push for a lease id this session does not currently own", async () => {
+    const connection = new StubConnection();
+    connection.responses.push(rawGrant);
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+    await session.lease(input);
+
+    const notices: unknown[] = [];
+    session.onLeaseLost((notice) => notices.push(notice));
+    connection.pushLeaseLost({ deviceId: "other", leaseId: "some-other-lease", reason: "killed" });
+
+    expect(notices).toEqual([]);
+    expect(session.status()).toMatchObject({ held: true, lease_id: "lse_9f2c" });
+  });
+
+  it("ignores malformed lease-lost pushes without throwing", async () => {
+    const connection = new StubConnection();
+    connection.responses.push(rawGrant);
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+    await session.lease(input);
+
+    const notices: unknown[] = [];
+    session.onLeaseLost((notice) => notices.push(notice));
+    expect(() => connection.pushLeaseLost({} as never)).not.toThrow();
+
+    expect(notices).toEqual([]);
+    expect(session.status()).toMatchObject({ held: true, lease_id: "lse_9f2c" });
+  });
+
+  it("ignores a lease-lost push that arrives for a lease this session already released itself", async () => {
+    const connection = new StubConnection();
+    connection.responses.push(rawGrant, { leaseId: "lse_9f2c" });
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+    await session.lease(input);
+    await session.release({ lease_id: "lse_9f2c" });
+
+    const notices: unknown[] = [];
+    session.onLeaseLost((notice) => notices.push(notice));
+    // The daemon suppresses this in practice (issue #15), but the client stays
+    // defensive: a stale push for an id this session no longer owns is a no-op.
+    connection.pushLeaseLost({ deviceId: "ABCD", leaseId: "lse_9f2c", reason: "expired" });
+    expect(notices).toEqual([]);
+  });
 });
 
 class StubConnection implements DaemonConnection {
   readonly requests: Array<{ readonly payload: unknown; readonly type: string }> = [];
   readonly responses: unknown[] = [];
   closeCalls = 0;
+  readonly #listeners = new Set<(kind: string, payload: unknown) => void>();
 
   async request(type: string, payload: unknown): Promise<unknown> {
     this.requests.push({ payload, type });
@@ -329,8 +439,17 @@ class StubConnection implements DaemonConnection {
     return response instanceof Promise ? response : response;
   }
 
-  onPush(): () => void {
-    return () => undefined;
+  onPush(listener: (kind: string, payload: unknown) => void): () => void {
+    this.#listeners.add(listener);
+    return () => this.#listeners.delete(listener);
+  }
+
+  pushLeaseLost(payload: {
+    readonly deviceId: string;
+    readonly leaseId: string;
+    readonly reason: string;
+  }): void {
+    for (const listener of this.#listeners) listener("lease-lost", payload);
   }
 
   async close(): Promise<void> {

--- a/src/mcp/session.ts
+++ b/src/mcp/session.ts
@@ -1,8 +1,15 @@
-import { parseRawLeaseGrant, type RawLeaseGrant } from "../daemon-client/contracts.js";
+import {
+  parseRawLeaseGrant,
+  parseRawLeaseLost,
+  type RawLeaseGrant,
+} from "../daemon-client/contracts.js";
 import { DaemonClientError, type DaemonConnection } from "../daemon-client/protocol.js";
 import type {
+  HeldLeaseStatus,
   LeaseSimulatorInput,
   LeaseSimulatorOutput,
+  LeaseStatusOutput,
+  NoLeaseStatus,
   ReleaseSimulatorInput,
   ReleaseSimulatorOutput,
 } from "./contracts.js";
@@ -16,6 +23,22 @@ export interface McpSessionOptions {
 export interface McpErrorResult {
   readonly code: string;
   readonly message: string;
+}
+
+/** Delivered to `onLeaseLost` listeners when this session's held lease ends elsewhere. */
+export interface LeaseLostNotice {
+  readonly deviceId: string;
+  readonly leaseId: string;
+  readonly reason: string;
+}
+
+interface OwnedLease {
+  readonly device: string;
+  readonly deviceId: string;
+  readonly expiresAtMs: number;
+  readonly leaseId: string;
+  readonly os: string;
+  readonly platform: "android" | "ios";
 }
 
 interface LeaseAbortWatch {
@@ -51,7 +74,9 @@ export class McpSession {
   #closePromise: Promise<void> | undefined;
   #rejectClosed!: (reason: McpSessionError) => void;
   #sessionClosed: Promise<never>;
-  #ownedLeaseId: string | undefined;
+  #ownedLease: OwnedLease | undefined;
+  #pushUnsubscribe: (() => void) | undefined;
+  readonly #leaseLostListeners = new Set<(notice: LeaseLostNotice) => void>();
   #mutations: Promise<void> = Promise.resolve();
 
   constructor(options: McpSessionOptions) {
@@ -73,7 +98,7 @@ export class McpSession {
   release(input: ReleaseSimulatorInput): Promise<ReleaseSimulatorOutput> {
     return this.#mutate(async () => {
       this.#throwIfClosed();
-      if (this.#ownedLeaseId !== input.lease_id) {
+      if (this.#ownedLease?.leaseId !== input.lease_id) {
         throw new McpSessionError("LEASE_NOT_OWNED", "This session does not own that lease");
       }
       const connection = await this.#connectionForUse();
@@ -83,18 +108,32 @@ export class McpSession {
           this.#sessionClosed,
         ]);
       } catch (error: unknown) {
-        if (isNoLongerActiveLease(error)) this.#ownedLeaseId = undefined;
+        if (isNoLongerActiveLease(error)) this.#ownedLease = undefined;
         throw error;
       }
-      this.#ownedLeaseId = undefined;
+      this.#ownedLease = undefined;
       return { lease_id: input.lease_id, released: true };
     });
+  }
+
+  /** This session's current lease, or an explicit "no lease held" result. Cheap, local, and safe to poll. */
+  status(): LeaseStatusOutput {
+    this.#throwIfClosed();
+    return this.#ownedLease === undefined ? noLeaseStatus() : heldLeaseStatus(this.#ownedLease);
+  }
+
+  /** Notifies when this session's held lease ends elsewhere (expiry or a force-release). */
+  onLeaseLost(listener: (notice: LeaseLostNotice) => void): () => void {
+    this.#leaseLostListeners.add(listener);
+    return () => this.#leaseLostListeners.delete(listener);
   }
 
   close(): Promise<void> {
     if (this.#closePromise !== undefined) return this.#closePromise;
     this.#closed = true;
-    this.#ownedLeaseId = undefined;
+    this.#ownedLease = undefined;
+    this.#pushUnsubscribe?.();
+    this.#pushUnsubscribe = undefined;
     this.#rejectClosed(new McpSessionError("SESSION_CLOSED", "MCP session is closed"));
     const connection = this.#connection;
     this.#connection = undefined;
@@ -181,7 +220,14 @@ export class McpSession {
       throw new McpSessionError("INVALID_LEASE_GRANT", "Daemon returned a non-held lease grant");
     }
     const output = leaseSimulatorOutputSchema.parse(leaseSimulatorOutput(grant));
-    this.#ownedLeaseId = grant.lease.id;
+    this.#ownedLease = {
+      device: output.device,
+      deviceId: output.device_id,
+      expiresAtMs: output.expires_at_ms,
+      leaseId: output.lease_id,
+      os: output.os,
+      platform: output.platform,
+    };
     return output;
   }
 
@@ -214,6 +260,7 @@ export class McpSession {
         this.#throwIfClosed();
       }
       this.#connection = connection;
+      this.#pushUnsubscribe = connection.onPush((kind, payload) => this.#handlePush(kind, payload));
       return connection;
     } catch (error: unknown) {
       this.#throwIfClosed();
@@ -226,7 +273,23 @@ export class McpSession {
   async #closeConnection(): Promise<void> {
     const connection = this.#connection;
     this.#connection = undefined;
+    this.#pushUnsubscribe?.();
+    this.#pushUnsubscribe = undefined;
     if (connection !== undefined) await this.#closeDaemonConnection(connection);
+  }
+
+  /** Relays a daemon lease-lost push to this session's own listeners (e.g. an MCP logging notification). */
+  #handlePush(kind: string, payload: unknown): void {
+    if (kind !== "lease-lost") return;
+    let notice: LeaseLostNotice;
+    try {
+      notice = parseRawLeaseLost(payload);
+    } catch {
+      return;
+    }
+    if (this.#ownedLease === undefined || this.#ownedLease.leaseId !== notice.leaseId) return;
+    this.#ownedLease = undefined;
+    for (const listener of this.#leaseLostListeners) listener(notice);
   }
 
   async #closeDaemonConnection(connection: DaemonConnection): Promise<void> {
@@ -294,6 +357,23 @@ function timeoutMilliseconds(timeoutSeconds: number): number {
     );
   }
   return timeoutSeconds * 1_000;
+}
+
+function noLeaseStatus(): NoLeaseStatus {
+  return { held: false };
+}
+
+function heldLeaseStatus(lease: OwnedLease): HeldLeaseStatus {
+  return {
+    device: lease.device,
+    device_id: lease.deviceId,
+    expires_at_ms: lease.expiresAtMs,
+    held: true,
+    lease_id: lease.leaseId,
+    os: lease.os,
+    platform: lease.platform,
+    state: "leased",
+  };
 }
 
 function leaseSimulatorOutput(grant: RawLeaseGrant): LeaseSimulatorOutput {


### PR DESCRIPTION
## What changed

- **`lease_status` MCP tool** (`src/mcp/server.ts`, `src/mcp/contracts.ts`): read-only, no input. Returns this MCP session's current lease (`lease_id`, `device`, `os`, `platform`, `device_id`, `expires_at_ms`, `state`) or `{ held: false }`. It's a local read of `McpSession` state — no daemon round-trip — so it's cheap and safe to poll repeatedly (e.g. after a context compaction).
- **Lease-lost notification**:
  - `DaemonServer` (`src/daemon/server.ts`) subscribes to the existing post-commit `lease.expired` / `lease.released` events at `start()` (unsubscribing at `stop()`) and pushes a `lease-lost` push frame `{ leaseId, deviceId, reason }` to whichever connection's `heldLeaseIds` still contains that lease, then stops tracking it as held on that connection.
  - `McpSession` (`src/mcp/session.ts`) subscribes to its daemon connection's push channel, and on a `lease-lost` push whose `leaseId` matches its currently owned lease, clears that ownership and notifies `onLeaseLost` listeners.
  - `createMcpServer` (`src/mcp/server.ts`) relays that as an MCP `notifications/message` logging notification (`level: "warning"`, `logger: "pitlane"`, `data: { lease_id, device_id, reason, message }`). The server now declares the `logging` capability so the notification is actually sent.
- **No redundant self-notification**: `DaemonServer`'s `lease.release` / `lease.release-all` handlers now clear a connection's own held-lease bookkeeping *before* the release commits (restoring it if the release fails), so a connection that explicitly releases its own lease never gets a duplicate `lease-lost` push for the release it just asked for — while a TTL expiry, `pitlane release --all`, `nuke`, or a different connection force-releasing that lease still reaches the actual holder.
- README MCP section and `docs/CLI.md`'s `pitlane mcp` entry updated to document the third tool and the notification.

## Scope note

This does **not** depend on or implement #12 (heartbeat-driven sliding TTL). The lease-lost push only reacts to the event bus facts (`lease.expired`, `lease.released`) that already exist on `main` today — no heartbeat, no TTL behavior change. The issue's `address` field (from #14) is intentionally omitted; `lease_status` reports `device_id` (`driverDeviceId`) only, matching what `lease_simulator` already returns.

## Why

Per issue #15: an MCP agent holding a device for a while has no cheap way to ask "do I still hold a device?", and no way to learn its lease ended (expired, or force-released by `pitlane release --all` / `nuke` / doctor expiry) other than poking the device and inferring failure. `McpSession.#ownedLeaseId` would otherwise keep claiming ownership of a lease that no longer exists.

## How I verified it

- `pnpm check` (typecheck, lint, format, `vitest run src`) is green: 50 test files, 344 passed / 2 skipped.
- `pnpm fallow --ci` is green, with the same 32 pre-existing findings as `main` (no new findings).
- New/updated tests:
  - `src/mcp/session.test.ts`: `status()` reflects no-lease / held / released states and throws `SESSION_CLOSED` when closed; a `lease-lost` push clears ownership and fires listeners; a push for a lease id the session doesn't currently own (mismatched id, malformed payload, or already self-released) is a no-op.
  - `src/mcp/server.test.ts`: `lease_status` is listed and both schema-valid states pass `leaseStatusOutputSchema`; a daemon `lease-lost` push arrives at the MCP client as a `notifications/message` with the documented shape, and a subsequent `release_simulator` for that lease id fails with `LEASE_NOT_OWNED` (not a transport error).
  - `src/daemon/server.test.ts` (real sockets, `FakeClock`): a TTL backstop expiry pushes `lease-lost` to the real holder and closing that connection afterward doesn't hang or error the daemon; a different connection force-releasing another connection's held lease pushes `lease-lost` to the actual holder, and the holder's own follow-up `lease.release` then gets `UNKNOWN_LEASE` rather than a transport error; a connection that explicitly releases its own lease gets no redundant push (checked via frame ordering); `lease.expired`/`lease.released` events for leases with no live holder are ignored without breaking the daemon.

## Acceptance criteria (from the issue)

- [x] `lease_status` returns the held lease's details, and a well-formed "none" result when the session holds nothing.
- [x] Expiring or force-releasing a lease pushes a notification to the holding connection and clears `McpSession`'s owned-lease state.
- [x] After a lease-lost notification, `release_simulator` for that lease id returns `LEASE_NOT_OWNED` rather than a transport error.
- [x] A push to a closed connection cannot break the daemon — `writeFrame` no-ops on a closed socket, and the event bus already isolates handler failures from emitters (`src/bus/index.ts`'s `#dispatch`).
- [x] README MCP section documents the third tool and the notification.
- [x] `pnpm check` green.

Closes #15

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJpxZonwJvftcpNpk6CLFK)_