### PR TITLE
feat: relay lease progress to MCP clients as progress notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ call `lease_simulator` again rather than keep operating on it; a subsequent
 `release_simulator` for that lease id fails with `LEASE_NOT_OWNED` instead of
 succeeding.
 
+If the `lease_simulator` call's request carries a `_meta.progressToken`, a
+cold provision — waiting in the queue, provisioning, booting, or reclaiming a
+device — is reported as MCP `notifications/progress` for that request, each
+carrying a human-readable `message` (e.g. queue position, or an ETA in
+seconds) and a `progress` value that only increases. Clients that don't
+supply a progress token see no change: the tool call behaves exactly as
+before, just blocking until it resolves.
+
 ## Configuration
 
 Pitlane reads `~/.pitlane/config.json` and merges it over built-in

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,7 +35,10 @@ MCP client ──spawns──> stdio MCP ┘                                    
 - **stdio MCP server**: its process owns one agent session and exposes MCP over
   stdin/stdout. A lease is held by that process's daemon connection until the
   session explicitly releases it or the MCP transport disconnects, at which
-  point the connection closes and releases the lease.
+  point the connection closes and releases the lease. Like the CLI, it relays
+  the daemon's progress pushes for the in-flight `lease_simulator` request —
+  as MCP `notifications/progress` instead of stderr JSON lines, and only when
+  the client supplied a progress token.
 - **Daemon**: owns all state, serializes all decisions. Started on demand,
   reachable over a unix socket.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -136,8 +136,10 @@ server auto-starts the daemon when needed and exposes the focused
 `list_devices`, `lease_simulator`, `release_simulator`, and `lease_status`
 tool surface for one agent session. If that session's held lease ends
 elsewhere (expiry or a force-release), the server relays it as an MCP logging
-notification. See [../README.md](../README.md#mcp-integration-optional) for
-details.
+notification. A `lease_simulator` call that carries a `_meta.progressToken`
+gets queue/provisioning/boot progress relayed as MCP `notifications/progress`
+for that request. See [../README.md](../README.md#mcp-integration-optional)
+for details.
 
 The requester identity for leases made through this server is
 `PITLANE_AGENT_ID`, falling back to a pid-derived value — see

--- a/src/daemon-client/contracts.ts
+++ b/src/daemon-client/contracts.ts
@@ -75,6 +75,30 @@ export function parseRawLeaseLost(value: unknown): RawLeaseLost {
   return { deviceId: payload.deviceId, leaseId: payload.leaseId, reason: payload.reason };
 }
 
+export type RawLeaseProgress =
+  | { readonly stage: "queued"; readonly queuePosition: number }
+  | { readonly stage: "provisioning" | "booting" | "reclaiming"; readonly etaMs: number };
+
+/** Parses a "progress" push frame delivered to the requesting connection while a lease is in flight. */
+export function parseRawLeaseProgress(value: unknown): RawLeaseProgress {
+  const payload = requireObject(value, "Daemon sent an invalid progress notification");
+  if (payload.stage === "queued") {
+    if (typeof payload.queuePosition !== "number") {
+      throw new Error("Daemon sent an invalid progress notification");
+    }
+    return { queuePosition: payload.queuePosition, stage: "queued" };
+  }
+  if (
+    (payload.stage === "provisioning" ||
+      payload.stage === "booting" ||
+      payload.stage === "reclaiming") &&
+    typeof payload.etaMs === "number"
+  ) {
+    return { etaMs: payload.etaMs, stage: payload.stage };
+  }
+  throw new Error("Daemon sent an invalid progress notification");
+}
+
 function requireObject(value: unknown, message: string): Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new Error(message);

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -4,6 +4,7 @@ import {
   CallToolResultSchema,
   ListToolsResultSchema,
   LoggingMessageNotificationSchema,
+  ProgressNotificationSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { describe, expect, it } from "vitest";
 
@@ -160,6 +161,77 @@ describe("MCP server", () => {
     }
   });
 
+  it("relays queued/provisioning/booting/reclaiming progress as notifications/progress when a token is supplied", async () => {
+    const deferredGrant = deferredResponse();
+    const connection = new StubConnection([deferredGrant.promise]);
+    const { client, close } = await connectedServer(connection);
+    try {
+      const progressEvents: unknown[] = [];
+      const leaseCall = client.request(
+        {
+          method: "tools/call",
+          params: {
+            arguments: { device: "iPhone 17 Pro", platform: "ios" },
+            name: "lease_simulator",
+          },
+        },
+        CallToolResultSchema,
+        { onprogress: (progress) => progressEvents.push(progress) },
+      );
+      await waitFor(() => connection.calls.length === 1);
+
+      connection.pushProgress({ queuePosition: 2, stage: "queued" });
+      connection.pushProgress({ etaMs: 9_000, stage: "provisioning" });
+      connection.pushProgress({ etaMs: 4_000, stage: "booting" });
+      connection.pushProgress({ etaMs: 1_000, stage: "reclaiming" });
+      await waitFor(() => progressEvents.length === 4);
+
+      expect(progressEvents).toEqual([
+        expect.objectContaining({ message: "Queued behind 2 other requests" }),
+        expect.objectContaining({ message: "Provisioning device (~9s remaining)" }),
+        expect.objectContaining({ message: "Booting device (~4s remaining)" }),
+        expect.objectContaining({ message: "Reclaiming device (~1s remaining)" }),
+      ]);
+      const values = progressEvents.map((event) => (event as { progress: number }).progress);
+      expect(values).toEqual([...values].sort((a, b) => a - b));
+      expect(new Set(values).size).toBe(values.length);
+
+      deferredGrant.resolve(grant);
+      const lease = await leaseCall;
+      expect(lease.isError).not.toBe(true);
+    } finally {
+      await close();
+    }
+  });
+
+  it("emits nothing when the client supplied no progress token", async () => {
+    const deferredGrant = deferredResponse();
+    const connection = new StubConnection([deferredGrant.promise]);
+    const { client, close } = await connectedServer(connection);
+    try {
+      const progressEvents: unknown[] = [];
+      client.setNotificationHandler(ProgressNotificationSchema, (notification) => {
+        progressEvents.push(notification.params);
+      });
+
+      const leaseCall = call(client, "lease_simulator", {
+        device: "iPhone 17 Pro",
+        platform: "ios",
+      });
+      await waitFor(() => connection.calls.length === 1);
+
+      connection.pushProgress({ queuePosition: 1, stage: "queued" });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(progressEvents).toEqual([]);
+
+      deferredGrant.resolve(grant);
+      await leaseCall;
+      expect(progressEvents).toEqual([]);
+    } finally {
+      await close();
+    }
+  });
+
   it("forwards the platform filter for list_devices and never triggers a lease request", async () => {
     const connection = new StubConnection([catalog]);
     const { client, close } = await connectedServer(connection);
@@ -244,6 +316,18 @@ function text(result: { content: Array<{ type: string; text?: string }> }): stri
   return first.text;
 }
 
+function deferredResponse(): { promise: Promise<unknown>; resolve: (value: unknown) => void } {
+  let resolve!: (value: unknown) => void;
+  const promise = new Promise<unknown>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  while (!predicate()) await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 class StubConnection implements DaemonConnection {
   closeCalls = 0;
   readonly calls: Array<{ readonly payload: unknown; readonly type: string }> = [];
@@ -262,6 +346,10 @@ class StubConnection implements DaemonConnection {
     readonly reason: string;
   }): void {
     for (const listener of this.#listeners) listener("lease-lost", payload);
+  }
+
+  pushProgress(payload: unknown): void {
+    for (const listener of this.#listeners) listener("progress", payload);
   }
   async request(type: string, payload: unknown): Promise<unknown> {
     this.calls.push({ payload, type });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -57,8 +57,8 @@ function leaseProgressParams(progress: LeaseProgressNotice): {
 }
 
 /**
- * Converges toward (but never reaches) 1000 as `remaining` (a queue position or an ETA in
- * seconds) shrinks toward 0, so it never collides with the next stage's base.
+ * Climbs toward 1000 as `remaining` (a queue position or an ETA in seconds) shrinks toward 0,
+ * staying at or below the next stage's base so stages never overlap.
  */
 function withinStageProgress(remaining: number): number {
   return Math.round(1_000 / (Math.max(remaining, 0) + 1));
@@ -77,10 +77,12 @@ function createLeaseProgressReporter(
   return (progress) => {
     const { message, progress: rawProgress } = leaseProgressParams(progress);
     lastProgress = Math.max(rawProgress, lastProgress + 1);
+    // Progress is advisory: a transport that went away mid-lease must not surface here as an
+    // unhandled rejection and take the server down with it.
     void sendNotification({
       method: "notifications/progress",
       params: { message, progress: lastProgress, progressToken, total: TOTAL_PROGRESS },
-    });
+    }).catch(() => undefined);
   };
 }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ProgressNotification } from "@modelcontextprotocol/sdk/types.js";
 
 import {
   leaseSimulatorInputSchema,
@@ -10,9 +11,78 @@ import {
   releaseSimulatorInputSchema,
   releaseSimulatorOutputSchema,
 } from "./contracts.js";
-import { McpSession, toMcpErrorResult } from "./session.js";
+import { McpSession, type LeaseProgressNotice, toMcpErrorResult } from "./session.js";
 
 const SERVER_INFO = { name: "pitlane", version: "1.0.0" };
+
+/**
+ * Progress is reported on a 3-stage scale (queued / provisioning-or-reclaiming / booting), each
+ * worth 1000 units, so a fresh stage's base always exceeds the previous stage's maximum.
+ */
+const STAGE_BASE_PROGRESS: Record<LeaseProgressNotice["stage"], number> = {
+  booting: 2_000,
+  provisioning: 1_000,
+  queued: 0,
+  reclaiming: 1_000,
+};
+const TOTAL_PROGRESS = 3_000;
+
+/** Maps a lease progress push onto an MCP progress notification's `params`. */
+function leaseProgressParams(progress: LeaseProgressNotice): {
+  readonly message: string;
+  readonly progress: number;
+} {
+  const base = STAGE_BASE_PROGRESS[progress.stage];
+  if (progress.stage === "queued") {
+    const position = Math.max(progress.queuePosition, 0);
+    return {
+      message:
+        position === 0
+          ? "Next in queue"
+          : `Queued behind ${position} other request${position === 1 ? "" : "s"}`,
+      progress: base + withinStageProgress(position),
+    };
+  }
+  const etaSeconds = Math.max(0, Math.ceil(progress.etaMs / 1_000));
+  const verb =
+    progress.stage === "provisioning"
+      ? "Provisioning"
+      : progress.stage === "booting"
+        ? "Booting"
+        : "Reclaiming";
+  return {
+    message: `${verb} device (~${etaSeconds}s remaining)`,
+    progress: base + withinStageProgress(etaSeconds),
+  };
+}
+
+/**
+ * Converges toward (but never reaches) 1000 as `remaining` (a queue position or an ETA in
+ * seconds) shrinks toward 0, so it never collides with the next stage's base.
+ */
+function withinStageProgress(remaining: number): number {
+  return Math.round(1_000 / (Math.max(remaining, 0) + 1));
+}
+
+/**
+ * Builds a per-lease-request `onProgress` callback that relays daemon progress as
+ * `notifications/progress`, clamping so the value MCP requires to increase monotonically never
+ * goes backwards even though queue position and ETAs can.
+ */
+function createLeaseProgressReporter(
+  progressToken: string | number,
+  sendNotification: (notification: ProgressNotification) => Promise<void>,
+): (progress: LeaseProgressNotice) => void {
+  let lastProgress = 0;
+  return (progress) => {
+    const { message, progress: rawProgress } = leaseProgressParams(progress);
+    lastProgress = Math.max(rawProgress, lastProgress + 1);
+    void sendNotification({
+      method: "notifications/progress",
+      params: { message, progress: lastProgress, progressToken, total: TOTAL_PROGRESS },
+    });
+  };
+}
 
 /** Creates the MCP tool surface for one lease-owning session. */
 export function createMcpServer(session: McpSession): McpServer {
@@ -29,7 +99,12 @@ export function createMcpServer(session: McpSession): McpServer {
     },
     async (input, extra) => {
       try {
-        const output = await session.lease(input, extra.signal);
+        const progressToken = extra._meta?.progressToken;
+        const onProgress =
+          progressToken === undefined
+            ? undefined
+            : createLeaseProgressReporter(progressToken, extra.sendNotification);
+        const output = await session.lease(input, extra.signal, onProgress);
         return success(output);
       } catch (error: unknown) {
         return failure(error);

--- a/src/mcp/session.test.ts
+++ b/src/mcp/session.test.ts
@@ -482,6 +482,160 @@ describe("McpSession", () => {
     connection.pushLeaseLost({ deviceId: "ABCD", leaseId: "lse_9f2c", reason: "expired" });
     expect(notices).toEqual([]);
   });
+
+  it("relays progress pushes to the in-flight lease request's onProgress callback", async () => {
+    const connection = new StubConnection();
+    const grant = deferred<unknown>();
+    connection.responses.push(grant.promise);
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+
+    const progressEvents: unknown[] = [];
+    const lease = session.lease(input, undefined, (progress) => progressEvents.push(progress));
+    await waitFor(() => connection.requests.length === 1);
+
+    connection.pushProgress({ queuePosition: 2, stage: "queued" });
+    connection.pushProgress({ etaMs: 9_000, stage: "provisioning" });
+
+    expect(progressEvents).toEqual([
+      { queuePosition: 2, stage: "queued" },
+      { etaMs: 9_000, stage: "provisioning" },
+    ]);
+
+    grant.resolve(rawGrant);
+    await lease;
+  });
+
+  it("does nothing when a lease request has no onProgress callback", async () => {
+    const connection = new StubConnection();
+    const grant = deferred<unknown>();
+    connection.responses.push(grant.promise);
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+
+    const lease = session.lease(input);
+    await waitFor(() => connection.requests.length === 1);
+    expect(() => connection.pushProgress({ queuePosition: 3, stage: "queued" })).not.toThrow();
+
+    grant.resolve(rawGrant);
+    await lease;
+  });
+
+  it("stops relaying progress once the lease request has settled", async () => {
+    const connection = new StubConnection();
+    connection.responses.push(rawGrant);
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+
+    const progressEvents: unknown[] = [];
+    await session.lease(input, undefined, (progress) => progressEvents.push(progress));
+    connection.pushProgress({ etaMs: 5_000, stage: "booting" });
+
+    expect(progressEvents).toEqual([]);
+  });
+
+  it("scopes the progress listener to one request: no leakage across sequential lease calls", async () => {
+    const connection = new StubConnection();
+    connection.responses.push(rawGrant, { leaseId: "lse_9f2c" });
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+
+    const firstProgress: unknown[] = [];
+    await session.lease(input, undefined, (progress) => firstProgress.push(progress));
+    await session.release({ lease_id: "lse_9f2c" });
+
+    const secondGrant = deferred<unknown>();
+    connection.responses.push(secondGrant.promise);
+    const secondProgress: unknown[] = [];
+    const secondLease = session.lease(input, undefined, (progress) =>
+      secondProgress.push(progress),
+    );
+    await waitFor(() => connection.requests.length === 3);
+
+    connection.pushProgress({ etaMs: 1_000, stage: "booting" });
+
+    expect(firstProgress).toEqual([]);
+    expect(secondProgress).toEqual([{ etaMs: 1_000, stage: "booting" }]);
+
+    secondGrant.resolve({ ...rawGrant, lease: { ...rawGrant.lease, id: "lse_second" } });
+    await secondLease;
+  });
+
+  it("stops relaying progress once a cancelled lease request tears down", async () => {
+    const connection = new StubConnection();
+    const grant = deferred<unknown>();
+    connection.responses.push(grant.promise);
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+    const controller = new AbortController();
+    const progressEvents: unknown[] = [];
+    const lease = session.lease(input, controller.signal, (progress) =>
+      progressEvents.push(progress),
+    );
+    await waitFor(() => connection.requests.length === 1);
+
+    controller.abort();
+    await expect(lease).rejects.toMatchObject({ code: "CANCELLED" });
+    connection.pushProgress({ etaMs: 1_000, stage: "booting" });
+
+    expect(progressEvents).toEqual([]);
+    grant.resolve(rawGrant);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  it("stops relaying progress once the session closes", async () => {
+    const connection = new StubConnection();
+    const grant = deferred<unknown>();
+    connection.responses.push(grant.promise);
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+
+    const progressEvents: unknown[] = [];
+    const lease = session.lease(input, undefined, (progress) => progressEvents.push(progress));
+    await waitFor(() => connection.requests.length === 1);
+
+    await session.close();
+    connection.pushProgress({ queuePosition: 1, stage: "queued" });
+
+    expect(progressEvents).toEqual([]);
+    await expect(lease).rejects.toMatchObject({ code: "SESSION_CLOSED" });
+    grant.resolve(rawGrant);
+  });
+
+  it("ignores malformed progress pushes without throwing", async () => {
+    const connection = new StubConnection();
+    const grant = deferred<unknown>();
+    connection.responses.push(grant.promise);
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+
+    const progressEvents: unknown[] = [];
+    const lease = session.lease(input, undefined, (progress) => progressEvents.push(progress));
+    await waitFor(() => connection.requests.length === 1);
+
+    expect(() => connection.pushProgress({ stage: "not-a-stage" })).not.toThrow();
+    expect(() => connection.pushProgress({ stage: "queued" })).not.toThrow();
+    expect(() => connection.pushProgress({ stage: "provisioning" })).not.toThrow();
+    expect(() => connection.pushProgress(null)).not.toThrow();
+
+    expect(progressEvents).toEqual([]);
+    grant.resolve(rawGrant);
+    await lease;
+  });
 });
 
 class StubConnection implements DaemonConnection {
@@ -508,6 +662,10 @@ class StubConnection implements DaemonConnection {
     readonly reason: string;
   }): void {
     for (const listener of this.#listeners) listener("lease-lost", payload);
+  }
+
+  pushProgress(payload: unknown): void {
+    for (const listener of this.#listeners) listener("progress", payload);
   }
 
   async close(): Promise<void> {

--- a/src/mcp/session.ts
+++ b/src/mcp/session.ts
@@ -2,7 +2,9 @@ import {
   parseRawCatalog,
   parseRawLeaseGrant,
   parseRawLeaseLost,
+  parseRawLeaseProgress,
   type RawLeaseGrant,
+  type RawLeaseProgress,
 } from "../daemon-client/contracts.js";
 import { DaemonClientError, type DaemonConnection } from "../daemon-client/protocol.js";
 import type {
@@ -38,6 +40,9 @@ export interface LeaseLostNotice {
   readonly leaseId: string;
   readonly reason: string;
 }
+
+/** Delivered to a `lease()` call's own `onProgress` callback while that request is in flight. */
+export type LeaseProgressNotice = RawLeaseProgress;
 
 interface OwnedLease {
   readonly device: string;
@@ -83,6 +88,8 @@ export class McpSession {
   #sessionClosed: Promise<never>;
   #ownedLease: OwnedLease | undefined;
   #pushUnsubscribe: (() => void) | undefined;
+  /** Scoped to the in-flight `lease()` call; cleared once that call settles or the session closes. */
+  #leaseProgressListener: ((progress: LeaseProgressNotice) => void) | undefined;
   readonly #leaseLostListeners = new Set<(notice: LeaseLostNotice) => void>();
   #mutations: Promise<void> = Promise.resolve();
 
@@ -95,10 +102,19 @@ export class McpSession {
     void this.#sessionClosed.catch(() => undefined);
   }
 
-  lease(input: LeaseSimulatorInput, signal?: AbortSignal): Promise<LeaseSimulatorOutput> {
+  /**
+   * `onProgress` is scoped to this call only: it receives queue/provisioning/boot updates for
+   * this request while it is in flight, and is torn down on completion, error, cancellation, or
+   * session close. It never leaks across sequential lease requests.
+   */
+  lease(
+    input: LeaseSimulatorInput,
+    signal?: AbortSignal,
+    onProgress?: (progress: LeaseProgressNotice) => void,
+  ): Promise<LeaseSimulatorOutput> {
     return this.#mutate(() => {
       this.#throwIfClosed();
-      return this.#lease(input, signal);
+      return this.#lease(input, signal, onProgress);
     });
   }
 
@@ -162,6 +178,7 @@ export class McpSession {
     if (this.#closePromise !== undefined) return this.#closePromise;
     this.#closed = true;
     this.#ownedLease = undefined;
+    this.#leaseProgressListener = undefined;
     this.#pushUnsubscribe?.();
     this.#pushUnsubscribe = undefined;
     this.#rejectClosed(new McpSessionError("SESSION_CLOSED", "MCP session is closed"));
@@ -177,10 +194,15 @@ export class McpSession {
     return this.#closePromise;
   }
 
-  async #lease(input: LeaseSimulatorInput, signal?: AbortSignal): Promise<LeaseSimulatorOutput> {
+  async #lease(
+    input: LeaseSimulatorInput,
+    signal?: AbortSignal,
+    onProgress?: (progress: LeaseProgressNotice) => void,
+  ): Promise<LeaseSimulatorOutput> {
     throwIfAborted(signal);
 
     const abortWatch = this.#watchLeaseAbort(signal);
+    this.#leaseProgressListener = onProgress;
     let responseReceived = false;
     try {
       const connection = await this.#connectionForUse();
@@ -192,6 +214,7 @@ export class McpSession {
       await this.#cleanupFailedLease(responseReceived, abortWatch.cleanup());
       throw error;
     } finally {
+      this.#leaseProgressListener = undefined;
       abortWatch.dispose();
     }
   }
@@ -308,8 +331,12 @@ export class McpSession {
     if (connection !== undefined) await this.#closeDaemonConnection(connection);
   }
 
-  /** Relays a daemon lease-lost push to this session's own listeners (e.g. an MCP logging notification). */
+  /** Relays a daemon push to this session's own listeners (lease-lost facts, in-flight lease progress). */
   #handlePush(kind: string, payload: unknown): void {
+    if (kind === "progress") {
+      this.#handleLeaseProgress(payload);
+      return;
+    }
     if (kind !== "lease-lost") return;
     let notice: LeaseLostNotice;
     try {
@@ -320,6 +347,18 @@ export class McpSession {
     if (this.#ownedLease === undefined || this.#ownedLease.leaseId !== notice.leaseId) return;
     this.#ownedLease = undefined;
     for (const listener of this.#leaseLostListeners) listener(notice);
+  }
+
+  /** Relays a daemon progress push to the in-flight `lease()` call's own `onProgress`, if any. */
+  #handleLeaseProgress(payload: unknown): void {
+    if (this.#leaseProgressListener === undefined) return;
+    let progress: LeaseProgressNotice;
+    try {
+      progress = parseRawLeaseProgress(payload);
+    } catch {
+      return;
+    }
+    this.#leaseProgressListener(progress);
   }
 
   async #closeDaemonConnection(connection: DaemonConnection): Promise<void> {


### PR DESCRIPTION
## What changed

- **`McpSession.lease()`** (`src/mcp/session.ts`) now accepts an optional third argument, `onProgress`, scoped strictly to that one call: it's set right before the daemon request and cleared in the same `finally` that already runs on success, error, cancellation, or session close — so it can never leak into a later sequential `lease()` call. `#handlePush` now branches on `kind === "progress"` (alongside the existing `"lease-lost"` handling) and relays the parsed payload to that listener, swallowing parse failures the same way the existing lease-lost path already does.
- **`parseRawLeaseProgress`** (`src/daemon-client/contracts.ts`): a new `parseRaw*` helper, matching the file's existing style, that validates the daemon's `{ push: "progress", payload }` frame into a `RawLeaseProgress` discriminated union (`queued` + `queuePosition`, or `provisioning` / `booting` / `reclaiming` + `etaMs`). Malformed payloads throw and are ignored by the session, never surfaced to the MCP client.
- **`lease_simulator` handler** (`src/mcp/server.ts`): reads `extra._meta?.progressToken`; when present, wires a reporter into `session.lease()` that maps each stage onto MCP `notifications/progress` via `extra.sendNotification`. When no token was supplied, `onProgress` is `undefined` and nothing changes versus today.
- **Progress mapping**: a 3-stage scale (`queued` / `provisioning`-or-`reclaiming` / `booting`, 1000 units each) with a small within-stage contribution from the queue position or ETA, so the value trends toward the next stage's base as the wait shortens. Every notification also carries a human-readable `message` (queue position, or "~Ns remaining"). Because a raw queue position or ETA can transiently move backwards (someone joins the queue ahead, an ETA re-estimates upward) but MCP requires `progress` to only increase within a token, the reporter tracks the last value sent and clamps to `lastSent + 1` when the raw computation wouldn't be strictly greater.
- README, `docs/CLI.md`, and `docs/ARCHITECTURE.md` updated to document progress reporting alongside the existing lease-lost notification docs.

## Why

Per issue #16: a cold provision can take up to ~90s (plus ~30s to boot), and the MCP session subscribed to nothing from the daemon's existing progress pushes — `DaemonServer` already streams `queued`/`provisioning`/`booting`/`reclaiming` scoped per `requesterId`, the CLI already consumes them for its stderr progress lines, but `lease_simulator` just hung silently until the daemon responded. This wires the existing daemon-side stream through to MCP clients that ask for it, with zero daemon changes.

## How I verified it

- `pnpm check` is green (typecheck, lint, format, `vitest run src`): 50 test files, 390 passed / 2 skipped.
- `pnpm fallow audit --base HEAD` (what the pre-commit hook actually runs) reports no issues in the 8 changed files.
- New tests:
  - `src/mcp/session.test.ts`: progress pushes are relayed to the in-flight `lease()` call's `onProgress`; a call made without `onProgress` doesn't throw when progress arrives; the listener stops firing once the request settles, once it's cancelled, and once the session closes; a second sequential `lease()` call's listener never receives anything meant for (or leftover from) the first; malformed progress payloads are ignored without throwing.
  - `src/mcp/server.test.ts`: a `lease_simulator` call with a progress token (via the MCP client's `onprogress` option) receives `notifications/progress` for `queued`/`provisioning`/`booting`/`reclaiming` with the expected messages, and the `progress` values are strictly increasing and unique; a call without a token receives no `notifications/progress` at all.

## Acceptance criteria (from the issue)

- [x] A lease request with a `progressToken` emits progress notifications for queued / provisioning / booting / reclaiming stages.
- [x] A request without a progress token behaves exactly as today.
- [x] Notifications stop on completion, on cancellation, and on session close; no listener leaks across sequential lease requests.
- [x] README MCP section mentions progress reporting.
- [x] `pnpm check` green.

## Notes / things I did not do

- No daemon-side changes, per the issue and per `docs/agent-rules/architecture.md` — progress pushes and their per-`requesterId` scoping already existed in `DaemonServer`/`WaitQueue`/`DeviceProvisioner`.
- No new business event and no `EVENTS.md` change — this is client-side relay of an existing push frame, not a new fact on the event bus.
- The numeric `progress` scale (0–3000 across 3 named stages) is my own design choice to satisfy MCP's "must increase" requirement honestly from the daemon's queue-position/ETA data; there's no daemon-side "percent complete" to relay directly, so if a different scale or unit is preferred I'm open to adjusting it.

Closes #16
