### PR TITLE
Emit structured CLI errors and document every exit code

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ same lease workflow through a local stdio server.
 ```sh
 pnpm install
 pnpm build
-pitlane lease --platform ios --device "iPhone 16" --detach --json
+pitlane lease --platform ios --device "iPhone 16" --detach
 pitlane status --json
 ```
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,21 +1,45 @@
 # CLI reference
 
 Part of the user manual: every command the pitlane CLI is expected to
-implement. Except for `pitlane mcp`, commands accept `--json` for
-machine-readable output (agents are the primary audience). Their
-progress/diagnostics go to **stderr** as JSON lines; results go to **stdout**.
-`pitlane mcp` instead reserves stdout for MCP JSON-RPC framing.
+implement. Results are JSON on **stdout**; progress/diagnostics are JSON
+lines on **stderr** — this is the default output, not an opt-in, because
+agents are the primary audience. `status` and `daemon <start|stop|status|logs>`
+are the exception: they default to a human-oriented view for interactive/
+operator use and accept `--json` to switch to the structured form. Every
+other command's output is already unconditionally JSON, so passing `--json`
+to it is a usage error (exit 2) rather than a silent no-op. `pitlane mcp`
+reserves stdout for MCP JSON-RPC framing and accepts no flags at all.
+
+On failure, every command writes one structured line to stderr:
+
+```json
+{"error":{"code":"NO_CAPACITY","message":"No device capacity is currently available"}}
+```
+
+`code` is the daemon's own error code where the failure came from the
+daemon, or a stable CLI-level code otherwise: `USAGE` for bad flags/missing
+arguments/unknown commands, `INTERNAL` for anything unexpected.
 
 ## Global exit codes
 
-| Code | Meaning |
-|---|---|
-| 0 | success (for `lease` held mode: lease ended normally) |
-| 1 | internal / unexpected error |
-| 2 | usage error (bad flags, missing required args) |
-| 10 | timed out waiting for a device (`--timeout` elapsed) |
-| 11 | capacity reached and `--no-wait` was set |
-| 12 | spec unresolvable (unknown model, or runtime not installed and no `--allow-download`) |
+| Exit | Error code | Meaning |
+|---|---|---|
+| 0 | — | success (for `lease` held mode: lease ended normally) |
+| 1 | `INTERNAL` | internal / unexpected error |
+| 2 | `USAGE` | usage error (bad flags, missing required args, unknown command) |
+| 2 | `BAD_FRAME` | malformed request frame sent to the daemon |
+| 2 | `BAD_REQUEST` | request payload failed validation |
+| 10 | `QUEUE_TIMEOUT` | timed out waiting for a device (`--timeout` elapsed) |
+| 11 | `NO_CAPACITY` | capacity reached and `--no-wait` was set |
+| 12 | `NO_DRIVER` | no driver registered for the requested platform |
+| 12 | `RUNTIME_MISSING` | runtime not installed and no `--allow-download` |
+| 12 | `UNKNOWN_MODEL` | unknown device model for the platform |
+| 13 | `REQUESTER_ALREADY_LEASED` | requester already holds a lease or has a pending request — one lease per agent in v1; release the named lease first |
+
+This table matches `DAEMON_ERROR_EXIT_CODES` in `src/cli/index.ts` exactly.
+A daemon error code with no entry here (for example `UNKNOWN_LEASE` or
+`HELD_LEASE_RENEWAL`, both surfaced by `lease renew`) falls back to exit 1;
+the structured stderr line still reports the specific code.
 
 ---
 
@@ -27,7 +51,7 @@ and booting, then — in held mode — keeps running to hold the lease.
 ```
 pitlane lease --platform <ios|android> --device <model> [--os <version>]
               [--timeout <duration>] [--no-wait] [--detach]
-              [--allow-download] [--json]
+              [--allow-download]
 ```
 
 - `--platform`, `--device` — required. `--os` defaults to the newest runtime
@@ -40,6 +64,10 @@ pitlane lease --platform <ios|android> --device <model> [--os <version>]
   them; install the runtime through Xcode first.
 - `--detach` — detached mode: print the lease result and exit; the lease is
   TTL-bound and must be renewed with `pitlane lease renew`.
+
+One lease per requester in v1: leasing while you already hold a lease or
+have a request queued fails with `REQUESTER_ALREADY_LEASED` (exit 13); the
+error message names the existing lease id to release first.
 
 **Held mode (default):** intended to be run in the background by the agent.
 As soon as the device is ready, one JSON line is printed on stdout:
@@ -63,7 +91,8 @@ work stages; reclaiming work is reported separately:
 ### `pitlane lease renew <lease-id> [--ttl <duration>]`
 
 Detached mode only: extend the lease TTL. Exit 1 if the lease is unknown or
-already expired.
+already expired (error code `UNKNOWN_LEASE`), or if it is a held-mode lease,
+which cannot be renewed (error code `HELD_LEASE_RENEWAL`).
 
 ## `pitlane release <lease-id> | --all`
 

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -44,6 +44,7 @@ describe("CLI boundary", () => {
     ["RUNTIME_MISSING", 12],
     ["UNKNOWN_MODEL", 12],
     ["BAD_REQUEST", 2],
+    ["REQUESTER_ALREADY_LEASED", 13],
   ] as const)("maps %s daemon errors to exit %d", async (code, expected) => {
     const output = outputCapture();
     const connection = new StubConnection();
@@ -55,19 +56,68 @@ describe("CLI boundary", () => {
     expect(errorExitCode(new DaemonClientError(code, "failed"))).toBe(expected);
   });
 
+  it("writes a single structured JSON error line to stderr for a daemon error", async () => {
+    const output = outputCapture();
+    const connection = new StubConnection();
+    connection.response("status.get", new DaemonClientError("NO_CAPACITY", "No capacity"));
+
+    await expect(
+      runCli(["status"], output.environmentWith({ connect: async () => connection })),
+    ).resolves.toBe(11);
+    expect(output.stdout).toBe("");
+    expect(output.stderr.trim().split("\n")).toHaveLength(1);
+    expect(JSON.parse(output.stderr)).toEqual({
+      error: { code: "NO_CAPACITY", message: "No capacity" },
+    });
+  });
+
+  it("gives REQUESTER_ALREADY_LEASED its own exit code and an actionable message", async () => {
+    const output = outputCapture();
+    const connection = new StubConnection();
+    connection.response(
+      "lease.request",
+      new DaemonClientError(
+        "REQUESTER_ALREADY_LEASED",
+        "Requester test-requester already holds lease lse_1; release it (`pitlane release lse_1`) before requesting another device",
+      ),
+    );
+
+    await expect(
+      runCli(
+        ["lease", "--platform", "ios", "--device", "iPhone 16", "--detach"],
+        output.environmentWith({ connect: async () => connection }),
+      ),
+    ).resolves.toBe(13);
+    expect(output.stdout).toBe("");
+    const parsed = JSON.parse(output.stderr) as { error: { code: string; message: string } };
+    expect(parsed.error.code).toBe("REQUESTER_ALREADY_LEASED");
+    expect(parsed.error.message).toContain("lse_1");
+    expect(parsed.error.message).toContain("pitlane release lse_1");
+  });
+
   it("parses human durations and bare milliseconds", () => {
     expect(parseDuration("90s")).toBe(90_000);
     expect(parseDuration("10m")).toBe(600_000);
     expect(parseDuration("250")).toBe(250);
   });
 
-  it("reports missing lease arguments as usage errors", async () => {
+  it("reports missing lease arguments as a structured USAGE error", async () => {
     const output = outputCapture();
 
     await expect(runCli(["lease"], output.environment)).resolves.toBe(2);
     expect(output.stdout).toBe("");
-    expect(output.stderr).toContain("--platform");
-    expect(output.stderr).toContain("Usage:");
+    expect(output.stderr.trim().split("\n")).toHaveLength(1);
+    expect(JSON.parse(output.stderr)).toEqual({
+      error: { code: "USAGE", message: expect.stringContaining("--platform") },
+    });
+  });
+
+  it("rejects --json on a command whose output is already unconditionally JSON", async () => {
+    const output = outputCapture();
+
+    await expect(runCli(["list", "--json"], output.environment)).resolves.toBe(2);
+    expect(output.stdout).toBe("");
+    expect(JSON.parse(output.stderr)).toMatchObject({ error: { code: "USAGE" } });
   });
 
   it("lists the MCP server in root help", async () => {
@@ -135,12 +185,12 @@ describe("CLI boundary", () => {
         runCli(["mcp", argument], output.environmentWith({ runMcpStdio: runner })),
       ).resolves.toBe(2);
       expect(output.stdout).toBe("");
-      expect(output.stderr).toContain("Usage:");
+      expect(JSON.parse(output.stderr)).toMatchObject({ error: { code: "USAGE" } });
       expect(runner).not.toHaveBeenCalled();
     },
   );
 
-  it("reports MCP startup failures safely on stderr", async () => {
+  it("reports MCP startup failures as a structured INTERNAL error on stderr", async () => {
     const output = outputCapture();
     const runner = vi.fn(async () => {
       throw new Error("MCP startup failed");
@@ -148,7 +198,9 @@ describe("CLI boundary", () => {
 
     await expect(runCli(["mcp"], output.environmentWith({ runMcpStdio: runner }))).resolves.toBe(1);
     expect(output.stdout).toBe("");
-    expect(output.stderr).toBe("MCP startup failed\n");
+    expect(JSON.parse(output.stderr)).toEqual({
+      error: { code: "INTERNAL", message: "MCP startup failed" },
+    });
     expect(runner).toHaveBeenCalledTimes(1);
   });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -28,6 +28,7 @@ const DAEMON_ERROR_EXIT_CODES: Readonly<Record<string, number>> = {
   NO_CAPACITY: 11,
   NO_DRIVER: 12,
   QUEUE_TIMEOUT: 10,
+  REQUESTER_ALREADY_LEASED: 13,
   RUNTIME_MISSING: 12,
   UNKNOWN_MODEL: 12,
 };
@@ -148,10 +149,28 @@ export async function runCli(
         throw new UsageError(`Unknown command: ${argv[0]}`);
     }
   } catch (error: unknown) {
-    environment.stderr.write(`${errorMessage(error)}\n`);
-    if (error instanceof UsageError) environment.stderr.write(`${USAGE}\n`);
+    writeError(environment, error);
     return errorExitCode(error);
   }
+}
+
+/**
+ * Every CLI failure writes exactly one structured line to stderr so agents
+ * can branch on `error.code` instead of parsing prose. `code` is the
+ * daemon's own error code where the failure came from the daemon, and a
+ * stable CLI-level code otherwise (`USAGE` for bad flags/arguments,
+ * `INTERNAL` for anything unexpected).
+ */
+function writeError(environment: CliEnvironment, error: unknown): void {
+  environment.stderr.write(
+    `${JSON.stringify({ error: { code: cliErrorCode(error), message: errorMessage(error) } })}\n`,
+  );
+}
+
+function cliErrorCode(error: unknown): string {
+  if (error instanceof UsageError) return "USAGE";
+  if (error instanceof DaemonClientError) return error.code;
+  return "INTERNAL";
 }
 
 async function runMcp(argv: readonly string[], environment: CliEnvironment): Promise<number> {
@@ -195,7 +214,6 @@ async function runLease(argv: readonly string[], environment: CliEnvironment): P
     "no-wait": { type: "boolean" },
     os: { type: "string" },
     platform: { type: "string" },
-    json: { type: "boolean" },
     timeout: { type: "string" },
   });
   if (values.help) {
@@ -247,7 +265,6 @@ async function runLease(argv: readonly string[], environment: CliEnvironment): P
 async function runRenew(argv: readonly string[], environment: CliEnvironment): Promise<number> {
   const values = commandArgs(argv, {
     help: { type: "boolean", short: "h" },
-    json: { type: "boolean" },
     ttl: { type: "string" },
   });
   const { positionals } = values;
@@ -270,7 +287,6 @@ async function runRelease(argv: readonly string[], environment: CliEnvironment):
   const values = commandArgs(argv, {
     all: { type: "boolean" },
     help: { type: "boolean", short: "h" },
-    json: { type: "boolean" },
     yes: { type: "boolean" },
   });
   const { positionals } = values;
@@ -314,12 +330,11 @@ async function runList(argv: readonly string[], environment: CliEnvironment): Pr
   const values = commandArgs(argv, {
     devices: { type: "boolean" },
     help: { type: "boolean", short: "h" },
-    json: { type: "boolean" },
     leases: { type: "boolean" },
     rules: { type: "boolean" },
   });
   if (values.help) {
-    environment.stdout.write("Usage: pitlane list [--devices|--leases|--rules] [--json]\n");
+    environment.stdout.write("Usage: pitlane list [--devices|--leases|--rules]\n");
     return 0;
   }
   if ([values.devices, values.leases, values.rules].filter(Boolean).length > 1)
@@ -333,11 +348,10 @@ async function runCleanup(argv: readonly string[], environment: CliEnvironment):
   const values = commandArgs(argv, {
     "dry-run": { type: "boolean" },
     help: { type: "boolean", short: "h" },
-    json: { type: "boolean" },
     rule: { type: "string" },
   });
   if (values.help) {
-    environment.stdout.write("Usage: pitlane cleanup [--dry-run] [--rule <name>] [--json]\n");
+    environment.stdout.write("Usage: pitlane cleanup [--dry-run] [--rule <name>]\n");
     return 0;
   }
   writeResult(
@@ -354,10 +368,9 @@ async function runDoctor(argv: readonly string[], environment: CliEnvironment): 
   const values = commandArgs(argv, {
     fix: { type: "boolean" },
     help: { type: "boolean", short: "h" },
-    json: { type: "boolean" },
   });
   if (values.help) {
-    environment.stdout.write("Usage: pitlane doctor [--fix] [--json]\n");
+    environment.stdout.write("Usage: pitlane doctor [--fix]\n");
     return 0;
   }
   writeResult(
@@ -371,11 +384,10 @@ async function runNuke(argv: readonly string[], environment: CliEnvironment): Pr
   const values = commandArgs(argv, {
     "delete-devices": { type: "boolean" },
     help: { type: "boolean", short: "h" },
-    json: { type: "boolean" },
     yes: { type: "boolean" },
   });
   if (values.help) {
-    environment.stdout.write("Usage: pitlane nuke [--delete-devices] [--yes] [--json]\n");
+    environment.stdout.write("Usage: pitlane nuke [--delete-devices] [--yes]\n");
     return 0;
   }
   const confirmed =
@@ -394,11 +406,10 @@ async function runEvents(argv: readonly string[], environment: CliEnvironment): 
   const values = commandArgs(argv, {
     follow: { type: "boolean" },
     help: { type: "boolean", short: "h" },
-    json: { type: "boolean" },
     since: { type: "string" },
   });
   if (values.help) {
-    environment.stdout.write("Usage: pitlane events [--follow] [--since <duration>] [--json]\n");
+    environment.stdout.write("Usage: pitlane events [--follow] [--since <duration>]\n");
     return 0;
   }
   const connection = await environment.connect();
@@ -482,12 +493,12 @@ async function runDaemon(argv: readonly string[], environment: CliEnvironment): 
 // fallow-ignore-next-line complexity -- config subcommand parsing is a single CLI boundary.
 async function runConfig(argv: readonly string[], environment: CliEnvironment): Promise<number> {
   const command = argv[0];
-  if (command === undefined || command === "--json") {
+  if (command === undefined) {
     writeResult(environment, await requestOnce(environment, "config.get", {}));
     return 0;
   }
   if (command === "get") {
-    const values = commandArgs(argv.slice(1), { json: { type: "boolean" } });
+    const values = commandArgs(argv.slice(1), {});
     const key = requiredPositional(values.positionals, "key");
     const value = readConfigValue(
       requireObject(await requestOnce(environment, "config.get", {})),
@@ -498,7 +509,7 @@ async function runConfig(argv: readonly string[], environment: CliEnvironment): 
     return 0;
   }
   if (command === "set") {
-    const values = commandArgs(argv.slice(1), { json: { type: "boolean" } });
+    const values = commandArgs(argv.slice(1), {});
     const [key, rawValue, ...extra] = values.positionals;
     if (key === undefined || rawValue === undefined || extra.length > 0)
       throw new UsageError("Usage: pitlane config set <key> <value>");

--- a/src/core/lease-acquisition-coordinator.test.ts
+++ b/src/core/lease-acquisition-coordinator.test.ts
@@ -128,7 +128,11 @@ describe("LeaseAcquisitionCoordinator", () => {
 
     await expect(
       harness.coordinator.request(request, { mode: "held", requesterId: "agent" }),
-    ).rejects.toThrow("Requester already has a lease");
+    ).rejects.toMatchObject({
+      existingLeaseId: granted.lease.id,
+      message: expect.stringContaining(granted.lease.id),
+      name: "RequesterAlreadyLeasedError",
+    });
     expect(granted.lease.requesterId).toBe("agent");
   });
 

--- a/src/core/lease-acquisition-coordinator.ts
+++ b/src/core/lease-acquisition-coordinator.ts
@@ -134,16 +134,19 @@ export class LeaseAcquisitionCoordinator implements AcquisitionMaintenance {
           );
           throw new NukeCancelledError();
         }
-        const alreadyActive = this.options.registry.snapshot.leases.some(
+        const activeLease = this.options.registry.snapshot.leases.find(
           (lease) => lease.requesterId === options.requesterId,
         );
-        if (alreadyActive || this.options.queue.hasPendingRequester(options.requesterId)) {
+        if (
+          activeLease !== undefined ||
+          this.options.queue.hasPendingRequester(options.requesterId)
+        ) {
           this.options.eventBus.emit(
             "lease.rejected",
             { requestSpec: request, reason: "already-leased" },
             "lease-acquisition-coordinator",
           );
-          throw new RequesterAlreadyLeasedError(options.requesterId);
+          throw new RequesterAlreadyLeasedError(options.requesterId, activeLease?.id);
         }
         const accepted = this.#newWaiter(request, options);
         this.options.eventBus.emit(

--- a/src/core/lease-engine.test.ts
+++ b/src/core/lease-engine.test.ts
@@ -12,7 +12,6 @@ import {
   NoCapacityError,
   QueueTimeoutError,
   Registry,
-  RequesterAlreadyLeasedError,
 } from "./index.js";
 
 const gibibyte = 1024 ** 3;
@@ -773,7 +772,11 @@ describe("LeaseEngine", () => {
 
     await expect(
       harness.engine.request(request, { mode: "held", requesterId: "agent-1" }),
-    ).rejects.toBeInstanceOf(RequesterAlreadyLeasedError);
+    ).rejects.toMatchObject({
+      existingLeaseId: first.lease.id,
+      message: expect.stringContaining(first.lease.id),
+      name: "RequesterAlreadyLeasedError",
+    });
     await harness.engine.release(first.lease.id, "explicit");
     expect(harness.clock.pendingTimerCount).toBe(0);
     await expect(

--- a/src/core/wait-queue.ts
+++ b/src/core/wait-queue.ts
@@ -39,8 +39,16 @@ export class QueueTimeoutError extends Error {
 }
 
 export class RequesterAlreadyLeasedError extends Error {
-  constructor(readonly requesterId: string) {
-    super(`Requester already has a lease or pending request: ${requesterId}`);
+  constructor(
+    readonly requesterId: string,
+    /** The requester's existing lease, when the conflict is a granted lease rather than a queued request. */
+    readonly existingLeaseId?: string,
+  ) {
+    super(
+      existingLeaseId === undefined
+        ? `Requester already has a lease or pending request: ${requesterId}`
+        : `Requester ${requesterId} already holds lease ${existingLeaseId}; release it (\`pitlane release ${existingLeaseId}\`) before requesting another device`,
+    );
     this.name = "RequesterAlreadyLeasedError";
   }
 }


### PR DESCRIPTION
Closes #18

## What changed

- Every CLI failure now writes exactly one structured line to stderr:
  `{"error":{"code":"...","message":"..."}}`, instead of prose. `code` is
  the daemon's own error code where the failure came from the daemon
  (`DaemonClientError.code`), or a stable CLI-level code otherwise:
  `USAGE` for bad flags/missing arguments/unknown commands, `INTERNAL`
  for anything unexpected.
- `REQUESTER_ALREADY_LEASED` is added to `DAEMON_ERROR_EXIT_CODES` with
  its own exit code (13). Its message is now actionable: the coordinator
  looks up the requester's existing granted lease (when the conflict is
  an active lease rather than a still-queued request) and the error names
  it, e.g. `Requester agent-1 already holds lease lse_1; release it
  (\`pitlane release lse_1\`) before requesting another device`.
- `docs/CLI.md`'s exit-code table is rewritten to list every code in
  `DAEMON_ERROR_EXIT_CODES` (including the ones that were already
  implemented but undocumented: `BAD_FRAME`, `NO_DRIVER`) plus the
  CLI-level `USAGE`/`INTERNAL` codes, and states the fallback for
  daemon codes with no dedicated exit status (`UNKNOWN_LEASE`,
  `HELD_LEASE_RENEWAL`, both surfaced by `lease renew`, still exit 1).
- Fixed a stale `README.md` example that passed `--json` to `lease`.
- The one remaining prose stderr write — a non-fatal "release failed
  after signal" diagnostic in held-mode `lease` — now goes through the
  same `writeError` helper as every other failure, so it's a structured
  `{"error":{"code":"INTERNAL","message":"..."}}` line too. Stderr is
  documented as JSON lines; this was the one place that broke that
  contract, since an agent parsing stderr line-by-line as JSON would hit
  a parse error on it.
- Unknown-command and missing-required-argument `USAGE` errors now end
  their `message` with a pointer to `pitlane --help`, so a human hitting
  one from a terminal isn't stranded with only a JSON blob now that the
  full command banner is no longer dumped to stderr on every failure.

**Merged `main`** (this branch was cut before #24/#25/#26 landed). Conflicts
were in `docs/CLI.md` (main added `--agent-id` to `lease`'s usage block,
this PR removed `--json` from it — kept both) and `src/cli/index.test.ts`
(main added a `fallbackRequesterId` test next to the one this PR rewrote —
kept both). `src/cli/index.ts` auto-merged without markers but needed one
manual fix: main's rewritten `lease --help` text had reintroduced `[--json]`
in its usage synopsis (unrelated to the conflict itself, so git didn't flag
it) — removed, since `lease` still doesn't accept the flag. Also updated an
existing main test (`enforces one lease per --agent-id`) that asserted the
pre-this-PR fallback exit code (1) for the already-leased case; it now
asserts the dedicated exit 13 and the `REQUESTER_ALREADY_LEASED` code.

## The `--json` decision

`--json` was accepted-but-inert on most commands: `list`, `cleanup`,
`doctor`, `nuke`, `events`, `config`, `lease`, `lease renew`, and
`release` already always printed JSON regardless of the flag, while
`status` and `daemon <sub>` genuinely toggle between a human-oriented
default and `--json`'s structured form (documented and covered by
existing tests). Main's `catalog` command (merged in after this branch
was cut) follows the same genuine-toggle shape as `status`/`daemon`
(`writeResult` only when `--json` is set, a human-formatted device/model/
runtime listing otherwise), so it falls on the same side of the policy.

Given the repo's stated agent-first premise (`docs/ABOUT.md`: "CLI lease
results are one JSON line on stdout"; `pitlane events` docs already say
its output is JSON lines unconditionally, no flag mentioned) and that
most commands were already unconditionally JSON, I picked: **`--json`
is meaningful only on the commands that have a genuine non-JSON default
(`status`, `catalog`, `daemon <sub>`); every other command's output is
already unconditionally JSON, so `--json` there is rejected as an
unrecognized option** (a usage error, exit 2) rather than silently
accepted and ignored. This directly fixes the reported bug (`lease
--json` is now an error instead of a no-op) with a minimal, low-risk
diff — it avoids inventing new human-formatted renderers for commands
whose output was never documented as anything but JSON lines/objects,
while preserving `status`'s (and now `catalog`'s) existing, tested,
documented human/JSON toggle. `pitlane mcp` continues to reject all
flags, unchanged. `docs/CLI.md`'s intro paragraph names all three
exceptions explicitly.

## Exit-code table (final)

| Exit | Error code | Meaning |
|---|---|---|
| 0 | — | success (for `lease` held mode: lease ended normally) |
| 1 | `INTERNAL` | internal / unexpected error |
| 2 | `USAGE` | usage error (bad flags, missing required args, unknown command) |
| 2 | `BAD_FRAME` | malformed request frame sent to the daemon |
| 2 | `BAD_REQUEST` | request payload failed validation |
| 10 | `QUEUE_TIMEOUT` | timed out waiting for a device (`--timeout` elapsed) |
| 11 | `NO_CAPACITY` | capacity reached and `--no-wait` was set |
| 12 | `NO_DRIVER` | no driver registered for the requested platform |
| 12 | `RUNTIME_MISSING` | runtime not installed and no `--allow-download` |
| 12 | `UNKNOWN_MODEL` | unknown device model for the platform |
| 13 | `REQUESTER_ALREADY_LEASED` | requester already holds a lease or has a pending request — one lease per agent in v1; release the named lease first |

This matches `DAEMON_ERROR_EXIT_CODES` in `src/cli/index.ts` exactly, and the
previously documented codes (10 / 11 / 12 / 2 / 1) are unchanged.

## Test coverage added

In `src/cli/index.test.ts`:
- `REQUESTER_ALREADY_LEASED` added to the exit-code mapping table
  (`it.each`), asserting exit 13.
- New test asserting the structured stderr shape for a daemon error
  (`NO_CAPACITY`): exactly one JSON line, `{"error":{"code":...,"message":...}}`.
- New test for the `REQUESTER_ALREADY_LEASED` path end-to-end through
  `lease`, asserting exit 13 and that the message names the conflicting
  lease id and the `pitlane release <id>` remedy.
- Rewrote the missing-arguments usage-error test to assert a structured
  `USAGE` JSON line instead of prose.
- New test asserting `--json` is rejected (usage error) on a
  now-always-JSON command (`list`).
- Rewrote the MCP-input-rejection and MCP-startup-failure tests to
  assert structured `USAGE`/`INTERNAL` JSON instead of prose.
- New test asserting the post-signal lease-release failure is a single
  structured `{"error":{"code":"INTERNAL",...}}` stderr line, not prose.
- Updated main's `enforces one lease per --agent-id` test to expect exit
  13 and `REQUESTER_ALREADY_LEASED` instead of the old fallback exit 1.

In `src/core/lease-engine.test.ts` and
`src/core/lease-acquisition-coordinator.test.ts`: extended the existing
"duplicate requester" tests to assert `existingLeaseId` is set to the
requester's granted lease id and that the message names it.

## Verification

`pnpm check` (typecheck + lint + format:check + test) is green on the
merged tree: 50 test files, 381 passed / 2 skipped.
