### PR TITLE
fix(daemon): claim the socket before startup convergence runs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -300,6 +300,35 @@ request multiplexing, `IpcDaemonConnector` performs the hello handshake, and
 or refused daemon. This keeps transport, detached-process logging, and startup
 policies replaceable without introducing an ambient dependency container.
 
+### Startup: claim first, converge after
+
+Reachability does not depend on startup recovery work. `DaemonServer#start`
+claims the socket (`DaemonEndpointHost#start`) before running `startDaemon`'s
+`converge` callback — `doctor.reconcile()` followed by
+`leaseEngine.convergeRunningCapacity()`, the two calls that shell out per
+driver/device and, since running-capacity convergence releases orphaned held
+leases and awaits the resulting device reclaim, can take tens of seconds. Two
+consequences follow from claiming first:
+
+- A second daemon racing to start now discovers `DaemonAlreadyRunningError`
+  from the claim itself, before it does any device work — not after, as when
+  convergence ran first.
+- `hello` and `status.get` answer immediately, `status.get` reporting
+  `health: "starting"` while convergence is in flight and `"running"` once it
+  resolves. Every other request type parks on the same readiness promise
+  `#awaitReady` awaits, and proceeds normally once convergence completes; no
+  request can observe half-converged state, and in particular no lease is
+  granted before convergence finishes. A slow startup becomes a slow response
+  instead of `DaemonStartupCoordinator`'s client-side timeout firing a false
+  failure for a daemon that was starting normally.
+
+If convergence itself throws, `start()` stops the daemon (closing the
+listener and any connections that raced in during convergence) rather than
+leaving it accepting connections it can never serve; parked requests reject
+with `DAEMON_STARTUP_FAILED` instead of hanging. Moving the underlying device
+reclaim off the startup path entirely — the remaining source of startup
+latency — is a deliberately separate, more invasive follow-up.
+
 Operational logging is a separate concern from the event bus: `pitlane events`
 carries business facts (lease granted, device cleaned up, …) in an in-memory
 ring buffer that resets on restart, while the `Logger` port writes durable,

--- a/src/daemon/main.test.ts
+++ b/src/daemon/main.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { connect } from "node:net";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { FakeDriver } from "../core/index.js";
@@ -74,6 +75,72 @@ describe("startDaemon", () => {
   });
 });
 
+describe("startDaemon startup readiness", () => {
+  // Reproduces the issue #41 symptom end-to-end through the real startDaemon wiring:
+  // doctor.reconcile() shells out to driver.listManaged() per driver, which is where
+  // real convergence time is lost. Here it's held open on the FakeClock so the test
+  // can prove the socket answers hello/status.get ("starting"), parks lease.request,
+  // and only then converges -- without waiting on a real clock.
+  it("claims the socket and answers hello/status.get while doctor.reconcile is still in flight", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "pitlane-main-slow-"));
+    temporaryDirectories.push(directory);
+    const clock = new FakeClock(1_000);
+    const socketPath = join(directory, "daemon.sock");
+    const startPromise = startDaemon({
+      clock,
+      dataDirectory: directory,
+      drivers: [
+        new FakeDriver({
+          availableOsVersions: ["26.5"],
+          clock,
+          latencyMs: { listManaged: 30_000 },
+          platform: "ios",
+        }),
+      ],
+      filesystem: new MemoryFilesystem(),
+      socketPath,
+      statePath: join(directory, "state.json"),
+      version: "1.2.3",
+    } as StartDaemonOptions).then((daemon) => {
+      runningDaemons.push(daemon);
+      return daemon;
+    });
+
+    const client = await connectRetrying(socketPath);
+    try {
+      await client.request("hello", {
+        clientVersion: "test",
+        protocolVersion: DAEMON_PROTOCOL_VERSION,
+      });
+      const starting = await client.request("status.get", {});
+      expect(starting.payload).toMatchObject({ health: "starting" });
+
+      const parkedLease = client.request("lease.request", {
+        mode: "detached",
+        request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      });
+      let leaseSettled = false;
+      void parkedLease.then(() => {
+        leaseSettled = true;
+      });
+      // Round-tripping another status.get proves the parked request was already
+      // dispatched (and is awaiting the readiness gate) without relying on a timer.
+      await client.request("status.get", {});
+      expect(leaseSettled).toBe(false);
+
+      clock.advance(30_000);
+      const daemon = await startPromise;
+      expect(daemon).toBeDefined();
+
+      await expect(parkedLease).resolves.toMatchObject({ ok: true });
+      const running = await client.request("status.get", {});
+      expect(running.payload).toMatchObject({ health: "running" });
+    } finally {
+      client.socket.end();
+    }
+  });
+});
+
 describe("discoverDrivers", () => {
   it("logs a skip when the Android SDK cannot be found, without throwing", async () => {
     const sink = new MemoryLogSink();
@@ -98,3 +165,61 @@ describe("discoverDrivers", () => {
     );
   });
 });
+
+interface MinimalClient {
+  readonly socket: import("node:net").Socket;
+  request(
+    type: string,
+    payload: unknown,
+  ): Promise<{ readonly ok: boolean; readonly payload?: unknown }>;
+}
+
+/** Minimal newline-delimited-JSON client, mirroring the real daemon protocol framing. */
+function connectClient(socketPath: string): Promise<MinimalClient> {
+  return new Promise((resolve, reject) => {
+    const socket = connect(socketPath);
+    let buffer = "";
+    let nextId = 1;
+    const waiters = new Map<string, (frame: { ok: boolean; payload?: unknown }) => void>();
+    socket.once("connect", () => {
+      socket.on("data", (chunk: Buffer) => {
+        buffer += chunk.toString("utf8");
+        for (;;) {
+          const newline = buffer.indexOf("\n");
+          if (newline < 0) break;
+          const line = buffer.slice(0, newline);
+          buffer = buffer.slice(newline + 1);
+          if (line.trim() === "") continue;
+          const frame = JSON.parse(line) as { id?: string; ok: boolean; payload?: unknown };
+          if (typeof frame.id === "string") {
+            waiters.get(frame.id)?.(frame);
+            waiters.delete(frame.id);
+          }
+        }
+      });
+      resolve({
+        socket,
+        request: (type, payload) =>
+          new Promise((resolveRequest) => {
+            const id = `req-${String(nextId)}`;
+            nextId += 1;
+            waiters.set(id, resolveRequest);
+            socket.write(`${JSON.stringify({ id, payload, type })}\n`);
+          }),
+      });
+    });
+    socket.once("error", reject);
+  });
+}
+
+async function connectRetrying(socketPath: string, timeoutMs = 2_000): Promise<MinimalClient> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      return await connectClient(socketPath);
+    } catch (error: unknown) {
+      if (Date.now() >= deadline) throw error;
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+  }
+}

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -108,8 +108,6 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
   });
   const doctor = new Doctor({ clock, drivers, eventBus, leaseExpirer: leaseEngine, registry });
   const nuke = new Nuke({ executor: leaseEngine, registry });
-  await doctor.reconcile();
-  await leaseEngine.convergeRunningCapacity();
   const daemon = new DaemonServer({
     capacity: leaseEngine,
     catalog: leaseEngine,
@@ -133,6 +131,15 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
     nuke,
     registry,
     version: options.version ?? "1.0.0",
+    // Runs after the socket is claimed (see DaemonServer#start): reachability no
+    // longer depends on doctor reconciliation or running-capacity convergence, which
+    // can shell out per driver/device and, since #38, await an orphaned lease's
+    // device reclaim (~34s for one simulator). Requests other than hello/status.get
+    // park until this resolves.
+    converge: async () => {
+      await doctor.reconcile();
+      await leaseEngine.convergeRunningCapacity();
+    },
   });
   await daemon.start();
   return daemon;

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -334,17 +334,28 @@ describe("DaemonServer", () => {
     });
   });
 
-  it("recovers a stale socket file and refuses a second live daemon", async () => {
+  it("recovers a stale socket file and refuses a second live daemon before running any device work", async () => {
     const directory = await mkdtemp(join(tmpdir(), "pitlane-stale-"));
     temporaryDirectories.push(directory);
     const socketPath = join(directory, "daemon.sock");
     await new NodeFilesystem().writeFileAtomic(socketPath, "stale");
     const first = await createHarness({ socketPath });
-    const second = await createHarness({ socketPath, start: false });
+    let convergeCalls = 0;
+    const second = await createHarness({
+      converge: () => {
+        convergeCalls += 1;
+        return Promise.resolve();
+      },
+      socketPath,
+      start: false,
+    });
 
     await expect(second.daemon.start()).rejects.toMatchObject({
       name: "DaemonAlreadyRunningError",
     });
+    // The claim (and its DaemonAlreadyRunningError) happens before convergence:
+    // a lost startup race must not run device work at all.
+    expect(convergeCalls).toBe(0);
     await second.daemon.stop("failed-start");
     const client = await createClient(socketPath);
     await hello(client);
@@ -467,6 +478,158 @@ describe("DaemonServer", () => {
     await client.close();
   });
 });
+
+describe("DaemonServer startup readiness", () => {
+  it("claims a connectable socket before startup convergence finishes", async () => {
+    const converge = deferred<void>();
+    const harness = await createHarness({ converge: () => converge.promise, start: false });
+    const startPromise = harness.daemon.start();
+
+    const client = await createClientRetrying(harness.socketPath);
+    await hello(client);
+    await client.close();
+
+    converge.resolve();
+    await startPromise;
+  });
+
+  it("answers hello and status.get with health starting during convergence, then running once converged", async () => {
+    const converge = deferred<void>();
+    const harness = await createHarness({ converge: () => converge.promise, start: false });
+    const startPromise = harness.daemon.start();
+
+    const client = await createClientRetrying(harness.socketPath);
+    await hello(client);
+    await expect(client.request("status.get", {})).resolves.toMatchObject({
+      ok: true,
+      payload: { health: "starting" },
+    });
+
+    converge.resolve();
+    await startPromise;
+
+    await expect(client.request("status.get", {})).resolves.toMatchObject({
+      ok: true,
+      payload: { health: "running" },
+    });
+    await client.close();
+  });
+
+  it("parks a request type other than hello/status.get until convergence completes, then serves it", async () => {
+    const converge = deferred<void>();
+    const harness = await createHarness({ converge: () => converge.promise, start: false });
+    const startPromise = harness.daemon.start();
+
+    const client = await createClientRetrying(harness.socketPath);
+    await hello(client);
+
+    const parked = client.request("list.get", { kind: "devices" });
+    // Requests on one connection are dispatched in arrival order without waiting for
+    // the previous one to finish (`#read` fires `#dispatchLine` per line without
+    // awaiting), so once this status.get round-trips, the parked request's dispatch
+    // has already reached (and registered on) the readiness gate.
+    await expect(client.request("status.get", {})).resolves.toMatchObject({ ok: true });
+
+    converge.resolve();
+    await startPromise;
+
+    await expect(parked).resolves.toMatchObject({ ok: true, payload: [] });
+    await client.close();
+  });
+
+  it("rejects startup, and does not hang a parked request, when convergence fails", async () => {
+    const converge = deferred<void>();
+    const harness = await createHarness({ converge: () => converge.promise, start: false });
+    const startPromise = harness.daemon.start();
+
+    const client = await createClientRetrying(harness.socketPath);
+    await hello(client);
+    const parked = client.request("list.get", { kind: "devices" });
+    // Round-tripping status.get first proves this request's dispatch has already
+    // started (and so is already tracked in `#parkedDispatches`) before the failure
+    // below -- this is not a race the assertion happens to win: `start()`'s catch
+    // path explicitly drains `#parkedDispatches` (awaiting each dispatch's own
+    // response write) before it closes any socket, so a request tracked at this
+    // point is genuinely guaranteed a DAEMON_STARTUP_FAILED response, not merely
+    // likely to get one before the connection drops.
+    await expect(client.request("status.get", {})).resolves.toMatchObject({ ok: true });
+
+    converge.reject(new Error("boom"));
+
+    await expect(startPromise).rejects.toThrow("boom");
+    await expect(parked).resolves.toMatchObject({
+      error: { code: "DAEMON_STARTUP_FAILED" },
+      ok: false,
+    });
+  });
+
+  it("has lease-lost subscriptions wired before a lease.request parked on convergence proceeds", async () => {
+    // Guards the invariant documented in `start()`: subscriptions are set up only
+    // after convergence resolves, and a parked request must never observe a window
+    // where its own grant can be silently force-released without a `lease-lost`
+    // push. Grants the held lease while convergence is still pending, then --
+    // immediately once convergence resolves and the grant comes back -- force
+    // releases that very lease from a second connection and asserts the push
+    // arrives, proving the subscription was already active by the time the grant
+    // reached the client.
+    const converge = deferred<void>();
+    const harness = await createHarness({ converge: () => converge.promise, start: false });
+    const startPromise = harness.daemon.start();
+
+    const holder = await createClientRetrying(harness.socketPath);
+    await hello(holder);
+    const parkedGrant = holder.request("lease.request", {
+      mode: "held",
+      requesterId: "holder",
+      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+    });
+
+    converge.resolve();
+    await startPromise;
+    const grant = await parkedGrant;
+    expect(grant.ok).toBe(true);
+    const leaseId = leaseIdOf(grant);
+
+    const evictor = await createClientRetrying(harness.socketPath);
+    await hello(evictor);
+    await evictor.request("lease.release", { leaseId });
+
+    await expect(holder.nextFrame((frame) => frame.push === "lease-lost")).resolves.toMatchObject({
+      payload: { leaseId },
+    });
+  });
+});
+
+/**
+ * `daemon.start()` claims the socket well before its own promise settles (that promise
+ * also waits on convergence), so a test that connects while convergence is deliberately
+ * held open must poll for the listener rather than assume it exists synchronously.
+ */
+async function createClientRetrying(socketPath: string, timeoutMs = 2_000): Promise<Client> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      return await createClient(socketPath);
+    } catch (error: unknown) {
+      if (Date.now() >= deadline) throw error;
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+  }
+}
+
+function deferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+  readonly reject: (error: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, reject, resolve };
+}
 
 describe("DaemonServer lease heartbeat", () => {
   it("slides a held lease's deadline past the backstop while its holder keeps ponging, and stops sliding once it stops", async () => {
@@ -742,6 +905,7 @@ async function createHarness(
     readonly socketPath?: string;
     readonly start?: boolean;
     readonly clock?: FakeClock;
+    readonly converge?: () => Promise<void>;
     readonly driver?: FakeDriver;
     readonly logger?: Logger;
     readonly stateFilesystem?: MemoryFilesystem;
@@ -799,6 +963,7 @@ async function createHarness(
     catalog: engine,
     clock,
     config,
+    ...(options.converge === undefined ? {} : { converge: options.converge }),
     defaultRequesterId: "test-process",
     eventBus,
     host: new DaemonEndpointHost({

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -65,7 +65,16 @@ export interface DaemonServerOptions {
   readonly nuke?: Nuke;
   readonly registry: Registry;
   readonly version: string;
+  /**
+   * Startup recovery work (doctor reconciliation, running-capacity convergence) run
+   * *after* the socket is claimed, so reachability never depends on it. `hello` and
+   * `status.get` answer immediately; every other request type parks on this promise.
+   * A rejection here stops the daemon rather than leaving it half-open — see `start()`.
+   */
+  readonly converge?: () => Promise<void>;
 }
+
+type DaemonHealth = "starting" | "running" | "failed";
 
 export class DaemonServer {
   readonly #connections = new Set<Connection>();
@@ -76,6 +85,16 @@ export class DaemonServer {
   #heartbeatNonce = 0;
   #stopping = false;
   #stopPromise: Promise<void> | undefined;
+  #health: DaemonHealth = "starting";
+  #readyPromise: Promise<void> | undefined;
+  /**
+   * Every `#dispatchLine` call that starts while `#health` is still `"starting"`,
+   * tracked so a convergence failure can genuinely drain them -- await each one's
+   * own response actually being written -- before closing sockets, rather than
+   * hoping a `stop()` scheduling gap gives them time to run. See the catch in
+   * `start()`.
+   */
+  readonly #parkedDispatches = new Set<Promise<void>>();
 
   constructor(private readonly options: DaemonServerOptions) {
     this.#protocolVersion = options.protocolVersion ?? DAEMON_PROTOCOL_VERSION;
@@ -87,8 +106,53 @@ export class DaemonServer {
     return this.options.host.endpoint;
   }
 
+  /**
+   * Claims the socket first so reachability never depends on startup recovery work:
+   * a lost startup race throws `DaemonAlreadyRunningError` here, before `converge()`
+   * runs any device work. Only after the claim does convergence run; `hello` and
+   * `status.get` answer throughout, every other request parks on `#readyPromise`
+   * (see `#awaitReady`). Node keeps servicing accepted connections while this
+   * function's own awaits are pending, so callers observe the socket as connectable
+   * well before this promise settles.
+   */
   async start(): Promise<void> {
     await this.options.host.start((connection) => this.#accept(connection));
+    const readyPromise = this.#converge();
+    this.#readyPromise = readyPromise;
+    try {
+      await readyPromise;
+    } catch (error: unknown) {
+      // Convergence failed after the socket was claimed: stop rather than sit there
+      // accepting connections we can never serve. Drain `#parkedDispatches` first --
+      // genuinely wait for each dispatch that started during the window to finish,
+      // not just for `#awaitReady()` to reject -- so a request already parked on
+      // `#readyPromise` gets its `DAEMON_STARTUP_FAILED` response actually written
+      // before `stop()` below closes its socket. This is not a hopeful scheduling
+      // gap: `#dispatchLine` awaits its own response write before returning, so
+      // draining the tracked promise really does wait for that write. A dispatch
+      // that hasn't reached the gate yet, or a brand-new connection that arrives in
+      // the narrow window between this drain and `stop()` flipping `#stopping`,
+      // still degrades safely -- the client sees the socket close, which since #40
+      // surfaces as typed `DAEMON_CONNECTION_LOST`, not a hang.
+      await Promise.allSettled(this.#parkedDispatches);
+      await this.stop("convergence-failed").catch(() => undefined);
+      throw error;
+    }
+
+    // Subscribed only now, after convergence, not before `start()` claimed the
+    // socket: the only thing that emits `lease.released` during convergence is
+    // `convergeRunningCapacity()`'s own orphaned-held-lease release, and by
+    // definition no live connection holds an orphaned lease on a daemon that has
+    // just started (a held lease's liveness is its daemon connection, which cannot
+    // have survived the restart). So nothing emitted during the window needs a
+    // `lease-lost` push. A parked `lease.request` is safe too: `start()`'s own
+    // continuation is registered on `#readyPromise` before any later request's (the
+    // client can only reach the gate after `host.start()`'s callback is wired, well
+    // after `start()` began awaiting), so on the shared microtask queue this
+    // subscribe runs before any parked request resumes past `#awaitReady()` -- see
+    // "answers hello and status.get..." / "parks a request type..." tests, and the
+    // dedicated ordering test below. The next event type added that can fire during
+    // convergence should re-check this invariant rather than assume it still holds.
     this.#unsubscribeLeaseLost.push(
       this.options.eventBus.subscribe("lease.expired", (envelope) =>
         this.#notifyLeaseLost(envelope.payload.leaseId, envelope.payload.deviceId, "expired"),
@@ -114,6 +178,30 @@ export class DaemonServer {
       version: this.options.version,
     });
     this.#scheduleHeartbeatTick();
+  }
+
+  async #converge(): Promise<void> {
+    try {
+      await this.options.converge?.();
+      this.#health = "running";
+    } catch (error: unknown) {
+      this.#health = "failed";
+      this.#logger.error("Daemon failed to converge at startup", {
+        message: errorMessage(error),
+        stack: errorStack(error),
+      });
+      throw error;
+    }
+  }
+
+  /** Every request type but `hello` (handled separately) and `status.get` parks here. */
+  async #awaitReady(): Promise<void> {
+    if (this.#readyPromise === undefined) return;
+    try {
+      await this.#readyPromise;
+    } catch {
+      throw new StartupFailedError();
+    }
   }
 
   stop(reason = "requested"): Promise<void> {
@@ -177,8 +265,25 @@ export class DaemonServer {
       if (line.trim() === "") {
         continue;
       }
-      void this.#dispatchLine(connection, line);
+      this.#dispatch(connection, line);
     }
+  }
+
+  /**
+   * Fires `#dispatchLine` without awaiting it, same as before, but while `#health` is
+   * still `"starting"` also tracks the call in `#parkedDispatches` so a convergence
+   * failure can drain it deterministically. Tracking every dispatch during the
+   * window (not just the ones that turn out to park) is simplest and harmless --
+   * `hello`/`status.get` calls just settle almost immediately and fall out of the set.
+   */
+  #dispatch(connection: Connection, line: string): void {
+    const dispatched = this.#dispatchLine(connection, line);
+    if (this.#health !== "starting") {
+      void dispatched;
+      return;
+    }
+    this.#parkedDispatches.add(dispatched);
+    void dispatched.finally(() => this.#parkedDispatches.delete(dispatched));
   }
 
   async #dispatchLine(connection: Connection, line: string): Promise<void> {
@@ -287,6 +392,9 @@ export class DaemonServer {
 
   // fallow-ignore-next-line complexity -- command dispatch is intentionally centralized at the protocol boundary.
   async #handleRequest(connection: Connection, frame: RequestFrame): Promise<unknown> {
+    if (frame.type !== "status.get") {
+      await this.#awaitReady();
+    }
     switch (frame.type) {
       case "lease.request":
         return this.#requestLease(connection, frame.payload);
@@ -466,7 +574,7 @@ export class DaemonServer {
       ...snapshot,
       leases: snapshot.leases.map((lease) => this.#decorateLease(lease)),
       capacity: { ...capacity, global: { ...running.global, warm: warmDevices.length } },
-      health: "running",
+      health: this.#health,
       queueDepth: this.options.queue.queueDepth,
     };
   }
@@ -636,6 +744,14 @@ class ProtocolError extends Error {
   }
 }
 
+/** Thrown to a parked request when startup convergence rejected; see `#awaitReady`. */
+class StartupFailedError extends Error {
+  constructor() {
+    super("Daemon failed to start");
+    this.name = "StartupFailedError";
+  }
+}
+
 function objectPayload(value: unknown): Record<string, unknown> {
   if (!isObject(value)) {
     throw new ProtocolError("BAD_REQUEST", "Payload must be an object");
@@ -727,6 +843,9 @@ function errorCode(error: unknown): string {
   }
   if (error instanceof UnknownLeaseError) {
     return "UNKNOWN_LEASE";
+  }
+  if (error instanceof StartupFailedError) {
+    return "DAEMON_STARTUP_FAILED";
   }
   return "INTERNAL";
 }


### PR DESCRIPTION
## What changed

`startDaemon` ran `doctor.reconcile()` and
`leaseEngine.convergeRunningCapacity()` -- the latter, since #38, awaits the
device reclaim of any orphaned held lease, tens of seconds for one simulator
-- before ever claiming the daemon socket. Nothing could connect until all of
that finished, and `DaemonStartupCoordinator` on the client gives up after a
fixed 5s and reports `Timed out starting pitlane daemon` for a daemon that is
starting normally and will be reachable shortly. The same ordering meant a
daemon that lost a startup race did its full device work before ever
discovering it should have thrown `DaemonAlreadyRunningError`.

- **Claim first, converge after.** `DaemonServer#start` now claims the
  socket (`host.start()`) before running a new `converge` option --
  `doctor.reconcile()` followed by `convergeRunningCapacity()`, moved out of
  `main.ts` and passed to `DaemonServer` as a closure. Node keeps servicing
  accepted connections while `converge()`'s own awaits are pending, so the
  socket is connectable and answering long before `start()`'s promise
  settles.
- **Readiness gates dispatch, not the socket.** `hello` was already handled
  before any gate; `status.get` now reports a new `health: "starting"` while
  convergence runs (it was hardcoded `"running"`) and `"running"` once it
  resolves. Every other request type awaits the same readiness promise
  (`#awaitReady`) before `#handleRequest` proceeds, so a slow startup becomes
  a slow response instead of a false failure, and no request -- in
  particular no `lease.request` -- can observe half-converged state.
- **The race hazard moves earlier.** Because `host.start()` runs before
  `converge()`, a losing daemon's claim throws `DaemonAlreadyRunningError`
  immediately, before it touches any driver or device.
- **Convergence failure stops the daemon, and the recovery is genuinely
  deterministic, not a scheduling gap.** If `converge()` throws after the
  socket is claimed, every dispatch that started while `health` was
  `"starting"` is tracked in `#parkedDispatches`; `start()` awaits
  `Promise.allSettled` over that set -- which means waiting for each
  dispatch's own response write to actually complete, since `#dispatchLine`
  awaits that write before returning -- before calling `stop()`, which closes
  the listener and any connections that raced in during convergence. A
  request already parked on the readiness gate is therefore guaranteed a
  `DAEMON_STARTUP_FAILED` response before its socket closes, not merely
  likely to get one. A request that hasn't reached the gate yet, or a
  brand-new connection racing the final `#stopping` flip, still degrades
  safely: the client sees the socket close, which since #40 surfaces as
  typed `DAEMON_CONNECTION_LOST`, not a hang.
- **Lease-lost subscriptions (and the heartbeat tick) start only after
  convergence resolves**, which is safe but rests on an invariant worth
  spelling out: the only `lease.released` fired during convergence comes from
  `convergeRunningCapacity()`'s own orphaned held-lease release, which by
  construction has no live connection to notify. A parked `lease.request`
  doesn't race the gap either -- `start()`'s own continuation registers on
  the readiness promise before any later request's, so the subscriptions are
  wired synchronously ahead of any parked request resuming past the gate.
  Documented in `start()`, and covered by a new test that force-releases a
  lease granted right as convergence resolves and asserts the `lease-lost`
  push still arrives.
- `startupTimeoutMs` is untouched, per the issue: startup time stays
  unbounded, and the claim now happening in well under a second (measured
  0.28s on a clean start pre-fix) means the existing 5s default is already
  comfortable.

Deliberately not in scope, per the issue's own notes: moving the device
reclaim off the startup path entirely. That's the actual latency fix and a
separate, more invasive change once this lands.

## How it was verified

`pnpm check` is green: typecheck, oxlint, oxfmt, vitest (52 files, 493
passed / 2 skipped). New tests in `src/daemon/server.test.ts` (a new
"DaemonServer startup readiness" describe block) cover: the socket is
connectable before convergence finishes; `hello`/`status.get` answer with
`health: "starting"` during convergence and `"running"` after; a `list.get`
request parks and then succeeds once convergence completes (proven by
round-tripping a `status.get` first, since dispatch for a connection's lines
is fired in arrival order without waiting on the previous one); a second
daemon losing the socket race now never invokes `converge` at all; a
convergence rejection fails `start()` while an already-parked request
deterministically resolves with `DAEMON_STARTUP_FAILED` rather than hanging
(ran 15x in a row locally with no flakes, since it's no longer relying on a
scheduling gap); and a lease granted right as convergence resolves still
gets its `lease-lost` push when force-released immediately after, proving
the lease-lost subscriptions are wired before a parked request can observe
their absence. A new `src/daemon/main.test.ts`
test exercises the same behavior through the real `startDaemon` wiring, using
`FakeDriver`'s `listManaged` latency on a `FakeClock` to hold
`doctor.reconcile()` open deterministically and a minimal raw-socket client.

Also verified against a real daemon and a real simulator, since that's the
only way to actually reproduce the issue's symptom. Built with `pnpm build`,
ran against an isolated `HOME` (`/tmp/pitlane-repro-home`, a fresh data
directory, kept short because unix socket paths have a length limit).
Leased an iPhone 16 in held mode, waited for it to become `leased`, then
`kill -9`'d the daemon process I had started myself for this. Before this
fix this is exactly the scenario from the issue: the next `pitlane status`
would report a false timeout. After: it returned in well under a second,
reporting `Daemon: starting` throughout the ~25s the orphaned lease's device
reclaim took, then `Daemon: running`. `daemon.log` from that run confirms the
ordering directly:

```
{"timestamp":1787232948808,...,"message":"Discovered driver","fields":{"platform":"ios"}}
{"timestamp":1787232948812,...,"message":"Claimed daemon socket",...}
{"timestamp":1787232974206,...,"message":"Daemon started",...}
```

Socket claimed 4ms after driver discovery; convergence (the orphaned lease's
release and device reclaim) didn't finish until ~25.4s later, and every
`pitlane status` call in between answered immediately instead of timing out.
Cleaned up afterward with `pitlane nuke --delete-devices --yes` (registry-owned
destruction, not manual `simctl`), stopped the daemon I'd started, and
removed the isolated data directory. Never touched the pre-existing unrelated
daemon/simulator already running on the machine from another worktree.

Closes #41
