### PR TITLE
feat(android): write and verify provenance marks on managed emulators

### DIFF
--- a/docs/IDEAS.md
+++ b/docs/IDEAS.md
@@ -45,12 +45,6 @@ A third driver (devicectl / adb-over-USB) where `provision` is a no-op and
 `reclaim` is uninstall-and-reset. Also the litmus test that the core/driver
 boundary held.
 
-## Foreign-usage detection
-
-Leases are advisory; detect when a managed device changes state without
-pitlane doing it (someone booted it via `simctl` directly) and emit an event /
-flag it in `status`.
-
 ## Clone-from-golden baseline option (iOS)
 
 `simctl clone` is as cheap as erase but preserves a *provisioned* baseline

--- a/src/drivers/android/index.test.ts
+++ b/src/drivers/android/index.test.ts
@@ -354,6 +354,7 @@ describe("AndroidDriver", () => {
         ["-s", "emulator-5554", "shell", "getprop", "init.svc.bootanim"],
         "",
       ),
+      markWriteExpectation("emulator-5554", "device-0"),
     ]);
     const restartedDriver = await createDriver(harness.filesystem, restartedRunner);
 
@@ -394,6 +395,7 @@ describe("AndroidDriver", () => {
         ["-s", "emulator-5554", "shell", "getprop", "init.svc.bootanim"],
         "",
       ),
+      markWriteExpectation("emulator-5554", "device-0"),
     ]);
     const restartedDriver = await createDriver(harness.filesystem, restartedRunner);
 
@@ -514,7 +516,12 @@ describe("AndroidDriver", () => {
       processResult(binaries.adb, ["devices"], "List of devices attached\nemulator-5554\tdevice\n"),
       processResult(
         binaries.adb,
-        ["-s", "emulator-5554", "shell", "getprop", "ro.boot.qemu.avd_name"],
+        [
+          "-s",
+          "emulator-5554",
+          "shell",
+          "getprop ro.boot.qemu.avd_name; cat /data/local/tmp/pitlane-mark.json 2>/dev/null || true",
+        ],
         "pitlane_running\n",
       ),
     ]);
@@ -568,6 +575,241 @@ describe("AndroidDriver", () => {
     expect(reality.devices).toEqual([
       expect.objectContaining({ deviceId: "pitlane_idle", runState: "stopped" }),
     ]);
+  });
+
+  it("rewrites the mark on makeReady's early-return branch without duplicating the config.ini line", async () => {
+    const filesystem = await androidFilesystem({ config: "hw.ramSize=2048\n" });
+    const clock = new FakeClock();
+    const runner = new ScriptedProcessRunner([
+      processResult(binaries.avdmanager, ["list", "device"], pixelDevices),
+      processResult(binaries.avdmanager, [
+        "create",
+        "avd",
+        "-n",
+        "pitlane_one",
+        "-k",
+        /.+/,
+        "-d",
+        "pixel_8",
+      ]),
+      processResult(binaries.emulator, ["-version"], "Android emulator version 36.1.9"),
+      processResult(binaries.adb, ["devices"], "List of devices attached\n"),
+      ...baselineBuildExpectations({ launchArgs: ["-no-snapshot-load"] }),
+      markWriteExpectation("emulator-5554", "device-2"),
+      // Second makeReady call: `state.handle` is still set from the first call, so this takes
+      // the early-return branch -- it must still wait for readiness and rewrite the mark.
+      processResult(
+        binaries.adb,
+        ["-s", "emulator-5554", "shell", "getprop", "sys.boot_completed"],
+        "1\n",
+      ),
+      processResult(
+        binaries.adb,
+        ["-s", "emulator-5554", "shell", "getprop", "init.svc.bootanim"],
+        "",
+      ),
+      markWriteExpectation("emulator-5554", "device-3"),
+    ]);
+    const driver = await createDriver(filesystem, runner, { clock, ids: ["one"] });
+    const spec = await driver.resolveSpec(
+      { model: "Pixel 8", osVersion: "34", platform: "android" },
+      { allowDownload: false },
+    );
+    const device = await driver.provision(spec);
+
+    await driver.makeReady(device);
+    await driver.makeReady(device);
+
+    const config = await filesystem.readFile(`${avdDirectory}/pitlane_one.avd/config.ini`);
+    expect(config.split(/\r?\n/).filter((line) => line.startsWith("pitlane.mark="))).toEqual([
+      "pitlane.mark=device-3",
+    ]);
+    expect(config).toContain("hw.ramSize=2048");
+  });
+
+  it("rewrites the mark on reclaim's snapshot-restore success path", async () => {
+    const harness = await provisionedHarness({ forBaselineReclaim: true });
+    await harness.driver.makeReady(harness.device);
+
+    await harness.driver.reclaim(harness.device, { clean: "standard" });
+
+    const config = await harness.filesystem.readFile(`${avdDirectory}/pitlane_one.avd/config.ini`);
+    expect(config).toContain("pitlane.mark=device-3");
+    expect(harness.runner.calls).toContainEqual(
+      expect.objectContaining({
+        args: markWriteExpectation("emulator-5554", "device-3").match.args,
+      }),
+    );
+  });
+
+  it("does not change the config hash when pitlane.mark is present in config.ini", async () => {
+    const withoutMark = await androidFilesystem({ config: "hw.ramSize=2048\n" });
+    const withMark = await androidFilesystem({
+      config: "hw.ramSize=2048\npitlane.mark=some-token\n",
+    });
+    const buildExpectations = (): ScriptedProcessExpectation[] => [
+      processResult(binaries.avdmanager, ["list", "device"], pixelDevices),
+      processResult(binaries.avdmanager, [
+        "create",
+        "avd",
+        "-n",
+        "pitlane_one",
+        "-k",
+        /.+/,
+        "-d",
+        "pixel_8",
+      ]),
+      processResult(binaries.emulator, ["-version"], "Android emulator version 36.1.9"),
+      processResult(binaries.adb, ["devices"], "List of devices attached\n"),
+    ];
+    const driverA = await createDriver(
+      withoutMark,
+      new ScriptedProcessRunner(buildExpectations()),
+      {
+        ids: ["one"],
+      },
+    );
+    const driverB = await createDriver(withMark, new ScriptedProcessRunner(buildExpectations()), {
+      ids: ["one"],
+    });
+    const spec = { model: "Pixel 8", osVersion: "34", platform: "android" } as const;
+    await driverA.resolveSpec(spec, { allowDownload: false });
+    await driverB.resolveSpec(spec, { allowDownload: false });
+
+    const deviceA = await driverA.provision(spec);
+    const deviceB = await driverB.provision(spec);
+
+    expect((deviceA.driverData as { configHash: string }).configHash).toBe(
+      (deviceB.driverData as { configHash: string }).configHash,
+    );
+  });
+
+  it("listManaged reports matching durable and erasable marks for a running device", async () => {
+    const filesystem = await androidFilesystem({
+      config: "hw.ramSize=2048\npitlane.mark=tok-123\n",
+    });
+    const runner = new ScriptedProcessRunner([
+      processResult(binaries.adb, ["devices"], "List of devices attached\nemulator-5554\tdevice\n"),
+      processResult(
+        binaries.adb,
+        [
+          "-s",
+          "emulator-5554",
+          "shell",
+          "getprop ro.boot.qemu.avd_name; cat /data/local/tmp/pitlane-mark.json 2>/dev/null || true",
+        ],
+        'pitlane_one\n{"token":"tok-123"}',
+      ),
+    ]);
+    const driver = await createDriver(filesystem, runner);
+
+    const reality = await driver.listManaged();
+
+    const device = reality.devices.find((candidate) => candidate.deviceId === "pitlane_one");
+    expect(device?.mark).toEqual({
+      durable: "tok-123",
+      erasable: "tok-123",
+      erasableReadable: true,
+    });
+  });
+
+  it("listManaged reports an erased running device when the erasable mark file is gone", async () => {
+    const filesystem = await androidFilesystem({
+      config: "hw.ramSize=2048\npitlane.mark=tok-123\n",
+    });
+    const runner = new ScriptedProcessRunner([
+      processResult(binaries.adb, ["devices"], "List of devices attached\nemulator-5554\tdevice\n"),
+      processResult(
+        binaries.adb,
+        [
+          "-s",
+          "emulator-5554",
+          "shell",
+          "getprop ro.boot.qemu.avd_name; cat /data/local/tmp/pitlane-mark.json 2>/dev/null || true",
+        ],
+        "pitlane_one\n",
+      ),
+    ]);
+    const driver = await createDriver(filesystem, runner);
+
+    const reality = await driver.listManaged();
+
+    const device = reality.devices.find((candidate) => candidate.deviceId === "pitlane_one");
+    expect(device?.mark).toEqual({
+      durable: "tok-123",
+      erasable: undefined,
+      erasableReadable: true,
+    });
+  });
+
+  it("keeps listManaged alive when a serial dies between the scan and the read", async () => {
+    const filesystem = await androidFilesystem({
+      config: "hw.ramSize=2048\npitlane.mark=tok-123\n",
+    });
+    const runner = new ScriptedProcessRunner([
+      processResult(binaries.adb, ["devices"], "List of devices attached\nemulator-5554\tdevice\n"),
+      {
+        match: {
+          args: [
+            "-s",
+            "emulator-5554",
+            "shell",
+            "getprop ro.boot.qemu.avd_name; cat /data/local/tmp/pitlane-mark.json 2>/dev/null || true",
+          ],
+          command: binaries.adb,
+        },
+        result: { code: 1, stderr: "device 'emulator-5554' not found", stdout: "" },
+      },
+    ]);
+    const driver = await createDriver(filesystem, runner);
+
+    // An emulator can vanish between `adb devices` and the read. Losing the whole
+    // reality view over one dead serial would strand every other managed device.
+    const reality = await driver.listManaged();
+
+    const device = reality.devices.find((candidate) => candidate.deviceId === "pitlane_one");
+    expect(device?.runState).toBe("transitioning");
+    // The durable half is a host file and stays readable; the erasable half genuinely
+    // was not read, so it must report unreadable rather than absent -- absent would
+    // classify as a foreign erase.
+    expect(device?.mark).toEqual({
+      durable: "tok-123",
+      erasable: undefined,
+      erasableReadable: false,
+    });
+  });
+
+  it("listManaged reports erasableReadable: false for a stopped, marked device", async () => {
+    const filesystem = await androidFilesystem({
+      config: "hw.ramSize=2048\npitlane.mark=tok-123\n",
+    });
+    const runner = new ScriptedProcessRunner([
+      processResult(binaries.adb, ["devices"], "List of devices attached\n"),
+    ]);
+    const driver = await createDriver(filesystem, runner);
+
+    const reality = await driver.listManaged();
+
+    const device = reality.devices.find((candidate) => candidate.deviceId === "pitlane_one");
+    expect(device?.mark).toEqual({
+      durable: "tok-123",
+      erasable: undefined,
+      erasableReadable: false,
+    });
+  });
+
+  it("listManaged reports no mark for a stopped, pre-existing AVD with no durable key (upgrade path)", async () => {
+    const filesystem = await androidFilesystem();
+    await filesystem.mkdirp(`${avdDirectory}/pitlane_legacy.avd`);
+    const runner = new ScriptedProcessRunner([
+      processResult(binaries.adb, ["devices"], "List of devices attached\n"),
+    ]);
+    const driver = await createDriver(filesystem, runner);
+
+    const reality = await driver.listManaged();
+
+    const device = reality.devices.find((candidate) => candidate.deviceId === "pitlane_legacy");
+    expect(device?.mark).toBeUndefined();
   });
 });
 
@@ -640,16 +882,23 @@ async function provisionedHarness(
     processResult(binaries.adb, ["devices"], "List of devices attached\n"),
   ];
 
+  // The mock idGenerator's first call is spent on the AVD name above, so `makeReady`'s tail
+  // mark write is always the second call, and (when a snapshot-reclaim follows) the third.
+  const firstMarkToken = "device-2";
+  const secondMarkToken = "device-3";
+
   if (options.forReclaim === true) {
     expectations.push(
       processResult(binaries.emulator, ["-version"], "Android emulator version 36.1.9"),
       processResult(binaries.adb, ["-s", "emulator-5554", "emu", "kill"]),
       ...baselineBuildExpectations({ launchArgs: ["-wipe-data", "-no-snapshot-load"] }),
+      markWriteExpectation("emulator-5554", firstMarkToken),
     );
   } else if (options.forFullCleanBoot === true) {
     expectations.push(
       processResult(binaries.adb, ["-s", "emulator-5554", "emu", "kill"]),
       ...baselineBuildExpectations({ launchArgs: ["-wipe-data", "-no-snapshot-load"] }),
+      markWriteExpectation("emulator-5554", firstMarkToken),
     );
   } else {
     expectations.push(
@@ -659,6 +908,9 @@ async function provisionedHarness(
         launchArgs: ["-no-snapshot-load"],
       }),
     );
+    if ((options.bootCompleted ?? "1\n").trim() === "1") {
+      expectations.push(markWriteExpectation("emulator-5554", firstMarkToken));
+    }
   }
 
   if (options.forBaselineReclaim === true) {
@@ -679,6 +931,7 @@ async function provisionedHarness(
         ["-s", "emulator-5554", "shell", "getprop", "init.svc.bootanim"],
         "",
       ),
+      markWriteExpectation("emulator-5554", secondMarkToken),
     );
   }
 
@@ -838,4 +1091,14 @@ function processResult(command: string, args: readonly (string | RegExp)[], stdo
     match: { args, command },
     result: { code: 0, stderr: "", stdout },
   };
+}
+
+/** The adb shell call `#writeErasableMark` makes as the second half of every mark write. */
+function markWriteExpectation(serial: string, token: string): ScriptedProcessExpectation {
+  return processResult(binaries.adb, [
+    "-s",
+    serial,
+    "shell",
+    `echo '${JSON.stringify({ token })}' > /data/local/tmp/pitlane-mark.json`,
+  ]);
 }

--- a/src/drivers/android/index.ts
+++ b/src/drivers/android/index.ts
@@ -8,6 +8,7 @@ import {
   DriverCrashError,
   type DriverReality,
   type ObservedDevice,
+  type ObservedMark,
   type ReclaimResult,
   RuntimeMissingError,
   UnknownModelError,
@@ -17,6 +18,7 @@ import type {
   Filesystem,
   IdGenerator,
   ProcessHandle,
+  ProcessResult,
   ProcessRunner,
 } from "../../ports/index.js";
 import { isAndroidDriverData, type AndroidDriverData } from "./data.js";
@@ -29,6 +31,8 @@ const PORT_POLL_INTERVAL_MS = 2_000;
 const SDK_DOWNLOAD_TIMEOUT_MS = 20 * 60_000;
 const SNAPSHOT_BOOT_ESTIMATE_MS = 4_000;
 const CLEAN_BASELINE = "pitlane_clean_baseline";
+const DURABLE_MARK_KEY = "pitlane.mark";
+const ERASABLE_MARK_PATH = "/data/local/tmp/pitlane-mark.json";
 
 export interface AndroidDriverOptions {
   readonly clock: Clock;
@@ -198,6 +202,11 @@ export class AndroidDriver implements Driver {
       const state = this.#stateFor(data);
       if (state.handle !== undefined) {
         await this.#waitForReadiness(data, this.#clock.now());
+        // The device was already running (or booting) under this driver instance -- reclaim
+        // never touched it, so its mark can't have gone stale. Re-mark anyway: this is the
+        // single readiness transition that lets a caller re-lease an already-ready device
+        // without ever seeing a moment where "ready" and "marked" disagree.
+        await this.#writeMark(data);
         return;
       }
 
@@ -232,6 +241,10 @@ export class AndroidDriver implements Driver {
         await this.#shutdown(data, state);
         await this.#startEmulator(data, state, ["-snapshot", CLEAN_BASELINE], true);
       }
+      // Covers all three boot paths above (wipe, snapshot restore, cold boot -- including the
+      // baseline-capture restart) with a single call: whichever path ran, the device is ready
+      // now and must be re-marked unconditionally.
+      await this.#writeMark(data);
     });
   }
 
@@ -244,6 +257,9 @@ export class AndroidDriver implements Driver {
       const state = this.#stateFor(data);
 
       if (options.clean === "full") {
+        // No mark write here: `-wipe-data` hasn't happened yet -- it's deferred to the next
+        // `makeReady` (`state.needsWipe`) -- so there is no post-erase moment on this path to
+        // mark. The next `makeReady` call covers it via its unconditional tail write.
         await this.#shutdown(data, state);
         state.needsWipe = true;
         state.snapshotExpected = false;
@@ -278,6 +294,10 @@ export class AndroidDriver implements Driver {
         return { state: "shutdown", strategy: "wipe" };
       }
       await this.#waitForReadiness(data, this.#clock.now());
+      // Snapshot restore reverts the erasable half of the mark to whatever it was at capture
+      // time, and this path returns "ready" directly without going through `makeReady` --
+      // skipping this write would leave the mark frozen at a stale generation forever.
+      await this.#writeMark(data);
       return { state: "ready", strategy: "snapshot" };
     });
   }
@@ -308,13 +328,30 @@ export class AndroidDriver implements Driver {
   async listManaged(): Promise<DriverReality> {
     const avdNames = await this.#listAvdNames();
     const { settledSerials, unattributableTransitionalSerial } = await this.#scanAdbSerials();
-    const { processes, runningByAvdName } = await this.#resolveRunningAvds(settledSerials);
+    const { processes, runningByAvdName, erasableMarkByAvdName, unreadableSerial } =
+      await this.#resolveRunningAvds(settledSerials);
+    const unattributable = unattributableTransitionalSerial || unreadableSerial;
 
-    const devices: ObservedDevice[] = avdNames.map((avdName) =>
-      observedAndroidDevice(avdName, runningByAvdName, unattributableTransitionalSerial),
+    const devices: ObservedDevice[] = await Promise.all(
+      avdNames.map((avdName) =>
+        this.#observedDevice(avdName, runningByAvdName, unattributable, erasableMarkByAvdName),
+      ),
     );
 
     return { devices, processes };
+  }
+
+  async #observedDevice(
+    avdName: string,
+    runningByAvdName: ReadonlySet<string>,
+    unattributableTransitionalSerial: boolean,
+    erasableMarkByAvdName: ReadonlyMap<string, string | undefined>,
+  ): Promise<ObservedDevice> {
+    const base = observedAndroidDevice(avdName, runningByAvdName, unattributableTransitionalSerial);
+    const running = runningByAvdName.has(avdName);
+    const durable = await this.#readDurableMark(avdName);
+    const mark = buildObservedMark(durable, running, erasableMarkByAvdName.get(avdName));
+    return mark === undefined ? base : { ...base, mark };
   }
 
   async #listAvdNames(): Promise<string[]> {
@@ -355,23 +392,44 @@ export class AndroidDriver implements Driver {
     return { settledSerials, unattributableTransitionalSerial };
   }
 
+  /**
+   * Reads the running AVD's name and its erasable mark in a single `adb shell` round trip
+   * per serial -- the mark read is folded into the `getprop` call that this method already
+   * makes, so it costs nothing extra.
+   */
   async #resolveRunningAvds(settledSerials: readonly string[]): Promise<{
+    readonly erasableMarkByAvdName: ReadonlyMap<string, string | undefined>;
     readonly processes: readonly DriverDevice[];
     readonly runningByAvdName: ReadonlySet<string>;
+    readonly unreadableSerial: boolean;
   }> {
     const processes: DriverDevice[] = [];
     const runningByAvdName = new Set<string>();
+    const erasableMarkByAvdName = new Map<string, string | undefined>();
+    let unreadableSerial = false;
     for (const candidate of settledSerials) {
-      const name = await this.#runOrThrow(this.#sdk.adb, [
+      // `adb shell` reports the exit status of the last command it ran, so a missing
+      // mark file would fail the whole invocation -- and a missing mark file is exactly
+      // the foreign-erase case this feature exists to detect. `|| true` keeps an absent
+      // mark an observation rather than a crash.
+      const output = await this.#adbShellOrUndefined([
         "-s",
         candidate,
         "shell",
-        "getprop",
-        "ro.boot.qemu.avd_name",
+        `getprop ro.boot.qemu.avd_name; cat ${ERASABLE_MARK_PATH} 2>/dev/null || true`,
       ]);
-      const avdName = name.stdout.trim();
+      // An emulator can die between `adb devices` and this call. Losing the whole
+      // reality view over one dead serial would strand every other device, so treat it
+      // like a transitional serial: unattributable this tick, nothing concluded.
+      if (output === undefined) {
+        unreadableSerial = true;
+        continue;
+      }
+      const [nameLine = "", ...markLines] = output.stdout.split(/\r?\n/);
+      const avdName = nameLine.trim();
       if (!avdName.startsWith("pitlane_")) continue;
       runningByAvdName.add(avdName);
+      erasableMarkByAvdName.set(avdName, parseErasableMark(markLines.join("\n")));
       const port = Number(candidate.slice("emulator-".length));
       processes.push({
         deviceId: avdName,
@@ -384,7 +442,16 @@ export class AndroidDriver implements Driver {
         } satisfies AndroidDriverData,
       });
     }
-    return { processes, runningByAvdName };
+    return { erasableMarkByAvdName, processes, runningByAvdName, unreadableSerial };
+  }
+
+  /** Undefined when the serial could not be reached at all, as opposed to answering. */
+  async #adbShellOrUndefined(args: readonly string[]): Promise<ProcessResult | undefined> {
+    try {
+      return await this.#runOrThrow(this.#sdk.adb, args);
+    } catch {
+      return undefined;
+    }
   }
 
   async listCatalog(): Promise<DriverCatalogEntry> {
@@ -504,9 +571,7 @@ export class AndroidDriver implements Driver {
 
   async #avdConfig(avdName: string): Promise<string> {
     try {
-      const contents = await this.#filesystem.readFile(
-        `${this.#avdDirectory}/${avdName}.avd/config.ini`,
-      );
+      const contents = await this.#filesystem.readFile(this.#configIniPath(avdName));
       return contents
         .split(/\r?\n/)
         .filter((line) => /^(image\.sysdir\.1|hw\.|disk\.dataPartition\.)/.test(line))
@@ -514,6 +579,67 @@ export class AndroidDriver implements Driver {
         .join("\n");
     } catch {
       return "";
+    }
+  }
+
+  #configIniPath(avdName: string): string {
+    return `${this.#avdDirectory}/${avdName}.avd/config.ini`;
+  }
+
+  /**
+   * Writes the same provenance token into both regions of the mark: the durable
+   * `pitlane.mark` key in `config.ini` (host-side, survives an erase) and the erasable
+   * `/data/local/tmp/pitlane-mark.json` file on the device (destroyed by an erase). Must be
+   * called after every readiness transition -- see the call sites in `makeReady` and
+   * `reclaim` for why "the tail of `makeReady`" alone is not sufficient.
+   */
+  async #writeMark(data: AndroidDriverData): Promise<void> {
+    const token = this.#idGenerator.generate();
+    await Promise.all([
+      this.#writeDurableMark(data.avdName, token),
+      this.#writeErasableMark(data.serial, token),
+    ]);
+  }
+
+  async #writeDurableMark(avdName: string, token: string): Promise<void> {
+    const path = this.#configIniPath(avdName);
+    let contents: string;
+    try {
+      contents = await this.#filesystem.readFile(path);
+    } catch {
+      contents = "";
+    }
+    const lines = contents === "" ? [] : contents.replace(/\r?\n$/, "").split(/\r?\n/);
+    const markLine = `${DURABLE_MARK_KEY}=${token}`;
+    const existingIndex = lines.findIndex((line) => line.startsWith(`${DURABLE_MARK_KEY}=`));
+    if (existingIndex >= 0) {
+      lines[existingIndex] = markLine;
+    } else {
+      lines.push(markLine);
+    }
+    await this.#filesystem.writeFileAtomic(path, `${lines.join("\n")}\n`);
+  }
+
+  async #writeErasableMark(serial: string, token: string): Promise<void> {
+    const payload = JSON.stringify({ token });
+    await this.#runOrThrow(this.#sdk.adb, [
+      "-s",
+      serial,
+      "shell",
+      `echo '${payload}' > ${ERASABLE_MARK_PATH}`,
+    ]);
+  }
+
+  async #readDurableMark(avdName: string): Promise<string | undefined> {
+    try {
+      const contents = await this.#filesystem.readFile(this.#configIniPath(avdName));
+      const line = contents
+        .split(/\r?\n/)
+        .find((entry) => entry.startsWith(`${DURABLE_MARK_KEY}=`));
+      const value = line?.slice(`${DURABLE_MARK_KEY}=`.length).trim();
+      return value === undefined || value === "" ? undefined : value;
+    } catch {
+      return undefined;
     }
   }
 
@@ -956,6 +1082,37 @@ function observedAndroidDevice(
         ? "transitioning"
         : "stopped",
   };
+}
+
+/**
+ * `undefined` (no `mark` at all) only when the durable key is absent *and* the device isn't
+ * running: that is the upgrade path for an AVD provisioned before marks existed, where the
+ * erasable half is also unreadable and can't corroborate either way. Reporting a half-empty
+ * mark there would read as tampering (`durable-mark-missing`) on every tick forever. Once the
+ * device is running with neither half present, a mark object is the correct, honest reading.
+ */
+function buildObservedMark(
+  durable: string | undefined,
+  running: boolean,
+  erasable: string | undefined,
+): ObservedMark | undefined {
+  if (durable === undefined && !running) {
+    return undefined;
+  }
+  return { durable, erasable: running ? erasable : undefined, erasableReadable: running };
+}
+
+function parseErasableMark(raw: string): string | undefined {
+  const trimmed = raw.trim();
+  if (trimmed === "") {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as { readonly token?: unknown };
+    return typeof parsed.token === "string" ? parsed.token : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function portsFromAdbDevices(output: string): number[] {


### PR DESCRIPTION
Android half of Phase 2 of #23, stacked on #30 (`feat/provenance-marks-core`). The iOS half is #31.

## What this adds

One token written into both regions of every managed AVD:

| Region | Location | Survives |
|---|---|---|
| Durable | `pitlane.mark=<token>` in `config.ini` | `-wipe-data`, snapshot restore, `avdmanager move` |
| Erasable | `/data/local/tmp/pitlane-mark.json` | nothing — destroyed by `-wipe-data`, reverted by snapshot restore |

`listManaged()` reads both and reports them as `ObservedMark`; the core classifies the drift.

## Re-marking is unconditional, on five call sites

This is the part the issue's original plan got wrong. "Write the mark at the tail of `makeReady`" is not sufficient:

- `reclaim()`'s standard path loads a snapshot and returns `{ state: "ready" }` **without going through `makeReady` at all**
- re-leasing a still-running device **early-returns** from `makeReady` on `state.handle !== undefined`

A snapshot restore reverts userdata to its capture-time contents, so a token written after baseline capture disappears on every reclaim, and one present at capture reappears forever. The only rule that holds is: re-mark whenever the device became ready, after whichever path ran. That means all three `makeReady` boot paths, the `makeReady` early return, and the snapshot-restore path inside `reclaim`.

`clean: "full"` needs no write of its own — it only sets `needsWipe` and shuts down, and the next `makeReady` covers it.

## Two bugs the real-emulator run caught

Unit tests with a fake process runner passed while both of these were live.

**1. `listManaged` threw on the foreign-erase case it exists to detect.** `adb shell` reports the exit status of the last command it ran, so `getprop …; cat /data/local/tmp/pitlane-mark.json` exited non-zero the moment the mark file was missing, `#runOrThrow` threw, and the whole reality view was lost:

```
FAILURE: DriverCrashError: adb -s emulator-5554 shell getprop ro.boot.qemu.avd_name; cat /data/local/tmp/pitlane-mark.json failed:
cat: /data/local/tmp/pitlane-mark.json: No such file or directory
    at #resolveRunningAvds (drivers/android/index.js:284:28)
    at async AndroidDriver.listManaged (drivers/android/index.js:227:72)
```

That is precisely the state a foreign wipe leaves behind — so as written, the feature crashed instead of reporting. An absent mark is now an observation (`… || true`), not a failure.

**2. A dead serial took the whole reality view down.** An emulator can vanish between `adb devices` and the per-serial read. That serial is now treated as unattributable for the tick — the same conservative path already used for transitional adb states — rather than throwing.

## `erasableReadable`, and why it is not `erasable === undefined`

The erasable mark lives on the userdata partition and is only reachable over `adb` while the emulator runs. Without the distinction, every shut-down emulator would report as erased on every reaper tick. A stopped device reports `erasableReadable: false` and the core draws no conclusion.

## Upgrade path

An AVD provisioned before this feature has no `pitlane.mark`. When the durable key is absent **and** the device is stopped (so the erasable half cannot corroborate), `mark` is omitted entirely rather than reported half-empty, so pre-existing AVDs stay quiet instead of reporting as tampered every tick.

## Config hash

`pitlane.mark` sits outside the `^(image\.sysdir\.1|hw\.|disk\.dataPartition\.)` filter `#avdConfig` hashes, so rotating the token never invalidates the quickboot baseline. Covered by a test.

## Real-SDK verification

Real emulator, `system-images;android-35;default;arm64-v8a`, driving the compiled driver.

```
STEP 1  provision + makeReady
        durable  11c91fa9-5455-42f0-a7c0-6ab6c2323190
        erasable 11c91fa9-5455-42f0-a7c0-6ab6c2323190   match: true

STEP 2  reclaim standard (snapshot path)      -> { state: 'ready', strategy: 'snapshot' }
        durable  da639550-0234-445d-9693-de845cd66df3
        erasable da639550-0234-445d-9693-de845cd66df3   match: true, rotated: true

STEP 3  reclaim full (wipe path) + makeReady  -> { state: 'shutdown', strategy: 'wipe' }
        durable  fcc40cae-f2b1-4d54-8c51-22d986e989a7
        erasable fcc40cae-f2b1-4d54-8c51-22d986e989a7   match: true

STEP 4  makeReady on an already-running device (early return)
        durable  c64569e1-178e-4834-be83-d8dfcdf6bade
        erasable c64569e1-178e-4834-be83-d8dfcdf6bade   match: true, rotated: true

STEP 5  foreign wipe (relaunch with -wipe-data), then listManaged
        runState running
        mark { durable: "c64569e1-…", erasableReadable: true }   erasable absent -> classifies `erased`

STEP 6  emulator killed, then listManaged
        runState stopped
        mark { durable: "c64569e1-…", erasableReadable: false }  -> no finding, correctly

STEP 7  destroy -> no pitlane_* AVDs and no emulator processes left
```

Step 2 is the one that matters: the token both **matches across regions** and **rotated** from step 1, so the snapshot-restore path really does re-mark and routine reclaim never self-reports.

## Gate

`tsc --noEmit`, `oxlint src`, `oxfmt --check .` clean; `vitest run src` 405 passed / 2 skipped across 50 files; `fallow audit --base HEAD` green.

Refs #23


---

## Clean end-to-end re-run on the final code

The transcript above was assembled from two runs — steps 1–4 from the run that
then crashed at step 5, and steps 5–7 re-run after the fix. A full uninterrupted
7-step run has since been done against the final build, on a fresh AVD:

```
STEP 1  provision + makeReady                 durable = erasable = 8bd0c02b-…   match
STEP 2  reclaim standard (snapshot path)      durable = erasable = 2f5a92b6-…   match, rotated from step 1
        -> { state: 'ready', strategy: 'snapshot' }
STEP 3  reclaim full (wipe path) + makeReady  durable = erasable = b35a2ba3-…   match
        -> { state: 'shutdown', strategy: 'wipe' }
STEP 4  makeReady on running device           durable = erasable = dfda918e-…   match, rotated from step 3
STEP 5  foreign -wipe-data, then listManaged  runState running
        mark { durable: "dfda918e-…", erasableReadable: true }, erasable absent -> `erased`
STEP 6  emulator killed, then listManaged     runState transitioning
        mark { durable: "dfda918e-…", erasableReadable: false } -> no finding
STEP 7  destroy                               EXIT:0, no pitlane_* AVDs, no emulator processes
```

Every step passes, and step 5 — which previously threw `DriverCrashError` out of
`listManaged` — now reports the erase cleanly.

One incidental observation: step 6 reported `runState: transitioning` rather
than `stopped`, because the emulator was killed three seconds earlier and adb
still listed the serial in a non-`device` state. That is the conservative
unattributable-serial fallback doing its job — a device mid-shutdown draws no
conclusion. `erasableReadable: false` means no finding either way. A later
manual run with a longer settle reported `stopped`, as expected.
