### PR TITLE
fix(mcp): reconnect the session after a daemon restart

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -38,7 +38,22 @@ MCP client ──spawns──> stdio MCP ┘                                    
   point the connection closes and releases the lease. Like the CLI, it relays
   the daemon's progress pushes for the in-flight `lease_simulator` request —
   as MCP `notifications/progress` instead of stderr JSON lines, and only when
-  the client supplied a progress token.
+  the client supplied a progress token. Unlike the CLI, this process outlives
+  any single daemon connection: `McpSession` does not cache a dead connection.
+  `DaemonConnection#onClose` (`src/daemon-client/protocol.ts`) tells the
+  session the moment its connection dies — from a graceful `daemon stop`, a
+  crash, or `kill -9` — and the next tool call reconnects lazily, auto-starting
+  the daemon exactly as the CLI does. A held lease never survives its
+  connection dying (the daemon releases it on graceful close, and
+  `StartupConverger` sweeps any orphaned lease from an ungraceful death at its
+  own startup — see "Lease subsystem boundaries and wiring" above), so the
+  session never asks the daemon whether its old lease survived; it clears
+  `#ownedLease` and fires `onLeaseLost` (reason
+  `daemon-connection-lost`) so the agent hears the fact instead of silently
+  reacquiring a device. A dead connection surfaces as typed
+  `DAEMON_CONNECTION_LOST` (mid-request) or `DAEMON_UNAVAILABLE` (a failed
+  reconnect), not the opaque `INTERNAL`; only idempotent, read-only requests
+  (`catalog.get`) retry once, never `lease.request`.
 - **Daemon**: owns all state, serializes all decisions. Started on demand,
   reachable over a unix socket.
 

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -701,6 +701,10 @@ class StubConnection implements DaemonConnection {
     return () => this.#listeners.delete(listener);
   }
 
+  onClose(): () => void {
+    return () => undefined;
+  }
+
   push(kind: string, payload: unknown): void {
     for (const listener of this.#listeners) {
       listener(kind, payload);

--- a/src/daemon-client/connection.test.ts
+++ b/src/daemon-client/connection.test.ts
@@ -111,9 +111,60 @@ describe("IpcDaemonConnection", () => {
     const client = new IpcDaemonConnection(await ipc.connect("/daemon.sock"));
     const pending = client.request("wait", {});
     await server?.close();
-    await expect(pending).rejects.toThrow("Daemon connection closed");
+    await expect(pending).rejects.toMatchObject({
+      code: "DAEMON_CONNECTION_LOST",
+      message: "Daemon connection closed",
+    });
     await client.close();
     await client.close();
+  });
+
+  it("notifies onClose exactly once when the underlying socket dies", async () => {
+    const ipc = new MemoryIpcTransport();
+    let server: Awaited<ReturnType<typeof ipc.connect>> | undefined;
+    await ipc.listen("/daemon.sock", (connection) => {
+      server = connection;
+    });
+    const client = new IpcDaemonConnection(await ipc.connect("/daemon.sock"));
+    let closeCount = 0;
+    client.onClose(() => (closeCount += 1));
+
+    await server?.close();
+    expect(closeCount).toBe(1);
+
+    // The socket is already gone; explicitly closing on top must not fire onClose again.
+    await client.close();
+    expect(closeCount).toBe(1);
+  });
+
+  it("notifies onClose exactly once when closed explicitly, and a later socket death is a no-op", async () => {
+    const ipc = new MemoryIpcTransport();
+    let server: Awaited<ReturnType<typeof ipc.connect>> | undefined;
+    await ipc.listen("/daemon.sock", (connection) => {
+      server = connection;
+    });
+    const client = new IpcDaemonConnection(await ipc.connect("/daemon.sock"));
+    let closeCount = 0;
+    client.onClose(() => (closeCount += 1));
+
+    await client.close();
+    expect(closeCount).toBe(1);
+    await server?.close();
+    expect(closeCount).toBe(1);
+  });
+
+  it("rejects a request made after the socket has already closed with DAEMON_CONNECTION_LOST", async () => {
+    const ipc = new MemoryIpcTransport();
+    let server: Awaited<ReturnType<typeof ipc.connect>> | undefined;
+    await ipc.listen("/daemon.sock", (connection) => {
+      server = connection;
+    });
+    const client = new IpcDaemonConnection(await ipc.connect("/daemon.sock"));
+    await server?.close();
+
+    await expect(client.request("status.get", {})).rejects.toMatchObject({
+      code: "DAEMON_CONNECTION_LOST",
+    });
   });
 
   it("rejects pending work when the daemon sends malformed JSON", async () => {

--- a/src/daemon-client/connection.ts
+++ b/src/daemon-client/connection.ts
@@ -9,6 +9,7 @@ interface PendingRequest {
 
 export class IpcDaemonConnection implements DaemonConnection {
   readonly #listeners = new Set<(kind: string, payload: unknown) => void>();
+  readonly #closeListeners = new Set<() => void>();
   readonly #pending = new Map<number, PendingRequest>();
   #buffer = "";
   #nextId = 1;
@@ -17,12 +18,14 @@ export class IpcDaemonConnection implements DaemonConnection {
   constructor(private readonly connection: IpcConnection) {
     connection.onData((chunk) => this.#read(chunk));
     connection.onError((error) => this.#failPending(error));
-    connection.onClose(() => this.#failPending(new Error("Daemon connection closed")));
+    connection.onClose(() => this.#handleClosed());
   }
 
   request(type: string, payload: unknown): Promise<unknown> {
     if (this.#closed || this.connection.closed)
-      return Promise.reject(new Error("Daemon connection is closed"));
+      return Promise.reject(
+        new DaemonClientError("DAEMON_CONNECTION_LOST", "Daemon connection is closed"),
+      );
     const id = this.#nextId++;
     return new Promise((resolve, reject) => {
       this.#pending.set(id, { reject, resolve });
@@ -38,11 +41,23 @@ export class IpcDaemonConnection implements DaemonConnection {
     return () => this.#listeners.delete(listener);
   }
 
+  onClose(listener: () => void): () => void {
+    this.#closeListeners.add(listener);
+    return () => this.#closeListeners.delete(listener);
+  }
+
   async close(): Promise<void> {
     if (this.#closed) return;
-    this.#closed = true;
-    this.#failPending(new Error("Daemon connection closed"));
+    this.#handleClosed();
     await this.connection.close();
+  }
+
+  /** Idempotent: fires at most once, whether triggered by the socket dying or by our own `close()`. */
+  #handleClosed(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#failPending(new DaemonClientError("DAEMON_CONNECTION_LOST", "Daemon connection closed"));
+    for (const listener of this.#closeListeners) listener();
   }
 
   #read(chunk: string): void {

--- a/src/daemon-client/protocol.ts
+++ b/src/daemon-client/protocol.ts
@@ -1,6 +1,8 @@
 export interface DaemonConnection {
   request(type: string, payload: unknown): Promise<unknown>;
   onPush(listener: (kind: string, payload: unknown) => void): () => void;
+  /** Fires exactly once, whenever the connection closes — from a live socket drop or from `close()`. */
+  onClose(listener: () => void): () => void;
   close(): Promise<void>;
 }
 

--- a/src/daemon-client/startup-coordinator.test.ts
+++ b/src/daemon-client/startup-coordinator.test.ts
@@ -120,6 +120,7 @@ describe("DaemonStartupCoordinator", () => {
 function stubConnection(): DaemonConnection {
   return {
     close: async () => undefined,
+    onClose: () => () => undefined,
     onPush: () => () => undefined,
     request: async () => undefined,
   };

--- a/src/mcp/main.test.ts
+++ b/src/mcp/main.test.ts
@@ -212,6 +212,10 @@ class LeaseConnection implements DaemonConnection {
   onPush(): () => void {
     return () => undefined;
   }
+
+  onClose(): () => void {
+    return () => undefined;
+  }
   async request(_type: string, payload: unknown): Promise<unknown> {
     this.lastRequesterId = (payload as { readonly requesterId?: unknown }).requesterId;
     return {

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -340,6 +340,10 @@ class StubConnection implements DaemonConnection {
     this.#listeners.add(listener);
     return () => this.#listeners.delete(listener);
   }
+
+  onClose(): () => void {
+    return () => undefined;
+  }
   pushLeaseLost(payload: {
     readonly deviceId: string;
     readonly leaseId: string;

--- a/src/mcp/session.test.ts
+++ b/src/mcp/session.test.ts
@@ -681,13 +681,166 @@ describe("McpSession", () => {
     grant.resolve(rawGrant);
     await lease;
   });
+
+  it("reconnects lazily after a daemon restart between two calls", async () => {
+    const connectionA = new StubConnection();
+    connectionA.responses.push({ platforms: [] });
+    const connectionB = new StubConnection();
+    connectionB.responses.push({ platforms: [] });
+    const connections = [connectionA, connectionB];
+    let connectCalls = 0;
+    const session = new McpSession({
+      connect: async () => {
+        connectCalls += 1;
+        return connections.shift()!;
+      },
+      requesterId: "mcp-session-1",
+    });
+
+    await expect(session.listDevices({})).resolves.toEqual({ platforms: [] });
+    expect(connectCalls).toBe(1);
+
+    // The daemon restarts: the socket underneath the cached connection dies.
+    connectionA.emitClose();
+
+    await expect(session.listDevices({})).resolves.toEqual({ platforms: [] });
+    expect(connectCalls).toBe(2);
+    expect(connectionA.requests).toEqual([{ payload: {}, type: "catalog.get" }]);
+    expect(connectionB.requests).toEqual([{ payload: {}, type: "catalog.get" }]);
+  });
+
+  it("surfaces DAEMON_CONNECTION_LOST, without retrying, when the connection dies mid lease request", async () => {
+    const connection = new StubConnection();
+    const grant = deferred<unknown>();
+    connection.responses.push(grant.promise);
+    let connectCalls = 0;
+    const session = new McpSession({
+      connect: async () => {
+        connectCalls += 1;
+        return connection;
+      },
+      requesterId: "mcp-session-1",
+    });
+
+    const lease = session.lease(input);
+    await waitFor(() => connection.requests.length === 1);
+
+    // The socket dies while the daemon is still deciding on the lease request.
+    connection.emitClose();
+    grant.reject(new DaemonClientError("DAEMON_CONNECTION_LOST", "Daemon connection closed"));
+
+    await expect(lease).rejects.toMatchObject({ code: "DAEMON_CONNECTION_LOST" });
+    // A retry here could provision and grant a second device -- must never happen.
+    expect(connectCalls).toBe(1);
+    expect(connection.requests).toHaveLength(1);
+    expect(session.status()).toEqual({ held: false });
+  });
+
+  it("retries a read-only catalog.get once after the connection dies mid-request", async () => {
+    const connection = new StubConnection();
+    const firstResponse = deferred<unknown>();
+    connection.responses.push(firstResponse.promise);
+    connection.responses.push({ platforms: [] });
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+
+    const listing = session.listDevices({});
+    await waitFor(() => connection.requests.length === 1);
+    connection.emitClose();
+    firstResponse.reject(
+      new DaemonClientError("DAEMON_CONNECTION_LOST", "Daemon connection closed"),
+    );
+
+    await expect(listing).resolves.toEqual({ platforms: [] });
+    expect(connection.requests).toEqual([
+      { payload: {}, type: "catalog.get" },
+      { payload: {}, type: "catalog.get" },
+    ]);
+  });
+
+  it("forces a fresh connection on retry when DAEMON_CONNECTION_LOST arrives without #connection having been cleared yet", async () => {
+    // This pins the ordering IpcDaemonConnection.request() also rejects synchronously once it
+    // observes the transport already closed, which can race ahead of the underlying `onClose`
+    // propagating back to `#handleConnectionClosed`. `connectionA` here rejects the same way but
+    // deliberately never calls `emitClose()`, so `#connection` is still set to it when the retry
+    // runs -- the retry must not just hand back the same dead connection.
+    const connectionA = new StubConnection();
+    connectionA.responses.push(
+      new DaemonClientError("DAEMON_CONNECTION_LOST", "Daemon connection is closed"),
+    );
+    const connectionB = new StubConnection();
+    connectionB.responses.push({ platforms: [] });
+    const connections = [connectionA, connectionB];
+    let connectCalls = 0;
+    const session = new McpSession({
+      connect: async () => {
+        connectCalls += 1;
+        return connections.shift()!;
+      },
+      requesterId: "mcp-session-1",
+    });
+
+    await expect(session.listDevices({})).resolves.toEqual({ platforms: [] });
+    expect(connectCalls).toBe(2);
+    expect(connectionA.requests).toEqual([{ payload: {}, type: "catalog.get" }]);
+    expect(connectionB.requests).toEqual([{ payload: {}, type: "catalog.get" }]);
+  });
+
+  it("clears an owned lease and notifies onLeaseLost when the connection dies across a restart", async () => {
+    const connection = new StubConnection();
+    connection.responses.push(rawGrant);
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+    await session.lease(input);
+    expect(session.status()).toMatchObject({ held: true, lease_id: "lse_9f2c" });
+
+    const notices: unknown[] = [];
+    session.onLeaseLost((notice) => notices.push(notice));
+
+    // A graceful stop or an ungraceful crash both release the held lease daemon-side (see
+    // DaemonServer#stop / the startup path's orphan sweep) -- the reconnect never asks.
+    connection.emitClose();
+
+    expect(notices).toEqual([
+      { deviceId: "ABCD", leaseId: "lse_9f2c", reason: "daemon-connection-lost" },
+    ]);
+    expect(session.status()).toEqual({ held: false });
+  });
+
+  it("surfaces DAEMON_UNAVAILABLE when reconnecting after a restart fails", async () => {
+    const connection = new StubConnection();
+    connection.responses.push({ platforms: [] });
+    let connectCalls = 0;
+    const session = new McpSession({
+      connect: async () => {
+        connectCalls += 1;
+        if (connectCalls === 1) return connection;
+        throw new Error("ECONNREFUSED");
+      },
+      requesterId: "mcp-session-1",
+    });
+
+    await expect(session.listDevices({})).resolves.toEqual({ platforms: [] });
+    connection.emitClose();
+
+    await expect(session.listDevices({})).rejects.toMatchObject({
+      code: "DAEMON_UNAVAILABLE",
+    });
+    expect(connectCalls).toBe(2);
+  });
 });
 
 class StubConnection implements DaemonConnection {
   readonly requests: Array<{ readonly payload: unknown; readonly type: string }> = [];
   readonly responses: unknown[] = [];
   closeCalls = 0;
+  #closed = false;
   readonly #listeners = new Set<(kind: string, payload: unknown) => void>();
+  readonly #closeListeners = new Set<() => void>();
 
   async request(type: string, payload: unknown): Promise<unknown> {
     this.requests.push({ payload, type });
@@ -699,6 +852,18 @@ class StubConnection implements DaemonConnection {
   onPush(listener: (kind: string, payload: unknown) => void): () => void {
     this.#listeners.add(listener);
     return () => this.#listeners.delete(listener);
+  }
+
+  onClose(listener: () => void): () => void {
+    this.#closeListeners.add(listener);
+    return () => this.#closeListeners.delete(listener);
+  }
+
+  /** Simulates the socket dying under this connection (daemon restart/crash). */
+  emitClose(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    for (const listener of this.#closeListeners) listener();
   }
 
   pushLeaseLost(payload: {
@@ -726,12 +891,19 @@ class StubConnection implements DaemonConnection {
   }
 }
 
-function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+function deferred<T>(): {
+  promise: Promise<T>;
+  reject: (error: unknown) => void;
+  resolve: (value: T) => void;
+} {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((next) => {
-    resolve = next;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
   });
-  return { promise, resolve };
+  promise.catch(() => undefined);
+  return { promise, reject, resolve };
 }
 
 async function waitFor(predicate: () => boolean): Promise<void> {

--- a/src/mcp/session.ts
+++ b/src/mcp/session.ts
@@ -89,6 +89,7 @@ export class McpSession {
   #sessionClosed: Promise<never>;
   #ownedLease: OwnedLease | undefined;
   #pushUnsubscribe: (() => void) | undefined;
+  #closeUnsubscribe: (() => void) | undefined;
   /** Scoped to the in-flight `lease()` call; cleared once that call settles or the session closes. */
   #leaseProgressListener: ((progress: LeaseProgressNotice) => void) | undefined;
   readonly #leaseLostListeners = new Set<(notice: LeaseLostNotice) => void>();
@@ -143,14 +144,10 @@ export class McpSession {
   listDevices(input: ListDevicesInput): Promise<ListDevicesOutput> {
     return this.#mutate(async () => {
       this.#throwIfClosed();
-      const connection = await this.#connectionForUse();
-      const response = await Promise.race([
-        connection.request(
-          "catalog.get",
-          input.platform === undefined ? {} : { platform: input.platform },
-        ),
-        this.#sessionClosed,
-      ]);
+      const response = await this.#requestReadOnly(
+        "catalog.get",
+        input.platform === undefined ? {} : { platform: input.platform },
+      );
       const catalog = parseRawCatalog(response);
       return listDevicesOutputSchema.parse({
         platforms: catalog.platforms.map((entry) => ({
@@ -182,6 +179,8 @@ export class McpSession {
     this.#leaseProgressListener = undefined;
     this.#pushUnsubscribe?.();
     this.#pushUnsubscribe = undefined;
+    this.#closeUnsubscribe?.();
+    this.#closeUnsubscribe = undefined;
     this.#rejectClosed(new McpSessionError("SESSION_CLOSED", "MCP session is closed"));
     const connection = this.#connection;
     this.#connection = undefined;
@@ -303,6 +302,11 @@ export class McpSession {
     else if (responseReceived) await this.#closeConnection().catch(() => undefined);
   }
 
+  /**
+   * Reconnects lazily: a dead `#connection` (cleared by `#handleConnectionClosed`, below) makes
+   * the next call re-run `#connect()`, which auto-starts the daemon exactly as the CLI does and
+   * re-negotiates capabilities (e.g. the heartbeat) at `hello`, free of charge.
+   */
   async #connectionForUse(): Promise<DaemonConnection> {
     if (this.#connection !== undefined) return this.#connection;
     this.#connecting ??= this.#connect();
@@ -315,10 +319,12 @@ export class McpSession {
       }
       this.#connection = connection;
       this.#pushUnsubscribe = connection.onPush((kind, payload) => this.#handlePush(kind, payload));
+      this.#closeUnsubscribe = connection.onClose(() => this.#handleConnectionClosed(connection));
       return connection;
     } catch (error: unknown) {
       this.#throwIfClosed();
-      throw error;
+      if (error instanceof DaemonClientError || error instanceof McpSessionError) throw error;
+      throw new DaemonClientError("DAEMON_UNAVAILABLE", errorMessage(error));
     } finally {
       if (this.#connecting === connecting) this.#connecting = undefined;
     }
@@ -329,7 +335,60 @@ export class McpSession {
     this.#connection = undefined;
     this.#pushUnsubscribe?.();
     this.#pushUnsubscribe = undefined;
+    this.#closeUnsubscribe?.();
+    this.#closeUnsubscribe = undefined;
     if (connection !== undefined) await this.#closeDaemonConnection(connection);
+  }
+
+  /**
+   * The invariant this relies on: a dead connection means the held lease is already gone
+   * daemon-side, by one of three paths — a graceful `daemon stop` releases held leases before
+   * exiting, an ordinary connection close releases that connection's held leases the same way,
+   * and an ungraceful death leaves the lease persisted for the startup path to release as
+   * `orphaned`. So this never asks the daemon; it just stops believing the lease is ours and
+   * tells the agent (#15's `onLeaseLost` channel) so it can decide whether to re-lease.
+   */
+  #handleConnectionClosed(connection: DaemonConnection): void {
+    if (this.#connection !== connection) return;
+    this.#connection = undefined;
+    this.#pushUnsubscribe?.();
+    this.#pushUnsubscribe = undefined;
+    this.#closeUnsubscribe = undefined;
+    if (this.#ownedLease === undefined) return;
+    const lease = this.#ownedLease;
+    this.#ownedLease = undefined;
+    for (const listener of this.#leaseLostListeners) {
+      listener({
+        deviceId: lease.deviceId,
+        leaseId: lease.leaseId,
+        reason: "daemon-connection-lost",
+      });
+    }
+  }
+
+  /**
+   * Retries at most once, and only for idempotent, read-only requests. A `lease.request` must
+   * never go through here: retrying it after a mid-request connection death could provision and
+   * grant a *second* device, which would violate "reconnecting never implicitly acquires one".
+   */
+  async #requestReadOnly(type: string, payload: unknown): Promise<unknown> {
+    const connection = await this.#connectionForUse();
+    try {
+      return await Promise.race([connection.request(type, payload), this.#sessionClosed]);
+    } catch (error: unknown) {
+      if (!(error instanceof DaemonClientError) || error.code !== "DAEMON_CONNECTION_LOST") {
+        throw error;
+      }
+      // The close listener may not have run yet -- `IpcDaemonConnection.request()` also
+      // rejects synchronously once it observes the transport already closed, ahead of the
+      // underlying `onClose` propagating back to `#handleConnectionClosed`. Don't trust that
+      // ordering: if this is still the connection that just failed, drop it explicitly so
+      // `#connectionForUse()` is forced to build a fresh one instead of handing back the same
+      // dead connection.
+      if (this.#connection === connection) await this.#closeConnection().catch(() => undefined);
+      const retryConnection = await this.#connectionForUse();
+      return await Promise.race([retryConnection.request(type, payload), this.#sessionClosed]);
+    }
   }
 
   /**
@@ -422,6 +481,10 @@ function throwIfAborted(signal: AbortSignal | undefined): void {
 }
 
 function noop(): void {}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
 
 function daemonLeaseRequest(
   input: LeaseSimulatorInput,


### PR DESCRIPTION
## What changed

`McpSession` cached its daemon connection in `#connection` forever:
nothing subscribed to the socket closing. When the daemon restarted or
crashed, every later tool call was handed to the dead connection and
returned an opaque `{"code":"INTERNAL"}`, while the daemon itself was
perfectly healthy. Recovery meant restarting the whole MCP client —
for an editor-hosted agent, the whole app.

- **Plumbed closure through the port**: `DaemonConnection` gains
  `onClose(listener): () => void`, implemented in `IpcDaemonConnection`
  alongside the existing `onPush`. It fires exactly once, whether the
  underlying socket dies or `close()` is called explicitly — the
  second case is a deliberate no-op guard, not a race, since `close()`
  triggers the same `connection.onClose` callback internally.
- **Reconnect is lazy**: `McpSession` subscribes to `onClose` in
  `#connectionForUse`. On close it clears `#connection` and
  `#pushUnsubscribe`, so the *next* call re-runs `#connect()` —
  auto-starting the daemon and re-negotiating capabilities (e.g. the
  heartbeat) at `hello`, exactly as the CLI already does. Nothing
  retries proactively; a session that never makes another call never
  reconnects.
- **The reconnect never asks the daemon about the old lease**, because
  it structurally can't have survived. Verified three independent
  paths in the source: a graceful `daemon stop` releases held leases
  with reason `closed` before exiting (`DaemonServer#stop` →
  `#releaseHeld`); an ordinary connection close releases that
  connection's `heldLeaseIds` the same way; and an ungraceful death
  leaves the lease persisted, which the startup path (#38, already
  merged) then releases as `orphaned`. So the close handler just stops
  *believing* the lease is ours — clears `#ownedLease` and fires the
  existing `onLeaseLost` listeners (reason `daemon-connection-lost`,
  #15's channel) so the agent hears the fact instead of the session
  silently reacquiring a device. `status()` already reads `#ownedLease`
  locally with no round-trip (#25); clearing it here is what keeps
  that honest across a restart.
- **Two distinct, typed errors**, replacing the bare
  `new Error("Daemon connection is closed")` / `"closed"` rejections in
  `IpcDaemonConnection`, so `toMcpErrorResult` stops falling through to
  `INTERNAL`: `DAEMON_CONNECTION_LOST` for a connection that died
  (raised from `IpcDaemonConnection` itself, on close and for any
  request racing it), and `DAEMON_UNAVAILABLE` for a fresh `#connect()`
  attempt that fails (wrapped in `McpSession#connectionForUse`).
- **No blanket retry.** The issue's original text suggested retrying
  once on any request; that's wrong for `lease.request` — a retry
  after a mid-request death could provision and grant a *second*
  device, violating "reconnecting never implicitly acquires one." Only
  idempotent, read-only requests retry, via a new `#requestReadOnly`
  helper used by `listDevices` (`catalog.get`). `lease.request` and
  `lease.release` never go through it.
- **`release()` needed no special case.** By the time a `release()`
  call's own request could fail with `DAEMON_CONNECTION_LOST`, the
  close listener has already cleared `#ownedLease` synchronously (the
  connection's `#failPending` reject is a microtask; the close-listener
  notification that runs in the same tick as the socket event is not),
  so a subsequent release attempt for that lease id already hits the
  existing `LEASE_NOT_OWNED` path — no new branch required.

## How it was verified

`pnpm check` is green: typecheck, oxlint, oxfmt, vitest (52 files, 487
passed / 2 skipped). New tests in `src/mcp/session.test.ts` cover a
restart between two calls (fresh connection, `connect` called again),
a connection dying mid `lease.request` (typed `DAEMON_CONNECTION_LOST`,
no retry, no second `connect` call), a `catalog.get` retrying once
after a mid-request death, a lease held across a restart (`onLeaseLost`
fires with `daemon-connection-lost`, `status()` reports `held: false`),
and a failed reconnect surfacing `DAEMON_UNAVAILABLE`. New tests in
`src/daemon-client/connection.test.ts` cover `onClose` firing exactly
once for both a live socket death and an explicit `close()`, and a
request made after the socket is already gone rejecting with
`DAEMON_CONNECTION_LOST`.

Also verified against a real daemon, since a unit test can't prove
this one: built with `pnpm build`, drove `pitlane mcp` over stdio with
hand-written JSON-RPC frames against an isolated `HOME` (a fresh data
directory, to keep this out of the real `~/.pitlane` device registry),
took a held lease (`lse_ac1d7813-...`), then `kill -9`'d the daemon
process I had started myself for this. The still-running MCP process
received the push:

```json
{"method":"notifications/message","params":{"data":{"device_id":"D7EDDB83-CCB1-4671-BB61-8409A2C94DD2","lease_id":"lse_ac1d7813-78f3-4fdf-bbfc-fcce568ad9a6","message":"Pitlane lease ended; this session no longer holds the device.","reason":"daemon-connection-lost"},"level":"warning","logger":"pitlane"},"jsonrpc":"2.0"}
```

and `lease_status` immediately reported `{"held":false}` — all local,
no round-trip needed. After restarting the daemon (which itself swept
the orphaned lease per #38, `leases: []` on the fresh daemon), the same
MCP process's next `list_devices` call round-tripped successfully
against the new connection, and a fresh `lease_simulator` /
`release_simulator` pair worked normally — no client restart, no
`INTERNAL`. Cleaned up afterward: released the test lease, deleted the
simulator device that call created, stopped the daemon I started, and
removed the isolated data directory. Never touched the real
`~/.pitlane` registry or any process I hadn't started myself.

Closes #35