### PR TITLE
feat(doctor): detect foreign state changes on managed devices

### DIFF
--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -29,6 +29,7 @@ in short: `subject.past-tense-fact`, emitted post-commit, facts not commands.
 | `device.purge-failed` | device id, lease id, attempted strategy, duration, stable error summary | release-time purge failed after the resulting state committed; the first version may still reuse a readiness-checked device | WarmPoolCoordinator | implemented |
 | `device.shutdown` | device id, initiator (rule/command) | device stopped, still on disk | Registry; WarmPoolCoordinator for interrupted reclaim recovery | implemented |
 | `device.deleted` | device id, initiator | device removed from disk and registry | Registry | implemented |
+| `device.foreign-state-detected` | device id, platform, expected (running/stopped), observed (running/stopped) | doctor reconcile found a managed device's observed boot state disagreeing with the committed registry state | Doctor | implemented |
 | `runtime.deleted` | runtime id, initiator | runtime / system image GC'd | — | planned |
 
 ## System

--- a/src/bus/index.test.ts
+++ b/src/bus/index.test.ts
@@ -126,6 +126,7 @@ describe("EventBus", () => {
       | "device.purge-failed"
       | "device.shutdown"
       | "device.deleted"
+      | "device.foreign-state-detected"
       | "runtime.deleted"
       | "daemon.started"
       | "daemon.stopping"

--- a/src/bus/index.ts
+++ b/src/bus/index.ts
@@ -55,6 +55,12 @@ export interface EventMap {
   "daemon.started": { readonly version: string; readonly configSnapshot: unknown };
   "daemon.stopping": { readonly reason: string };
   "disk.pressure-detected": { readonly freeBytes: number; readonly threshold: number };
+  "device.foreign-state-detected": {
+    readonly deviceId: string;
+    readonly platform: string;
+    readonly expected: string;
+    readonly observed: string;
+  };
   "cleanup.executed": {
     readonly ruleName: string;
     readonly action: string;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -652,7 +652,9 @@ function formatStatus(status: Record<string, unknown>): string {
   });
   const deviceLines = devices.map((device) => {
     const record = requireObject(device);
-    return `Device ${String(record.id)}: ${String(record.state)}`;
+    const foreignStateMarker =
+      record.foreignStateDetectedAt === undefined ? "" : " (foreign state change)";
+    return `Device ${String(record.id)}: ${String(record.state)}${foreignStateMarker}`;
   });
   const leaseLines = leases.map((lease) => {
     const record = requireObject(lease);

--- a/src/core/doctor.test.ts
+++ b/src/core/doctor.test.ts
@@ -60,6 +60,100 @@ describe("Doctor", () => {
     expect(eventBus.replay().at(-1)).toMatchObject({ event: "doctor.reconciled" });
   });
 
+  it("reports but does not correct a leased-state device with no lease record", async () => {
+    const clock = new FakeClock(10_000);
+    const eventBus = new EventBus(clock);
+    const filesystem = new MemoryFilesystem();
+    await filesystem.writeFileAtomic(
+      "/state.json",
+      JSON.stringify({
+        devices: [
+          {
+            createdAt: 1,
+            driverData: { fakeDeviceId: "pitlane-stale" },
+            driverDeviceId: "pitlane-stale",
+            id: "dev_1",
+            spec: { model: "Phone", osVersion: "1", platform: "ios" },
+            state: "leased",
+          },
+        ],
+        leases: [],
+      }),
+    );
+    const registry = await Registry.load({
+      clock,
+      eventBus,
+      filesystem,
+      idGenerator: sequence(),
+      statePath: "/state.json",
+    });
+    const driver = new FakeDriver({ clock, platform: "ios" });
+    driver.setManagedReality({
+      devices: [
+        {
+          deviceId: "pitlane-stale",
+          driverData: { fakeDeviceId: "pitlane-stale" },
+          runState: "stopped",
+        },
+      ],
+      processes: [],
+    });
+
+    const report = await new Doctor({ clock, drivers: [driver], eventBus, registry }).reconcile({
+      fix: true,
+    });
+
+    expect(report.findings.map((finding) => finding.kind)).toContain("foreign-state-change");
+    expect(registry.snapshot.devices[0]?.state).toBe("leased");
+    expect(registry.snapshot.devices[0]?.foreignStateDetectedAt).toBe(10_000);
+  });
+
+  it("keeps the first-detected timestamp when drift persists across ticks", async () => {
+    const clock = new FakeClock(10_000);
+    const eventBus = new EventBus(clock);
+    const registry = await Registry.load({
+      clock,
+      eventBus,
+      filesystem: new MemoryFilesystem(),
+      idGenerator: sequence(),
+      statePath: "/state.json",
+    });
+    const device = await registry.registerDevice({
+      driverData: { fakeDeviceId: "pitlane-drift" },
+      driverDeviceId: "pitlane-drift",
+      provisionDuration: 0,
+      spec: { model: "Phone", osVersion: "1", platform: "ios" },
+    });
+    await registry.transitionDevice(device.id, "ready", {
+      event: "device.ready",
+      payload: { bootDuration: 0, deviceId: device.id },
+    });
+    await registry.createLease({
+      deviceId: device.id,
+      mode: "held",
+      requesterId: "agent",
+      ttlDeadline: 99_000,
+    });
+    const driver = new FakeDriver({ clock, platform: "ios" });
+    driver.setManagedReality({
+      devices: [
+        {
+          deviceId: "pitlane-drift",
+          driverData: { fakeDeviceId: "pitlane-drift" },
+          runState: "stopped",
+        },
+      ],
+      processes: [],
+    });
+    const doctor = new Doctor({ clock, drivers: [driver], eventBus, registry });
+
+    await doctor.reconcile();
+    clock.advance(60_000);
+    await doctor.reconcile();
+
+    expect(registry.snapshot.devices[0]?.foreignStateDetectedAt).toBe(10_000);
+  });
+
   it("fixes registry-attributable drift and leaves unregistered reality report-only", async () => {
     const clock = new FakeClock(10_000);
     const eventBus = new EventBus(clock);

--- a/src/core/doctor.test.ts
+++ b/src/core/doctor.test.ts
@@ -38,7 +38,13 @@ describe("Doctor", () => {
     });
     const driver = new FakeDriver({ clock, platform: "ios" });
     driver.setManagedReality({
-      devices: [{ deviceId: "pitlane-orphan", driverData: { fakeDeviceId: "pitlane-orphan" } }],
+      devices: [
+        {
+          deviceId: "pitlane-orphan",
+          driverData: { fakeDeviceId: "pitlane-orphan" },
+          runState: "running",
+        },
+      ],
       processes: [{ deviceId: "pitlane-process", driverData: { fakeDeviceId: "pitlane-process" } }],
     });
 
@@ -76,7 +82,13 @@ describe("Doctor", () => {
     });
     const driver = new FakeDriver({ clock, platform: "ios" });
     driver.setManagedReality({
-      devices: [{ deviceId: "pitlane-orphan", driverData: { fakeDeviceId: "pitlane-orphan" } }],
+      devices: [
+        {
+          deviceId: "pitlane-orphan",
+          driverData: { fakeDeviceId: "pitlane-orphan" },
+          runState: "running",
+        },
+      ],
       processes: [{ deviceId: "pitlane-process", driverData: { fakeDeviceId: "pitlane-process" } }],
     });
     const doctor = new Doctor({ clock, drivers: [driver], eventBus, registry });
@@ -130,7 +142,7 @@ describe("Doctor", () => {
     });
     const driver = new FakeDriver({ clock, platform: "ios" });
     driver.setManagedReality({
-      devices: [{ deviceId: "live", driverData: { fakeDeviceId: "live" } }],
+      devices: [{ deviceId: "live", driverData: { fakeDeviceId: "live" }, runState: "running" }],
       processes: [],
     });
     const leaseEngine = new LeaseEngine({
@@ -154,7 +166,340 @@ describe("Doctor", () => {
     expect(registry.snapshot.leases).toEqual([]);
     expect(eventBus.replay()).toContainEqual(expect.objectContaining({ event: "lease.expired" }));
   });
+
+  it("reports foreign-state-change for a device booted outside Pitlane, on both platforms", async () => {
+    const clock = new FakeClock(10_000);
+    const eventBus = new EventBus(clock);
+    const registry = await Registry.load({
+      clock,
+      eventBus,
+      filesystem: new MemoryFilesystem(),
+      idGenerator: sequence(),
+      statePath: "/state.json",
+    });
+    const iosDevice = await shutdownDevice(registry, "pitlane-ios-1", "ios");
+    const androidDevice = await shutdownDevice(registry, "pitlane_android-1", "android");
+
+    const iosDriver = new FakeDriver({ clock, platform: "ios" });
+    iosDriver.setManagedReality({
+      devices: [{ deviceId: "pitlane-ios-1", driverData: {}, runState: "running" }],
+      processes: [],
+    });
+    const androidDriver = new FakeDriver({ clock, platform: "android" });
+    androidDriver.setManagedReality({
+      devices: [{ deviceId: "pitlane_android-1", driverData: {}, runState: "running" }],
+      processes: [],
+    });
+
+    const report = await new Doctor({
+      clock,
+      drivers: [iosDriver, androidDriver],
+      eventBus,
+      registry,
+    }).reconcile();
+
+    expect(report.findings.filter((finding) => finding.kind === "foreign-state-change")).toEqual([
+      {
+        deviceId: iosDevice.id,
+        expected: "stopped",
+        kind: "foreign-state-change",
+        observed: "running",
+        platform: "ios",
+      },
+      {
+        deviceId: androidDevice.id,
+        expected: "stopped",
+        kind: "foreign-state-change",
+        observed: "running",
+        platform: "android",
+      },
+    ]);
+  });
+
+  it("reports foreign-state-change for a device shut down outside Pitlane, on both platforms", async () => {
+    const clock = new FakeClock(10_000);
+    const eventBus = new EventBus(clock);
+    const registry = await Registry.load({
+      clock,
+      eventBus,
+      filesystem: new MemoryFilesystem(),
+      idGenerator: sequence(),
+      statePath: "/state.json",
+    });
+    const iosDevice = await readyDevice(registry, "pitlane-ios-2", "ios");
+    const androidDevice = await readyDevice(registry, "pitlane_android-2", "android");
+
+    const iosDriver = new FakeDriver({ clock, platform: "ios" });
+    iosDriver.setManagedReality({
+      devices: [{ deviceId: "pitlane-ios-2", driverData: {}, runState: "stopped" }],
+      processes: [],
+    });
+    const androidDriver = new FakeDriver({ clock, platform: "android" });
+    androidDriver.setManagedReality({
+      devices: [{ deviceId: "pitlane_android-2", driverData: {}, runState: "stopped" }],
+      processes: [],
+    });
+
+    const report = await new Doctor({
+      clock,
+      drivers: [iosDriver, androidDriver],
+      eventBus,
+      registry,
+    }).reconcile();
+
+    expect(report.findings.filter((finding) => finding.kind === "foreign-state-change")).toEqual([
+      {
+        deviceId: iosDevice.id,
+        expected: "running",
+        kind: "foreign-state-change",
+        observed: "stopped",
+        platform: "ios",
+      },
+      {
+        deviceId: androidDevice.id,
+        expected: "running",
+        kind: "foreign-state-change",
+        observed: "stopped",
+        platform: "android",
+      },
+    ]);
+  });
+
+  it("never reports drift when the observed state is transitioning", async () => {
+    const clock = new FakeClock(10_000);
+    const eventBus = new EventBus(clock);
+    const registry = await Registry.load({
+      clock,
+      eventBus,
+      filesystem: new MemoryFilesystem(),
+      idGenerator: sequence(),
+      statePath: "/state.json",
+    });
+    await readyDevice(registry, "pitlane-transition", "ios");
+
+    const driver = new FakeDriver({ clock, platform: "ios" });
+    driver.setManagedReality({
+      devices: [{ deviceId: "pitlane-transition", driverData: {}, runState: "transitioning" }],
+      processes: [],
+    });
+
+    const report = await new Doctor({ clock, drivers: [driver], eventBus, registry }).reconcile();
+
+    expect(report.findings.filter((finding) => finding.kind === "foreign-state-change")).toEqual(
+      [],
+    );
+  });
+
+  it("never reports drift for provisioning or reclaiming registry devices", async () => {
+    const clock = new FakeClock(10_000);
+    const eventBus = new EventBus(clock);
+    const registry = await Registry.load({
+      clock,
+      eventBus,
+      filesystem: new MemoryFilesystem(),
+      idGenerator: sequence(),
+      statePath: "/state.json",
+    });
+    await registry.registerDevice({
+      driverData: {},
+      driverDeviceId: "pitlane-provisioning",
+      provisionDuration: 0,
+      spec: { model: "Phone", osVersion: "1", platform: "ios" },
+    });
+    const reclaiming = await readyDevice(registry, "pitlane-reclaiming", "ios");
+    const lease = await registry.createLease({
+      deviceId: reclaiming.id,
+      mode: "held",
+      requesterId: "agent",
+      ttlDeadline: 999_999,
+    });
+    await registry.beginRelease(lease.id);
+
+    const driver = new FakeDriver({ clock, platform: "ios" });
+    driver.setManagedReality({
+      devices: [
+        { deviceId: "pitlane-provisioning", driverData: {}, runState: "stopped" },
+        { deviceId: "pitlane-reclaiming", driverData: {}, runState: "stopped" },
+      ],
+      processes: [],
+    });
+
+    const report = await new Doctor({ clock, drivers: [driver], eventBus, registry }).reconcile();
+
+    expect(report.findings.filter((finding) => finding.kind === "foreign-state-change")).toEqual(
+      [],
+    );
+  });
+
+  it("--fix reconciles an unleased device's state to observed reality in both directions", async () => {
+    const clock = new FakeClock(10_000);
+    const eventBus = new EventBus(clock);
+    const registry = await Registry.load({
+      clock,
+      eventBus,
+      filesystem: new MemoryFilesystem(),
+      idGenerator: sequence(),
+      statePath: "/state.json",
+    });
+    const bootedOutside = await shutdownDevice(registry, "pitlane-booted", "ios");
+    const shutdownOutside = await readyDevice(registry, "pitlane-shutdown", "ios");
+
+    const driver = new FakeDriver({ clock, platform: "ios" });
+    driver.setManagedReality({
+      devices: [
+        { deviceId: "pitlane-booted", driverData: {}, runState: "running" },
+        { deviceId: "pitlane-shutdown", driverData: {}, runState: "stopped" },
+      ],
+      processes: [],
+    });
+
+    await new Doctor({ clock, drivers: [driver], eventBus, registry }).reconcile({ fix: true });
+
+    const snapshot = registry.snapshot;
+    const booted = snapshot.devices.find((device) => device.id === bootedOutside.id);
+    const shutdown = snapshot.devices.find((device) => device.id === shutdownOutside.id);
+    expect(booted?.state).toBe("ready");
+    expect(booted?.foreignStateDetectedAt).toBeUndefined();
+    expect(shutdown?.state).toBe("shutdown");
+    expect(shutdown?.foreignStateDetectedAt).toBeUndefined();
+  });
+
+  it("--fix leaves a leased device untouched while still reporting the finding", async () => {
+    const clock = new FakeClock(10_000);
+    const eventBus = new EventBus(clock);
+    const registry = await Registry.load({
+      clock,
+      eventBus,
+      filesystem: new MemoryFilesystem(),
+      idGenerator: sequence(),
+      statePath: "/state.json",
+    });
+    const device = await readyDevice(registry, "pitlane-leased", "ios");
+    await registry.createLease({
+      deviceId: device.id,
+      mode: "held",
+      requesterId: "agent",
+      ttlDeadline: 999_999,
+    });
+
+    const driver = new FakeDriver({ clock, platform: "ios" });
+    driver.setManagedReality({
+      devices: [{ deviceId: "pitlane-leased", driverData: {}, runState: "stopped" }],
+      processes: [],
+    });
+
+    const report = await new Doctor({ clock, drivers: [driver], eventBus, registry }).reconcile({
+      fix: true,
+    });
+
+    expect(report.findings.filter((finding) => finding.kind === "foreign-state-change")).toEqual([
+      {
+        deviceId: device.id,
+        expected: "running",
+        kind: "foreign-state-change",
+        observed: "stopped",
+        platform: "ios",
+      },
+    ]);
+    const snapshot = registry.snapshot;
+    const stillLeased = snapshot.devices.find((candidate) => candidate.id === device.id);
+    expect(stillLeased?.state).toBe("leased");
+    expect(stillLeased?.foreignStateDetectedAt).toBeDefined();
+  });
+
+  it("emits device.foreign-state-detected once per finding, post-commit", async () => {
+    const clock = new FakeClock(10_000);
+    const eventBus = new EventBus(clock);
+    const registry = await Registry.load({
+      clock,
+      eventBus,
+      filesystem: new MemoryFilesystem(),
+      idGenerator: sequence(),
+      statePath: "/state.json",
+    });
+    const bootedOutside = await shutdownDevice(registry, "pitlane-booted", "ios");
+    const shutdownOutside = await readyDevice(registry, "pitlane-shutdown", "ios");
+
+    const driver = new FakeDriver({ clock, platform: "ios" });
+    driver.setManagedReality({
+      devices: [
+        { deviceId: "pitlane-booted", driverData: {}, runState: "running" },
+        { deviceId: "pitlane-shutdown", driverData: {}, runState: "stopped" },
+      ],
+      processes: [],
+    });
+
+    await new Doctor({ clock, drivers: [driver], eventBus, registry }).reconcile({ fix: true });
+
+    const events = eventBus.replay();
+    const foreignStateEvents = events.filter(
+      (event) => event.event === "device.foreign-state-detected",
+    );
+    expect(foreignStateEvents).toHaveLength(2);
+    expect(foreignStateEvents).toEqual([
+      expect.objectContaining({
+        payload: {
+          deviceId: bootedOutside.id,
+          expected: "stopped",
+          observed: "running",
+          platform: "ios",
+        },
+      }),
+      expect.objectContaining({
+        payload: {
+          deviceId: shutdownOutside.id,
+          expected: "running",
+          observed: "stopped",
+          platform: "ios",
+        },
+      }),
+    ]);
+
+    // Post-commit: the registry mutations that resolved the drift are already committed
+    // by the time the fact is published, and doctor.reconciled is the final event.
+    const commitEvents = events.filter(
+      (event) => event.event === "device.ready" || event.event === "device.shutdown",
+    );
+    const lastCommitSeq = Math.max(...commitEvents.map((event) => event.seq));
+    const firstForeignStateSeq = Math.min(...foreignStateEvents.map((event) => event.seq));
+    expect(firstForeignStateSeq).toBeGreaterThan(lastCommitSeq);
+    expect(events.at(-1)?.event).toBe("doctor.reconciled");
+  });
 });
+
+async function readyDevice(
+  registry: Registry,
+  driverDeviceId: string,
+  platform: "ios" | "android",
+) {
+  const device = await registry.registerDevice({
+    driverData: {},
+    driverDeviceId,
+    provisionDuration: 0,
+    spec: { model: "Phone", osVersion: "1", platform },
+  });
+  await registry.transitionDevice(device.id, "ready", {
+    event: "device.ready",
+    payload: { bootDuration: 0, deviceId: device.id },
+  });
+  return registry.snapshot.devices.find((candidate) => candidate.id === device.id)!;
+}
+
+async function shutdownDevice(
+  registry: Registry,
+  driverDeviceId: string,
+  platform: "ios" | "android",
+) {
+  await readyDevice(registry, driverDeviceId, platform);
+  const device = registry.snapshot.devices.find(
+    (candidate) => candidate.driverDeviceId === driverDeviceId,
+  )!;
+  await registry.transitionDevice(device.id, "shutdown", {
+    event: "device.shutdown",
+    payload: { deviceId: device.id, initiator: "test" },
+  });
+  return registry.snapshot.devices.find((candidate) => candidate.id === device.id)!;
+}
 
 function sequence() {
   let next = 1;

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -1,7 +1,7 @@
 import type { EventBus } from "../bus/index.js";
 import type { Clock } from "../ports/index.js";
-import type { Platform } from "./domain.js";
-import type { Driver, DriverDevice } from "./driver.js";
+import type { DeviceRecord, DeviceState, Platform } from "./domain.js";
+import type { Driver, DriverDevice, ObservedDevice } from "./driver.js";
 import type { LeaseExpirer } from "./lease-ports.js";
 import type { Registry } from "./registry.js";
 
@@ -13,7 +13,14 @@ export type DoctorFinding =
     }
   | { readonly kind: "orphan-device"; readonly device: DriverDevice; readonly platform: Platform }
   | { readonly kind: "orphan-process"; readonly device: DriverDevice; readonly platform: Platform }
-  | { readonly kind: "expired-live-lease"; readonly leaseId: string; readonly deviceId: string };
+  | { readonly kind: "expired-live-lease"; readonly leaseId: string; readonly deviceId: string }
+  | {
+      readonly kind: "foreign-state-change";
+      readonly deviceId: string;
+      readonly platform: Platform;
+      readonly expected: "running" | "stopped";
+      readonly observed: "running" | "stopped";
+    };
 
 export interface DoctorReport {
   readonly findings: readonly DoctorFinding[];
@@ -44,75 +51,201 @@ export class Doctor {
         reality.devices.map((device) => key(driver.platform, device.deviceId)),
       ),
     );
+    const observedDevices = new Map<string, ObservedDevice>(
+      realities.flatMap(({ driver, reality }) =>
+        reality.devices.map((device) => [key(driver.platform, device.deviceId), device] as const),
+      ),
+    );
     const registryDeviceKeys = new Set(
       snapshot.devices.map((device) => key(device.spec.platform, device.driverDeviceId)),
     );
     const findings: DoctorFinding[] = [];
 
     for (const device of snapshot.devices) {
-      if (
-        device.state !== "deleted" &&
-        !realDeviceKeys.has(key(device.spec.platform, device.driverDeviceId))
-      ) {
-        findings.push({
-          deviceId: device.id,
-          kind: "registry-device-missing",
-          platform: device.spec.platform,
-        });
+      const deviceFindings = registryDriftFindings(device, realDeviceKeys, observedDevices);
+      findings.push(...deviceFindings);
+      if (deviceFindings.some((finding) => finding.kind === "foreign-state-change")) {
+        await this.options.registry.markForeignStateDetected(device.id, this.options.clock.now());
       }
     }
-    for (const { driver, reality } of realities) {
-      for (const device of reality.devices) {
-        if (!registryDeviceKeys.has(key(driver.platform, device.deviceId))) {
-          findings.push({ device, kind: "orphan-device", platform: driver.platform });
-        }
-      }
-      for (const device of reality.processes) {
-        if (!registryDeviceKeys.has(key(driver.platform, device.deviceId))) {
-          findings.push({ device, kind: "orphan-process", platform: driver.platform });
-        }
-      }
-    }
-    for (const lease of snapshot.leases) {
-      if (lease.ttlDeadline <= this.options.clock.now()) {
-        findings.push({ deviceId: lease.deviceId, kind: "expired-live-lease", leaseId: lease.id });
-      }
-    }
+    findings.push(...orphanFindings(realities, registryDeviceKeys));
+    findings.push(...expiredLeaseFindings(snapshot.leases, this.options.clock.now()));
 
     const report = { findings };
     if (fix) {
       await this.#applySafeFixes(findings);
     }
+    this.#emitForeignStateEvents(findings);
     this.options.eventBus.emit("doctor.reconciled", { driftFindings: findings }, "doctor");
     return report;
+  }
+
+  #emitForeignStateEvents(findings: readonly DoctorFinding[]): void {
+    for (const finding of findings) {
+      if (finding.kind !== "foreign-state-change") continue;
+      this.options.eventBus.emit(
+        "device.foreign-state-detected",
+        {
+          deviceId: finding.deviceId,
+          expected: finding.expected,
+          observed: finding.observed,
+          platform: finding.platform,
+        },
+        "doctor",
+      );
+    }
   }
 
   async #applySafeFixes(findings: readonly DoctorFinding[]): Promise<void> {
     for (const finding of findings) {
       switch (finding.kind) {
-        case "registry-device-missing": {
-          const snapshot = this.options.registry.snapshot;
-          if (snapshot.leases.some((lease) => lease.deviceId === finding.deviceId)) {
-            continue;
-          }
-          const device = snapshot.devices.find((candidate) => candidate.id === finding.deviceId);
-          if (device !== undefined && device.state !== "deleted") {
-            await this.options.registry.markDeviceMissing(finding.deviceId, "doctor");
-          }
+        case "registry-device-missing":
+          await this.#fixMissingDevice(finding.deviceId);
           break;
-        }
         case "orphan-device":
-        case "orphan-process": {
+        case "orphan-process":
           // Registry-only destruction: unregistered reality is report-only.
           break;
-        }
         case "expired-live-lease":
           if (this.options.leaseExpirer !== undefined) {
             await this.options.leaseExpirer.expire(finding.leaseId);
           }
           break;
+        case "foreign-state-change":
+          await this.#fixForeignStateChange(finding);
+          break;
       }
     }
+  }
+
+  async #fixMissingDevice(deviceId: string): Promise<void> {
+    const snapshot = this.options.registry.snapshot;
+    if (snapshot.leases.some((lease) => lease.deviceId === deviceId)) {
+      return;
+    }
+    const device = snapshot.devices.find((candidate) => candidate.id === deviceId);
+    if (device !== undefined && device.state !== "deleted") {
+      await this.options.registry.markDeviceMissing(deviceId, "doctor");
+    }
+  }
+
+  async #fixForeignStateChange(
+    finding: Extract<DoctorFinding, { readonly kind: "foreign-state-change" }>,
+  ): Promise<void> {
+    const snapshot = this.options.registry.snapshot;
+    if (snapshot.leases.some((lease) => lease.deviceId === finding.deviceId)) {
+      return;
+    }
+    const device = snapshot.devices.find((candidate) => candidate.id === finding.deviceId);
+    if (device === undefined) {
+      return;
+    }
+    if (finding.expected === "running" && finding.observed === "stopped") {
+      await this.options.registry.transitionDevice(finding.deviceId, "shutdown", {
+        event: "device.shutdown",
+        payload: { deviceId: finding.deviceId, initiator: "doctor" },
+      });
+    } else if (finding.expected === "stopped" && finding.observed === "running") {
+      await this.options.registry.transitionDevice(finding.deviceId, "ready", {
+        event: "device.ready",
+        payload: { bootDuration: 0, deviceId: finding.deviceId },
+      });
+    }
+    await this.options.registry.clearForeignStateDetected(finding.deviceId);
+  }
+}
+
+/** Existence and boot-state drift for a single registry device against observed reality. */
+function registryDriftFindings(
+  device: DeviceRecord,
+  realDeviceKeys: ReadonlySet<string>,
+  observedDevices: ReadonlyMap<string, ObservedDevice>,
+): DoctorFinding[] {
+  const findings: DoctorFinding[] = [];
+  const deviceKey = key(device.spec.platform, device.driverDeviceId);
+
+  if (device.state !== "deleted" && !realDeviceKeys.has(deviceKey)) {
+    findings.push({
+      deviceId: device.id,
+      kind: "registry-device-missing",
+      platform: device.spec.platform,
+    });
+  }
+
+  const expected = expectedRunState(device.state);
+  const observed = expected === undefined ? undefined : observedDevices.get(deviceKey);
+  if (
+    expected !== undefined &&
+    observed !== undefined &&
+    observed.runState !== "transitioning" &&
+    observed.runState !== expected
+  ) {
+    findings.push({
+      deviceId: device.id,
+      expected,
+      kind: "foreign-state-change",
+      observed: observed.runState,
+      platform: device.spec.platform,
+    });
+  }
+
+  return findings;
+}
+
+function orphanFindings(
+  realities: readonly {
+    readonly driver: Driver;
+    readonly reality: {
+      readonly devices: readonly DriverDevice[];
+      readonly processes: readonly DriverDevice[];
+    };
+  }[],
+  registryDeviceKeys: ReadonlySet<string>,
+): DoctorFinding[] {
+  const findings: DoctorFinding[] = [];
+  for (const { driver, reality } of realities) {
+    for (const device of reality.devices) {
+      if (!registryDeviceKeys.has(key(driver.platform, device.deviceId))) {
+        findings.push({ device, kind: "orphan-device", platform: driver.platform });
+      }
+    }
+    for (const device of reality.processes) {
+      if (!registryDeviceKeys.has(key(driver.platform, device.deviceId))) {
+        findings.push({ device, kind: "orphan-process", platform: driver.platform });
+      }
+    }
+  }
+  return findings;
+}
+
+function expiredLeaseFindings(
+  leases: readonly {
+    readonly id: string;
+    readonly deviceId: string;
+    readonly ttlDeadline: number;
+  }[],
+  now: number,
+): DoctorFinding[] {
+  return leases
+    .filter((lease) => lease.ttlDeadline <= now)
+    .map((lease) => ({
+      deviceId: lease.deviceId,
+      kind: "expired-live-lease" as const,
+      leaseId: lease.id,
+    }));
+}
+
+function expectedRunState(state: DeviceState): "running" | "stopped" | undefined {
+  switch (state) {
+    case "ready":
+    case "leased":
+      return "running";
+    case "shutdown":
+      return "stopped";
+    case "provisioning":
+    case "reclaiming":
+    case "deleted":
+      return undefined;
   }
 }
 

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -140,16 +140,22 @@ export class Doctor {
     if (device === undefined) {
       return;
     }
-    if (finding.expected === "running" && finding.observed === "stopped") {
+    // Only `ready` and `shutdown` have a legal transition to the opposite run state. A
+    // device recorded as `leased` with no lease record reaches here past the lease guard
+    // above; correcting it would throw IllegalTransition and abort the whole reconcile,
+    // so leave it to the report rather than crashing the reaper tick.
+    if (device.state === "ready" && finding.observed === "stopped") {
       await this.options.registry.transitionDevice(finding.deviceId, "shutdown", {
         event: "device.shutdown",
         payload: { deviceId: finding.deviceId, initiator: "doctor" },
       });
-    } else if (finding.expected === "stopped" && finding.observed === "running") {
+    } else if (device.state === "shutdown" && finding.observed === "running") {
       await this.options.registry.transitionDevice(finding.deviceId, "ready", {
         event: "device.ready",
         payload: { bootDuration: 0, deviceId: finding.deviceId },
       });
+    } else {
+      return;
     }
     await this.options.registry.clearForeignStateDetected(finding.deviceId);
   }

--- a/src/core/domain.ts
+++ b/src/core/domain.ts
@@ -22,6 +22,7 @@ export interface DeviceRecord {
   readonly driverData: unknown;
   readonly createdAt: number;
   readonly lastLeaseEndedAt?: number;
+  readonly foreignStateDetectedAt?: number;
 }
 
 export interface LeaseRecord {

--- a/src/core/driver.ts
+++ b/src/core/driver.ts
@@ -11,10 +11,22 @@ export interface DriverDevice {
   readonly driverData: unknown;
 }
 
+/**
+ * Observed boot state of a managed device. `transitioning` covers states a
+ * driver cannot settle into `running` or `stopped` yet -- simulators report
+ * `Booting` / `Shutting Down`, emulators appear `offline` in `adb devices`
+ * before they answer `getprop` -- and must never produce a drift finding.
+ */
+export type ObservedRunState = "running" | "stopped" | "transitioning";
+
+export interface ObservedDevice extends DriverDevice {
+  readonly runState: ObservedRunState;
+}
+
 /** Reality observable by a driver without trusting the registry. */
 export interface DriverReality {
   /** Devices whose platform-owned name proves that Pitlane created them. */
-  readonly devices: readonly DriverDevice[];
+  readonly devices: readonly ObservedDevice[];
   /** Running, Pitlane-attributable device processes not necessarily in the registry. */
   readonly processes: readonly DriverDevice[];
 }

--- a/src/core/fake-driver.ts
+++ b/src/core/fake-driver.ts
@@ -5,6 +5,8 @@ import {
   type Driver,
   type DriverCatalogEntry,
   type DriverDevice,
+  type DriverReality,
+  type ObservedRunState,
   RuntimeMissingError,
   UnknownModelError,
 } from "./driver.js";
@@ -60,9 +62,7 @@ export class FakeDriver implements Driver {
   readonly #reclaimResult: "ready" | "shutdown";
   readonly #reclaimStrategy: "erase" | "snapshot" | "wipe";
   readonly #devices = new Map<string, "provisioned" | "ready" | "shutdown">();
-  #managedReality:
-    | { readonly devices: readonly DriverDevice[]; readonly processes: readonly DriverDevice[] }
-    | undefined;
+  #managedReality: DriverReality | undefined;
 
   constructor(options: FakeDriverOptions) {
     this.#availableOsVersions = new Set(options.availableOsVersions ?? ["latest"]);
@@ -162,18 +162,16 @@ export class FakeDriver implements Driver {
     this.#managedReality = removeManagedDevice(this.#managedReality, device.deviceId);
   }
 
-  async listManaged(): Promise<{
-    readonly devices: readonly DriverDevice[];
-    readonly processes: readonly DriverDevice[];
-  }> {
+  async listManaged(): Promise<DriverReality> {
     await this.#beforeCall("listManaged");
     if (this.#managedReality !== undefined) {
       return cloneReality(this.#managedReality);
     }
     return {
-      devices: [...this.#devices.keys()].map((deviceId) => ({
+      devices: [...this.#devices.entries()].map(([deviceId, status]) => ({
         deviceId,
         driverData: { fakeDeviceId: deviceId },
+        runState: runStateFor(status),
       })),
       processes: [],
     };
@@ -208,17 +206,19 @@ export class FakeDriver implements Driver {
     }
   }
 
-  setManagedReality(reality: {
-    readonly devices: readonly DriverDevice[];
-    readonly processes: readonly DriverDevice[];
-  }): void {
+  setManagedReality(reality: DriverReality): void {
     const managed = {
       devices: reality.devices.filter(isPitlaneManaged),
       processes: reality.processes.filter(isPitlaneManaged),
     };
     this.#managedReality = cloneReality(managed);
-    for (const device of [...reality.devices, ...reality.processes]) {
-      this.#devices.set(device.deviceId, "shutdown");
+    for (const device of reality.devices) {
+      this.#devices.set(device.deviceId, statusFor(device.runState));
+    }
+    for (const device of reality.processes) {
+      if (!this.#devices.has(device.deviceId)) {
+        this.#devices.set(device.deviceId, "ready");
+      }
     }
   }
 
@@ -261,10 +261,29 @@ function isPitlaneManaged(device: DriverDevice): boolean {
   return device.deviceId.startsWith("pitlane-") || device.deviceId.startsWith("pitlane_");
 }
 
-function cloneReality(reality: {
-  readonly devices: readonly DriverDevice[];
-  readonly processes: readonly DriverDevice[];
-}): { readonly devices: readonly DriverDevice[]; readonly processes: readonly DriverDevice[] } {
+function runStateFor(status: "provisioned" | "ready" | "shutdown"): ObservedRunState {
+  switch (status) {
+    case "ready":
+      return "running";
+    case "shutdown":
+      return "stopped";
+    case "provisioned":
+      return "transitioning";
+  }
+}
+
+function statusFor(runState: ObservedRunState): "provisioned" | "ready" | "shutdown" {
+  switch (runState) {
+    case "running":
+      return "ready";
+    case "stopped":
+      return "shutdown";
+    case "transitioning":
+      return "provisioned";
+  }
+}
+
+function cloneReality(reality: DriverReality): DriverReality {
   return {
     devices: reality.devices.map((device) => ({ ...device })),
     processes: reality.processes.map((device) => ({ ...device })),
@@ -272,25 +291,17 @@ function cloneReality(reality: {
 }
 
 function removeManagedDevice(
-  reality:
-    | { readonly devices: readonly DriverDevice[]; readonly processes: readonly DriverDevice[] }
-    | undefined,
+  reality: DriverReality | undefined,
   deviceId: string,
-):
-  | { readonly devices: readonly DriverDevice[]; readonly processes: readonly DriverDevice[] }
-  | undefined {
+): DriverReality | undefined {
   if (reality === undefined) return undefined;
   return { ...reality, devices: reality.devices.filter((device) => device.deviceId !== deviceId) };
 }
 
 function removeManagedProcess(
-  reality:
-    | { readonly devices: readonly DriverDevice[]; readonly processes: readonly DriverDevice[] }
-    | undefined,
+  reality: DriverReality | undefined,
   deviceId: string,
-):
-  | { readonly devices: readonly DriverDevice[]; readonly processes: readonly DriverDevice[] }
-  | undefined {
+): DriverReality | undefined {
   if (reality === undefined) return undefined;
   return {
     ...reality,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -16,6 +16,9 @@ export {
   type DriverCatalogEntry,
   DriverCrashError,
   type DriverDevice,
+  type DriverReality,
+  type ObservedDevice,
+  type ObservedRunState,
   RuntimeMissingError,
   UnknownModelError,
 } from "./driver.js";

--- a/src/core/nuke.test.ts
+++ b/src/core/nuke.test.ts
@@ -22,8 +22,8 @@ describe("Nuke", () => {
     const driver = new FakeDriver({ clock, platform: "ios" });
     driver.setManagedReality({
       devices: [
-        { deviceId: "managed", driverData: { fakeDeviceId: "managed" } },
-        { deviceId: "foreign", driverData: { fakeDeviceId: "foreign" } },
+        { deviceId: "managed", driverData: { fakeDeviceId: "managed" }, runState: "running" },
+        { deviceId: "foreign", driverData: { fakeDeviceId: "foreign" }, runState: "running" },
       ],
       processes: [],
     });

--- a/src/core/registry.ts
+++ b/src/core/registry.ts
@@ -186,6 +186,11 @@ export class Registry {
   /** Flags a device whose observed boot state disagrees with the committed registry state. */
   async markForeignStateDetected(deviceId: string, at: number): Promise<DeviceRecord> {
     const { device, index } = this.#requireDeviceRecord(deviceId);
+    // Doctor re-reports persistent drift on every reaper tick; keep the first-detected
+    // timestamp and skip the commit so a flagged device stops rewriting state.json.
+    if (device.foreignStateDetectedAt !== undefined) {
+      return cloneDevice(device);
+    }
     const updated = { ...device, foreignStateDetectedAt: at };
     const devices = [...this.#devices];
     devices[index] = updated;

--- a/src/core/registry.ts
+++ b/src/core/registry.ts
@@ -142,15 +142,7 @@ export class Registry {
     to: DeviceState,
     event?: RegistryDeviceEvent,
   ): Promise<DeviceRecord> {
-    const index = this.#devices.findIndex((device) => device.id === deviceId);
-    if (index === -1) {
-      throw new UnknownDeviceError(deviceId);
-    }
-
-    const device = this.#devices[index];
-    if (device === undefined) {
-      throw new UnknownDeviceError(deviceId);
-    }
+    const { device, index } = this.#requireDeviceRecord(deviceId);
     if (to === "deleted" && this.#leases.some((lease) => lease.deviceId === deviceId)) {
       throw new RegistryEventError(`Cannot delete device with an active lease: ${deviceId}`);
     }
@@ -178,10 +170,9 @@ export class Registry {
   }
 
   /** Commits accepted first-version purge-failure disposition without a success fact. */
+  // fallow-ignore-next-line unused-class-member -- called through WarmPoolCoordinator's registry port.
   async completeFailedPurge(deviceId: string, to: "ready" | "shutdown"): Promise<DeviceRecord> {
-    const index = this.#devices.findIndex((device) => device.id === deviceId);
-    const device = this.#devices[index];
-    if (index === -1 || device === undefined) throw new UnknownDeviceError(deviceId);
+    const { device, index } = this.#requireDeviceRecord(deviceId);
     if (device.state !== "reclaiming") {
       throw new RegistryEventError(`Device is not reclaiming: ${deviceId}`);
     }
@@ -192,13 +183,33 @@ export class Registry {
     return cloneDevice(updated);
   }
 
+  /** Flags a device whose observed boot state disagrees with the committed registry state. */
+  async markForeignStateDetected(deviceId: string, at: number): Promise<DeviceRecord> {
+    const { device, index } = this.#requireDeviceRecord(deviceId);
+    const updated = { ...device, foreignStateDetectedAt: at };
+    const devices = [...this.#devices];
+    devices[index] = updated;
+    await this.#commit(devices, this.#leases);
+    return cloneDevice(updated);
+  }
+
+  /** Clears the foreign-state flag once `doctor --fix` has reconciled the device. */
+  async clearForeignStateDetected(deviceId: string): Promise<DeviceRecord> {
+    const { device, index } = this.#requireDeviceRecord(deviceId);
+    if (device.foreignStateDetectedAt === undefined) {
+      return cloneDevice(device);
+    }
+    const { foreignStateDetectedAt: _foreignStateDetectedAt, ...rest } = device;
+    const updated = rest as DeviceRecord;
+    const devices = [...this.#devices];
+    devices[index] = updated;
+    await this.#commit(devices, this.#leases);
+    return cloneDevice(updated);
+  }
+
   /** Records externally verified disappearance; no driver verb is invoked. */
   async markDeviceMissing(deviceId: string, initiator: string): Promise<DeviceRecord> {
-    const index = this.#devices.findIndex((device) => device.id === deviceId);
-    const device = this.#devices[index];
-    if (index === -1 || device === undefined) {
-      throw new UnknownDeviceError(deviceId);
-    }
+    const { device, index } = this.#requireDeviceRecord(deviceId);
     if (this.#leases.some((lease) => lease.deviceId === deviceId)) {
       throw new RegistryEventError(`Cannot mark leased device missing: ${deviceId}`);
     }
@@ -272,6 +283,7 @@ export class Registry {
     return { device: cloneDevice(reclaiming), lease: cloneLease(lease) };
   }
 
+  // fallow-ignore-next-line unused-class-member -- called through LeaseLifecycle's registry port.
   async renewLease(leaseId: string, ttlDeadline: number): Promise<LeaseRecord> {
     const index = this.#leases.findIndex((lease) => lease.id === leaseId);
     const lease = this.#leases[index];
@@ -284,6 +296,18 @@ export class Registry {
     leases[index] = renewed;
     await this.#commit(this.#devices, leases);
     return cloneLease(renewed);
+  }
+
+  #requireDeviceRecord(deviceId: string): {
+    readonly device: DeviceRecord;
+    readonly index: number;
+  } {
+    const index = this.#devices.findIndex((device) => device.id === deviceId);
+    const device = this.#devices[index];
+    if (index === -1 || device === undefined) {
+      throw new UnknownDeviceError(deviceId);
+    }
+    return { device, index };
   }
 
   async #commit(devices: DeviceRecord[], leases: LeaseRecord[]): Promise<void> {
@@ -356,6 +380,7 @@ const deviceRecordKeys = [
   "driverData",
   "createdAt",
   "lastLeaseEndedAt",
+  "foreignStateDetectedAt",
 ] as const;
 const leaseRecordKeys = [
   "id",
@@ -403,7 +428,16 @@ function parseDevice(value: unknown): DeviceRecord {
     throw new RegistryLoadError("Invalid device record in registry state");
   }
 
-  const { createdAt, driverData, driverDeviceId, id, lastLeaseEndedAt, spec, state } = value;
+  const {
+    createdAt,
+    driverData,
+    driverDeviceId,
+    foreignStateDetectedAt,
+    id,
+    lastLeaseEndedAt,
+    spec,
+    state,
+  } = value;
   if (
     typeof id !== "string" ||
     typeof driverDeviceId !== "string" ||
@@ -411,13 +445,15 @@ function parseDevice(value: unknown): DeviceRecord {
     !(isDeviceState(state) || state === "warm") ||
     !isDeviceSpec(spec) ||
     !("driverData" in value) ||
-    (lastLeaseEndedAt !== undefined && typeof lastLeaseEndedAt !== "number")
+    (lastLeaseEndedAt !== undefined && typeof lastLeaseEndedAt !== "number") ||
+    (foreignStateDetectedAt !== undefined && typeof foreignStateDetectedAt !== "number")
   ) {
     throw new RegistryLoadError("Invalid device record in registry state");
   }
 
   return {
     ...(lastLeaseEndedAt === undefined ? {} : { lastLeaseEndedAt }),
+    ...(foreignStateDetectedAt === undefined ? {} : { foreignStateDetectedAt }),
     createdAt,
     driverData,
     driverDeviceId,

--- a/src/drivers/android/index.test.ts
+++ b/src/drivers/android/index.test.ts
@@ -505,6 +505,70 @@ describe("AndroidDriver", () => {
 
     expect(runner.calls.some((call) => call.command === binaries.sdkmanager)).toBe(false);
   });
+
+  it("joins adb devices with getprop to compute runState per AVD: running, stopped, transitioning", async () => {
+    const filesystem = await androidFilesystem();
+    await filesystem.mkdirp(`${avdDirectory}/pitlane_running.avd`);
+    await filesystem.mkdirp(`${avdDirectory}/pitlane_stopped.avd`);
+    const runner = new ScriptedProcessRunner([
+      processResult(binaries.adb, ["devices"], "List of devices attached\nemulator-5554\tdevice\n"),
+      processResult(
+        binaries.adb,
+        ["-s", "emulator-5554", "shell", "getprop", "ro.boot.qemu.avd_name"],
+        "pitlane_running\n",
+      ),
+    ]);
+    const driver = await createDriver(filesystem, runner);
+
+    const reality = await driver.listManaged();
+
+    expect(
+      [...reality.devices]
+        .map((device) => ({ deviceId: device.deviceId, runState: device.runState }))
+        .sort((left, right) => left.deviceId.localeCompare(right.deviceId)),
+    ).toEqual([
+      { deviceId: "pitlane_running", runState: "running" },
+      { deviceId: "pitlane_stopped", runState: "stopped" },
+    ]);
+    expect(reality.processes).toEqual([expect.objectContaining({ deviceId: "pitlane_running" })]);
+  });
+
+  it("treats an otherwise-stopped AVD as transitioning when an unattributable transitional serial is present", async () => {
+    const filesystem = await androidFilesystem();
+    await filesystem.mkdirp(`${avdDirectory}/pitlane_idle.avd`);
+    const runner = new ScriptedProcessRunner([
+      processResult(
+        binaries.adb,
+        ["devices"],
+        "List of devices attached\nemulator-5556\toffline\n",
+      ),
+    ]);
+    const driver = await createDriver(filesystem, runner);
+
+    const reality = await driver.listManaged();
+
+    expect(reality.devices).toEqual([
+      expect.objectContaining({ deviceId: "pitlane_idle", runState: "transitioning" }),
+    ]);
+    // Only settled `device`-state serials are counted as running processes; the
+    // unattributable offline serial never appears here regardless of the AVD fallback above.
+    expect(reality.processes).toEqual([]);
+  });
+
+  it("still resolves a stopped AVD as stopped when adb reports no serials at all", async () => {
+    const filesystem = await androidFilesystem();
+    await filesystem.mkdirp(`${avdDirectory}/pitlane_idle.avd`);
+    const runner = new ScriptedProcessRunner([
+      processResult(binaries.adb, ["devices"], "List of devices attached\n"),
+    ]);
+    const driver = await createDriver(filesystem, runner);
+
+    const reality = await driver.listManaged();
+
+    expect(reality.devices).toEqual([
+      expect.objectContaining({ deviceId: "pitlane_idle", runState: "stopped" }),
+    ]);
+  });
 });
 
 const live = process.env.PITLANE_LIVE_ANDROID === "1" ? it : it.skip;

--- a/src/drivers/android/index.ts
+++ b/src/drivers/android/index.ts
@@ -6,6 +6,8 @@ import {
   type DriverCatalogEntry,
   type DriverDevice,
   DriverCrashError,
+  type DriverReality,
+  type ObservedDevice,
   type ReclaimResult,
   RuntimeMissingError,
   UnknownModelError,
@@ -303,34 +305,63 @@ export class AndroidDriver implements Driver {
     });
   }
 
-  async listManaged(): Promise<{
-    readonly devices: readonly DriverDevice[];
-    readonly processes: readonly DriverDevice[];
-  }> {
-    const devices: DriverDevice[] = [];
+  async listManaged(): Promise<DriverReality> {
+    const avdNames = await this.#listAvdNames();
+    const { settledSerials, unattributableTransitionalSerial } = await this.#scanAdbSerials();
+    const { processes, runningByAvdName } = await this.#resolveRunningAvds(settledSerials);
+
+    const devices: ObservedDevice[] = avdNames.map((avdName) =>
+      observedAndroidDevice(avdName, runningByAvdName, unattributableTransitionalSerial),
+    );
+
+    return { devices, processes };
+  }
+
+  async #listAvdNames(): Promise<string[]> {
+    const avdNames: string[] = [];
     if (await this.#filesystem.exists(this.#avdDirectory)) {
       for (const entry of await this.#filesystem.readdir(this.#avdDirectory)) {
         const match = /^(pitlane_.+)\.avd$/.exec(entry);
         if (match?.[1] === undefined) continue;
-        const avdName = match[1];
-        devices.push({
-          deviceId: avdName,
-          driverData: {
-            avdName,
-            configHash: "recovered",
-            imageIdentity: "",
-            port: 0,
-            serial: "",
-          } satisfies AndroidDriverData,
-        });
+        avdNames.push(match[1]);
       }
     }
+    return avdNames;
+  }
 
-    const processes: DriverDevice[] = [];
+  /**
+   * Serials attached in a settled `device` state can answer `getprop`, so they can be
+   * attributed to an AVD by name. A serial in any other adb state (offline, unauthorized,
+   * booting, ...) cannot answer `getprop` yet, so it cannot be attributed to an AVD name --
+   * `unattributableTransitionalSerial` records that this tick saw at least one such serial.
+   */
+  async #scanAdbSerials(): Promise<{
+    readonly settledSerials: readonly string[];
+    readonly unattributableTransitionalSerial: boolean;
+  }> {
     const attached = await this.#runOrThrow(this.#sdk.adb, ["devices"]);
-    for (const serial of attached.stdout.matchAll(/^((?:emulator)-\d+)\s+device$/gm)) {
-      const candidate = serial[1];
-      if (candidate === undefined) continue;
+    const settledSerials: string[] = [];
+    let unattributableTransitionalSerial = false;
+    for (const match of attached.stdout.matchAll(/^((?:emulator)-\d+)\s+(\S+)$/gm)) {
+      const candidate = match[1];
+      const state = match[2];
+      if (candidate === undefined || state === undefined) continue;
+      if (state === "device") {
+        settledSerials.push(candidate);
+      } else {
+        unattributableTransitionalSerial = true;
+      }
+    }
+    return { settledSerials, unattributableTransitionalSerial };
+  }
+
+  async #resolveRunningAvds(settledSerials: readonly string[]): Promise<{
+    readonly processes: readonly DriverDevice[];
+    readonly runningByAvdName: ReadonlySet<string>;
+  }> {
+    const processes: DriverDevice[] = [];
+    const runningByAvdName = new Set<string>();
+    for (const candidate of settledSerials) {
       const name = await this.#runOrThrow(this.#sdk.adb, [
         "-s",
         candidate,
@@ -340,6 +371,7 @@ export class AndroidDriver implements Driver {
       ]);
       const avdName = name.stdout.trim();
       if (!avdName.startsWith("pitlane_")) continue;
+      runningByAvdName.add(avdName);
       const port = Number(candidate.slice("emulator-".length));
       processes.push({
         deviceId: avdName,
@@ -352,7 +384,7 @@ export class AndroidDriver implements Driver {
         } satisfies AndroidDriverData,
       });
     }
-    return { devices, processes };
+    return { processes, runningByAvdName };
   }
 
   async listCatalog(): Promise<DriverCatalogEntry> {
@@ -899,6 +931,31 @@ async function systemImageVersion(filesystem: Filesystem, imagePath: string): Pr
 
 function serialFor(port: number): string {
   return `emulator-${port}`;
+}
+
+function observedAndroidDevice(
+  avdName: string,
+  runningByAvdName: ReadonlySet<string>,
+  unattributableTransitionalSerial: boolean,
+): ObservedDevice {
+  return {
+    deviceId: avdName,
+    driverData: {
+      avdName,
+      configHash: "recovered",
+      imageIdentity: "",
+      port: 0,
+      serial: "",
+    } satisfies AndroidDriverData,
+    // Conservative: an emulator serial we can't attribute (transitional adb state) might
+    // belong to any AVD that otherwise looks stopped, so treat all of them as transitioning
+    // for this tick rather than risk a false-positive foreign-state-change finding.
+    runState: runningByAvdName.has(avdName)
+      ? "running"
+      : unattributableTransitionalSerial
+        ? "transitioning"
+        : "stopped",
+  };
 }
 
 function portsFromAdbDevices(output: string): number[] {

--- a/src/drivers/ios/fixtures/simctl-list-devices.json
+++ b/src/drivers/ios/fixtures/simctl-list-devices.json
@@ -1,0 +1,31 @@
+{
+  "devices": {
+    "com.apple.CoreSimulator.SimRuntime.iOS-26-5": [
+      {
+        "name": "pitlane-booted",
+        "udid": "00000000-0000-0000-0000-000000000101",
+        "state": "Booted"
+      },
+      {
+        "name": "pitlane-shutdown",
+        "udid": "00000000-0000-0000-0000-000000000102",
+        "state": "Shutdown"
+      },
+      {
+        "name": "pitlane-booting",
+        "udid": "00000000-0000-0000-0000-000000000103",
+        "state": "Booting"
+      },
+      {
+        "name": "pitlane-shutting-down",
+        "udid": "00000000-0000-0000-0000-000000000104",
+        "state": "Shutting Down"
+      },
+      {
+        "name": "Not Pitlane",
+        "udid": "00000000-0000-0000-0000-000000000105",
+        "state": "Booted"
+      }
+    ]
+  }
+}

--- a/src/drivers/ios/index.test.ts
+++ b/src/drivers/ios/index.test.ts
@@ -17,9 +17,17 @@ import {
 import { IosSimctlDriver } from "./index.js";
 
 const listFixture = readFileSync(new URL("./fixtures/simctl-list.json", import.meta.url), "utf8");
+const listDevicesFixture = readFileSync(
+  new URL("./fixtures/simctl-list-devices.json", import.meta.url),
+  "utf8",
+);
 const listInvocation = {
   command: "xcrun",
   args: ["simctl", "list", "-j", "devicetypes", "runtimes"],
+} as const;
+const listDevicesInvocation = {
+  command: "xcrun",
+  args: ["simctl", "list", "-j", "devices"],
 } as const;
 const spec = { model: "iPhone 16", osVersion: "26.5", platform: "ios" } as const;
 const driverData = {
@@ -284,6 +292,40 @@ describe("IosSimctlDriver", () => {
     await driver.listCatalog();
 
     expect(runner.calls).toEqual([{ ...listInvocation, options: { timeoutMs: 30_000 } }]);
+  });
+
+  it("maps simctl device state to runState and filters to pitlane- devices", async () => {
+    const runner = new ScriptedProcessRunner([
+      { match: listDevicesInvocation, result: { code: 0, stderr: "", stdout: listDevicesFixture } },
+    ]);
+    const driver = createDriver(runner);
+
+    const reality = await driver.listManaged();
+
+    expect(
+      reality.devices.map((device) => ({ deviceId: device.deviceId, runState: device.runState })),
+    ).toEqual([
+      { deviceId: "00000000-0000-0000-0000-000000000101", runState: "running" },
+      { deviceId: "00000000-0000-0000-0000-000000000102", runState: "stopped" },
+      { deviceId: "00000000-0000-0000-0000-000000000103", runState: "transitioning" },
+      { deviceId: "00000000-0000-0000-0000-000000000104", runState: "transitioning" },
+    ]);
+  });
+
+  it("populates processes from booted managed devices only", async () => {
+    const runner = new ScriptedProcessRunner([
+      { match: listDevicesInvocation, result: { code: 0, stderr: "", stdout: listDevicesFixture } },
+    ]);
+    const driver = createDriver(runner);
+
+    const reality = await driver.listManaged();
+
+    expect(reality.processes).toEqual([
+      expect.objectContaining({
+        deviceId: "00000000-0000-0000-0000-000000000101",
+        runState: "running",
+      }),
+    ]);
   });
 
   it.skipIf(process.env.PITLANE_LIVE_IOS !== "1")(

--- a/src/drivers/ios/index.ts
+++ b/src/drivers/ios/index.ts
@@ -5,6 +5,9 @@ import {
   type DriverCatalogEntry,
   type DriverDevice,
   DriverCrashError,
+  type DriverReality,
+  type ObservedDevice,
+  type ObservedRunState,
   RuntimeMissingError,
   UnknownModelError,
 } from "../../core/index.js";
@@ -172,12 +175,11 @@ export class IosSimctlDriver implements Driver {
     await this.#simctl(["delete", data.udid], COMMAND_TIMEOUT_MS);
   }
 
-  async listManaged(): Promise<{
-    readonly devices: readonly DriverDevice[];
-    readonly processes: readonly DriverDevice[];
-  }> {
+  async listManaged(): Promise<DriverReality> {
     const result = await this.#simctl(["list", "-j", "devices"], COMMAND_TIMEOUT_MS);
-    return { devices: parseManagedDevices(JSON.parse(result.stdout) as unknown), processes: [] };
+    const devices = parseManagedDevices(JSON.parse(result.stdout) as unknown);
+    const processes = devices.filter((device) => device.runState === "running");
+    return { devices, processes };
   }
 
   async listCatalog(): Promise<DriverCatalogEntry> {
@@ -323,11 +325,11 @@ class IosRuntimeMissingError extends RuntimeMissingError {
 }
 
 // fallow-ignore-next-line complexity -- runtime-keyed device JSON is walked and filtered in one pass by design.
-function parseManagedDevices(value: unknown): DriverDevice[] {
+function parseManagedDevices(value: unknown): ObservedDevice[] {
   if (!isRecord(value) || !isRecord(value.devices)) {
     throw new DriverCrashError("Invalid simctl device list JSON");
   }
-  const devices: DriverDevice[] = [];
+  const devices: ObservedDevice[] = [];
   for (const runtimeDevices of Object.values(value.devices)) {
     if (!Array.isArray(runtimeDevices)) continue;
     for (const device of runtimeDevices) {
@@ -343,10 +345,18 @@ function parseManagedDevices(value: unknown): DriverDevice[] {
           runtimeId: "",
           udid: device.udid,
         } satisfies IosDriverData,
+        runState: simctlRunState(device.state),
       });
     }
   }
   return devices;
+}
+
+/** `simctl` reports `Booting` / `Shutting Down` mid-transition; both must read as `transitioning`, never as drift. */
+function simctlRunState(state: unknown): ObservedRunState {
+  if (state === "Booted") return "running";
+  if (state === "Shutdown") return "stopped";
+  return "transitioning";
 }
 
 function parseCatalog(value: unknown): SimctlCatalog {


### PR DESCRIPTION
## Summary

Implements **Phase 1 only** of #23: Doctor now compares each managed device's
*observed boot state* (running/stopped) against the state Pitlane's registry
last committed, and reports/reconciles the drift. Phase 2 (provenance marks
for foreign erase/wipe) and Phase 3 (removing the IDEAS.md entry) are
intentionally excluded — see "Scope" below.

### Driver reality gains a run state (`src/core/driver.ts`)

- `DriverReality.devices` is now `readonly ObservedDevice[]`, adding a
  required `runState: "running" | "stopped" | "transitioning"`.
  `transitioning` covers states a driver cannot settle into yet (simulators
  report `Booting`/`Shutting Down`; emulators appear `offline` in `adb
  devices` before they answer `getprop`) and must never produce a finding.
  `DriverDevice` and `processes` are unchanged.

### iOS driver (`src/drivers/ios/index.ts`)

- `parseManagedDevices` now reads simctl's `state` field (it was previously
  discarded): `Booted` → running, `Shutdown` → stopped, anything else
  (`Booting`, `Shutting Down`, unknown/missing) → transitioning.
- `listManaged()` populates `processes` from booted devices, replacing the
  hardcoded `processes: []` stub. This makes the existing `orphan-process`
  finding reachable on iOS for the first time, and is a prerequisite for the
  state comparison below.

### Android driver (`src/drivers/android/index.ts`)

- `listManaged()` widens the `adb devices` scan to see every serial's adb
  state (not only settled `device`), and joins settled serials to AVD names
  via `getprop ro.boot.qemu.avd_name` exactly as before. `processes` still
  only includes settled `device`-state serials — unchanged semantics.
- An emulator serial in a non-`device` adb state (offline, unauthorized,
  booting, ...) cannot answer `getprop`, so it can't be attributed to an AVD
  name. When one is present, every AVD that would otherwise read as
  `stopped` is instead treated as `transitioning` for that tick — deliberately
  conservative, since a missed finding is safer than a false positive during
  Pitlane's own boot.
- Refactored into `#listAvdNames` / `#scanAdbSerials` / `#resolveRunningAvds`
  to keep `listManaged` readable.

### Doctor (`src/core/doctor.ts`)

- New `foreign-state-change` finding: registry state maps to an expected run
  state (`ready`/`leased` → running, `shutdown` → stopped); `provisioning`,
  `reclaiming`, and `deleted` are skipped as in-flight/gone. The finding only
  fires when both sides are settled and disagree — `transitioning` observed
  state is always skipped.
- `--fix` reconciles unleased devices via `registry.transitionDevice` (a
  registry-only correction — no driver verb is invoked, per safety rule 1)
  and skips leased devices, mirroring the existing `registry-device-missing`
  guard.
- Refactored `reconcile`/`#applySafeFixes` into smaller helpers
  (`registryDriftFindings`, `orphanFindings`, `expiredLeaseFindings`,
  `#fixMissingDevice`, `#fixForeignStateChange`) to keep complexity in check.

### Event (`src/bus/index.ts`, `docs/EVENTS.md`)

- New `device.foreign-state-detected` event (`{ deviceId, platform, expected,
  observed }`), emitted by Doctor **post-commit** — after `#applySafeFixes`
  has run, alongside the existing `doctor.reconciled` emission, one event per
  finding. Documented in `docs/EVENTS.md` under "Device lifecycle".

### Status flag (`src/core/domain.ts`, `src/core/registry.ts`, `src/cli/index.ts`)

- New `DeviceRecord.foreignStateDetectedAt?: number`, set via
  `Registry.markForeignStateDetected` on every detection and cleared via
  `Registry.clearForeignStateDetected` when `--fix` reconciles the device.
  `parseDevice` extended so it survives a registry reload.
- `formatStatus` renders a `(foreign state change)` marker on the device
  line. `#status` in `src/daemon/server.ts` already spreads the full
  `DeviceRecord` snapshot, so no server change was needed — verified rather
  than assumed.
- Extracted a private `Registry#requireDeviceRecord` helper to avoid
  duplicating the device-lookup preamble across the two new mutators and the
  existing ones.

### Fake driver and tests (`src/core/fake-driver.ts`)

- `FakeDriver` derives `runState` from its internal
  `provisioned/ready/shutdown` device map; `setManagedReality` now accepts
  explicit `runState` values so tests can drive drift scenarios directly.
- All existing `DriverReality`/`setManagedReality` call sites across the
  suite were updated for the new required field.

## Scope: why Phase 1 ships alone

Per the issue's own resolved decision, Phase 1 (state comparison) is
self-contained and satisfies most of the acceptance criteria on its own; the
iOS `processes`/`state` fix is also a hard prerequisite for Phase 2 regardless.
Since `simctl erase` refuses to run on a booted device, a foreign erase of a
leased (booted) device must pass through `Shutdown` first — which Phase 1
already detects, covering the headline scenario in the common case. Phase 2
(provenance marks, for the erase-while-idle and shutdown→erase→boot-within-one-tick
gaps) and Phase 3 (removing the `docs/IDEAS.md` entry once both phases ship)
are separable features better reviewed on their own; no Phase 2 code
(`filesystem` port on the iOS driver, `pitlane.mark`, `pitlane-mark.json`) is
included here.

## Test plan

- [x] `src/core/doctor.test.ts`: findings for booted-outside and
      shut-down-outside on both platforms; no finding for `transitioning`;
      no finding for `provisioning`/`reclaiming`; `--fix` reconciles an
      unleased device in both directions; `--fix` leaves a leased device
      untouched while still reporting the finding; the event is emitted
      post-commit, once per finding.
- [x] `src/drivers/ios/index.test.ts`: `parseManagedDevices` maps
      `Booted`/`Shutdown`/`Booting`/`Shutting Down`; `processes` is populated
      from booted devices only.
- [x] `src/drivers/android/index.test.ts`: `runState` join across
      running/stopped/transitioning, including the unattributable-transitional-serial
      fallback.
- [x] `pnpm run typecheck && pnpm run lint && pnpm run format:check && pnpm run test` — all green (393 passed, 2 pre-existing live-SDK smoke tests skipped).
- [x] `pnpm exec fallow audit --base main` — clean (0 dead code, 0 duplication; 2 inherited high-complexity findings on pre-existing, untouched-logic functions excluded from the gate).

Refs #23


---

## Review follow-up

Two defects found reviewing the first commit, both fixed in `a135eb2` with
regression tests that fail without the fix:

1. **`--fix` could abort the entire reconcile.** `#fixForeignStateChange`
   checked the *finding* (`expected`/`observed`) rather than the device's
   committed state. A device recorded as `leased` with no matching lease record
   passes the lease guard, and the resulting `leased → shutdown` transition
   threw `IllegalTransition`, taking down the whole `reconcile()` call —
   every remaining fix included — and erroring the reaper tick every 60 s.
   Reachable from a state file where the device and lease tables disagree,
   which is exactly the inconsistency `doctor` exists to surface. The
   correction is now gated on `device.state` being `ready` or `shutdown`,
   the only two states with a legal transition to the opposite run state;
   anything else is reported and left alone.

2. **`foreignStateDetectedAt` rewrote `state.json` every tick.** `Doctor`
   re-reports persistent drift on each reaper tick and the mutator committed
   unconditionally, so a drifted device that `--fix` cannot correct (a leased
   one) rewrote the registry file once a minute indefinitely, and the field
   tracked "last detected" rather than "first detected". `markForeignStateDetected`
   is now idempotent.

Verified locally on the branch: `tsc --noEmit` clean, `oxlint src` clean,
`oxfmt --check .` clean, `vitest run src` 395 passed / 2 skipped across 50
files, `fallow audit --base main` and the commit-time `--base HEAD` gate both
green.

The SDK assumptions behind Phase 2 were verified on real tooling before this
work started — results are in the first comment on #23 and folded into the
issue body.
