### PR TITLE
fix(lease): release held leases orphaned by a daemon restart

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -75,11 +75,19 @@ commits the resulting running or non-running state. Global and platform limits
 are checked atomically; no driver-specific runtime details participate in this
 decision.
 
-At startup, `StartupConverger` restores persisted lease TTL timers, recovers
-unleased interrupted reclaims through the warm-pool recovery port, then
-deterministically shuts down excess unleased, unclaimed `ready` registry
-devices through `CleanupActionExecutor`. Leased devices are never touched, so
-a lowered limit may remain visibly over-limit until leases naturally release.
+At startup, `StartupConverger` first releases every persisted `held` lease
+(reason `orphaned`) through the normal release path — a held lease's liveness
+is its daemon connection, so it cannot have a live holder across a restart,
+and this runs before timers are restored so an orphaned lease's timer is
+never re-armed. It then restores persisted TTL timers for the remaining
+(`detached`) leases, whose liveness is the TTL rather than a connection,
+recovers unleased interrupted reclaims through the warm-pool recovery port,
+and finally deterministically shuts down excess unleased, unclaimed `ready`
+registry devices through `CleanupActionExecutor`. Running this release step
+before timer restoration and capacity convergence means the devices it frees
+are visible to both. Leased devices that survive the orphan sweep are never
+touched, so a lowered limit may remain visibly over-limit until leases
+naturally release.
 
 ## Device state machine
 
@@ -183,9 +191,10 @@ capacity coordinator into these direct transactional call chains:
   `CleanupActionExecutor`; the executor revalidates registry ownership,
   lease/state safety, and delegates the driver operation to
   `ManagedDeviceLifecycle`.
-- `StartupConverger` runs timer restoration, interrupted-reclaim recovery, and
-  running-capacity convergence in that order. `NukeService` coordinates lease
-  release, pending-request cancellation, and registry-scoped reset operations.
+- `StartupConverger` runs orphaned held-lease release, timer restoration,
+  interrupted-reclaim recovery, and running-capacity convergence in that
+  order. `NukeService` coordinates lease release, pending-request
+  cancellation, and registry-scoped reset operations.
 
 The serialized decision gate protects only short read-decide-commit sections.
 Driver work remains outside it. Component boundaries use direct calls for

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -15,7 +15,7 @@ in short: `subject.past-tense-fact`, emitted post-commit, facts not commands.
 | `lease.queued` | request id, queue position | no capacity; request entered the wait queue | LeaseAcquisitionCoordinator | implemented |
 | `lease.granted` | lease id, device id, requester, mode (held/detached) | a device was assigned and handed out | LeaseLifecycle | implemented |
 | `lease.renewed` | lease id, new deadline | detached-mode renew succeeded, **or** a held-mode connection that declared the `heartbeat` capability answered a `lease.heartbeat` push (fires once per lease per `lease.heartbeatIntervalMs` while the holder stays alive) | LeaseLifecycle | implemented |
-| `lease.released` | lease id, device id, reason (closed/explicit/killed) | holder connection closed or explicit release | LeaseLifecycle | implemented |
+| `lease.released` | lease id, device id, reason (closed/explicit/killed/orphaned) | holder connection closed, explicit release, or (orphaned) a `held` lease found still persisted at daemon startup, which cannot have a live holder across a restart | LeaseLifecycle | implemented |
 | `lease.expired` | lease id, device id | TTL backstop fired without a heartbeat sliding it first — for a capability-declaring holder this means it stopped ponging (crashed, hung, or lost its socket); for one that never declared the capability it means the grant-time TTL (or the last explicit `pitlane lease renew`) simply ran out, exactly as before this change | LeaseLifecycle | implemented |
 | `lease.rejected` | request spec, reason (timeout/no-wait/unresolvable-spec/already-leased/boot-timeout/killed) | a request ended without a grant | LeaseAcquisitionCoordinator / WaitQueue | implemented |
 

--- a/src/bus/index.ts
+++ b/src/bus/index.ts
@@ -17,7 +17,7 @@ export interface EventMap {
   "lease.released": {
     readonly leaseId: string;
     readonly deviceId: string;
-    readonly reason: "closed" | "explicit" | "killed";
+    readonly reason: "closed" | "explicit" | "killed" | "orphaned";
   };
   "lease.expired": { readonly leaseId: string; readonly deviceId: string };
   "lease.rejected": {

--- a/src/core/lease-engine.test.ts
+++ b/src/core/lease-engine.test.ts
@@ -353,7 +353,7 @@ describe("LeaseEngine", () => {
     const unleasedDevice = await seedReady(harness);
     await harness.registry.createLease({
       deviceId: leasedDevice.id,
-      mode: "held",
+      mode: "detached",
       requesterId: "active",
       ttlDeadline: 2_000,
     });
@@ -425,7 +425,7 @@ describe("LeaseEngine", () => {
       const device = await seedReady(harness);
       await harness.registry.createLease({
         deviceId: device.id,
-        mode: "held",
+        mode: "detached",
         requesterId,
         ttlDeadline: 2_000,
       });

--- a/src/core/lease-engine.ts
+++ b/src/core/lease-engine.ts
@@ -164,6 +164,11 @@ export class LeaseEngine {
         },
       },
       registry: options.registry,
+      releases: {
+        releaseOrphaned: async (leaseId) => {
+          await this.#releaseCoordinator.release(leaseId, "orphaned");
+        },
+      },
       timers: this.#leases,
     });
   }

--- a/src/core/lease-lifecycle.ts
+++ b/src/core/lease-lifecycle.ts
@@ -100,8 +100,13 @@ export class LeaseLifecycle {
   /**
    * Slides a held lease's deadline back out to a full backstop from now, driven by an
    * application-level heartbeat from its holder. Goes through the registry (not a direct
-   * `expiryScheduler.replace`) so the persisted `ttlDeadline` never goes stale: a daemon
-   * restart mid-lease must restore the slid deadline, not the grant-time one.
+   * `expiryScheduler.replace`) so the persisted `ttlDeadline` stays truthful for readers within
+   * this daemon's lifetime: `status` / `list --leases` derive `lastHeartbeatAt` from it
+   * (`DaemonServer#decorateLease`), and a stale in-memory-only slide would make that reading
+   * wrong immediately, not just after a restart. It does *not* mean the slid deadline survives
+   * a restart -- a held lease's liveness is its daemon connection, so `StartupConverger`
+   * releases every held lease as orphaned on startup regardless of how recently it was slid;
+   * see `startup-converger.ts`.
    */
   // fallow-ignore-next-line unused-class-member -- called by LeaseReleaseCoordinator through the lifecycle port (same as the sibling renew).
   async heartbeat(leaseId: string): Promise<LeaseRecord> {
@@ -124,7 +129,7 @@ export class LeaseLifecycle {
 
   async beginRelease(
     leaseId: string,
-    reason: "closed" | "explicit" | "killed" | "expired",
+    reason: "closed" | "explicit" | "killed" | "orphaned" | "expired",
   ): Promise<ReleasedLease> {
     const released = await this.options.registry.beginRelease(leaseId);
     this.options.expiryScheduler.cancel(leaseId);

--- a/src/core/lease-ports.ts
+++ b/src/core/lease-ports.ts
@@ -4,6 +4,8 @@ import type { DeviceRequest } from "./driver.js";
 import type { PlatformCatalog } from "./driver-catalog.js";
 import type { LeaseGrant, LeaseRequestOptions } from "./wait-queue.js";
 
+/** Client-requestable subset only -- deliberately excludes internally-originated reasons
+ * like `orphaned` (startup orphan cleanup), which no client can ask for. */
 export type LeaseReleaseReason = "closed" | "explicit" | "killed";
 
 /** Lease commands used by daemon request handlers. */

--- a/src/core/lease-release-coordinator.ts
+++ b/src/core/lease-release-coordinator.ts
@@ -3,7 +3,7 @@ import type { ReleasedLease } from "./registry.js";
 import type { SerializedDecision } from "./serialized-decision.js";
 import type { WarmPoolCoordinator } from "./warm-pool-coordinator.js";
 
-export type LeaseReleaseReason = "closed" | "explicit" | "killed";
+export type LeaseReleaseReason = "closed" | "explicit" | "killed" | "orphaned";
 
 export interface LeaseReleaseCommands {
   release(leaseId: string, reason: LeaseReleaseReason): Promise<void>;

--- a/src/core/startup-converger.test.ts
+++ b/src/core/startup-converger.test.ts
@@ -54,9 +54,12 @@ function createHarness(
   const order: string[] = [];
   const claimed = new Set<string>();
   const cleanupCalls: string[] = [];
+  const releasedLeaseIds: string[] = [];
+  let leaseIdsAtTimerRestore: string[] | undefined;
   const timers = {
     restoreExpiryTimers: vi.fn(async () => {
       order.push("timers");
+      leaseIdsAtTimerRestore = leases.map((lease) => lease.id);
     }),
   };
   const recovery = {
@@ -75,6 +78,17 @@ function createHarness(
       return true;
     }),
   };
+  const releases = {
+    releaseOrphaned: vi.fn(async (leaseId: string) => {
+      order.push(`release:${leaseId}`);
+      releasedLeaseIds.push(leaseId);
+      const leaseIndex = leases.findIndex((lease) => lease.id === leaseId);
+      const lease = leases[leaseIndex];
+      if (lease === undefined) return;
+      leases.splice(leaseIndex, 1);
+      updateState(lease.deviceId, "ready");
+    }),
+  };
   const converger = new StartupConverger({
     capacity: {
       get runningCapacity() {
@@ -90,6 +104,7 @@ function createHarness(
         return { devices, leases };
       },
     },
+    releases,
     timers,
   });
 
@@ -99,7 +114,22 @@ function createHarness(
     if (current !== undefined) devices[index] = { ...current, state };
   }
 
-  return { claimed, cleanup, cleanupCalls, converger, devices, order, recovery, timers };
+  return {
+    claimed,
+    cleanup,
+    cleanupCalls,
+    converger,
+    devices,
+    get leaseIdsAtTimerRestore() {
+      return leaseIdsAtTimerRestore;
+    },
+    leases,
+    order,
+    recovery,
+    releasedLeaseIds,
+    releases,
+    timers,
+  };
 }
 
 describe("StartupConverger", () => {
@@ -151,7 +181,7 @@ describe("StartupConverger", () => {
         deviceId: first.id,
         grantedAt: 0,
         id: "lease-1",
-        mode: "held" as const,
+        mode: "detached" as const,
         requesterId: "a",
         ttlDeadline: 10,
       },
@@ -159,7 +189,7 @@ describe("StartupConverger", () => {
         deviceId: second.id,
         grantedAt: 0,
         id: "lease-2",
-        mode: "held" as const,
+        mode: "detached" as const,
         requesterId: "b",
         ttlDeadline: 10,
       },
@@ -200,5 +230,78 @@ describe("StartupConverger", () => {
     expect(harness.recovery.recoverInterruptedReclaim).toHaveBeenCalledOnce();
     expect(harness.cleanupCalls).toEqual(["ready"]);
     expect(harness.timers.restoreExpiryTimers).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases an orphaned held lease before timers are restored, freeing its device", async () => {
+    const held = device("held-device", "ios", "leased", 1);
+    const leases = [
+      {
+        deviceId: held.id,
+        grantedAt: 0,
+        id: "lease-held",
+        mode: "held" as const,
+        requesterId: "a",
+        ttlDeadline: 1000,
+      },
+    ];
+    const harness = createHarness([held], leases, { android: 1, global: 1, ios: 1 });
+
+    await harness.converger.converge();
+
+    expect(harness.releases.releaseOrphaned).toHaveBeenCalledTimes(1);
+    expect(harness.releases.releaseOrphaned).toHaveBeenCalledWith("lease-held");
+    expect(harness.order.indexOf("release:lease-held")).toBeLessThan(
+      harness.order.indexOf("timers"),
+    );
+    // The orphaned lease is gone from the registry by the time timers are restored, so its
+    // timer is never re-armed.
+    expect(harness.leaseIdsAtTimerRestore).toEqual([]);
+    expect(harness.devices.find((item) => item.id === held.id)?.state).toBe("ready");
+  });
+
+  it("keeps a detached lease's timer restoration untouched", async () => {
+    const detachedDevice = device("detached-device", "ios", "leased", 1);
+    const leases = [
+      {
+        deviceId: detachedDevice.id,
+        grantedAt: 0,
+        id: "lease-detached",
+        mode: "detached" as const,
+        requesterId: "a",
+        ttlDeadline: 1000,
+      },
+    ];
+    const harness = createHarness([detachedDevice], leases, { android: 1, global: 1, ios: 1 });
+
+    await harness.converger.converge();
+
+    expect(harness.releases.releaseOrphaned).not.toHaveBeenCalled();
+    expect(harness.leaseIdsAtTimerRestore).toEqual(["lease-detached"]);
+    expect(harness.devices.find((item) => item.id === detachedDevice.id)?.state).toBe("leased");
+  });
+
+  it("frees the orphaned lease's device before running-capacity convergence, making it a shutdown candidate", async () => {
+    const held = device("held-device", "ios", "leased", 1);
+    const leases = [
+      {
+        deviceId: held.id,
+        grantedAt: 0,
+        id: "lease-held",
+        mode: "held" as const,
+        requesterId: "a",
+        ttlDeadline: 1000,
+      },
+    ];
+    // maxRunning for ios is 0, so once the device is freed to "ready" it is over capacity
+    // and must be visible to the excess-capacity sweep that follows.
+    const harness = createHarness([held], leases, { android: 1, global: 0, ios: 0 });
+
+    await harness.converger.converge();
+
+    const releaseIndex = harness.order.indexOf("release:lease-held");
+    const cleanupIndex = harness.order.indexOf("cleanup:held-device");
+    expect(releaseIndex).toBeGreaterThanOrEqual(0);
+    expect(cleanupIndex).toBeGreaterThan(releaseIndex);
+    expect(harness.cleanupCalls).toEqual(["held-device"]);
   });
 });

--- a/src/core/startup-converger.ts
+++ b/src/core/startup-converger.ts
@@ -21,6 +21,16 @@ export interface InterruptedReclaimRecovery {
   recoverInterruptedReclaim(device: DeviceRecord): Promise<void>;
 }
 
+/**
+ * Releases a lease orphaned by a daemon restart. A held lease's liveness is
+ * its daemon connection, so any held lease found at startup has no holder by
+ * definition; this port drives it through the normal release path (reason
+ * `orphaned`) so the device is reclaimed and `lease.released` is emitted.
+ */
+export interface OrphanedLeaseRelease {
+  releaseOrphaned(leaseId: string): Promise<void>;
+}
+
 /** Read-only operation claim view used to avoid an in-flight device operation. */
 export interface DeviceClaimReader {
   isClaimed(deviceId: string): boolean;
@@ -33,6 +43,7 @@ export interface StartupConvergerOptions {
   readonly decisions: SerializedDecision;
   readonly interruptedReclaimRecovery: InterruptedReclaimRecovery;
   readonly registry: StartupRegistry;
+  readonly releases: OrphanedLeaseRelease;
   readonly timers: LeaseTimerRestorer;
 }
 
@@ -44,6 +55,7 @@ export class StartupConverger {
   constructor(private readonly options: StartupConvergerOptions) {}
 
   async converge(): Promise<void> {
+    await this.#releaseOrphanedHeldLeases();
     await this.options.timers.restoreExpiryTimers();
     await this.#recoverInterruptedReclaims();
 
@@ -59,6 +71,25 @@ export class StartupConverger {
         target: candidate.id,
       });
       if (!executed) refused.add(candidate.id);
+    }
+  }
+
+  /**
+   * A held lease's liveness is its daemon connection, so any lease still in
+   * `held` mode at startup is orphaned by definition — it cannot have a live
+   * holder across a restart. Release it (reason `orphaned`) before timers are
+   * restored, so its timer is never re-armed, and before capacity
+   * convergence, so the freed device is visible to it. Detached leases are
+   * untouched here; their liveness is the TTL, not a connection.
+   */
+  async #releaseOrphanedHeldLeases(): Promise<void> {
+    const orphanedLeaseIds = await this.options.decisions.run(() =>
+      this.options.registry.snapshot.leases
+        .filter((lease) => lease.mode === "held")
+        .map((lease) => lease.id),
+    );
+    for (const leaseId of orphanedLeaseIds) {
+      await this.options.releases.releaseOrphaned(leaseId);
     }
   }
 

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -543,7 +543,7 @@ describe("DaemonServer lease heartbeat", () => {
     await client.close();
   });
 
-  it("restores the heartbeat-slid deadline (not the grant-time one) across a daemon restart", async () => {
+  it("releases a held lease as orphaned across a daemon restart, even with a heartbeat-slid deadline", async () => {
     const leaseOverrides = { heartbeatIntervalMs: 10, heldTtlBackstopMs: 40 };
     const first = await createHarness({ lease: leaseOverrides });
     const holder = await createClient(first.socketPath);
@@ -554,6 +554,7 @@ describe("DaemonServer lease heartbeat", () => {
       request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
     });
     const leaseId = leaseIdOf(grant);
+    const deviceId = (grant.payload as { device: { id: string } }).device.id;
 
     first.clock.advance(10);
     const push = await holder.nextFrame((frame) => frame.push === "lease.heartbeat");
@@ -568,24 +569,23 @@ describe("DaemonServer lease heartbeat", () => {
     // leaving the last persisted registry state — the post-heartbeat slid deadline —
     // on disk. It is intentionally left running here; the afterEach hook tears it down.
 
-    // "Restart": a fresh daemon reloads that persisted registry state and, like the real
-    // startup path (src/daemon/main.ts), restores expiry timers via convergence.
+    // "Restart": a fresh daemon reloads that persisted registry state. A held lease's
+    // liveness is its daemon connection, so it cannot have survived the restart regardless
+    // of how recently its deadline was slid — the real startup path (src/daemon/main.ts)
+    // releases it as orphaned before any timer would otherwise be restored.
+    // The underlying device itself (unlike the daemon process) survives a restart, so the
+    // "restarted" harness is wired to the same fake driver instance as the crashed one.
     const second = await createHarness({
       clock: new FakeClock(1_010),
+      driver: first.driver,
       lease: leaseOverrides,
       stateFilesystem: first.stateFilesystem,
     });
     await second.engine.convergeRunningCapacity();
 
-    // The original grant-time deadline (1_040) elapses; a restore that used it instead of
-    // the slid one (1_050) would have expired the lease here.
-    second.clock.advance(30);
-    await Promise.resolve();
-    expect(second.registry.snapshot.leases).toMatchObject([{ id: leaseId }]);
-
-    // The slid deadline still fires.
-    second.clock.advance(10);
-    await expect.poll(() => second.registry.snapshot.leases).toEqual([]);
+    expect(second.registry.snapshot.leases).toEqual([]);
+    // The freed device is reclaimed and available to the next requester, not left shutdown.
+    expect(second.registry.snapshot.devices).toMatchObject([{ id: deviceId, state: "ready" }]);
     await holder.close();
   });
 
@@ -628,6 +628,7 @@ async function createHarness(
     readonly socketPath?: string;
     readonly start?: boolean;
     readonly clock?: FakeClock;
+    readonly driver?: FakeDriver;
     readonly stateFilesystem?: MemoryFilesystem;
   } = {},
 ) {
@@ -647,13 +648,15 @@ async function createHarness(
     idGenerator: sequence(),
     statePath: "/state.json",
   });
-  const driver = new FakeDriver({
-    availableOsVersions: ["26.5"],
-    clock,
-    ...(options.estimateMs === undefined ? {} : { estimateMs: options.estimateMs }),
-    ...(options.latencyMs === undefined ? {} : { latencyMs: options.latencyMs }),
-    platform: "ios",
-  });
+  const driver =
+    options.driver ??
+    new FakeDriver({
+      availableOsVersions: ["26.5"],
+      clock,
+      ...(options.estimateMs === undefined ? {} : { estimateMs: options.estimateMs }),
+      ...(options.latencyMs === undefined ? {} : { latencyMs: options.latencyMs }),
+      platform: "ios",
+    });
   const config = testConfig(options.lease);
   const engine = new LeaseEngine({
     clock,
@@ -700,7 +703,7 @@ async function createHarness(
     await daemon.start();
   }
 
-  return { clock, config, daemon, engine, eventBus, registry, socketPath, stateFilesystem };
+  return { clock, config, daemon, driver, engine, eventBus, registry, socketPath, stateFilesystem };
 }
 
 async function createClient(socketPath: string): Promise<Client> {


### PR DESCRIPTION
## What changed

A held lease's liveness *is* its daemon connection: when the daemon
restarts, the connection is gone by definition, but `StartupConverger`
called `timers.restoreExpiryTimers()` and re-armed the persisted
deadline anyway, parking the device for up to a full
`heldTtlBackstopMs` with no holder at all.

`StartupConverger.converge()` now releases every persisted `held`
lease first, before anything else runs:

- Reason `"orphaned"`, not `killed` -- the issue's prose says `killed`,
  but that reason already means `pitlane nuke`, and the acceptance
  criteria ask for a reason that distinguishes startup orphan cleanup.
  Added to `LeaseReleaseReason`, the `beginRelease` reason union, and
  the `lease.released` payload union (additive per the events rules).
- The lease goes through the **normal release path** -- registry
  `beginRelease` plus `WarmPoolCoordinator.reclaim` -- so the device is
  actually reclaimed and grantable again, not just detached from its
  timer. `lease.released` fires post-commit exactly as it does for any
  other release reason.
- **Ordering**: orphan release runs before `restoreExpiryTimers()` (so
  a released lease's timer is never armed -- by the time timers are
  restored the lease is already gone from the registry snapshot) and
  before the running-capacity excess sweep (so a freed device is
  immediately visible to it, verified by a new test).
- Detached leases are untouched here; their liveness is the TTL, not a
  connection, so they keep exactly today's timer-restoration behavior.

## Port shape

The release capability is a narrow `OrphanedLeaseRelease` port on
`StartupConvergerOptions`, matching the style of its existing
`LeaseTimerRestorer` / `InterruptedReclaimRecovery` neighbours rather
than a reach-in to `LeaseEngine`. `lease-engine.ts` wires it to the
existing `LeaseReleaseCoordinator.release(id, "orphaned")`.

`orphaned` only exists on the internal `LeaseReleaseReason`
(`lease-release-coordinator.ts`), not on the client-facing one of the
same name in `lease-ports.ts` used by `LeaseCommands.release` for
daemon request handlers. That split is deliberate, not an oversight:
no client should be able to *ask* for an orphan release, only the
daemon can originate one at startup. Left a comment on the
`lease-ports.ts` type saying so, since the two types sharing a name
otherwise reads as something to "fix" by widening the narrow one.

## Serialization

`StartupConverger` collects the orphaned lease ids inside one
`this.options.decisions.run(...)` call (a synchronous filter, no
awaits), lets that section complete, and only then calls
`releases.releaseOrphaned(leaseId)` per lease outside the decision
section. `SerializedDecision.run` is not reentrant on the same
instance -- calling it from inside another `run` on that instance
deadlocks -- and `LeaseReleaseCoordinator.release()` opens its own
`decisions.run` internally, so nesting had to be avoided explicitly.
Startup cannot hang: each release fully awaits its own reclaim before
the loop moves to the next lease, so there's no unbounded wait buried
in the decision section.

## Existing tests changed

Two pre-existing scenarios encoded the old assumption that a `held`
lease can survive a startup convergence run untouched
(`src/core/lease-engine.test.ts`'s "converges startup excess..." and
"reports unavoidable leased running overage"). Both now use `detached`
leases to keep testing "genuinely still-leased devices are left
alone," since a `held` lease can no longer be one of those by
definition. A `src/daemon/server.test.ts` test that asserted a
heartbeat-slid deadline survives a restart is rewritten to assert the
lease is released as orphaned instead -- that test's entire premise
was the behavior this PR removes.

That property -- a heartbeat-slid deadline surviving a restart -- was
#33's, and #33's `LeaseLifecycle.heartbeat()` doc comment argued for
going through the registry (instead of a direct
`expiryScheduler.replace`) specifically so a restart would restore the
*slid* deadline rather than the grant-time one. That argument no
longer holds: no held lease's deadline is restored across a restart
at all now, slid or otherwise. Updated the comment to state what is
still true -- the registry write keeps `ttlDeadline` truthful for
`status` / `list --leases` readers *within* a daemon's lifetime, since
`DaemonServer#decorateLease` derives `lastHeartbeatAt` from it -- and
to point at `StartupConverger` for what actually happens across a
restart now.

## How it was verified

`pnpm check` is green (typecheck, oxlint, oxfmt, vitest: 50 files, 449
passed / 2 skipped). New unit tests in
`src/core/startup-converger.test.ts` cover: a held lease is released
with reason `orphaned` and its timer is never armed (asserted by
snapshotting the lease ids visible at the moment
`restoreExpiryTimers()` runs); a detached lease keeps its restored
timer; the freed device becomes a shutdown candidate under tight
running-capacity limits, proving it's visible to the sweep that
follows.

Also verified against a hand-written `state.json` fed to a real
daemon composition (not a fake harness) built from `pnpm build`'s
`dist` output, since exercising a real simulator wasn't necessary to
prove the daemon-side behavior: seeded a `state.json` with one device
`state: "leased"` and one `held` lease with a far-future
`ttlDeadline`, then ran the real `startDaemon()` startup path
(`doctor.reconcile()` + `engine.convergeRunningCapacity()`) against
it. Before: device `leased`, lease present. After: lease gone, device
back to `ready`. A second run with direct `EventBus` access confirmed
`lease.released` fires with `payload.reason === "orphaned"`.

Closes #13

