### PR TITLE
feat(ios): write and verify provenance marks on managed simulators

### DIFF
--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -131,6 +131,7 @@ async function discoverDrivers(options: {
     drivers.push(
       new IosSimctlDriver({
         clock: options.clock,
+        filesystem: options.filesystem,
         idGenerator: options.idGenerator,
         processRunner: options.processRunner,
       }),

--- a/src/drivers/ios/fixtures/simctl-list-devices.json
+++ b/src/drivers/ios/fixtures/simctl-list-devices.json
@@ -4,27 +4,32 @@
       {
         "name": "pitlane-booted",
         "udid": "00000000-0000-0000-0000-000000000101",
-        "state": "Booted"
+        "state": "Booted",
+        "dataPath": "/Devices/00000000-0000-0000-0000-000000000101/data"
       },
       {
         "name": "pitlane-shutdown",
         "udid": "00000000-0000-0000-0000-000000000102",
-        "state": "Shutdown"
+        "state": "Shutdown",
+        "dataPath": "/Devices/00000000-0000-0000-0000-000000000102/data"
       },
       {
         "name": "pitlane-booting",
         "udid": "00000000-0000-0000-0000-000000000103",
-        "state": "Booting"
+        "state": "Booting",
+        "dataPath": "/Devices/00000000-0000-0000-0000-000000000103/data"
       },
       {
         "name": "pitlane-shutting-down",
         "udid": "00000000-0000-0000-0000-000000000104",
-        "state": "Shutting Down"
+        "state": "Shutting Down",
+        "dataPath": "/Devices/00000000-0000-0000-0000-000000000104/data"
       },
       {
         "name": "Not Pitlane",
         "udid": "00000000-0000-0000-0000-000000000105",
-        "state": "Booted"
+        "state": "Booted",
+        "dataPath": "/Devices/00000000-0000-0000-0000-000000000105/data"
       }
     ]
   }

--- a/src/drivers/ios/index.test.ts
+++ b/src/drivers/ios/index.test.ts
@@ -420,6 +420,33 @@ describe("IosSimctlDriver", () => {
     ]);
   });
 
+  it("derives the data path from the cached devices root instead of re-listing", async () => {
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp(dataPath);
+    const runner = new ScriptedProcessRunner([
+      {
+        match: listDevicesInvocation,
+        result: { code: 0, stderr: "", stdout: deviceListResponse("Shutdown") },
+      },
+      { match: { command: "xcrun", args: ["simctl", "shutdown", driverData.udid] } },
+      { match: { command: "xcrun", args: ["simctl", "erase", driverData.udid] } },
+    ]);
+    const driver = createDriver(runner, new FakeClock(), filesystem);
+
+    await driver.listManaged();
+    await driver.reclaim({ deviceId: driverData.udid, driverData }, { clean: "full" });
+
+    // `simctl list` costs ~260ms and reclaim runs on every release, so the
+    // devices root learned during listManaged must keep it off the lease path.
+    expect(runner.calls.map((call) => call.args)).toEqual([
+      ["simctl", "list", "-j", "devices"],
+      ["simctl", "shutdown", driverData.udid],
+      ["simctl", "erase", driverData.udid],
+    ]);
+    expect(await filesystem.exists(erasableMarkPath)).toBe(true);
+    expect(await filesystem.exists(durableMarkPath)).toBe(true);
+  });
+
   it("reports matching provenance tokens for a healthy managed device", async () => {
     const filesystem = new MemoryFilesystem();
     await filesystem.mkdirp(dataPath);

--- a/src/drivers/ios/index.test.ts
+++ b/src/drivers/ios/index.test.ts
@@ -10,9 +10,12 @@ import {
 } from "../../core/index.js";
 import {
   FakeClock,
+  MemoryFilesystem,
+  NodeFilesystem,
   NodeProcessRunner,
   ScriptedProcessRunner,
   SystemClock,
+  type Filesystem,
 } from "../../ports/index.js";
 import { IosSimctlDriver } from "./index.js";
 
@@ -36,6 +39,19 @@ const driverData = {
   runtimeId: "com.apple.CoreSimulator.SimRuntime.iOS-26-5",
   udid: "00000000-0000-0000-0000-000000000001",
 } as const;
+const dataPath = `/Devices/${driverData.udid}/data`;
+const durableMarkPath = `/Devices/${driverData.udid}/pitlane-mark.json`;
+const erasableMarkPath = `${dataPath}/pitlane-mark.json`;
+
+function deviceListResponse(state: string): string {
+  return JSON.stringify({
+    devices: {
+      "com.apple.CoreSimulator.SimRuntime.iOS-26-5": [
+        { name: driverData.name, udid: driverData.udid, state, dataPath },
+      ],
+    },
+  });
+}
 
 describe("IosSimctlDriver", () => {
   it("resolves an exact model and requested installed runtime", async () => {
@@ -126,8 +142,14 @@ describe("IosSimctlDriver", () => {
         },
         result: { code: 0, stderr: "", stdout: `${driverData.udid}\n` },
       },
+      {
+        match: listDevicesInvocation,
+        result: { code: 0, stderr: "", stdout: deviceListResponse("Shutdown") },
+      },
     ]);
-    const driver = createDriver(runner);
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp(dataPath);
+    const driver = createDriver(runner, new FakeClock(), filesystem);
     await driver.resolveSpec(
       { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
       { allowDownload: false },
@@ -150,6 +172,7 @@ describe("IosSimctlDriver", () => {
         command: "xcrun",
         options: { timeoutMs: 30_000 },
       },
+      { ...listDevicesInvocation, options: { timeoutMs: 30_000 } },
     ]);
   });
 
@@ -246,15 +269,84 @@ describe("IosSimctlDriver", () => {
         },
       },
       { match: { command: "xcrun", args: ["simctl", "erase", driverData.udid] } },
+      {
+        match: listDevicesInvocation,
+        result: { code: 0, stderr: "", stdout: deviceListResponse("Shutdown") },
+      },
     ]);
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp(dataPath);
 
     await expect(
-      createDriver(runner).reclaim({ deviceId: driverData.udid, driverData }, { clean: "full" }),
+      createDriver(runner, new FakeClock(), filesystem).reclaim(
+        { deviceId: driverData.udid, driverData },
+        { clean: "full" },
+      ),
     ).resolves.toEqual({ state: "shutdown", strategy: "erase" });
     expect(runner.calls.map((call) => call.args)).toEqual([
       ["simctl", "shutdown", driverData.udid],
       ["simctl", "erase", driverData.udid],
+      ["simctl", "list", "-j", "devices"],
     ]);
+  });
+
+  it("writes a fresh, different token on reclaim than the one written on provision", async () => {
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp(dataPath);
+    const runner = new ScriptedProcessRunner([
+      {
+        match: listInvocation,
+        result: { code: 0, stderr: "", stdout: listFixture },
+      },
+      {
+        match: {
+          command: "xcrun",
+          args: [
+            "simctl",
+            "create",
+            "pitlane-device-1",
+            driverData.deviceTypeId,
+            driverData.runtimeId,
+          ],
+        },
+        result: { code: 0, stderr: "", stdout: `${driverData.udid}\n` },
+      },
+      {
+        match: listDevicesInvocation,
+        result: { code: 0, stderr: "", stdout: deviceListResponse("Shutdown") },
+      },
+      { match: { command: "xcrun", args: ["simctl", "shutdown", driverData.udid] } },
+      { match: { command: "xcrun", args: ["simctl", "erase", driverData.udid] } },
+      {
+        match: listDevicesInvocation,
+        result: { code: 0, stderr: "", stdout: deviceListResponse("Shutdown") },
+      },
+    ]);
+    const driver = createTokenDriver(runner, filesystem);
+    await driver.resolveSpec(
+      { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      { allowDownload: false },
+    );
+    await driver.provision(spec);
+
+    const provisionedDurable = JSON.parse(await filesystem.readFile(durableMarkPath)) as {
+      token: string;
+    };
+    const provisionedErasable = JSON.parse(await filesystem.readFile(erasableMarkPath)) as {
+      token: string;
+    };
+    expect(provisionedDurable.token).toBe(provisionedErasable.token);
+
+    await driver.reclaim({ deviceId: driverData.udid, driverData }, { clean: "full" });
+
+    const reclaimedDurable = JSON.parse(await filesystem.readFile(durableMarkPath)) as {
+      token: string;
+    };
+    const reclaimedErasable = JSON.parse(await filesystem.readFile(erasableMarkPath)) as {
+      token: string;
+    };
+    expect(reclaimedDurable.token).toBe(reclaimedErasable.token);
+    expect(reclaimedDurable.token).not.toBe(provisionedDurable.token);
   });
 
   it("shuts down before deleting and uses benchmark estimates", async () => {
@@ -328,11 +420,85 @@ describe("IosSimctlDriver", () => {
     ]);
   });
 
+  it("reports matching provenance tokens for a healthy managed device", async () => {
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp(dataPath);
+    await filesystem.writeFileAtomic(durableMarkPath, JSON.stringify({ token: "tok-1" }));
+    await filesystem.writeFileAtomic(erasableMarkPath, JSON.stringify({ token: "tok-1" }));
+    const runner = new ScriptedProcessRunner([
+      {
+        match: listDevicesInvocation,
+        result: { code: 0, stderr: "", stdout: deviceListResponse("Shutdown") },
+      },
+    ]);
+
+    const reality = await createDriver(runner, new FakeClock(), filesystem).listManaged();
+
+    expect(reality.devices).toEqual([
+      expect.objectContaining({
+        mark: { durable: "tok-1", erasable: "tok-1", erasableReadable: true },
+      }),
+    ]);
+  });
+
+  it("reports erasable undefined when the data-container mark is gone (foreign erase)", async () => {
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp(dataPath);
+    await filesystem.writeFileAtomic(durableMarkPath, JSON.stringify({ token: "tok-1" }));
+    const runner = new ScriptedProcessRunner([
+      {
+        match: listDevicesInvocation,
+        result: { code: 0, stderr: "", stdout: deviceListResponse("Shutdown") },
+      },
+    ]);
+
+    const reality = await createDriver(runner, new FakeClock(), filesystem).listManaged();
+
+    expect(reality.devices).toEqual([
+      expect.objectContaining({
+        mark: { durable: "tok-1", erasable: undefined, erasableReadable: true },
+      }),
+    ]);
+  });
+
+  it("reports mark undefined when both provenance regions are absent (pre-upgrade device)", async () => {
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp(dataPath);
+    const runner = new ScriptedProcessRunner([
+      {
+        match: listDevicesInvocation,
+        result: { code: 0, stderr: "", stdout: deviceListResponse("Shutdown") },
+      },
+    ]);
+
+    const reality = await createDriver(runner, new FakeClock(), filesystem).listManaged();
+
+    expect(reality.devices[0]?.mark).toBeUndefined();
+  });
+
+  it("reads a corrupt mark file as undefined without throwing", async () => {
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp(dataPath);
+    await filesystem.writeFileAtomic(durableMarkPath, "not json");
+    await filesystem.writeFileAtomic(erasableMarkPath, JSON.stringify({ notAToken: true }));
+    const runner = new ScriptedProcessRunner([
+      {
+        match: listDevicesInvocation,
+        result: { code: 0, stderr: "", stdout: deviceListResponse("Shutdown") },
+      },
+    ]);
+
+    const reality = await createDriver(runner, new FakeClock(), filesystem).listManaged();
+
+    expect(reality.devices[0]?.mark).toBeUndefined();
+  });
+
   it.skipIf(process.env.PITLANE_LIVE_IOS !== "1")(
     "runs a provision-to-destroy smoke test against simctl",
     async () => {
       const driver = new IosSimctlDriver({
         clock: new SystemClock(),
+        filesystem: new NodeFilesystem(),
         idGenerator: { generate: () => `test-${process.pid}` },
         processRunner: new NodeProcessRunner(),
       });
@@ -356,10 +522,39 @@ describe("IosSimctlDriver", () => {
   );
 });
 
-function createDriver(runner: ScriptedProcessRunner, clock = new FakeClock()): IosSimctlDriver {
+function createDriver(
+  runner: ScriptedProcessRunner,
+  clock = new FakeClock(),
+  filesystem: Filesystem = new MemoryFilesystem(),
+): IosSimctlDriver {
   return new IosSimctlDriver({
     clock,
+    filesystem,
     idGenerator: { generate: () => "device-1" },
+    processRunner: runner,
+  });
+}
+
+/**
+ * `#idGenerator.generate()` names the device on its first call and mints
+ * mark tokens on every later call, so the first call must stay "device-1"
+ * to match `driverData.name` while later calls vary to prove the reclaim
+ * token differs from the provision token.
+ */
+function createTokenDriver(
+  runner: ScriptedProcessRunner,
+  filesystem: Filesystem = new MemoryFilesystem(),
+): IosSimctlDriver {
+  let calls = 0;
+  return new IosSimctlDriver({
+    clock: new FakeClock(),
+    filesystem,
+    idGenerator: {
+      generate: () => {
+        calls += 1;
+        return calls === 1 ? "device-1" : `tok-${String(calls)}`;
+      },
+    },
     processRunner: runner,
   });
 }

--- a/src/drivers/ios/index.ts
+++ b/src/drivers/ios/index.ts
@@ -11,11 +11,19 @@ import {
   RuntimeMissingError,
   UnknownModelError,
 } from "../../core/index.js";
+import type { ObservedMark } from "../../core/driver.js";
 import type { DeviceSpec } from "../../core/index.js";
-import type { Clock, IdGenerator, ProcessResult, ProcessRunner } from "../../ports/index.js";
+import type {
+  Clock,
+  Filesystem,
+  IdGenerator,
+  ProcessResult,
+  ProcessRunner,
+} from "../../ports/index.js";
 
 const COMMAND_TIMEOUT_MS = 30_000;
 const BOOTSTATUS_TIMEOUT_MS = 120_000;
+const MARK_FILE_NAME = "pitlane-mark.json";
 
 interface IosDriverData {
   readonly deviceTypeId: string;
@@ -26,6 +34,7 @@ interface IosDriverData {
 
 export interface IosSimctlDriverOptions {
   readonly clock: Clock;
+  readonly filesystem: Filesystem;
   readonly idGenerator: IdGenerator;
   readonly processRunner: ProcessRunner;
 }
@@ -61,12 +70,14 @@ type ProcessOutcome =
 export class IosSimctlDriver implements Driver {
   readonly platform = "ios" as const;
   readonly #clock: Clock;
+  readonly #filesystem: Filesystem;
   readonly #idGenerator: IdGenerator;
   readonly #processRunner: ProcessRunner;
   readonly #resolvedSpecs = new Map<string, ResolvedIosSpec>();
 
   constructor(options: IosSimctlDriverOptions) {
     this.#clock = options.clock;
+    this.#filesystem = options.filesystem;
     this.#idGenerator = options.idGenerator;
     this.#processRunner = options.processRunner;
   }
@@ -118,6 +129,11 @@ export class IosSimctlDriver implements Driver {
       throw new DriverCrashError("simctl create returned no device UDID");
     }
 
+    const dataPath = await this.#dataPathFor(udid);
+    if (dataPath !== undefined) {
+      await this.#writeMark(udid, dataPath);
+    }
+
     return {
       deviceId: udid,
       driverData: {
@@ -158,6 +174,12 @@ export class IosSimctlDriver implements Driver {
     const data = iosDriverData(device);
     await this.#shutdown(data.udid);
     await this.#simctl(["erase", data.udid], COMMAND_TIMEOUT_MS);
+
+    const dataPath = await this.#dataPathFor(data.udid);
+    if (dataPath !== undefined) {
+      await this.#writeMark(data.udid, dataPath);
+    }
+
     return { state: "shutdown", strategy: "erase" };
   }
 
@@ -177,7 +199,23 @@ export class IosSimctlDriver implements Driver {
 
   async listManaged(): Promise<DriverReality> {
     const result = await this.#simctl(["list", "-j", "devices"], COMMAND_TIMEOUT_MS);
-    const devices = parseManagedDevices(JSON.parse(result.stdout) as unknown);
+    const parsed = parseManagedDevices(JSON.parse(result.stdout) as unknown);
+    const devices: ObservedDevice[] = await Promise.all(
+      parsed.map(async (device) => {
+        const mark = await this.#readMark(device.dataPath);
+        return {
+          deviceId: device.udid,
+          driverData: {
+            deviceTypeId: "",
+            name: device.name,
+            runtimeId: "",
+            udid: device.udid,
+          } satisfies IosDriverData,
+          runState: device.runState,
+          ...(mark !== undefined ? { mark } : {}),
+        };
+      }),
+    );
     const processes = devices.filter((device) => device.runState === "running");
     return { devices, processes };
   }
@@ -200,6 +238,82 @@ export class IosSimctlDriver implements Driver {
         return 30_000;
       case "reclaim":
         return 1_000;
+    }
+  }
+
+  /**
+   * Looks up the data-container path simctl assigned a device. `simctl
+   * create` only returns the UDID, so this re-lists devices to find it --
+   * the same call `listManaged` makes, kept separate so provision/reclaim
+   * don't have to reach into listManaged's parsing for a single field.
+   */
+  async #dataPathFor(udid: string): Promise<string | undefined> {
+    const result = await this.#simctl(["list", "-j", "devices"], COMMAND_TIMEOUT_MS);
+    const parsed = parseManagedDevices(JSON.parse(result.stdout) as unknown);
+    return parsed.find((device) => device.udid === udid)?.dataPath;
+  }
+
+  /**
+   * Writes the same provenance token into both regions of a device: the
+   * device root (durable -- survives `simctl erase`) and the data container
+   * (erasable -- destroyed by it). Both halves are written together so a
+   * partial write never reads as drift.
+   */
+  async #writeMark(udid: string, dataPath: string): Promise<void> {
+    const token = this.#idGenerator.generate();
+    const contents = JSON.stringify({
+      token,
+      udid,
+      writtenAt: new Date(this.#clock.now()).toISOString(),
+    });
+    const durablePath = `${parentDirectory(dataPath)}/${MARK_FILE_NAME}`;
+    const erasablePath = `${dataPath}/${MARK_FILE_NAME}`;
+
+    await Promise.all([
+      this.#filesystem.writeFileAtomic(durablePath, contents),
+      this.#filesystem.writeFileAtomic(erasablePath, contents),
+    ]);
+  }
+
+  /**
+   * Reads both provenance regions for a managed device. Both regions are
+   * host-side files readable while the device is shut down, so
+   * `erasableReadable` is always `true` on iOS -- the field only ever goes
+   * `false` for Android, where the erasable mark lives on-device and is
+   * unreachable while the emulator isn't running. A device this driver never
+   * marked (both regions absent, e.g. provisioned before this feature
+   * shipped) reports `undefined` rather than a half-empty mark, so it stays
+   * quiet instead of classifying as tampered on every tick.
+   */
+  async #readMark(dataPath: string | undefined): Promise<ObservedMark | undefined> {
+    if (dataPath === undefined) {
+      return undefined;
+    }
+
+    const durable = await this.#readToken(`${parentDirectory(dataPath)}/${MARK_FILE_NAME}`);
+    const erasable = await this.#readToken(`${dataPath}/${MARK_FILE_NAME}`);
+
+    if (durable === undefined && erasable === undefined) {
+      return undefined;
+    }
+
+    return { durable, erasable, erasableReadable: true };
+  }
+
+  /**
+   * A missing file and a corrupt one both read as an absent mark -- the core
+   * classifies "absent" from "present but wrong" itself, and a read must
+   * never throw out of `listManaged`.
+   */
+  async #readToken(path: string): Promise<string | undefined> {
+    try {
+      const contents = await this.#filesystem.readFile(path);
+      const parsed = JSON.parse(contents) as unknown;
+      return isRecord(parsed) && typeof parsed.token === "string" && parsed.token !== ""
+        ? parsed.token
+        : undefined;
+    } catch {
+      return undefined;
     }
   }
 
@@ -324,12 +438,19 @@ class IosRuntimeMissingError extends RuntimeMissingError {
   }
 }
 
+interface ParsedManagedDevice {
+  readonly dataPath: string | undefined;
+  readonly name: string;
+  readonly runState: ObservedRunState;
+  readonly udid: string;
+}
+
 // fallow-ignore-next-line complexity -- runtime-keyed device JSON is walked and filtered in one pass by design.
-function parseManagedDevices(value: unknown): ObservedDevice[] {
+function parseManagedDevices(value: unknown): ParsedManagedDevice[] {
   if (!isRecord(value) || !isRecord(value.devices)) {
     throw new DriverCrashError("Invalid simctl device list JSON");
   }
-  const devices: ObservedDevice[] = [];
+  const devices: ParsedManagedDevice[] = [];
   for (const runtimeDevices of Object.values(value.devices)) {
     if (!Array.isArray(runtimeDevices)) continue;
     for (const device of runtimeDevices) {
@@ -338,18 +459,20 @@ function parseManagedDevices(value: unknown): ObservedDevice[] {
       }
       if (!device.name.startsWith("pitlane-")) continue;
       devices.push({
-        deviceId: device.udid,
-        driverData: {
-          deviceTypeId: "",
-          name: device.name,
-          runtimeId: "",
-          udid: device.udid,
-        } satisfies IosDriverData,
+        dataPath: typeof device.dataPath === "string" ? device.dataPath : undefined,
+        name: device.name,
         runState: simctlRunState(device.state),
+        udid: device.udid,
       });
     }
   }
   return devices;
+}
+
+/** Mirrors `parentPath` in the `Filesystem` port: the parent of a `dataPath` is the device root. */
+function parentDirectory(path: string): string {
+  const lastSeparator = path.lastIndexOf("/");
+  return lastSeparator <= 0 ? "/" : path.slice(0, lastSeparator);
 }
 
 /** `simctl` reports `Booting` / `Shutting Down` mid-transition; both must read as `transitioning`, never as drift. */

--- a/src/drivers/ios/index.ts
+++ b/src/drivers/ios/index.ts
@@ -74,6 +74,7 @@ export class IosSimctlDriver implements Driver {
   readonly #idGenerator: IdGenerator;
   readonly #processRunner: ProcessRunner;
   readonly #resolvedSpecs = new Map<string, ResolvedIosSpec>();
+  #devicesRoot: string | undefined;
 
   constructor(options: IosSimctlDriverOptions) {
     this.#clock = options.clock;
@@ -200,6 +201,7 @@ export class IosSimctlDriver implements Driver {
   async listManaged(): Promise<DriverReality> {
     const result = await this.#simctl(["list", "-j", "devices"], COMMAND_TIMEOUT_MS);
     const parsed = parseManagedDevices(JSON.parse(result.stdout) as unknown);
+    this.#rememberDevicesRoot(parsed);
     const devices: ObservedDevice[] = await Promise.all(
       parsed.map(async (device) => {
         const mark = await this.#readMark(device.dataPath);
@@ -242,15 +244,30 @@ export class IosSimctlDriver implements Driver {
   }
 
   /**
-   * Looks up the data-container path simctl assigned a device. `simctl
-   * create` only returns the UDID, so this re-lists devices to find it --
-   * the same call `listManaged` makes, kept separate so provision/reclaim
-   * don't have to reach into listManaged's parsing for a single field.
+   * Data-container path for a device. `simctl create` returns only the UDID,
+   * and a `simctl list` costs ~260ms -- enough to matter on `reclaim`, which
+   * runs on every release. So the devices root is learned once from simctl's
+   * own answer and every later lookup is derived from it, keeping the extra
+   * subprocess off the lease path. Falls back to listing until something has
+   * primed the root.
    */
   async #dataPathFor(udid: string): Promise<string | undefined> {
+    if (this.#devicesRoot !== undefined) {
+      return `${this.#devicesRoot}/${udid}/data`;
+    }
     const result = await this.#simctl(["list", "-j", "devices"], COMMAND_TIMEOUT_MS);
     const parsed = parseManagedDevices(JSON.parse(result.stdout) as unknown);
+    this.#rememberDevicesRoot(parsed);
     return parsed.find((device) => device.udid === udid)?.dataPath;
+  }
+
+  /** `<devicesRoot>/<UDID>/data` -- two levels up from any device's data container. */
+  #rememberDevicesRoot(devices: readonly ParsedManagedDevice[]): void {
+    if (this.#devicesRoot !== undefined) return;
+    const dataPath = devices.find((device) => device.dataPath !== undefined)?.dataPath;
+    if (dataPath === undefined) return;
+    const root = parentDirectory(parentDirectory(dataPath));
+    if (root !== "/") this.#devicesRoot = root;
   }
 
   /**


### PR DESCRIPTION
## What changed

Implements Phase 2a of #23 (iOS half of provenance marks), scoped to `src/drivers/ios/index.ts` and its tests only.

- `IosSimctlDriverOptions` now takes a `filesystem: Filesystem` port (threaded through `src/daemon/main.ts`'s `discoverDrivers`, matching the Android driver's house style).
- A private `#writeMark(udid, dataPath)` generates one token via the existing `#idGenerator` and writes it to both regions in one `Promise.all`, so a partial write is never possible. Called at exactly two moments: after `provision()` creates the device, and after the `simctl erase` inside `reclaim()` -- the only two places iOS ever wipes a data container (no snapshot path exists on this driver).
- `listManaged()` reads both regions per managed device and populates `ObservedDevice.mark`. Reads never throw: `#readToken` treats a missing file and an unparseable/token-less file identically as `undefined`, so one device's bad mark file can't take down the whole reality view.

## Durable / erasable path choice

- **Durable**: `<UDID>/pitlane-mark.json`, sibling of `device.plist` at the device root.
- **Erasable**: `<UDID>/data/pitlane-mark.json`, inside the data container.
- Both derived from `dataPath` as returned by `simctl list -j devices` (durable = its parent directory). No `homeDirectory` injection, no devices-root option -- the issue's gap 1 was confirmed stale on this point on this machine.
- Backed by the experiment already in the issue/branch history: a file at the device root survives `simctl erase`; a file inside `data/` does not; a stray file at the device root doesn't disturb boot.

## Both-absent upgrade-path decision

A device Pitlane provisioned before this feature shipped has no mark in either region. Reporting a half-empty `ObservedMark` there would make `provenanceDrift()` classify it as `durable-mark-missing` (tampering) on every reaper tick, forever. Instead, `#readMark` returns `undefined` for the whole reading when **both** regions are absent, so `listManaged()` omits `mark` for that device and the core's `observed.mark === undefined` short-circuit keeps it quiet. Only a device Pitlane has actually marked is ever judged. Covered by a dedicated test ("reports mark undefined when both provenance regions are absent (pre-upgrade device)").

`erasableReadable` is hardcoded `true` on iOS with a comment explaining why: both regions are host-side files, readable regardless of boot state -- the field exists for Android, where the erasable mark lives on-device and needs `adb`.

## Real-SDK verification (macOS 25.6, Xcode beta simctl)

Ran a scratch script (not committed) against the real driver and a real `iPhone 17 Pro` / iOS 27.0 simulator:

**1. provision -> both mark files exist, same token**
```
after provision: {
  durable: '{"token":"dc291622-...a74c9","udid":"6BDDBCFB-...","writtenAt":"2026-08-20T06:57:22.512Z"}',
  erasable: '{"token":"dc291622-...a74c9","udid":"6BDDBCFB-...","writtenAt":"2026-08-20T06:57:22.512Z"}'
}
```

**2. listManaged -> doctor logic classifies as no drift**
```
observed.mark: { durable: 'dc291622-...', erasable: 'dc291622-...', erasableReadable: true }
drift classification: undefined
```

**3. reclaim -> both files exist again with a new token; Pitlane's own erase never self-reports**
```
token before: dc291622-0e12-40e2-bcd2-1095138a74c9
token after:  f00441d2-995d-4ede-a787-41cd5108d424
different: true
durable === erasable after reclaim: true
```

**4. simulated foreign erase (`xcrun simctl erase <UDID>` run directly) -> erasable undefined, durable still stands**
```
observed.mark: { durable: 'f00441d2-...', erasable: undefined, erasableReadable: true }
drift classification: erased
```

**5. destroy -> no leftover pitlane-* simulators**
```
destroyed 6BDDBCFB-D148-4E7A-A9CC-BF723B2C6CF1
leftover pitlane sims: NONE
```

## Verification

- `tsc --noEmit`, `oxlint src`, `oxfmt --check .`, `vitest run src` -- all green (`pnpm` works fine in this sandbox, no need for direct binary invocation, though `./node_modules/.bin/*` was used for the standalone checks).
- `./node_modules/.bin/fallow audit --base HEAD --format compact` -- `No issues in 4 changed files`.
- Real-SDK verification above, run from a scratch script outside the repo, simulator cleaned up afterward.

Refs #23

---

## Review follow-up

**Extra `simctl list` removed from the lease path** (`b8a8e54`). Marking needs the
data-container path, which `simctl create` does not return, so the first
implementation issued a `simctl list -j devices` inside both `provision` and
`reclaim` — ~260 ms measured, and `reclaim` runs on every release.

The devices root is stable, so it is now learned once from simctl's own answer
(two levels up from any device's `dataPath`, primed by `listManaged` as well)
and later paths are derived from it. Verified against real simulators that the
derived path matches the `dataPath` simctl reports for every device, so the
cache is self-calibrating rather than a hardcoded layout guess. A cold
provision on a fresh machine still lists, so nothing regresses there.

Covered by a regression test asserting `listManaged` + `reclaim` issues exactly
one `simctl list`, with both mark files still written.
