### PR TITLE
feat(doctor): add provenance-mark contract and drift classification

### DIFF
--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -30,6 +30,7 @@ in short: `subject.past-tense-fact`, emitted post-commit, facts not commands.
 | `device.shutdown` | device id, initiator (rule/command) | device stopped, still on disk | Registry; WarmPoolCoordinator for interrupted reclaim recovery | implemented |
 | `device.deleted` | device id, initiator | device removed from disk and registry | Registry | implemented |
 | `device.foreign-state-detected` | device id, platform, expected (running/stopped), observed (running/stopped) | doctor reconcile found a managed device's observed boot state disagreeing with the committed registry state | Doctor | implemented |
+| `device.foreign-provenance-detected` | device id, platform, detail (erased/mark-mismatch/durable-mark-missing) | doctor reconcile found a managed device's provenance marks no longer proving Pitlane owns it | Doctor | implemented |
 | `runtime.deleted` | runtime id, initiator | runtime / system image GC'd | — | planned |
 
 ## System

--- a/src/bus/index.test.ts
+++ b/src/bus/index.test.ts
@@ -127,6 +127,7 @@ describe("EventBus", () => {
       | "device.shutdown"
       | "device.deleted"
       | "device.foreign-state-detected"
+      | "device.foreign-provenance-detected"
       | "runtime.deleted"
       | "daemon.started"
       | "daemon.stopping"

--- a/src/bus/index.ts
+++ b/src/bus/index.ts
@@ -55,6 +55,11 @@ export interface EventMap {
   "daemon.started": { readonly version: string; readonly configSnapshot: unknown };
   "daemon.stopping": { readonly reason: string };
   "disk.pressure-detected": { readonly freeBytes: number; readonly threshold: number };
+  "device.foreign-provenance-detected": {
+    readonly deviceId: string;
+    readonly platform: string;
+    readonly detail: string;
+  };
   "device.foreign-state-detected": {
     readonly deviceId: string;
     readonly platform: string;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -652,9 +652,12 @@ function formatStatus(status: Record<string, unknown>): string {
   });
   const deviceLines = devices.map((device) => {
     const record = requireObject(device);
-    const foreignStateMarker =
-      record.foreignStateDetectedAt === undefined ? "" : " (foreign state change)";
-    return `Device ${String(record.id)}: ${String(record.state)}${foreignStateMarker}`;
+    const markers = [
+      record.foreignStateDetectedAt === undefined ? undefined : "foreign state change",
+      record.foreignProvenanceDetectedAt === undefined ? undefined : "foreign provenance change",
+    ].filter((marker) => marker !== undefined);
+    const suffix = markers.length === 0 ? "" : ` (${markers.join(", ")})`;
+    return `Device ${String(record.id)}: ${String(record.state)}${suffix}`;
   });
   const leaseLines = leases.map((lease) => {
     const record = requireObject(lease);

--- a/src/core/doctor.test.ts
+++ b/src/core/doctor.test.ts
@@ -154,6 +154,120 @@ describe("Doctor", () => {
     expect(registry.snapshot.devices[0]?.foreignStateDetectedAt).toBe(10_000);
   });
 
+  it("classifies provenance-mark drift and never repairs it", async () => {
+    const cases = [
+      { detail: "erased", mark: { durable: "tok", erasable: undefined, erasableReadable: true } },
+      {
+        detail: "mark-mismatch",
+        mark: { durable: "tok", erasable: "other", erasableReadable: true },
+      },
+      {
+        detail: "durable-mark-missing",
+        mark: { durable: undefined, erasable: "tok", erasableReadable: true },
+      },
+      { detail: undefined, mark: { durable: "tok", erasable: "tok", erasableReadable: true } },
+      // Unreadable is not absent: an Android mark is only reachable over adb while
+      // the emulator runs, so a shut-down device must never read as erased.
+      { detail: undefined, mark: { durable: "tok", erasable: undefined, erasableReadable: false } },
+    ] as const;
+
+    for (const { detail, mark } of cases) {
+      const clock = new FakeClock(10_000);
+      const eventBus = new EventBus(clock);
+      const registry = await Registry.load({
+        clock,
+        eventBus,
+        filesystem: new MemoryFilesystem(),
+        idGenerator: sequence(),
+        statePath: "/state.json",
+      });
+      const device = await registry.registerDevice({
+        driverData: {},
+        driverDeviceId: "pitlane-marked",
+        provisionDuration: 0,
+        spec: { model: "Phone", osVersion: "1", platform: "ios" },
+      });
+      await registry.transitionDevice(device.id, "ready", {
+        event: "device.ready",
+        payload: { bootDuration: 0, deviceId: device.id },
+      });
+      const driver = new FakeDriver({ clock, platform: "ios" });
+      driver.setManagedReality({
+        devices: [{ deviceId: "pitlane-marked", driverData: {}, mark, runState: "running" }],
+        processes: [],
+      });
+
+      const report = await new Doctor({ clock, drivers: [driver], eventBus, registry }).reconcile({
+        fix: true,
+      });
+
+      const found = report.findings.filter(
+        (finding) => finding.kind === "foreign-provenance-change",
+      );
+      if (detail === undefined) {
+        expect(found).toEqual([]);
+        expect(registry.snapshot.devices[0]?.foreignProvenanceDetectedAt).toBeUndefined();
+      } else {
+        expect(found).toEqual([
+          { detail, deviceId: device.id, kind: "foreign-provenance-change", platform: "ios" },
+        ]);
+        expect(registry.snapshot.devices[0]?.foreignProvenanceDetectedAt).toBe(10_000);
+        expect(
+          eventBus.replay().some((entry) => entry.event === "device.foreign-provenance-detected"),
+        ).toBe(true);
+      }
+      // Report-only: --fix must never touch a device over a mark finding.
+      expect(registry.snapshot.devices[0]?.state).toBe("ready");
+    }
+  });
+
+  it("ignores provenance marks while Pitlane is itself erasing the device", async () => {
+    const clock = new FakeClock(10_000);
+    const eventBus = new EventBus(clock);
+    const registry = await Registry.load({
+      clock,
+      eventBus,
+      filesystem: new MemoryFilesystem(),
+      idGenerator: sequence(),
+      statePath: "/state.json",
+    });
+    const device = await registry.registerDevice({
+      driverData: {},
+      driverDeviceId: "pitlane-reclaiming",
+      provisionDuration: 0,
+      spec: { model: "Phone", osVersion: "1", platform: "ios" },
+    });
+    await registry.transitionDevice(device.id, "ready", {
+      event: "device.ready",
+      payload: { bootDuration: 0, deviceId: device.id },
+    });
+    const lease = await registry.createLease({
+      deviceId: device.id,
+      mode: "held",
+      requesterId: "agent",
+      ttlDeadline: 99_000,
+    });
+    await registry.beginRelease(lease.id);
+    const driver = new FakeDriver({ clock, platform: "ios" });
+    driver.setManagedReality({
+      devices: [
+        {
+          deviceId: "pitlane-reclaiming",
+          driverData: {},
+          mark: { durable: "tok", erasable: undefined, erasableReadable: true },
+          runState: "running",
+        },
+      ],
+      processes: [],
+    });
+
+    const report = await new Doctor({ clock, drivers: [driver], eventBus, registry }).reconcile();
+
+    expect(report.findings.map((finding) => finding.kind)).not.toContain(
+      "foreign-provenance-change",
+    );
+  });
+
   it("fixes registry-attributable drift and leaves unregistered reality report-only", async () => {
     const clock = new FakeClock(10_000);
     const eventBus = new EventBus(clock);

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -1,7 +1,7 @@
 import type { EventBus } from "../bus/index.js";
 import type { Clock } from "../ports/index.js";
 import type { DeviceRecord, DeviceState, Platform } from "./domain.js";
-import type { Driver, DriverDevice, ObservedDevice } from "./driver.js";
+import type { Driver, DriverDevice, ObservedDevice, ObservedMark } from "./driver.js";
 import type { LeaseExpirer } from "./lease-ports.js";
 import type { Registry } from "./registry.js";
 
@@ -20,7 +20,25 @@ export type DoctorFinding =
       readonly platform: Platform;
       readonly expected: "running" | "stopped";
       readonly observed: "running" | "stopped";
+    }
+  | {
+      readonly kind: "foreign-provenance-change";
+      readonly deviceId: string;
+      readonly platform: Platform;
+      readonly detail: ProvenanceDrift;
     };
+
+/**
+ * `erased` -- the durable mark stands but the erasable one is gone: the device
+ * was erased or wiped outside Pitlane.
+ * `mark-mismatch` -- both regions carry a token but they disagree, so
+ * something re-marked one region independently.
+ * `durable-mark-missing` -- the durable region carries no token at all: the
+ * device definition was recreated, or foreign tooling rewrote it. On Android
+ * that also catches an `avdmanager create` reusing a `pitlane_` name, which
+ * the prefix match in `listManaged` would otherwise adopt silently.
+ */
+export type ProvenanceDrift = "erased" | "mark-mismatch" | "durable-mark-missing";
 
 export interface DoctorReport {
   readonly findings: readonly DoctorFinding[];
@@ -67,6 +85,12 @@ export class Doctor {
       if (deviceFindings.some((finding) => finding.kind === "foreign-state-change")) {
         await this.options.registry.markForeignStateDetected(device.id, this.options.clock.now());
       }
+      if (deviceFindings.some((finding) => finding.kind === "foreign-provenance-change")) {
+        await this.options.registry.markForeignProvenanceDetected(
+          device.id,
+          this.options.clock.now(),
+        );
+      }
     }
     findings.push(...orphanFindings(realities, registryDeviceKeys));
     findings.push(...expiredLeaseFindings(snapshot.leases, this.options.clock.now()));
@@ -82,17 +106,25 @@ export class Doctor {
 
   #emitForeignStateEvents(findings: readonly DoctorFinding[]): void {
     for (const finding of findings) {
-      if (finding.kind !== "foreign-state-change") continue;
-      this.options.eventBus.emit(
-        "device.foreign-state-detected",
-        {
-          deviceId: finding.deviceId,
-          expected: finding.expected,
-          observed: finding.observed,
-          platform: finding.platform,
-        },
-        "doctor",
-      );
+      if (finding.kind === "foreign-state-change") {
+        this.options.eventBus.emit(
+          "device.foreign-state-detected",
+          {
+            deviceId: finding.deviceId,
+            expected: finding.expected,
+            observed: finding.observed,
+            platform: finding.platform,
+          },
+          "doctor",
+        );
+      }
+      if (finding.kind === "foreign-provenance-change") {
+        this.options.eventBus.emit(
+          "device.foreign-provenance-detected",
+          { detail: finding.detail, deviceId: finding.deviceId, platform: finding.platform },
+          "doctor",
+        );
+      }
     }
   }
 
@@ -113,6 +145,9 @@ export class Doctor {
           break;
         case "foreign-state-change":
           await this.#fixForeignStateChange(finding);
+          break;
+        case "foreign-provenance-change":
+          // Report-only: re-marking destroys the evidence, and the device may be leased.
           break;
       }
     }
@@ -178,14 +213,16 @@ function registryDriftFindings(
     });
   }
 
+  // `expected === undefined` means the registry is mid-transition (provisioning,
+  // reclaiming, deleted). Pitlane is acting on the device itself in those states,
+  // including erasing it, so neither run state nor marks are compared.
   const expected = expectedRunState(device.state);
-  const observed = expected === undefined ? undefined : observedDevices.get(deviceKey);
-  if (
-    expected !== undefined &&
-    observed !== undefined &&
-    observed.runState !== "transitioning" &&
-    observed.runState !== expected
-  ) {
+  const observed = observedDevices.get(deviceKey);
+  if (expected === undefined || observed === undefined) {
+    return findings;
+  }
+
+  if (observed.runState !== "transitioning" && observed.runState !== expected) {
     findings.push({
       deviceId: device.id,
       expected,
@@ -195,7 +232,35 @@ function registryDriftFindings(
     });
   }
 
+  const detail = observed.mark === undefined ? undefined : provenanceDrift(observed.mark);
+  if (detail !== undefined) {
+    findings.push({
+      detail,
+      deviceId: device.id,
+      kind: "foreign-provenance-change",
+      platform: device.spec.platform,
+    });
+  }
+
   return findings;
+}
+
+/**
+ * Report-only by design. Re-marking would overwrite the only evidence that the
+ * device was tampered with, and a fresh mark cannot be written to a leased
+ * device without disturbing its holder -- so the core never repairs a mark.
+ */
+function provenanceDrift(mark: ObservedMark): ProvenanceDrift | undefined {
+  if (mark.durable === undefined) {
+    return "durable-mark-missing";
+  }
+  if (!mark.erasableReadable) {
+    return undefined;
+  }
+  if (mark.erasable === undefined) {
+    return "erased";
+  }
+  return mark.erasable === mark.durable ? undefined : "mark-mismatch";
 }
 
 function orphanFindings(

--- a/src/core/domain.ts
+++ b/src/core/domain.ts
@@ -23,6 +23,7 @@ export interface DeviceRecord {
   readonly createdAt: number;
   readonly lastLeaseEndedAt?: number;
   readonly foreignStateDetectedAt?: number;
+  readonly foreignProvenanceDetectedAt?: number;
 }
 
 export interface LeaseRecord {

--- a/src/core/driver.ts
+++ b/src/core/driver.ts
@@ -19,8 +19,33 @@ export interface DriverDevice {
  */
 export type ObservedRunState = "running" | "stopped" | "transitioning";
 
+/**
+ * Provenance-mark readings for one managed device. Pitlane writes the same
+ * token into two regions of a device it owns: one that survives a fresh-state
+ * erase and one the erase destroys. Comparing the pair is what makes a foreign
+ * erase visible -- an erased device still exists and still boots, so run-state
+ * comparison alone can never see it.
+ *
+ * Where each region lives is the driver's business; the core only compares.
+ */
+export interface ObservedMark {
+  /** Token in the region that survives an erase, or undefined when absent. */
+  readonly durable: string | undefined;
+  /** Token in the region an erase destroys, or undefined when absent. */
+  readonly erasable: string | undefined;
+  /**
+   * False when the erasable region could not be read at all this tick -- an
+   * Android mark lives on the userdata partition and is only reachable over
+   * `adb` while the emulator runs. Unreadable is not the same as absent and
+   * must never be reported as an erase.
+   */
+  readonly erasableReadable: boolean;
+}
+
 export interface ObservedDevice extends DriverDevice {
   readonly runState: ObservedRunState;
+  /** Undefined from drivers that do not implement provenance marks. */
+  readonly mark?: ObservedMark;
 }
 
 /** Reality observable by a driver without trusting the registry. */

--- a/src/core/registry.ts
+++ b/src/core/registry.ts
@@ -198,6 +198,19 @@ export class Registry {
     return cloneDevice(updated);
   }
 
+  /** Flags a device whose provenance marks no longer prove Pitlane owns it. */
+  async markForeignProvenanceDetected(deviceId: string, at: number): Promise<DeviceRecord> {
+    const { device, index } = this.#requireDeviceRecord(deviceId);
+    if (device.foreignProvenanceDetectedAt !== undefined) {
+      return cloneDevice(device);
+    }
+    const updated = { ...device, foreignProvenanceDetectedAt: at };
+    const devices = [...this.#devices];
+    devices[index] = updated;
+    await this.#commit(devices, this.#leases);
+    return cloneDevice(updated);
+  }
+
   /** Clears the foreign-state flag once `doctor --fix` has reconciled the device. */
   async clearForeignStateDetected(deviceId: string): Promise<DeviceRecord> {
     const { device, index } = this.#requireDeviceRecord(deviceId);
@@ -386,6 +399,7 @@ const deviceRecordKeys = [
   "createdAt",
   "lastLeaseEndedAt",
   "foreignStateDetectedAt",
+  "foreignProvenanceDetectedAt",
 ] as const;
 const leaseRecordKeys = [
   "id",
@@ -437,6 +451,7 @@ function parseDevice(value: unknown): DeviceRecord {
     createdAt,
     driverData,
     driverDeviceId,
+    foreignProvenanceDetectedAt,
     foreignStateDetectedAt,
     id,
     lastLeaseEndedAt,
@@ -451,7 +466,8 @@ function parseDevice(value: unknown): DeviceRecord {
     !isDeviceSpec(spec) ||
     !("driverData" in value) ||
     (lastLeaseEndedAt !== undefined && typeof lastLeaseEndedAt !== "number") ||
-    (foreignStateDetectedAt !== undefined && typeof foreignStateDetectedAt !== "number")
+    (foreignStateDetectedAt !== undefined && typeof foreignStateDetectedAt !== "number") ||
+    (foreignProvenanceDetectedAt !== undefined && typeof foreignProvenanceDetectedAt !== "number")
   ) {
     throw new RegistryLoadError("Invalid device record in registry state");
   }
@@ -459,6 +475,7 @@ function parseDevice(value: unknown): DeviceRecord {
   return {
     ...(lastLeaseEndedAt === undefined ? {} : { lastLeaseEndedAt }),
     ...(foreignStateDetectedAt === undefined ? {} : { foreignStateDetectedAt }),
+    ...(foreignProvenanceDetectedAt === undefined ? {} : { foreignProvenanceDetectedAt }),
     createdAt,
     driverData,
     driverDeviceId,


### PR DESCRIPTION
Core half of Phase 2 of #23, stacked on #29 (`feat/foreign-state-change-detection`). The two driver halves stack on this one: iOS marks and Android marks.

## What this adds

- `ObservedMark` on `ObservedDevice` — the durable token, the erasable token, and whether the erasable region was readable at all this tick. Drivers that don't implement marks omit the field.
- `foreign-provenance-change` finding with a `ProvenanceDrift` detail: `erased`, `mark-mismatch`, `durable-mark-missing`.
- `device.foreign-provenance-detected` event plus its `EVENTS.md` row.
- `foreignProvenanceDetectedAt` on `DeviceRecord`, persisted and rendered in `pitlane status`.

## Design notes

**Why a pair of regions.** `simctl erase` leaves `device.plist` intact and `-wipe-data` leaves `config.ini` intact — verified on real SDKs, see the first comment on #23. An erased device therefore still exists and still boots, so the Phase 1 run-state comparison structurally cannot see it. Only a mark in the region the erase destroys can.

**`erasableReadable` is not `erasable === undefined`.** The Android erasable mark lives on the userdata partition and is only reachable over `adb` while the emulator runs. Without this distinction every shut-down emulator would report as erased on every tick.

**Report-only.** `--fix` never repairs a mark. Re-marking overwrites the only evidence the device was tampered with, and the device may be leased. Safety rule 1 governs destruction; this is the same instinct applied to evidence.

**Marks are not compared mid-transition.** `provisioning`, `reclaiming` and `deleted` skip both run-state and mark comparison, so Pitlane erasing a device never reports itself.

## Deliberate scope limit

This compares the two observed regions **against each other**. That covers erase, wipe, mark mismatch, and a foreign `avdmanager create` reusing a `pitlane_` name — every case in the Phase 2 acceptance criteria.

It does **not** cover a second Pitlane daemon that re-marks both regions consistently: both halves would agree and read as healthy. Catching that needs an expected token persisted in the registry and threaded back out of `provision` and `reclaim`, which is a materially larger change to the `Driver` contract. Deferred deliberately rather than half-built — the issue's bullet listing that case is noted as out of scope here.

Refs #23