### PR TITLE
feat(daemon): log startup, socket, driver, and connection lifecycle

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -261,6 +261,7 @@ Clock        — now(), timers (no direct Date/setTimeout in logic)
 SystemStats  — cpu count, total/free RAM, disk free
 IpcConnector / IpcListenerFactory — connect to and host daemon IPC endpoints
 DaemonLauncher — detached daemon startup with append-only combined logs
+Logger       — debug/info/warn/error(message, fields) plus child(module) scoping
 ```
 
 Real implementations are thin adapters wired up once at daemon startup;
@@ -283,6 +284,23 @@ request multiplexing, `IpcDaemonConnector` performs the hello handshake, and
 `DaemonStartupCoordinator` uses `Clock` plus `DaemonLauncher` to retry a missing
 or refused daemon. This keeps transport, detached-process logging, and startup
 policies replaceable without introducing an ambient dependency container.
+
+Operational logging is a separate concern from the event bus: `pitlane events`
+carries business facts (lease granted, device cleaned up, …) in an in-memory
+ring buffer that resets on restart, while the `Logger` port writes durable,
+structured JSON lines — one per record — for startup, socket claim/recovery,
+driver discovery, connection lifecycle, shutdown, and unexpected/handled
+errors. `startDaemon` builds the production `Logger` (`JsonLinesLogger` over a
+`NodeFileLogSink`) from `config.log` right after config loads, then hands
+module-scoped children (`logger.child("server")`, `.child("connection-host")`,
+`.child("driver-discovery")`) to each component so every line is attributable.
+The sink tracks bytes written and rotates `daemon.log` to `daemon.log.1`
+(replacing any previous generation) once `config.log.rotateBytes` is exceeded,
+so growth is bounded and `pitlane daemon logs` reads the rotated generation
+before the current file. The one exception is the fatal top-level handler: it
+cannot depend on `config.log` having loaded successfully, so it builds its own
+logger straight from the default log path at a fixed level, falling back to
+`console.error` only if that itself fails.
 
 ## Device requests
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -214,10 +214,19 @@ lines. `--follow` keeps streaming; `--since 1h` replays recent history.
 Manage the daemon explicitly. Other commands auto-start it on demand;
 `daemon` exists for operators and debugging. `logs` tails daemon logs.
 
+The daemon writes one structured JSON line per record to `~/.pitlane/daemon.log`
+(timestamp, level, module, message, and any fields) covering startup (version,
+protocol version, socket path, effective config), socket claim/stale-endpoint
+recovery, driver discovery, connection open/close, shutdown, and unexpected or
+handled errors. Growth is bounded: once the file passes `log.rotateBytes` it is
+rotated to `daemon.log.1` (replacing any previous generation), so `logs` always
+shows the current file with the immediately preceding one prepended.
+
 ## `pitlane config [get <key>|set <key> <value>]`
 
 Show the effective configuration (defaults + config file + overrides):
 managed and running capacity limits, idle tiers T1/T2/T3, TTLs, disk-pressure
-threshold. With no args, prints everything. Running capacity
+threshold, and the daemon's log level/rotation cap (`log.level`,
+`log.rotateBytes`). With no args, prints everything. Running capacity
 uses `limits.maxRunning` globally and `limits.<platform>.maxRunning` for each
 driver; both must have room before provisioning or booting a shutdown device.

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -22,6 +22,7 @@ import {
   errorExitCode,
   fallbackRequesterId,
   parseDuration,
+  readLogFile,
   runCli,
   type CliEnvironment,
   type DaemonConnection,
@@ -36,6 +37,33 @@ afterEach(async () => {
   await Promise.all(
     temporaryDirectories.splice(0).map((path) => rm(path, { force: true, recursive: true })),
   );
+});
+
+describe("readLogFile", () => {
+  it("returns just the current log when there is no rotated generation", async () => {
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp("/pitlane");
+    await filesystem.writeFileAtomic("/pitlane/daemon.log", "current\n");
+
+    await expect(readLogFile(filesystem, "/pitlane/daemon.log")).resolves.toBe("current\n");
+  });
+
+  it("prepends the rotated generation so a pre-rotation crash is not lost", async () => {
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp("/pitlane");
+    await filesystem.writeFileAtomic("/pitlane/daemon.log.1", "rotated\n");
+    await filesystem.writeFileAtomic("/pitlane/daemon.log", "current\n");
+
+    await expect(readLogFile(filesystem, "/pitlane/daemon.log")).resolves.toBe(
+      "rotated\ncurrent\n",
+    );
+  });
+
+  it("propagates the read failure when neither file exists", async () => {
+    const filesystem = new MemoryFilesystem();
+
+    await expect(readLogFile(filesystem, "/pitlane/daemon.log")).rejects.toThrow();
+  });
 });
 
 describe("CLI boundary", () => {
@@ -759,6 +787,7 @@ function testConfig(): Config {
       ios: { maxDevices: 1, maxRunning: 1 },
       maxRunning: 1 + 1,
     },
+    log: { level: "info", rotateBytes: 5 * 1024 * 1024 },
     ramBudget: { androidBytesPerDevice: 4 * gibibyte, iosBytesPerDevice: gibibyte },
   };
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,6 +8,7 @@ import {
   NodeFilesystem,
   NodeIpcTransport,
   SystemClock,
+  type Filesystem,
 } from "../ports/index.js";
 import { connectDaemon, connectExistingDaemon } from "../daemon-client/client.js";
 import { parseRawLeaseGrant } from "../daemon-client/contracts.js";
@@ -118,7 +119,7 @@ function defaultCliEnvironment(env: NodeJS.ProcessEnv = process.env): CliEnviron
       if (!(await filesystem.exists(configPath))) return {};
       return requireObject(JSON.parse(await filesystem.readFile(configPath)) as unknown);
     },
-    readLogFile: async () => filesystem.readFile(logPath),
+    readLogFile: async () => readLogFile(filesystem, logPath),
     signals: process,
     stderr: process.stderr,
     stdout: process.stdout,
@@ -731,6 +732,21 @@ function parseConfigValue(value: string): unknown {
     return value;
   }
 }
+/**
+ * Reads the rotated generation (if present) followed by the current log, so a fatal
+ * crash written just before rotation is never silently lost. `NodeFileLogSink` keeps
+ * at most one rotated generation at `<logPath>.1`.
+ */
+export async function readLogFile(filesystem: Filesystem, logPath: string): Promise<string> {
+  const rotatedPath = `${logPath}.1`;
+  const segments: string[] = [];
+  if (await filesystem.exists(rotatedPath)) {
+    segments.push(await filesystem.readFile(rotatedPath));
+  }
+  segments.push(await filesystem.readFile(logPath));
+  return segments.join("");
+}
+
 function requireObject(value: unknown): Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value))
     throw new Error("Daemon returned an invalid response");

--- a/src/core/acquisition-planner.test.ts
+++ b/src/core/acquisition-planner.test.ts
@@ -20,6 +20,7 @@ const config: Config = {
     maxRunning: 1,
   },
   ramBudget: { androidBytesPerDevice: 4 * gibibyte, iosBytesPerDevice: gibibyte },
+  log: { level: "info", rotateBytes: 5 * 1024 * 1024 },
 };
 
 function device(

--- a/src/core/capacity-coordinator.test.ts
+++ b/src/core/capacity-coordinator.test.ts
@@ -20,6 +20,7 @@ const config: Config = {
     maxRunning: 2,
   },
   ramBudget: { androidBytesPerDevice: 4 * gibibyte, iosBytesPerDevice: 1.5 * gibibyte },
+  log: { level: "info", rotateBytes: 5 * 1024 * 1024 },
 };
 
 function coordinator(): CapacityCoordinator {

--- a/src/core/capacity.test.ts
+++ b/src/core/capacity.test.ts
@@ -26,6 +26,7 @@ const config: Config = {
     maxRunning: 2,
   },
   ramBudget: { androidBytesPerDevice: 4 * gibibyte, iosBytesPerDevice: 1.5 * gibibyte },
+  log: { level: "info", rotateBytes: 5 * 1024 * 1024 },
 };
 
 function withStats(totalRamBytes: number): FakeSystemStats {

--- a/src/core/cleanup/idle-destroy.test.ts
+++ b/src/core/cleanup/idle-destroy.test.ts
@@ -14,6 +14,7 @@ const config: Config = {
     maxRunning: 1 + 1,
   },
   ramBudget: { androidBytesPerDevice: 1, iosBytesPerDevice: 1 },
+  log: { level: "info", rotateBytes: 5 * 1024 * 1024 },
 };
 
 function view(now: number): RegistryView {

--- a/src/core/cleanup/idle-shutdown.test.ts
+++ b/src/core/cleanup/idle-shutdown.test.ts
@@ -14,6 +14,7 @@ const config: Config = {
     maxRunning: 1 + 1,
   },
   ramBudget: { androidBytesPerDevice: 1, iosBytesPerDevice: 1 },
+  log: { level: "info", rotateBytes: 5 * 1024 * 1024 },
 };
 
 function view(now: number): RegistryView {

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -50,9 +50,42 @@ describe("loadConfig", () => {
         heartbeatIntervalMs: 5 * 60_000,
       },
       ramBudget: { androidBytesPerDevice: 4 * gibibyte, iosBytesPerDevice: 1.5 * gibibyte },
+      log: { level: "info", rotateBytes: 5 * 1024 * 1024 },
     });
     expect(Object.isFrozen(config)).toBe(true);
     expect(Object.isFrozen(config.limits)).toBe(true);
+  });
+
+  it("applies a file-level log override", async () => {
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp("/home/agent/.pitlane");
+    await filesystem.writeFileAtomic(
+      configPath,
+      JSON.stringify({ log: { level: "debug", rotateBytes: 1024 } }),
+    );
+
+    const config = await loadConfig({ configPath, filesystem, systemStats: createStats() });
+    expect(config.log).toEqual({ level: "debug", rotateBytes: 1024 });
+  });
+
+  it("rejects a log level outside the known set", async () => {
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp("/home/agent/.pitlane");
+    await filesystem.writeFileAtomic(configPath, JSON.stringify({ log: { level: "verbose" } }));
+
+    await expect(
+      loadConfig({ configPath, filesystem, systemStats: createStats() }),
+    ).rejects.toThrow("log.level");
+  });
+
+  it("rejects a non-positive-integer log rotation cap", async () => {
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp("/home/agent/.pitlane");
+    await filesystem.writeFileAtomic(configPath, JSON.stringify({ log: { rotateBytes: 0 } }));
+
+    await expect(
+      loadConfig({ configPath, filesystem, systemStats: createStats() }),
+    ).rejects.toThrow("log.rotateBytes");
   });
 
   it("applies file values over defaults and explicit overrides over file values", async () => {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,4 +1,4 @@
-import type { Filesystem, SystemStats } from "../ports/index.js";
+import type { Filesystem, LogLevel, SystemStats } from "../ports/index.js";
 
 const GIBIBYTE = 1024 ** 3;
 
@@ -25,6 +25,7 @@ export interface Config {
   };
   readonly diskPressure: { readonly freeBytesThreshold: number };
   readonly eventBuffer: { readonly capacity: number };
+  readonly log: { readonly level: LogLevel; readonly rotateBytes: number };
 }
 
 export type ConfigOverrides = DeepPartial<Config>;
@@ -103,6 +104,7 @@ function defaultConfig(systemStats: SystemStats): Config {
     },
     diskPressure: { freeBytesThreshold: 10 * GIBIBYTE },
     eventBuffer: { capacity: 1_000 },
+    log: { level: "info", rotateBytes: 5 * 1024 * 1024 },
   };
 }
 
@@ -165,6 +167,7 @@ const validators = {
   }),
   diskPressure: objectValidator({ freeBytesThreshold: nonNegativeNumber }),
   eventBuffer: objectValidator({ capacity: positiveInteger }),
+  log: objectValidator({ level: logLevel, rotateBytes: positiveInteger }),
 } satisfies Record<string, Validator>;
 
 function objectValidator(shape: Record<string, Validator>): Validator {
@@ -194,6 +197,16 @@ function positiveInteger(value: unknown, path: string): number {
   }
 
   return value;
+}
+
+const LOG_LEVELS: readonly LogLevel[] = ["debug", "info", "warn", "error"];
+
+function logLevel(value: unknown, path: string): LogLevel {
+  if (typeof value !== "string" || !LOG_LEVELS.includes(value as LogLevel)) {
+    throw invalidValue(path, `one of ${LOG_LEVELS.map((level) => `"${level}"`).join(", ")}`);
+  }
+
+  return value as LogLevel;
 }
 
 function nonNegativeNumber(value: unknown, path: string): number {

--- a/src/core/doctor.test.ts
+++ b/src/core/doctor.test.ts
@@ -726,5 +726,6 @@ function config(): Config {
       maxRunning: 1 + 1,
     },
     ramBudget: { androidBytesPerDevice: 1, iosBytesPerDevice: 1 },
+    log: { level: "info", rotateBytes: 5 * 1024 * 1024 },
   };
 }

--- a/src/core/lease-acquisition-coordinator.test.ts
+++ b/src/core/lease-acquisition-coordinator.test.ts
@@ -35,6 +35,7 @@ function config(maxDevices = 1): Config {
       maxRunning: 1,
     },
     ramBudget: { androidBytesPerDevice: 4 * gibibyte, iosBytesPerDevice: gibibyte },
+    log: { level: "info", rotateBytes: 5 * 1024 * 1024 },
   };
 }
 

--- a/src/core/lease-engine.test.ts
+++ b/src/core/lease-engine.test.ts
@@ -30,6 +30,7 @@ function config(overrides: Partial<Config["lease"]> = {}): Config {
       maxRunning: 1 + 1,
     },
     ramBudget: { androidBytesPerDevice: 4 * gibibyte, iosBytesPerDevice: gibibyte },
+    log: { level: "info", rotateBytes: 5 * 1024 * 1024 },
   };
 }
 

--- a/src/core/nuke.test.ts
+++ b/src/core/nuke.test.ts
@@ -145,5 +145,6 @@ function config(): Config {
       maxRunning: 1 + 1,
     },
     ramBudget: { androidBytesPerDevice: 1, iosBytesPerDevice: 1 },
+    log: { level: "info", rotateBytes: 5 * 1024 * 1024 },
   };
 }

--- a/src/core/reaper.test.ts
+++ b/src/core/reaper.test.ts
@@ -33,6 +33,7 @@ function config(): Config {
       maxRunning: 1 + 1,
     },
     ramBudget: { androidBytesPerDevice: 4 * gibibyte, iosBytesPerDevice: gibibyte },
+    log: { level: "info", rotateBytes: 5 * 1024 * 1024 },
   };
 }
 

--- a/src/core/warm-pool-coordinator.test.ts
+++ b/src/core/warm-pool-coordinator.test.ts
@@ -24,6 +24,7 @@ const config: Config = {
     maxRunning: 1,
   },
   ramBudget: { androidBytesPerDevice: 4 * gibibyte, iosBytesPerDevice: gibibyte },
+  log: { level: "info", rotateBytes: 5 * 1024 * 1024 },
 };
 
 class TestRegistry {

--- a/src/daemon/connection-host.test.ts
+++ b/src/daemon/connection-host.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  FakeClock,
   IpcError,
+  JsonLinesLogger,
   MemoryFilesystem,
   MemoryIpcTransport,
+  MemoryLogSink,
   type IpcConnection,
   type IpcConnector,
   type IpcListenerFactory,
@@ -90,6 +93,61 @@ describe("DaemonEndpointHost", () => {
     await expect(hostFor(filesystem, connector, ipc).start(() => undefined)).rejects.toThrow(
       "denied",
     );
+  });
+
+  it("logs claiming a fresh endpoint", async () => {
+    const filesystem = new MemoryFilesystem();
+    const ipc = new MemoryIpcTransport();
+    const sink = new MemoryLogSink();
+    const logger = new JsonLinesLogger({ clock: new FakeClock(), level: "debug", sink });
+    const host = new DaemonEndpointHost({
+      connector: ipc,
+      endpoint,
+      filesystem,
+      listenerFactory: ipc,
+      logger,
+    });
+
+    await host.start(() => undefined);
+
+    expect(sink.records).toContainEqual(
+      expect.objectContaining({
+        level: "info",
+        message: "Claimed daemon socket",
+        fields: { endpoint },
+      }),
+    );
+    await host.stop();
+  });
+
+  it("logs recovering a stale endpoint before claiming it", async () => {
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp("/pitlane");
+    await filesystem.writeFileAtomic(endpoint, "stale");
+    const ipc = new MemoryIpcTransport();
+    const sink = new MemoryLogSink();
+    const logger = new JsonLinesLogger({ clock: new FakeClock(), level: "debug", sink });
+    const host = new DaemonEndpointHost({
+      connector: ipc,
+      endpoint,
+      filesystem,
+      listenerFactory: ipc,
+      logger,
+    });
+
+    await host.start(() => undefined);
+
+    expect(sink.records).toContainEqual(
+      expect.objectContaining({ level: "warn", message: "Recovered stale daemon socket" }),
+    );
+    const claimedIndex = sink.records.findIndex(
+      (record) => record.message === "Claimed daemon socket",
+    );
+    const recoveredIndex = sink.records.findIndex(
+      (record) => record.message === "Recovered stale daemon socket",
+    );
+    expect(recoveredIndex).toBeLessThan(claimedIndex);
+    await host.stop();
   });
 });
 

--- a/src/daemon/connection-host.ts
+++ b/src/daemon/connection-host.ts
@@ -5,8 +5,9 @@ import type {
   IpcConnection,
   IpcConnector,
   IpcListenerFactory,
+  Logger,
 } from "../ports/index.js";
-import { IpcError } from "../ports/index.js";
+import { IpcError, NoopLogger } from "../ports/index.js";
 
 export interface ConnectionHost {
   readonly endpoint: string;
@@ -26,17 +27,20 @@ export interface DaemonEndpointHostOptions {
   readonly endpoint: string;
   readonly filesystem: Filesystem;
   readonly listenerFactory: IpcListenerFactory;
+  readonly logger?: Logger;
 }
 
 /** Owns endpoint claiming, stale-entry recovery, and listener lifecycle. */
 export class DaemonEndpointHost implements ConnectionHost {
   readonly endpoint: string;
+  readonly #logger: Logger;
   #listener: Awaited<ReturnType<IpcListenerFactory["listen"]>> | undefined;
   #ownsEndpoint = false;
   #stopped = false;
 
   constructor(private readonly options: DaemonEndpointHostOptions) {
     this.endpoint = options.endpoint;
+    this.#logger = options.logger ?? new NoopLogger();
   }
 
   // fallow-ignore-next-line complexity -- endpoint claim, stale recovery, and bind form one lifecycle transaction.
@@ -52,12 +56,17 @@ export class DaemonEndpointHost implements ConnectionHost {
       } catch (error: unknown) {
         if (error instanceof DaemonAlreadyRunningError) throw error;
         if (!(error instanceof IpcError) || !isUnavailable(error)) throw error;
+        this.#logger.warn("Recovered stale daemon socket", {
+          endpoint: this.endpoint,
+          reason: error.code,
+        });
         await this.options.filesystem.rm(this.endpoint);
       }
     }
     try {
       this.#listener = await this.options.listenerFactory.listen(this.endpoint, accept);
       this.#ownsEndpoint = true;
+      this.#logger.info("Claimed daemon socket", { endpoint: this.endpoint });
     } catch (error: unknown) {
       if (error instanceof IpcError && error.code === "address-in-use") {
         throw new DaemonAlreadyRunningError(this.endpoint);
@@ -74,6 +83,7 @@ export class DaemonEndpointHost implements ConnectionHost {
     if (this.#ownsEndpoint) {
       this.#ownsEndpoint = false;
       await this.options.filesystem.rm(this.endpoint);
+      this.#logger.info("Released daemon socket", { endpoint: this.endpoint });
     }
   }
 }

--- a/src/daemon/main.test.ts
+++ b/src/daemon/main.test.ts
@@ -1,0 +1,100 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { FakeDriver } from "../core/index.js";
+import { DAEMON_PROTOCOL_VERSION } from "../daemon-protocol/index.js";
+import {
+  CryptoIdGenerator,
+  FakeClock,
+  JsonLinesLogger,
+  MemoryFilesystem,
+  MemoryLogSink,
+  ScriptedProcessRunner,
+} from "../ports/index.js";
+import { discoverDrivers, startDaemon, type StartDaemonOptions } from "./main.js";
+import type { DaemonServer } from "./server.js";
+
+const runningDaemons: DaemonServer[] = [];
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(runningDaemons.splice(0).map((daemon) => daemon.stop("test")));
+  await Promise.all(
+    temporaryDirectories.splice(0).map((path) => rm(path, { force: true, recursive: true })),
+  );
+});
+
+async function start(overrides: Partial<StartDaemonOptions> = {}) {
+  const directory = await mkdtemp(join(tmpdir(), "pitlane-main-"));
+  temporaryDirectories.push(directory);
+  const sink = new MemoryLogSink();
+  const clock = new FakeClock(1_000);
+  const logger = new JsonLinesLogger({ clock, level: "debug", sink });
+  const daemon = await startDaemon({
+    clock,
+    dataDirectory: directory,
+    drivers: [new FakeDriver({ availableOsVersions: ["26.5"], clock, platform: "ios" })],
+    filesystem: new MemoryFilesystem(),
+    logger,
+    statePath: join(directory, "state.json"),
+    version: "1.2.3",
+    ...overrides,
+  } as StartDaemonOptions);
+  runningDaemons.push(daemon);
+  return { daemon, sink };
+}
+
+describe("startDaemon", () => {
+  it("writes a structured start record with version, protocol version, socket path, and effective config", async () => {
+    const { daemon, sink } = await start();
+
+    expect(sink.records).toContainEqual(
+      expect.objectContaining({
+        level: "info",
+        message: "Daemon started",
+        fields: expect.objectContaining({
+          version: "1.2.3",
+          protocolVersion: DAEMON_PROTOCOL_VERSION,
+          socketPath: daemon.socketPath,
+        }),
+      }),
+    );
+    const record = sink.records.find((entry) => entry.message === "Daemon started");
+    expect(record?.fields?.config).toMatchObject({ log: { level: "info" } });
+  });
+
+  it("scopes child loggers under daemon.<module> so records are attributable", async () => {
+    const { sink } = await start();
+
+    const modules = new Set(sink.records.map((record) => record.module));
+    expect(modules).toContain("daemon.server");
+    expect(modules).toContain("daemon.connection-host");
+  });
+});
+
+describe("discoverDrivers", () => {
+  it("logs a skip when the Android SDK cannot be found, without throwing", async () => {
+    const sink = new MemoryLogSink();
+    const logger = new JsonLinesLogger({ clock: new FakeClock(), level: "debug", sink });
+    const filesystem = new MemoryFilesystem();
+
+    const drivers = await discoverDrivers({
+      clock: new FakeClock(),
+      filesystem,
+      idGenerator: new CryptoIdGenerator(),
+      logger,
+      processRunner: new ScriptedProcessRunner([]),
+    });
+
+    expect(drivers.some((driver) => driver.platform === "android")).toBe(false);
+    expect(sink.records).toContainEqual(
+      expect.objectContaining({
+        level: "warn",
+        message: "Skipped Android driver: SDK missing",
+        module: "daemon.driver-discovery",
+      }),
+    );
+  });
+});

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -17,11 +17,14 @@ import { AndroidDriver, SdkMissingError } from "../drivers/android/index.js";
 import { IosSimctlDriver } from "../drivers/ios/index.js";
 import {
   CryptoIdGenerator,
+  JsonLinesLogger,
+  NodeFileLogSink,
   type Clock,
   type Filesystem,
   type IdGenerator,
   type IpcConnector,
   type IpcListenerFactory,
+  type Logger,
   NodeFilesystem,
   NodeIpcTransport,
   NodeProcessRunner,
@@ -43,6 +46,7 @@ export interface StartDaemonOptions {
   readonly filesystem?: Filesystem;
   readonly idGenerator?: IdGenerator;
   readonly ipc?: IpcConnector & IpcListenerFactory;
+  readonly logger?: Logger;
   readonly processRunner?: ProcessRunner;
   readonly socketPath?: string;
   readonly statePath?: string;
@@ -69,10 +73,21 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
     ...(options.configOverrides === undefined ? {} : { overrides: options.configOverrides }),
     systemStats,
   });
+  const logger =
+    options.logger ??
+    new JsonLinesLogger({
+      clock,
+      level: config.log.level,
+      sink: new NodeFileLogSink({
+        maxBytes: config.log.rotateBytes,
+        path: join(dataDirectory, "daemon.log"),
+      }),
+    });
   const eventBus = new EventBus(clock, config.eventBuffer.capacity);
   const registry = await Registry.load({ clock, eventBus, filesystem, idGenerator, statePath });
   const drivers =
-    options.drivers ?? (await discoverDrivers({ clock, filesystem, idGenerator, processRunner }));
+    options.drivers ??
+    (await discoverDrivers({ clock, filesystem, idGenerator, logger, processRunner }));
   const leaseEngine = new LeaseEngine({
     clock,
     config,
@@ -109,8 +124,10 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
       endpoint: socketPath,
       filesystem,
       listenerFactory: ipc,
+      logger: logger.child("connection-host"),
     }),
     leases: leaseEngine,
+    logger: logger.child("server"),
     queue: leaseEngine,
     reaper,
     nuke,
@@ -121,13 +138,15 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
   return daemon;
 }
 
-async function discoverDrivers(options: {
+export async function discoverDrivers(options: {
   readonly clock: Clock;
   readonly filesystem: Filesystem;
   readonly idGenerator: IdGenerator;
+  readonly logger: Logger;
   readonly processRunner: ProcessRunner;
 }): Promise<Driver[]> {
   const drivers: Driver[] = [];
+  const logger = options.logger.child("driver-discovery");
   if (process.platform === "darwin") {
     drivers.push(
       new IosSimctlDriver({
@@ -137,6 +156,7 @@ async function discoverDrivers(options: {
         processRunner: options.processRunner,
       }),
     );
+    logger.info("Discovered driver", { platform: "ios" });
   }
   try {
     drivers.push(
@@ -149,18 +169,42 @@ async function discoverDrivers(options: {
         processRunner: options.processRunner,
       }),
     );
+    logger.info("Discovered driver", { platform: "android" });
     return drivers;
   } catch (error: unknown) {
     if (error instanceof SdkMissingError) {
+      logger.warn("Skipped Android driver: SDK missing", { reason: error.message });
       return drivers;
     }
     throw error;
   }
 }
 
+/**
+ * Best-effort logger for the fatal startup handler below. It cannot depend on the
+ * daemon's own `Config` — that is exactly what may have failed to load — so it always
+ * writes to the default log location at a fixed level.
+ */
+export function createFatalLogger(): Logger {
+  return new JsonLinesLogger({
+    clock: new SystemClock(),
+    level: "error",
+    module: "daemon",
+    sink: new NodeFileLogSink({ path: join(homedir(), ".pitlane", "daemon.log") }),
+  });
+}
+
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
   void startDaemon().catch((error: unknown) => {
-    console.error(error);
+    const message = error instanceof Error ? error.message : String(error);
+    const stack = error instanceof Error ? error.stack : undefined;
+    try {
+      createFatalLogger().error("Daemon failed to start", { message, stack });
+    } catch {
+      // Logging itself failed (e.g. an unwritable data directory) -- fall back to
+      // the original behavior so the failure is not silently swallowed.
+      console.error(error);
+    }
     process.exitCode = 1;
   });
 }

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -9,9 +9,12 @@ import { type Config, CleanupReaper, FakeDriver, LeaseEngine, Registry } from ".
 import {
   FakeClock,
   FakeSystemStats,
+  JsonLinesLogger,
   MemoryFilesystem,
+  MemoryLogSink,
   NodeFilesystem,
   NodeIpcTransport,
+  type Logger,
 } from "../ports/index.js";
 import { DAEMON_PROTOCOL_VERSION } from "../daemon-protocol/index.js";
 import { DaemonEndpointHost } from "./connection-host.js";
@@ -617,6 +620,117 @@ describe("DaemonServer lease heartbeat", () => {
     });
     await holder.close();
   });
+
+  describe("operational logging", () => {
+    function logger(): { logger: Logger; sink: MemoryLogSink } {
+      const sink = new MemoryLogSink();
+      return {
+        logger: new JsonLinesLogger({ clock: new FakeClock(1_000), level: "debug", sink }),
+        sink,
+      };
+    }
+
+    it("logs the daemon start with version, protocol version, socket path, and effective config", async () => {
+      const { logger: log, sink } = logger();
+      const harness = await createHarness({ logger: log, start: false });
+
+      await harness.daemon.start();
+
+      expect(sink.records).toContainEqual(
+        expect.objectContaining({
+          level: "info",
+          message: "Daemon started",
+          fields: expect.objectContaining({
+            version: "test",
+            protocolVersion: DAEMON_PROTOCOL_VERSION,
+            socketPath: harness.socketPath,
+            config: harness.config,
+          }),
+        }),
+      );
+    });
+
+    it("logs a connection opening with its declared capabilities and closing afterward", async () => {
+      const { logger: log, sink } = logger();
+      const harness = await createHarness({ logger: log });
+      const client = await createClient(harness.socketPath);
+
+      await hello(client, { heartbeat: true });
+      expect(sink.records).toContainEqual(
+        expect.objectContaining({
+          level: "info",
+          message: "Connection opened",
+          fields: expect.objectContaining({ heartbeatCapability: true }),
+        }),
+      );
+
+      await client.close();
+      await expect
+        .poll(() => sink.records.some((record) => record.message === "Connection closed"))
+        .toBe(true);
+    });
+
+    it("logs a clean shutdown", async () => {
+      const { logger: log, sink } = logger();
+      const harness = await createHarness({ logger: log });
+
+      await harness.daemon.stop("test-shutdown");
+
+      expect(sink.records).toContainEqual(
+        expect.objectContaining({
+          level: "info",
+          message: "Daemon stopping",
+          fields: { reason: "test-shutdown" },
+        }),
+      );
+      expect(sink.records).toContainEqual(
+        expect.objectContaining({
+          level: "info",
+          message: "Daemon stopped",
+          fields: { reason: "test-shutdown" },
+        }),
+      );
+    });
+
+    it("logs an unhandled request error at error level", async () => {
+      const { logger: log, sink } = logger();
+      const harness = await createHarness({ logger: log });
+      const client = await createClient(harness.socketPath);
+      await hello(client);
+
+      await client.request("doctor.run", {});
+
+      expect(sink.records).toContainEqual(
+        expect.objectContaining({
+          level: "error",
+          message: "Unhandled request error",
+          fields: expect.objectContaining({ type: "doctor.run" }),
+        }),
+      );
+      await client.close();
+    });
+
+    it("logs a handled/expected request error below error level", async () => {
+      const { logger: log, sink } = logger();
+      const harness = await createHarness({ logger: log });
+      const client = await createClient(harness.socketPath);
+      await hello(client);
+
+      await client.request("lease.release", { leaseId: "not-a-lease" });
+
+      expect(sink.records).toContainEqual(
+        expect.objectContaining({
+          level: "debug",
+          message: "Handled request error",
+          fields: { code: "UNKNOWN_LEASE", type: "lease.release" },
+        }),
+      );
+      expect(sink.records).not.toContainEqual(
+        expect.objectContaining({ level: "error", message: "Unhandled request error" }),
+      );
+      await client.close();
+    });
+  });
 });
 
 // fallow-ignore-next-line complexity -- a test harness whose branches are all trivial optional-parameter defaulting.
@@ -629,6 +743,7 @@ async function createHarness(
     readonly start?: boolean;
     readonly clock?: FakeClock;
     readonly driver?: FakeDriver;
+    readonly logger?: Logger;
     readonly stateFilesystem?: MemoryFilesystem;
   } = {},
 ) {
@@ -693,6 +808,7 @@ async function createHarness(
       listenerFactory: new NodeIpcTransport(),
     }),
     leases: engine,
+    ...(options.logger === undefined ? {} : { logger: options.logger }),
     queue: engine,
     reaper,
     registry,
@@ -815,5 +931,6 @@ function testConfig(leaseOverrides?: Partial<Config["lease"]>): Config {
       maxRunning: 1 + 1,
     },
     ramBudget: { androidBytesPerDevice: 4 * gibibyte, iosBytesPerDevice: gibibyte },
+    log: { level: "info", rotateBytes: 5 * 1024 * 1024 },
   };
 }

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -23,7 +23,8 @@ import type {
   LeaseCommands,
   QueueControl,
 } from "../core/lease-ports.js";
-import type { Clock, IpcConnection, TimerHandle } from "../ports/index.js";
+import type { Clock, IpcConnection, Logger, TimerHandle } from "../ports/index.js";
+import { NoopLogger } from "../ports/index.js";
 import {
   DAEMON_PROTOCOL_VERSION,
   parseRequestFrame,
@@ -57,6 +58,7 @@ export interface DaemonServerOptions {
   readonly eventBus: EventBus;
   readonly host: ConnectionHost;
   readonly leases: LeaseCommands;
+  readonly logger?: Logger;
   readonly protocolVersion?: number;
   readonly queue: QueueControl;
   readonly reaper: CleanupReaper;
@@ -69,6 +71,7 @@ export class DaemonServer {
   readonly #connections = new Set<Connection>();
   readonly #protocolVersion: number;
   readonly #unsubscribeLeaseLost: Array<() => void> = [];
+  readonly #logger: Logger;
   #heartbeatTimer: TimerHandle | undefined;
   #heartbeatNonce = 0;
   #stopping = false;
@@ -76,6 +79,7 @@ export class DaemonServer {
 
   constructor(private readonly options: DaemonServerOptions) {
     this.#protocolVersion = options.protocolVersion ?? DAEMON_PROTOCOL_VERSION;
+    this.#logger = options.logger ?? new NoopLogger();
   }
 
   // fallow-ignore-next-line unused-class-member -- retained as a daemon compatibility facade.
@@ -103,6 +107,12 @@ export class DaemonServer {
       { configSnapshot: this.options.config, version: this.options.version },
       "daemon",
     );
+    this.#logger.info("Daemon started", {
+      config: this.options.config,
+      protocolVersion: this.#protocolVersion,
+      socketPath: this.options.host.endpoint,
+      version: this.options.version,
+    });
     this.#scheduleHeartbeatTick();
   }
 
@@ -116,6 +126,7 @@ export class DaemonServer {
   }
 
   async #stop(reason: string): Promise<void> {
+    this.#logger.info("Daemon stopping", { reason });
     this.options.eventBus.emit("daemon.stopping", { reason }, "daemon");
     if (this.#heartbeatTimer !== undefined) {
       this.options.clock.cancel(this.#heartbeatTimer);
@@ -128,6 +139,7 @@ export class DaemonServer {
       await connection.socket.close();
     }
     await this.options.host.stop();
+    this.#logger.info("Daemon stopped", { reason });
   }
 
   #accept(socket: IpcConnection): void {
@@ -212,7 +224,17 @@ export class DaemonServer {
         void this.stop("requested");
       }
     } catch (error: unknown) {
-      await this.#respondError(connection.socket, frame.id, errorCode(error), errorMessage(error));
+      const code = errorCode(error);
+      if (code === "INTERNAL") {
+        this.#logger.error("Unhandled request error", {
+          message: errorMessage(error),
+          stack: errorStack(error),
+          type: frame.type,
+        });
+      } else {
+        this.#logger.debug("Handled request error", { code, type: frame.type });
+      }
+      await this.#respondError(connection.socket, frame.id, code, errorMessage(error));
     }
   }
 
@@ -252,6 +274,10 @@ export class DaemonServer {
     connection.heartbeatCapability = isObject(payload.capabilities)
       ? payload.capabilities.heartbeat === true
       : false;
+    this.#logger.info("Connection opened", {
+      clientVersion: payload.clientVersion,
+      heartbeatCapability: connection.heartbeatCapability,
+    });
     await writeFrame(connection.socket, {
       id: frame.id,
       ok: true,
@@ -551,6 +577,9 @@ export class DaemonServer {
       return;
     }
     connection.closed = true;
+    if (connection.helloReceived) {
+      this.#logger.info("Connection closed", { heldLeaseCount: connection.heldLeaseIds.size });
+    }
     for (const disposeProgress of connection.progressDisposers) {
       disposeProgress();
     }
@@ -704,6 +733,10 @@ function errorCode(error: unknown): string {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function errorStack(error: unknown): string | undefined {
+  return error instanceof Error ? error.stack : undefined;
 }
 
 function writeFrame(socket: IpcConnection, frame: unknown): Promise<void> {

--- a/src/ports/index.ts
+++ b/src/ports/index.ts
@@ -13,6 +13,18 @@ export type { IpcErrorCode } from "./ipc.js";
 // fallow-ignore-next-line unused-type -- public listener lifecycle contract.
 export type { IpcListener } from "./ipc.js";
 export { type Clock, FakeClock, SystemClock, type TimerHandle } from "./clock.js";
+export {
+  JsonLinesLogger,
+  type LogLevel,
+  type Logger,
+  MemoryLogSink,
+  NodeFileLogSink,
+  NoopLogger,
+} from "./logger.js";
+// fallow-ignore-next-line unused-type -- public sink contract for consumers that implement their own.
+export type { LogSink } from "./logger.js";
+// fallow-ignore-next-line unused-type -- public shape of a parsed log line, for consumers of MemoryLogSink.records.
+export type { LogRecord } from "./logger.js";
 export { CryptoIdGenerator, type IdGenerator } from "./id-generator.js";
 export { FakeSystemStats, NodeSystemStats, type SystemStats } from "./system-stats.js";
 export {

--- a/src/ports/logger.test.ts
+++ b/src/ports/logger.test.ts
@@ -1,0 +1,207 @@
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { FakeClock } from "./clock.js";
+import { JsonLinesLogger, MemoryLogSink, NodeFileLogSink, NoopLogger } from "./logger.js";
+
+describe("JsonLinesLogger", () => {
+  it("writes one JSON object per line with timestamp, level, module, message, and fields", () => {
+    const clock = new FakeClock(1_000);
+    const sink = new MemoryLogSink();
+    const logger = new JsonLinesLogger({ clock, level: "debug", module: "daemon", sink });
+
+    logger.info("Daemon starting", { version: "1.0.0" });
+
+    expect(sink.records).toHaveLength(1);
+    expect(sink.records).toEqual([
+      {
+        timestamp: 1_000,
+        level: "info",
+        module: "daemon",
+        message: "Daemon starting",
+        fields: { version: "1.0.0" },
+      },
+    ]);
+  });
+
+  it("omits the fields key when no fields are given", () => {
+    const sink = new MemoryLogSink();
+    const logger = new JsonLinesLogger({ clock: new FakeClock(), sink });
+
+    logger.info("Daemon starting");
+
+    expect(sink.records[0]).not.toHaveProperty("fields");
+  });
+
+  it("derives the timestamp from the injected clock, never Date.now", () => {
+    const clock = new FakeClock(42);
+    const sink = new MemoryLogSink();
+    const logger = new JsonLinesLogger({ clock, sink });
+
+    logger.info("tick");
+    clock.advance(1_000);
+    logger.info("tock");
+
+    expect(sink.records.map((record) => record.timestamp)).toEqual([42, 1_042]);
+  });
+
+  it("filters records below the configured level", () => {
+    const sink = new MemoryLogSink();
+    const logger = new JsonLinesLogger({ clock: new FakeClock(), level: "warn", sink });
+
+    logger.debug("too quiet");
+    logger.info("still too quiet");
+    logger.warn("loud enough");
+    logger.error("also loud enough");
+
+    expect(sink.records.map((record) => record.message)).toEqual([
+      "loud enough",
+      "also loud enough",
+    ]);
+  });
+
+  it("defaults to the info level", () => {
+    const sink = new MemoryLogSink();
+    const logger = new JsonLinesLogger({ clock: new FakeClock(), sink });
+
+    logger.debug("dropped");
+    logger.info("kept");
+
+    expect(sink.records.map((record) => record.message)).toEqual(["kept"]);
+  });
+
+  it("scopes child loggers by dot-joining the module name", () => {
+    const sink = new MemoryLogSink();
+    const logger = new JsonLinesLogger({ clock: new FakeClock(), module: "daemon", sink });
+
+    logger.child("connection-host").info("Claimed socket");
+
+    expect(sink.records[0]?.module).toBe("daemon.connection-host");
+  });
+
+  it("nests grandchild module scopes", () => {
+    const sink = new MemoryLogSink();
+    const logger = new JsonLinesLogger({ clock: new FakeClock(), module: "daemon", sink });
+
+    logger.child("server").child("connection").info("opened");
+
+    expect(sink.records[0]?.module).toBe("daemon.server.connection");
+  });
+
+  it("a child logger inherits the configured level", () => {
+    const sink = new MemoryLogSink();
+    const logger = new JsonLinesLogger({ clock: new FakeClock(), level: "error", sink });
+
+    logger.child("server").warn("dropped");
+    logger.child("server").error("kept");
+
+    expect(sink.records.map((record) => record.message)).toEqual(["kept"]);
+  });
+});
+
+describe("NoopLogger", () => {
+  it("discards every record and returns itself for child()", () => {
+    const logger = new NoopLogger();
+    expect(() => {
+      logger.debug("x");
+      logger.info("x");
+      logger.warn("x");
+      logger.error("x");
+    }).not.toThrow();
+    expect(logger.child("scoped")).toBe(logger);
+  });
+});
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { force: true, recursive: true })),
+  );
+});
+
+async function tempDir(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "pitlane-logger-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+describe("NodeFileLogSink", () => {
+  it("appends one line per write to the target file", async () => {
+    const directory = await tempDir();
+    const path = join(directory, "daemon.log");
+    const sink = new NodeFileLogSink({ path });
+
+    sink.write('{"a":1}');
+    sink.write('{"a":2}');
+    sink.close();
+
+    expect(await readFile(path, "utf8")).toBe('{"a":1}\n{"a":2}\n');
+  });
+
+  it("creates the parent directory if missing", async () => {
+    const directory = await tempDir();
+    const path = join(directory, "nested", "daemon.log");
+    const sink = new NodeFileLogSink({ path });
+
+    sink.write("hello");
+    sink.close();
+
+    expect(await readFile(path, "utf8")).toBe("hello\n");
+  });
+
+  it("picks up the existing file size so rotation still triggers across restarts", async () => {
+    const directory = await tempDir();
+    const path = join(directory, "daemon.log");
+    const first = new NodeFileLogSink({ path, maxBytes: 40 });
+    first.write("a".repeat(30));
+    first.close();
+
+    const second = new NodeFileLogSink({ path, maxBytes: 40 });
+    second.write("b".repeat(30));
+    second.close();
+
+    expect(await readdir(directory)).toEqual(["daemon.log", "daemon.log.1"]);
+  });
+
+  it("rotates to <path>.1 once a write would exceed the cap, keeping exactly one generation", async () => {
+    const directory = await tempDir();
+    const path = join(directory, "daemon.log");
+    // "first\n" (6 bytes) + "second\n" (7 bytes) = 13 bytes, comfortably under the 30-byte
+    // cap; the third write ("third-line-here\n", 17 bytes) would push the file to 30 bytes
+    // exactly -- not over -- so a fourth write is what actually forces the rotation.
+    const sink = new NodeFileLogSink({ path, maxBytes: 30 });
+
+    sink.write("first"); // 6 bytes -> 6
+    sink.write("second"); // 7 bytes -> 13
+    sink.write("third-line-here"); // 16 bytes -> 29, still under the cap
+    sink.write("fourth"); // 7 bytes; 29 + 7 > 30, rotates first
+    sink.close();
+
+    const entries = await readdir(directory);
+    expect(entries.sort()).toEqual(["daemon.log", "daemon.log.1"]);
+    const rotated = await readFile(join(directory, "daemon.log.1"), "utf8");
+    expect(rotated).toBe("first\nsecond\nthird-line-here\n");
+    const current = await readFile(path, "utf8");
+    expect(current).toBe("fourth\n");
+  });
+
+  it("replaces an existing rotated generation instead of accumulating them", async () => {
+    const directory = await tempDir();
+    const path = join(directory, "daemon.log");
+    const sink = new NodeFileLogSink({ path, maxBytes: 10 });
+
+    sink.write("aaaaaaaaaa");
+    sink.write("bbbbbbbbbb"); // rotates: aaaa -> daemon.log.1
+    sink.write("cccccccccc"); // rotates again: bbbb -> daemon.log.1 (replacing aaaa)
+    sink.close();
+
+    expect(await readdir(directory)).toEqual(["daemon.log", "daemon.log.1"]);
+    expect(await readFile(join(directory, "daemon.log.1"), "utf8")).toContain("bbbbbbbbbb");
+    expect(await readFile(join(directory, "daemon.log.1"), "utf8")).not.toContain("aaaaaaaaaa");
+  });
+});

--- a/src/ports/logger.ts
+++ b/src/ports/logger.ts
@@ -1,0 +1,186 @@
+import { closeSync, fstatSync, mkdirSync, openSync, renameSync, writeSync } from "node:fs";
+import { dirname } from "node:path";
+
+import type { Clock } from "./clock.js";
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+const LEVEL_ORDER: Record<LogLevel, number> = { debug: 0, info: 1, warn: 2, error: 3 };
+
+export interface LogRecord {
+  readonly timestamp: number;
+  readonly level: LogLevel;
+  readonly module: string;
+  readonly message: string;
+  readonly fields?: Record<string, unknown>;
+}
+
+/** Operational (not business-event) logging port. Never `console` directly — see architecture rule 9. */
+export interface Logger {
+  debug(message: string, fields?: Record<string, unknown>): void;
+  info(message: string, fields?: Record<string, unknown>): void;
+  warn(message: string, fields?: Record<string, unknown>): void;
+  error(message: string, fields?: Record<string, unknown>): void;
+  /** Returns a logger scoped to `module`, dot-joined with any existing scope. */
+  child(module: string): Logger;
+}
+
+/** Receives one already-formatted line per record. Owns whatever storage/rotation backs it. */
+export interface LogSink {
+  write(line: string): void;
+}
+
+export interface JsonLinesLoggerOptions {
+  readonly clock: Clock;
+  readonly level?: LogLevel;
+  readonly module?: string;
+  readonly sink: LogSink;
+}
+
+/** Formats one JSON object per line and hands it to an injected {@link LogSink}. */
+export class JsonLinesLogger implements Logger {
+  readonly #clock: Clock;
+  readonly #level: LogLevel;
+  readonly #module: string;
+  readonly #sink: LogSink;
+
+  constructor(options: JsonLinesLoggerOptions) {
+    this.#clock = options.clock;
+    this.#level = options.level ?? "info";
+    this.#module = options.module ?? "daemon";
+    this.#sink = options.sink;
+  }
+
+  debug(message: string, fields?: Record<string, unknown>): void {
+    this.#log("debug", message, fields);
+  }
+
+  info(message: string, fields?: Record<string, unknown>): void {
+    this.#log("info", message, fields);
+  }
+
+  warn(message: string, fields?: Record<string, unknown>): void {
+    this.#log("warn", message, fields);
+  }
+
+  error(message: string, fields?: Record<string, unknown>): void {
+    this.#log("error", message, fields);
+  }
+
+  child(module: string): Logger {
+    return new JsonLinesLogger({
+      clock: this.#clock,
+      level: this.#level,
+      module: `${this.#module}.${module}`,
+      sink: this.#sink,
+    });
+  }
+
+  #log(level: LogLevel, message: string, fields?: Record<string, unknown>): void {
+    if (LEVEL_ORDER[level] < LEVEL_ORDER[this.#level]) {
+      return;
+    }
+    const record: LogRecord = {
+      timestamp: this.#clock.now(),
+      level,
+      module: this.#module,
+      message,
+      ...(fields === undefined ? {} : { fields }),
+    };
+    this.#sink.write(JSON.stringify(record));
+  }
+}
+
+/** Discards every record. Used as the default when no logger is injected. */
+export class NoopLogger implements Logger {
+  debug(_message: string, _fields?: Record<string, unknown>): void {}
+  info(_message: string, _fields?: Record<string, unknown>): void {}
+  warn(_message: string, _fields?: Record<string, unknown>): void {}
+  error(_message: string, _fields?: Record<string, unknown>): void {}
+
+  child(_module?: string): Logger {
+    return this;
+  }
+}
+
+/** In-memory sink for tests: exposes each record already parsed, never raw string fragments. */
+export class MemoryLogSink implements LogSink {
+  readonly #lines: string[] = [];
+
+  write(line: string): void {
+    this.#lines.push(line);
+  }
+
+  get records(): readonly LogRecord[] {
+    return this.#lines.map((line) => JSON.parse(line) as LogRecord);
+  }
+}
+
+const DEFAULT_MAX_BYTES = 5 * 1024 * 1024;
+
+export interface NodeFileLogSinkOptions {
+  readonly maxBytes?: number;
+  readonly path: string;
+}
+
+/**
+ * Appends to `path` via a held file descriptor, tracking bytes written. Once a write
+ * would push the file past `maxBytes`, the current file is renamed to `<path>.1`
+ * (replacing any existing generation) and a fresh file is opened. Exactly one rotated
+ * generation is kept.
+ *
+ * Writes are synchronous (`writeSync`), deliberately, not by oversight: this keeps
+ * records strictly ordered without a write queue, guarantees a line is never split
+ * across an interleaved write to the same fd (`NodeDaemonLauncher` hands the child an
+ * inherited append fd on this same path for uncaught fatal output -- see below), and is
+ * the only kind of write that reliably lands from a handler where the process is about
+ * to exit. This is sound only because volume is low by design: operational lifecycle
+ * lines (startup, connection churn, shutdown), not per-request logging.
+ *
+ * `#bytesWritten` only counts what this sink itself writes. The daemon launcher's
+ * inherited fd can append a fatal crash dump to the same file without going through
+ * this class, so the cap is a soft bound -- "one crash dump" -- not a hard guarantee
+ * that the file never exceeds `maxBytes`.
+ */
+export class NodeFileLogSink implements LogSink {
+  readonly #path: string;
+  readonly #maxBytes: number;
+  #fd: number;
+  #bytesWritten: number;
+
+  constructor(options: NodeFileLogSinkOptions) {
+    this.#path = options.path;
+    this.#maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
+    mkdirSync(dirname(this.#path), { recursive: true });
+    this.#fd = openSync(this.#path, "a");
+    this.#bytesWritten = fstatSync(this.#fd).size;
+  }
+
+  write(line: string): void {
+    const chunk = `${line}\n`;
+    const size = Buffer.byteLength(chunk);
+    if (this.#bytesWritten > 0 && this.#bytesWritten + size > this.#maxBytes) {
+      this.#rotate();
+    }
+    writeSync(this.#fd, chunk);
+    this.#bytesWritten += size;
+  }
+
+  /**
+   * Not called anywhere in production: `startDaemon` builds this sink once at startup
+   * and never tears it down, relying on the fd closing at process exit. Deliberate --
+   * threading a close-on-shutdown path through `main.ts` would couple the daemon's
+   * shutdown sequence to this specific adapter for no real benefit. Kept as a public
+   * method purely so tests can close and reopen deterministically.
+   */
+  close(): void {
+    closeSync(this.#fd);
+  }
+
+  #rotate(): void {
+    closeSync(this.#fd);
+    renameSync(this.#path, `${this.#path}.1`);
+    this.#fd = openSync(this.#path, "a");
+    this.#bytesWritten = 0;
+  }
+}


### PR DESCRIPTION
## What changed

`daemon.log` was always empty because the daemon's only write to either
stream was `console.error(error)` in the fatal startup handler. No startup
line, no shutdown line, no record of socket claim/recovery or driver
discovery -- `daemon logs` was a crash-dump viewer, not a log.

- **New `Logger` port** (`src/ports/logger.ts`), in keeping with
  `docs/agent-rules/architecture.md`: `debug/info/warn/error(message, fields)`
  plus `child(module)` for scoping. `JsonLinesLogger` formats one JSON object
  per line (`timestamp`, `level`, `module`, `message`, `fields`) and hands it
  to an injected `LogSink`, so tests assert parsed records via `MemoryLogSink`
  rather than string fragments.
- **Rotation lives in the sink**, not the caller: `NodeFileLogSink` owns an
  append handle on `~/.pitlane/daemon.log`, tracks bytes written (including
  picking up the existing file's size on restart via `fstatSync` on the held
  fd), and once a write would push past `config.log.rotateBytes` it closes
  the fd, renames the current file to `daemon.log.1` (replacing any previous
  generation), and reopens. Exactly one rotated generation is kept. The cap
  is a soft bound, not a hard guarantee: `#bytesWritten` only counts what
  this sink writes, and `NodeDaemonLauncher` hands the daemon child an
  inherited append fd on this same path for uncaught fatal output, so a
  crash dump can land without being counted and push the file a bit past
  `rotateBytes`. Bounded by "one crash dump," not exact -- documented on the
  class.
- **Coverage**: daemon start (version, protocol version, socket path,
  effective config) in `DaemonServer.start()`; socket claim and
  stale-endpoint recovery in `DaemonEndpointHost`; driver discovery results,
  including the Android SDK-missing skip, in `discoverDrivers`; connection
  open/close with declared capabilities and clean shutdown in `DaemonServer`;
  and request errors, split into `error`-level for anything mapping to
  `INTERNAL` versus `debug`-level for expected/handled daemon errors (queue
  timeouts, unknown leases, etc.) so a normal session stays quiet at the
  default `info` level.
- **Config**: a new `log` section (`level`, default `"info"`; `rotateBytes`,
  default 5 MiB), validated the same way as its neighbors and readable via
  `pitlane config get log`.

## Ordering: the fatal handler can't depend on config

`startDaemon` builds its logger from `config.log.level` right after config
loads, then hands module-scoped children (`logger.child("server")`, etc.) to
each component. But the top-level `.catch()` in `main.ts` is exactly where a
config-load failure lands, so it can't reuse that logger -- it may not exist.
It builds its own logger straight from the default log path
(`~/.pitlane/daemon.log`) at a fixed level, independent of any `Config`, and
only falls back to `console.error` if constructing *that* logger itself
throws (e.g. an unwritable data directory). Verified by hand: killing config
mid-load still produces a structured `"Daemon failed to start"` line in the
log rather than a bare stack trace on stderr.

## The CLI needed one change after all

The issue said `daemon logs` needs no change -- true for reading the log
itself, but not once rotation exists. `NodeDaemonLauncher` hands the child an
inherited append fd on the *same path* as both stdout and stderr for
uncaught fatal output, so a crash stack can land in `daemon.log.1` if it
happened to write right before a rotation. `readLogFile` (`src/cli/index.ts`)
now reads `daemon.log.1` (if present) followed by `daemon.log`, so nothing
written just before a rotation is silently lost.

## Scope

Deliberately operational-only: no bus events added or renamed, nothing in
`src/bus/`, `src/core/lease-*.ts`, `src/core/startup-converger.ts`, or
`src/core/registry.ts` touched, `docs/EVENTS.md` untouched. No lease payloads
or device identifiers are logged beyond what `pitlane events` already
exposes -- the daemon-start log's `config` field is the effective
configuration, not device or lease state.

Adding a required `Config.log` field meant every test file building a
`Config` literal needed the field added (mechanical, one line each) to keep
`pnpm check` green; none of the actual test logic in those files changed.

## Review follow-ups

A first review pass caught five things, all fixed here (amended into the
same commit rather than stacked):

- The constructor computed `#bytesWritten` with `existsSync(path) ? statSync(path).size : 0`
  right after `openSync(path, "a")`, which always creates the file -- so the
  `false` branch was dead and the code implied a case that can't happen. Now
  `fstatSync(this.#fd).size` off the descriptor already held.
- `NodeFileLogSink` uses synchronous `writeSync`, which is intentional --
  keeps records ordered, can't interleave a half-written line with the
  launcher's inherited fd on the same path, and is the only kind of write
  that reliably lands from a handler where the process is about to exit --
  but that reasoning wasn't written down anywhere. Now a comment on the
  class states it explicitly, plus that it's sound only because volume is
  low by design (lifecycle lines, not per-request logging).
- `close()` was never called in production, only from tests. Rather than
  threading a close-on-shutdown path through `main.ts` for a descriptor that
  closes at process exit anyway, documented on the method that this is
  deliberate, not accidental.
- The `"Unhandled request error"` log -- the single most important record in
  this change, since `INTERNAL` means "unanticipated" by definition -- threw
  away the stack. Added `errorStack(error)` alongside `errorMessage(error)`.
  (Extracted as a top-level helper, not an inline ternary, to keep
  `#dispatchLine` under Fallow's complexity threshold.)
- Rotation cap: see the updated bullet above -- now stated as a soft bound,
  not an exact guarantee.

## How it was verified

`pnpm check` green: typecheck, oxlint, oxfmt, and 476 tests passed (2
skipped, pre-existing). `pnpm fallow` (changed-files audit) reports no
issues.

Built with `pnpm build` and ran a real daemon against a scratch `HOME` (not
the user's own `~/.pitlane`, which had another daemon running) via
`HOME=$SCRATCH node dist/cli/main.js daemon start`. `daemon.log` picked up
structured lines for driver discovery, the Android SDK-missing skip, socket
claim, daemon start (with full effective config), connection open/close, and
-- on `daemon stop` -- stopping, socket release, and stopped. `pitlane daemon
logs` rendered them. The user's real `~/.pitlane/daemon.log` was read-only
verified to be untouched and still holds the pre-existing `ConfigError` crash
from before this fix, which is itself a nice before/after.

Closes #36
