### PR TITLE
test(daemon): drive handshake tests from DAEMON_PROTOCOL_VERSION

### DIFF
--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -13,6 +13,7 @@ import {
   NodeFilesystem,
   NodeIpcTransport,
 } from "../ports/index.js";
+import { DAEMON_PROTOCOL_VERSION } from "../daemon-protocol/index.js";
 import { DaemonEndpointHost } from "./connection-host.js";
 import { DaemonServer } from "./server.js";
 
@@ -50,7 +51,10 @@ describe("DaemonServer", () => {
     const harness = await createHarness();
     const holder = await createClient(harness.socketPath);
 
-    await holder.request("hello", { clientVersion: "test", protocolVersion: 1 });
+    await holder.request("hello", {
+      clientVersion: "test",
+      protocolVersion: DAEMON_PROTOCOL_VERSION,
+    });
     const grant = await holder.request("lease.request", {
       mode: "held",
       requesterId: "agent-1",
@@ -86,7 +90,25 @@ describe("DaemonServer", () => {
 
     const wrongVersion = await createClient(harness.socketPath);
     await expect(
-      wrongVersion.request("hello", { clientVersion: "test", protocolVersion: 2 }),
+      wrongVersion.request("hello", {
+        clientVersion: "test",
+        protocolVersion: DAEMON_PROTOCOL_VERSION + 1,
+      }),
+    ).resolves.toMatchObject({
+      error: { code: "PROTOCOL_VERSION_MISMATCH" },
+      ok: false,
+    });
+  });
+
+  // Protocol 2 added the `heartbeat` capability and the sliding held-lease TTL that
+  // depends on it, and shipped without back-compat shims. Rejecting v1 is therefore a
+  // deliberate product decision, not just arithmetic on the current constant.
+  it("rejects a protocol v1 client outright rather than serving it without heartbeats", async () => {
+    const harness = await createHarness();
+    const legacy = await createClient(harness.socketPath);
+
+    await expect(
+      legacy.request("hello", { clientVersion: "test", protocolVersion: 1 }),
     ).resolves.toMatchObject({
       error: { code: "PROTOCOL_VERSION_MISMATCH" },
       ok: false,
@@ -210,7 +232,9 @@ describe("DaemonServer", () => {
     const client = await createClient(harness.socketPath);
 
     client.send('{"id":"hello","type":"hel');
-    client.send('lo","payload":{"clientVersion":"test","protocolVersion":1}}\n');
+    client.send(
+      `lo","payload":{"clientVersion":"test","protocolVersion":${DAEMON_PROTOCOL_VERSION}}}\n`,
+    );
     await expect(client.nextFrame((frame) => frame.id === "hello")).resolves.toMatchObject({
       ok: true,
     });
@@ -666,7 +690,6 @@ async function createHarness(
       listenerFactory: new NodeIpcTransport(),
     }),
     leases: engine,
-    protocolVersion: 1,
     queue: engine,
     reaper,
     registry,
@@ -749,7 +772,7 @@ async function hello(client: Client, capabilities?: Record<string, unknown>): Pr
   await expect(
     client.request("hello", {
       clientVersion: "test",
-      protocolVersion: 1,
+      protocolVersion: DAEMON_PROTOCOL_VERSION,
       ...(capabilities === undefined ? {} : { capabilities }),
     }),
   ).resolves.toMatchObject({


### PR DESCRIPTION
Test-only follow-up to #33.

## The problem

`createHarness` in `src/daemon/server.test.ts` pinned the daemon to
`protocolVersion: 1`, and the handshake tests sent literals. After #33 bumped
`DAEMON_PROTOCOL_VERSION` to `2`, the mismatch test read backwards:

```ts
// daemon pinned to 1; 2 is the *current* real version
wrongVersion.request("hello", { clientVersion: "test", protocolVersion: 2 })
// -> expects PROTOCOL_VERSION_MISMATCH
```

It passed only because of the pin, and it asserted the opposite of what #33
actually shipped. Nothing verified the AC that a **v1** client is rejected — the
one rejection that is a deliberate product decision, since #33 deliberately
shipped no back-compat shims for the heartbeat capability.

## What changed

- `createHarness` no longer passes `protocolVersion`, so the daemon under test
  runs at the real `DAEMON_PROTOCOL_VERSION`.
- The `hello` helper, the explicit handshake in the connection-close test, and
  the torn-frame fragment all send `DAEMON_PROTOCOL_VERSION` instead of `1`.
- The mismatch test derives its incompatible version as
  `DAEMON_PROTOCOL_VERSION + 1`.
- New test: a client announcing `protocolVersion: 1` is rejected with
  `PROTOCOL_VERSION_MISMATCH`.

Net effect: the suite exercises the real constant, and no handshake test needs
editing on the next protocol bump. The new v1 test is also what proves the pin
is genuinely gone — it could not pass against a daemon still running at 1.

## Note for a follow-up

`DaemonServerOptions.protocolVersion` (`src/daemon/server.ts:60`) now has zero
callers — it existed only as this test seam. Left in place to keep this PR
test-only; worth deleting if nobody wants to pin a daemon's version in a future
test.

## Verification

`pnpm check` green — 50 test files, 446 passed / 2 skipped. `pnpm fallow --ci`
exits 0 with no new findings.
