### PR TITLE
test(e2e): deterministic end-to-end suite for the CLI, daemon, and MCP

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -1,7 +1,12 @@
 {
   // This file is JSONC: fallow reads these comments; generic JSON tools may not.
   "$schema": "./node_modules/fallow/schema.json",
-  "entry": ["src/index.ts", "src/cli/main.ts", "src/daemon/main.ts"],
+  // e2e/*.test.ts files are vitest entry points (not reached by static import from any
+  // other source file), and e2e/fake-driver/index.ts is loaded dynamically by the
+  // daemon via PITLANE_DRIVERS_MODULE (see docs/CLI.md) -- neither is visible to
+  // fallow's static reachability graph without being declared explicitly.
+  "entry": ["src/index.ts", "src/cli/main.ts", "src/daemon/main.ts", "e2e/**/*.test.ts"],
+  "dynamicallyLoaded": ["e2e/fake-driver/index.ts"],
   "ignoreDependencyOverrides": [
     // MCP SDK 1.29 transitively requires vulnerable node-server 1.x; lockfile/audit verify this patched override.
     { "package": "@hono/node-server", "source": "pnpm-workspace.yaml" },
@@ -11,7 +16,16 @@
   "duplicates": {
     // Hide pair-only clones; focus on widespread copy-paste
     // worth refactoring. Lower to 2 to report every duplicate pair.
-    "minOccurrences": 3
+    "minOccurrences": 3,
+    // e2e/fake-driver/fake-driver.ts intentionally parallels src/core/fake-driver.ts
+    // in shape (same Driver interface, same kind of scripted/latency/failure
+    // bookkeeping) but serves a different purpose: it runs out-of-process in a daemon
+    // spawned by the e2e suite, reads its script from a file re-read per call, and
+    // appends a call log -- src/core/fake-driver.ts is in-process only and has none
+    // of that. The two are expected to diverge, not be merged; see fallow's own
+    // guidance for code-duplication ("leave it duplicated when the similarity is
+    // accidental and likely to diverge").
+    "ignore": ["e2e/fake-driver/fake-driver.ts"]
     // Common additions (uncomment to enable):
     // "ignore": [
     //   "**/lib/**",          // for repos that publish transpiled output to lib/
@@ -22,5 +36,14 @@
   },
   "rules": {
     "unused-dependencies": "warn"
+  },
+  "health": {
+    "thresholdOverrides": [
+      {
+        "files": ["e2e/fake-driver/fake-driver.ts"],
+        "maxCrap": 45,
+        "reason": "This file has no wired coverage pipeline (fallow estimates 0% here), so CRAP is complexity-squared alone. The three flagged functions (#resolveOsVersion/#assertOsVersionAvailable, #beforeCall, compareVersions) are simple, deterministic script-interpretation/comparison helpers already reduced from a critical/high toError+resolveSpec pair (cyclomatic 11 and 9) down to cyclomatic 5-6 moderate; the daemon-level e2e flows exercise them on every run but that coverage isn't visible to this metric."
+      }
+    ]
   }
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -230,3 +230,30 @@ threshold, and the daemon's log level/rotation cap (`log.level`,
 `log.rotateBytes`). With no args, prints everything. Running capacity
 uses `limits.maxRunning` globally and `limits.<platform>.maxRunning` for each
 driver; both must have room before provisioning or booting a shutdown device.
+
+## Environment variables
+
+### `PITLANE_HOME`
+
+Overrides the data directory the CLI, MCP server, and daemon all use for
+`config.json`, `state.json`, `daemon.sock`, and `daemon.log`. Defaults to
+`~/.pitlane`. All three frontends resolve it through the same function
+(`resolvePitlaneHome` in `src/ports/paths.ts`), so setting it once in an
+agent's environment repoints every command at an isolated data directory —
+useful for running multiple independent pitlane instances on one machine, or
+for tests. When the CLI or MCP server auto-starts the daemon, the daemon
+process inherits the variable like the rest of the environment.
+
+### `PITLANE_DRIVERS_MODULE` (advanced / testing hook)
+
+Overrides driver discovery (`discoverDrivers` in `src/daemon/main.ts`) with a
+JavaScript module of your own instead of the real iOS/Android drivers. Point
+it at a file path; the daemon dynamically imports that module and calls its
+exported `createDrivers(context)` (the same `{ clock, filesystem,
+idGenerator, logger, processRunner }` context real discovery receives),
+which must return `Driver[]` (or a promise of it, matching
+`src/core/driver.ts`). This exists so tests — and anyone reproducing a bug
+without real hardware — can run the full daemon against a scripted driver
+instead of `simctl`/`adb`. It is not meant for production use: a module that
+fails to import, or does not export `createDrivers`, fails daemon startup
+loudly rather than silently falling back to real discovery.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,66 @@
+# End-to-end suite
+
+Deterministic end-to-end tests that run the **real** processes — a spawned
+daemon, the CLI as a subprocess, the MCP server driven by a real
+`@modelcontextprotocol/sdk` client — over a real unix socket.
+
+Unit tests (`src/**/*.test.ts`) already cover the core's logic in-process. These
+flows only assert what crosses a process boundary: exit codes, the structured
+stderr contract, MCP framing and notifications, daemon restarts, `kill -9`
+recovery. Anything provable in-process belongs in a unit test instead.
+
+## Lanes
+
+| Lane | Command                  | What it uses                      | Where it runs          |
+| ---- | ------------------------ | --------------------------------- | ---------------------- |
+| fast | `pnpm run test:e2e`      | scriptable fake driver, no SDKs   | every `pnpm run check` |
+| slow | `pnpm run test:e2e:slow` | real `simctl` / `adb` / emulators | manual, pre-release    |
+
+The slow flows are tagged `slow` plus `ios`/`android`, so the fast lane excludes
+them with `--tags-filter='!slow'`. Each also gates itself at runtime with
+`describe.skipIf` on platform and SDK availability. Filter further with, for
+example, `pnpm exec vitest run --project e2e --tags-filter='ios && !android'`.
+
+Flows run sequentially (`fileParallelism: false`) — they share one machine, and
+the daemon owns real OS resources.
+
+## How isolation works
+
+Each `withDaemon()` allocates a temp `PITLANE_HOME` (so config, state, socket and
+log are per-test) and, in the fast lane, points `PITLANE_DRIVERS_MODULE` at
+`e2e/fake-driver` — the daemon then talks to a scripted driver instead of real
+hardware without knowing the difference. Both variables are documented in
+[../docs/CLI.md](../docs/CLI.md#environment-variables).
+
+The fake driver reads a JSON script file, re-read on every call so a test can
+change behaviour mid-flight, and appends every call it receives to a log file.
+Assertions like "`doctor --fix` never destroyed a device" or "a missing runtime
+never triggered a download" read that log.
+
+## Writing a flow
+
+- Build on the helpers in `helpers/`; no flow should reimplement process
+  spawning, polling, or output parsing.
+- `waitFor` is the only timing primitive. **Never sleep for a fixed duration.**
+- Prefer one fat flow that exercises several features over many small tests —
+  the point is confidence in a release, not branch coverage.
+- Never weaken an assertion to get green. If a flow trips a real bug, mark that
+  assertion (`it.fails`) with a comment naming the suspected cause.
+
+Hooks must be registered at module scope. Vitest resolves `beforeEach`/`afterEach`
+from the call stack active during _collection_, so a hook registered from inside a
+running test body silently never fires — see the comment in `helpers/env.ts`.
+
+## Known gaps
+
+- **The slow lane does not pass reliably as a whole run.** Each of the three
+  flows passes on its own, but a combined `pnpm run test:e2e:slow` has failed on
+  every attempt so far: a daemon occasionally outlives `daemon stop` and trips
+  teardown's stray-process assertion, and the no-implicit-download flow has hit
+  its 300s timeout. Not yet root-caused, and not yet distinguished from the
+  reclaim stall recorded in [../docs/known-pitfalls.md](../docs/known-pitfalls.md).
+  Treat the slow lane as a manual, one-flow-at-a-time tool until that is fixed.
+- `daemon status` ignores `--json` and always prints raw JSON; documented by an
+  `it.fails` in `daemon-lifecycle.test.ts`.
+- Android is exercised through the fake driver in the fast lane; only
+  `slow-android-smoke.test.ts` touches a real emulator.

--- a/e2e/capacity-cleanup-nuke.test.ts
+++ b/e2e/capacity-cleanup-nuke.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, it } from "vitest";
+
+import { withDaemon } from "./helpers/index.js";
+import { waitForDeviceState, waitForLeaseCount } from "./helpers/status.js";
+import { waitFor } from "./helpers/wait.js";
+import type { CliBackgroundHandle } from "./helpers/cli.js";
+import type { ScriptedObservedDevice } from "./fake-driver/types.js";
+
+interface CapacitySnapshot {
+  readonly used: number;
+  readonly limit: number;
+  readonly running: number;
+  readonly maxRunning: number;
+  readonly warm: number;
+  readonly overLimit: boolean;
+}
+
+interface StatusResponse {
+  readonly capacity: {
+    readonly ios: CapacitySnapshot;
+    readonly global: Omit<CapacitySnapshot, "used" | "limit">;
+  };
+}
+
+async function status(env: Awaited<ReturnType<typeof withDaemon>>): Promise<StatusResponse> {
+  const result = await env.cli(["status", "--json"]);
+  if (result.code !== 0) throw new Error(`pitlane status failed: ${result.stderr}`);
+  return result.json as StatusResponse;
+}
+
+async function deviceRows(
+  env: Awaited<ReturnType<typeof withDaemon>>,
+): Promise<{ id: string; driverDeviceId: string; state: string }[]> {
+  const result = await env.cli(["list", "--devices"]);
+  if (result.code !== 0) throw new Error(`pitlane list --devices failed: ${result.stderr}`);
+  return result.json as { id: string; driverDeviceId: string; state: string }[];
+}
+
+function leaseHeld(
+  env: Awaited<ReturnType<typeof withDaemon>>,
+  agentId: string,
+): CliBackgroundHandle {
+  return env.cliBackground([
+    "lease",
+    "--platform",
+    "ios",
+    "--device",
+    "iPhone 16",
+    "--os",
+    "18.4",
+    "--agent-id",
+    agentId,
+  ]);
+}
+
+async function releaseAndForget(
+  env: Awaited<ReturnType<typeof withDaemon>>,
+  agentId: string,
+): Promise<void> {
+  const held = leaseHeld(env, agentId);
+  const grant = JSON.parse(await held.firstStdoutLine()) as { lease: string };
+  await env.cli(["release", grant.lease]);
+  held.kill("SIGKILL");
+  await held.waitForExit(15_000).catch(() => undefined);
+}
+
+/**
+ * Forces an immediate, synchronous reaper evaluation (rather than waiting on the slow
+ * 60s periodic tick or hoping an unrelated `lease.released` retriggers it) by polling
+ * `pitlane cleanup` itself until the target reaches `state` -- this is what lets an
+ * idle-threshold test converge in milliseconds without a fixed sleep: each poll tick
+ * both re-checks real elapsed time *and* forces the daemon to act on it.
+ */
+async function waitForCleanupToReach(
+  env: Awaited<ReturnType<typeof withDaemon>>,
+  driverDeviceId: string,
+  state: string,
+  timeout = 10_000,
+): Promise<void> {
+  await waitFor(
+    async () => {
+      await env.cli(["cleanup"]);
+      const rows = await deviceRows(env);
+      return rows.some((row) => row.driverDeviceId === driverDeviceId && row.state === state);
+    },
+    { timeout, interval: 50, label: `cleanup demotes ${driverDeviceId} to ${state}` },
+  );
+}
+
+describe("capacity, warm pool, cleanup, and nuke", () => {
+  it("distinguishes the managed-device limit from the running limit, and counts reclaiming as running, never warm", async () => {
+    const env = await withDaemon({
+      configOverrides: { limits: { maxRunning: 2, ios: { maxDevices: 1, maxRunning: 2 } } },
+    });
+    await env.driverScript.set({
+      ios: { knownModels: ["iPhone 16"], availableOsVersions: ["18.4"] },
+    });
+
+    const first = leaseHeld(env, "cap-a");
+    const grantA = JSON.parse(await first.firstStdoutLine()) as { lease: string; udid: string };
+
+    // maxRunning (2) has room, but maxDevices (1) does not: a second requester must
+    // still queue, because there is no second device to provision.
+    const second = leaseHeld(env, "cap-b");
+    await waitFor(() => second.progressEvents().some((event) => isQueuedAt(event, 1)), {
+      label: "second requester queues on the managed-device limit, not the running limit",
+    });
+
+    // Release the held device with a deliberately slow reclaim so its transient
+    // `reclaiming` state is observable. The release RPC itself waits for reclaim to
+    // finish before responding, so the poll for "reclaiming" must run concurrently
+    // with the release call, not after it.
+    await env.driverScript.merge({ ios: { latencyMs: { reclaim: 1_500 } } });
+    const releasePromise = env.cli(["release", grantA.lease]);
+
+    await waitFor(
+      async () => {
+        const rows = await deviceRows(env);
+        return rows.some((row) => row.driverDeviceId === grantA.udid && row.state === "reclaiming");
+      },
+      { label: "device visibly enters reclaiming" },
+    );
+
+    const duringReclaim = await status(env);
+    expect(duringReclaim.capacity.ios.running).toBe(1);
+    expect(duringReclaim.capacity.ios.warm).toBe(0);
+
+    const release = await releasePromise;
+    expect(release.code).toBe(0);
+
+    // The queued second requester is granted the same device once reclaim finishes
+    // and it becomes warm (`ready`) again.
+    const grantB = JSON.parse(await second.firstStdoutLine(15_000)) as {
+      lease: string;
+      udid: string;
+    };
+    expect(grantB.udid).toBe(grantA.udid);
+
+    first.kill("SIGKILL");
+    second.kill("SIGKILL");
+    await Promise.all([
+      first.waitForExit(15_000).catch(() => undefined),
+      second.waitForExit(15_000).catch(() => undefined),
+    ]);
+  });
+
+  it("reports overLimit when a lowered running limit can't yet be met, without evicting existing leases", async () => {
+    const env = await withDaemon({
+      configOverrides: { limits: { maxRunning: 3, ios: { maxDevices: 3, maxRunning: 3 } } },
+    });
+    await env.driverScript.set({
+      ios: { knownModels: ["iPhone 16"], availableOsVersions: ["18.4"] },
+    });
+
+    // Detached, not held: a graceful `daemon stop` (which `withConfig` triggers to
+    // pick up the new limit) releases every held-mode lease as part of closing its
+    // owning connection -- exactly like a normal held-mode client disconnecting. A
+    // detached lease has no owning connection, so it survives the restart, which is
+    // what actually exercises "a lowered limit doesn't evict an existing lease".
+    const leaseOne = await env.cli([
+      "lease",
+      "--platform",
+      "ios",
+      "--device",
+      "iPhone 16",
+      "--os",
+      "18.4",
+      "--agent-id",
+      "overlimit-one",
+      "--detach",
+    ]);
+    const grantOne = leaseOne.json as { lease: string };
+    const leaseTwo = await env.cli([
+      "lease",
+      "--platform",
+      "ios",
+      "--device",
+      "iPhone 16",
+      "--os",
+      "18.4",
+      "--agent-id",
+      "overlimit-two",
+      "--detach",
+    ]);
+    const grantTwo = leaseTwo.json as { lease: string };
+
+    await env.withConfig({ limits: { ios: { maxRunning: 1 } } }, async () => {
+      const afterLower = await status(env);
+      expect(afterLower.capacity.ios.overLimit).toBe(true);
+
+      // Pre-existing leases must never be evicted just because the limit dropped
+      // below what is currently held.
+      const leases = (await env.cli(["list", "--leases"])).json as { id: string }[];
+      expect(leases.map((lease) => lease.id)).toEqual(
+        expect.arrayContaining([grantOne.lease, grantTwo.lease]),
+      );
+    });
+
+    await env.cli(["release", "--all", "--yes"]);
+  });
+
+  it("demotes an idle device, previews cleanup without executing on --dry-run, and nuke touches only registry devices", async () => {
+    const env = await withDaemon({
+      configOverrides: {
+        // Tight on purpose: by the nuke phase this forces a real queued waiter
+        // (see the comment there) without needing a mid-test daemon restart, which
+        // would release the still-needed held lease.
+        limits: { maxRunning: 1, ios: { maxDevices: 2, maxRunning: 1 } },
+        idle: { shutdownAfterMs: 200 },
+      },
+    });
+    await env.driverScript.set({
+      ios: { knownModels: ["iPhone 16"], availableOsVersions: ["18.4"] },
+    });
+
+    const heldX = leaseHeld(env, "idle-x");
+    const grantX = JSON.parse(await heldX.firstStdoutLine()) as { lease: string; udid: string };
+    await env.cli(["release", grantX.lease]);
+    heldX.kill("SIGKILL");
+    await heldX.waitForExit(15_000).catch(() => undefined);
+    await waitForDeviceState(env, grantX.udid, "ready");
+
+    await waitForCleanupToReach(env, grantX.udid, "shutdown");
+
+    // cleanup --dry-run must report proposals without acting on them.
+    await releaseAndForget(env, "dryrun-z");
+    const rowsAfterZ = await deviceRows(env);
+    const readyDevice = rowsAfterZ.find((row) => row.state === "ready");
+    expect(readyDevice, "expected a ready (warm) device for the dry-run preview").toBeDefined();
+
+    await waitFor(
+      async () => {
+        const preview = await env.cli(["cleanup", "--dry-run"]);
+        const proposals = preview.json as { rule: string; target: string }[];
+        return proposals.some((proposal) => proposal.target === readyDevice?.id);
+      },
+      {
+        timeout: 10_000,
+        interval: 50,
+        label: "dry-run eventually proposes shutting the idle device down",
+      },
+    );
+
+    await env.driverLog.clear();
+    const dryRun = await env.cli(["cleanup", "--dry-run"]);
+    expect(dryRun.code).toBe(0);
+    const dryRunCalls = await env.driverLog.calls();
+    expect(
+      dryRunCalls.filter((call) => call.operation === "shutdown" || call.operation === "destroy"),
+      "--dry-run must never call a destructive/state-changing driver verb",
+    ).toEqual([]);
+
+    // nuke: force-releases held leases, clears the queue, destroys registry devices,
+    // and must never touch a device the driver reports but the registry doesn't know
+    // about (safety.md: registry-only destruction).
+    const heldForNuke = leaseHeld(env, "nuke-held");
+    await heldForNuke.firstStdoutLine();
+    // Managed devices are already at 2/2 and running at 1/1 from the idle/dry-run
+    // phase above, so this requester has no device to reuse or provision and queues.
+    const queuedForNuke = leaseHeld(env, "nuke-queued");
+    await waitFor(() => queuedForNuke.progressEvents().some((event) => isQueuedAt(event, 1)), {
+      label: "a waiter is queued before nuke",
+    });
+
+    // Stage an orphan device the fake driver reports but the registry never created,
+    // alongside the current real reality (so nuke's other actions are unaffected).
+    const rowsBeforeNuke = await deviceRows(env);
+    const stagedRealityDevices: ScriptedObservedDevice[] = [
+      ...rowsBeforeNuke
+        .filter((row) => row.state !== "deleted")
+        .map((row) => ({ deviceId: row.driverDeviceId, runState: "running" as const })),
+      { deviceId: "fake-ios-orphan-not-in-registry", runState: "running" },
+    ];
+    await env.driverScript.merge({ ios: { managedReality: { devices: stagedRealityDevices } } });
+
+    await env.driverLog.clear();
+    const nuke = await env.cli(["nuke", "--delete-devices", "--yes"]);
+    expect(nuke.code).toBe(0);
+
+    await Promise.all([
+      heldForNuke.waitForExit(15_000).catch(() => undefined),
+      queuedForNuke.waitForExit(15_000).catch(() => undefined),
+    ]);
+
+    await waitForLeaseCount(env, 0);
+    const nukeCalls = await env.driverLog.calls();
+    const touchedOrphan = nukeCalls.some(
+      (call) =>
+        (call.operation === "destroy" ||
+          call.operation === "shutdown" ||
+          call.operation === "reclaim") &&
+        JSON.stringify(call.arguments).includes("fake-ios-orphan-not-in-registry"),
+    );
+    expect(touchedOrphan, "nuke must never touch a device the registry does not manage").toBe(
+      false,
+    );
+    expect(
+      nukeCalls.some((call) => call.operation === "destroy"),
+      "nuke --delete-devices should have destroyed at least one registry device",
+    ).toBe(true);
+
+    const cliLeases = await env.cli(["list", "--leases"]);
+    expect(cliLeases.json).toEqual([]);
+  });
+});
+
+function isQueuedAt(event: unknown, position: number): boolean {
+  return (
+    typeof event === "object" &&
+    event !== null &&
+    (event as Record<string, unknown>).event === "queued" &&
+    (event as Record<string, unknown>).queue_position === position
+  );
+}

--- a/e2e/contention.test.ts
+++ b/e2e/contention.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { waitFor, withDaemon } from "./helpers/index.js";
+
+const LEASE_ARGS = ["lease", "--platform", "ios", "--device", "iPhone 16", "--os", "18.4"] as const;
+
+describe("contention & queueing", () => {
+  it("enforces one lease per requester, --no-wait, --timeout, and FIFO queueing", async () => {
+    const env = await withDaemon({
+      configOverrides: { limits: { maxRunning: 1, ios: { maxDevices: 1, maxRunning: 1 } } },
+    });
+    await env.driverScript.set({
+      ios: { knownModels: ["iPhone 16"], availableOsVersions: ["18.4"] },
+    });
+
+    const first = await env.cli([...LEASE_ARGS, "--agent-id", "agent-a", "--detach"]);
+    expect(first.code).toBe(0);
+    const firstGrant = first.json as { lease: string };
+
+    // Same requester leasing again: REQUESTER_ALREADY_LEASED, naming the existing lease.
+    const repeat = await env.cli([...LEASE_ARGS, "--agent-id", "agent-a", "--detach"]);
+    expect(repeat.code).toBe(13);
+    expect(repeat.error).toMatchObject({ code: "REQUESTER_ALREADY_LEASED" });
+    expect(repeat.error?.message).toContain(firstGrant.lease);
+
+    // A different requester at capacity with --no-wait fails immediately.
+    const noWait = await env.cli([...LEASE_ARGS, "--agent-id", "agent-b", "--no-wait", "--detach"]);
+    expect(noWait.code).toBe(11);
+    expect(noWait.error).toMatchObject({ code: "NO_CAPACITY" });
+
+    // A different requester with a short --timeout queues, then times out.
+    const timedOut = await env.cli(
+      [...LEASE_ARGS, "--agent-id", "agent-c", "--timeout", "300ms", "--detach"],
+      { timeout: 15_000 },
+    );
+    expect(timedOut.code).toBe(10);
+    expect(timedOut.error).toMatchObject({ code: "QUEUE_TIMEOUT" });
+
+    // Two held-mode waiters queue behind the holder; releasing grants them in FIFO order.
+    const waiterD = env.cliBackground([...LEASE_ARGS, "--agent-id", "agent-d"]);
+    await waitFor(() => waiterD.progressEvents().some((event) => isQueuedAt(event, 1)), {
+      label: "agent-d queued at position 1",
+    });
+
+    const waiterE = env.cliBackground([...LEASE_ARGS, "--agent-id", "agent-e"]);
+    await waitFor(() => waiterE.progressEvents().some((event) => isQueuedAt(event, 2)), {
+      label: "agent-e queued at position 2",
+    });
+
+    const release = await env.cli(["release", firstGrant.lease]);
+    expect(release.code).toBe(0);
+
+    const grantedD = JSON.parse(await waiterD.firstStdoutLine(15_000)) as {
+      device: string;
+      lease: string;
+    };
+    expect(grantedD.device).toBe("iPhone 16");
+
+    waiterD.kill("SIGTERM");
+    await waiterD.waitForExit(15_000);
+
+    const grantedE = JSON.parse(await waiterE.firstStdoutLine(15_000)) as {
+      device: string;
+      lease: string;
+    };
+    expect(grantedE.device).toBe("iPhone 16");
+    expect(grantedE.lease).not.toBe(grantedD.lease);
+
+    waiterE.kill("SIGTERM");
+    await waiterE.waitForExit(15_000);
+  });
+});
+
+function isQueuedAt(event: unknown, position: number): boolean {
+  return (
+    typeof event === "object" &&
+    event !== null &&
+    (event as Record<string, unknown>).event === "queued" &&
+    (event as Record<string, unknown>).queue_position === position
+  );
+}

--- a/e2e/daemon-lifecycle.test.ts
+++ b/e2e/daemon-lifecycle.test.ts
@@ -1,0 +1,108 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+import { waitFor, withDaemon } from "./helpers/index.js";
+
+describe("daemon lifecycle & recovery", () => {
+  it("auto-starts on the first CLI call, reports status, and does not double-spawn", async () => {
+    const env = await withDaemon({ mode: "auto" });
+
+    expect(existsSync(env.socketPath)).toBe(false);
+
+    const catalog = await env.cli(["catalog", "--json"]);
+    expect(catalog.code).toBe(0);
+    await waitFor(() => existsSync(env.socketPath), { label: "daemon.sock created by auto-start" });
+
+    const statusJson = await env.cli(["daemon", "status", "--json"]);
+    expect(statusJson.code).toBe(0);
+    expect(statusJson.json).toMatchObject({ health: "running" });
+
+    // "daemon start" while already running must not spawn a second daemon: the
+    // request-scoped connection each `daemon start` opens transiently would make a
+    // pid comparison via lsof racy, so compare content of daemon.log instead --
+    // a second daemon process would append its own "Daemon started" record.
+    const before = await readFile(env.logPath, "utf8");
+    const startedCountBefore = countOccurrences(before, "Daemon started");
+    const secondStart = await env.cli(["daemon", "start"]);
+    expect(secondStart.code).toBe(0);
+    const after = await readFile(env.logPath, "utf8");
+    expect(countOccurrences(after, "Daemon started")).toBe(startedCountBefore);
+  });
+
+  it("recovers from a kill -9 that leaves a stale socket behind", async () => {
+    const env = await withDaemon({ mode: "running" });
+    expect(existsSync(env.socketPath)).toBe(true);
+
+    await env.killDaemon("SIGKILL");
+    // kill -9 does not unlink the unix socket file -- it should still exist, stale.
+    expect(existsSync(env.socketPath)).toBe(true);
+
+    // `daemon status` deliberately never auto-starts (checking status shouldn't have
+    // the side effect of spawning a daemon) -- any other command does, and is how a
+    // real agent would recover from a stale socket left by a crash.
+    const catalog = await env.cli(["catalog", "--json"]);
+    expect(catalog.code).toBe(0);
+
+    const status = await env.cli(["daemon", "status", "--json"]);
+    expect(status.code).toBe(0);
+    expect(status.json).toMatchObject({ health: "running" });
+  });
+
+  // Suspected bug: `pitlane daemon status` always writes raw JSON via `writeResult`
+  // (src/cli/index.ts `runDaemon`, the "status" branch) regardless of `--json`,
+  // unlike its siblings `daemon start`/`daemon stop` which both branch on
+  // `values.json` to print "Daemon running"/"Daemon stopping" in human mode. This
+  // contradicts docs/CLI.md ("`daemon <start|stop|status|logs>` ... default to a
+  // human-oriented view ... and accept `--json`"). See final report.
+  it.fails("daemon status prints a human-oriented view by default", async () => {
+    const env = await withDaemon({ mode: "running" });
+
+    const statusHuman = await env.cli(["daemon", "status"]);
+    expect(statusHuman.code).toBe(0);
+    expect(statusHuman.stdout).toContain("Daemon running");
+  });
+
+  it("writes the documented structured startup lines to daemon.log", async () => {
+    const env = await withDaemon({ mode: "running" });
+
+    const contents = await readFile(env.logPath, "utf8");
+    const lines = contents
+      .trim()
+      .split("\n")
+      .filter((line) => line !== "")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+    expect(lines.length, "daemon.log is empty after startup -- see report").toBeGreaterThan(0);
+
+    const startRecord = lines.find((line) => line.message === "Daemon started");
+    expect(startRecord, "no 'Daemon started' record in daemon.log").toBeDefined();
+    expect(startRecord).toMatchObject({
+      fields: expect.objectContaining({
+        version: expect.any(String),
+        protocolVersion: expect.any(Number),
+        socketPath: env.socketPath,
+      }),
+    });
+
+    const modules = new Set(lines.map((line) => line.module));
+    expect(modules.has("daemon.driver-discovery"), "no driver-discovery log lines").toBe(true);
+    expect(modules.has("daemon.connection-host"), "no connection-host log lines").toBe(true);
+  });
+
+  it("rotates daemon.log to daemon.log.1 once past config.log.rotateBytes", async () => {
+    const env = await withDaemon({ mode: "auto" });
+
+    await env.withConfig({ log: { rotateBytes: 200 } }, async () => {
+      await waitFor(() => existsSync(`${env.logPath}.1`), {
+        timeout: 15_000,
+        label: "daemon.log.1 created after low rotateBytes",
+      });
+      expect(existsSync(env.logPath)).toBe(true);
+    });
+  });
+});
+
+function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}

--- a/e2e/doctor-drift.test.ts
+++ b/e2e/doctor-drift.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+
+import { withDaemon } from "./helpers/index.js";
+import type { CliBackgroundHandle } from "./helpers/cli.js";
+import type { ScriptedObservedDevice } from "./fake-driver/types.js";
+
+interface DeviceRow {
+  readonly id: string;
+  readonly driverDeviceId: string;
+  readonly state: string;
+  readonly foreignProvenanceDetectedAt?: number;
+}
+
+interface Finding {
+  readonly kind: string;
+  readonly deviceId?: string;
+  readonly device?: { readonly deviceId: string };
+  readonly detail?: string;
+}
+
+async function deviceRows(env: Awaited<ReturnType<typeof withDaemon>>): Promise<DeviceRow[]> {
+  const result = await env.cli(["list", "--devices"]);
+  if (result.code !== 0) throw new Error(`pitlane list --devices failed: ${result.stderr}`);
+  return result.json as DeviceRow[];
+}
+
+/** Launches a held-mode lease for `agentId`; caller launches every agent it needs
+ *  before awaiting any of their grants, so none is warm-pool reused for the next
+ *  (a sequential lease/release/lease would just reuse the same warm device). */
+function leaseHeld(
+  env: Awaited<ReturnType<typeof withDaemon>>,
+  agentId: string,
+): CliBackgroundHandle {
+  return env.cliBackground([
+    "lease",
+    "--platform",
+    "ios",
+    "--device",
+    "iPhone 16",
+    "--os",
+    "18.4",
+    "--agent-id",
+    agentId,
+  ]);
+}
+
+async function grantOf(held: CliBackgroundHandle): Promise<{ lease: string; udid: string }> {
+  return JSON.parse(await held.firstStdoutLine()) as { lease: string; udid: string };
+}
+
+describe("doctor and drift", () => {
+  it("reports registry vs. reality drift, applies only registry-safe fixes, and skips leased devices", async () => {
+    const env = await withDaemon({
+      configOverrides: {
+        limits: { maxRunning: 5, ios: { maxDevices: 5, maxRunning: 5 } },
+      },
+    });
+    await env.driverScript.set({
+      ios: { knownModels: ["iPhone 16"], availableOsVersions: ["18.4"] },
+    });
+
+    // A, C, D, E get released back to `ready` right after grant; B stays leased
+    // throughout as the "must skip a leased device" case. All five are launched
+    // before any grant is awaited, so capacity (5) covers them concurrently and
+    // none is warm-pool reused for the next.
+    const heldA = leaseHeld(env, "doctor-a");
+    const deviceA = await grantOf(heldA);
+    const heldB = leaseHeld(env, "doctor-b");
+    const deviceB = await grantOf(heldB);
+    const heldC = leaseHeld(env, "doctor-c");
+    const deviceC = await grantOf(heldC);
+    const heldD = leaseHeld(env, "doctor-d");
+    const deviceD = await grantOf(heldD);
+    const heldE = leaseHeld(env, "doctor-e");
+    const deviceE = await grantOf(heldE);
+    const distinctUdids = new Set([deviceA, deviceB, deviceC, deviceD, deviceE].map((d) => d.udid));
+    expect(distinctUdids.size, "expected 5 distinct devices, one per concurrent lease").toBe(5);
+
+    for (const device of [deviceA, deviceC, deviceD, deviceE]) {
+      const release = await env.cli(["release", device.lease]);
+      expect(release.code).toBe(0);
+    }
+    for (const held of [heldA, heldC, heldD, heldE]) {
+      held.kill("SIGKILL");
+      await held.waitForExit(15_000).catch(() => undefined);
+    }
+
+    const rows = await deviceRows(env);
+    const registryIdOf = (udid: string): string => {
+      const row = rows.find((candidate) => candidate.driverDeviceId === udid);
+      if (row === undefined) throw new Error(`No registry row for driverDeviceId ${udid}`);
+      return row.id;
+    };
+
+    const stagedDevices: ScriptedObservedDevice[] = [
+      { deviceId: deviceA.udid, runState: "stopped" },
+      { deviceId: deviceB.udid, runState: "stopped" },
+      // deviceC.udid deliberately omitted.
+      {
+        deviceId: deviceD.udid,
+        runState: "running",
+        mark: { durable: "tok-d", erasableReadable: true },
+      },
+      {
+        deviceId: deviceE.udid,
+        runState: "running",
+        mark: { durable: "tok-e", erasable: "stale", erasableReadable: false },
+      },
+      { deviceId: "fake-ios-99-unregistered", runState: "running" },
+    ];
+    await env.driverScript.merge({
+      ios: {
+        managedReality: {
+          devices: stagedDevices,
+          processes: [{ deviceId: "fake-ios-100-orphan" }],
+        },
+      },
+    });
+
+    const dryRun = await env.cli(["doctor"]);
+    expect(dryRun.code).toBe(0);
+    const findings = (dryRun.json as { findings: Finding[] }).findings;
+
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        kind: "foreign-state-change",
+        deviceId: registryIdOf(deviceA.udid),
+        expected: "running",
+        observed: "stopped",
+      }),
+    );
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        kind: "foreign-state-change",
+        deviceId: registryIdOf(deviceB.udid),
+        expected: "running",
+        observed: "stopped",
+      }),
+    );
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        kind: "registry-device-missing",
+        deviceId: registryIdOf(deviceC.udid),
+      }),
+    );
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        kind: "foreign-provenance-change",
+        deviceId: registryIdOf(deviceD.udid),
+        detail: "erased",
+      }),
+    );
+    expect(
+      findings.some((finding) => finding.deviceId === registryIdOf(deviceE.udid)),
+      "deviceE has an unreadable erasable mark and must produce no finding at all",
+    ).toBe(false);
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        kind: "orphan-device",
+        device: expect.objectContaining({ deviceId: "fake-ios-99-unregistered" }),
+      }),
+    );
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        kind: "orphan-process",
+        device: expect.objectContaining({ deviceId: "fake-ios-100-orphan" }),
+      }),
+    );
+
+    await env.driverLog.clear();
+    const fixed = await env.cli(["doctor", "--fix"]);
+    expect(fixed.code).toBe(0);
+
+    // Registry-only destruction (safety.md #1/#3): --fix must never call a destructive
+    // or state-changing driver verb. Every correction above is pure registry bookkeeping.
+    const calls = await env.driverLog.calls();
+    const destructiveOps = new Set(["destroy", "shutdown", "reclaim", "makeReady", "provision"]);
+    expect(
+      calls.filter((call) => destructiveOps.has(call.operation)),
+      `--fix must be registry-only; saw: ${JSON.stringify(calls.map((call) => call.operation))}`,
+    ).toEqual([]);
+
+    const rowsAfterFix = await deviceRows(env);
+    const rowA = rowsAfterFix.find((row) => row.id === registryIdOf(deviceA.udid));
+    expect(rowA?.state, "deviceA's foreign-state-change should have been corrected").toBe(
+      "shutdown",
+    );
+    const rowB = rowsAfterFix.find((row) => row.id === registryIdOf(deviceB.udid));
+    expect(rowB?.state, "leased deviceB must be left alone by --fix").toBe("leased");
+    const rowC = rowsAfterFix.find((row) => row.id === registryIdOf(deviceC.udid));
+    expect(rowC?.state, "vanished deviceC should be marked deleted, not recreated").toBe("deleted");
+    const rowD = rowsAfterFix.find((row) => row.id === registryIdOf(deviceD.udid));
+    expect(
+      rowD?.foreignProvenanceDetectedAt,
+      "provenance drift is report-only -- re-marking would destroy the evidence",
+    ).toBeGreaterThan(0);
+
+    heldB.kill("SIGKILL");
+    await heldB.waitForExit(15_000).catch(() => undefined);
+  });
+});

--- a/e2e/error-exit-codes.test.ts
+++ b/e2e/error-exit-codes.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import { withDaemon, type CliResult } from "./helpers/index.js";
+
+/**
+ * Asserts the documented failure contract from docs/CLI.md#global-exit-codes: exit
+ * code, exactly one structured JSON line on stderr, empty stdout.
+ */
+function expectStructuredFailure(result: CliResult, exitCode: number, errorCode: string): void {
+  expect(result.code).toBe(exitCode);
+  expect(result.stdout).toBe("");
+  expect(result.stderr.trim().split("\n")).toHaveLength(1);
+  expect(JSON.parse(result.stderr)).toEqual({
+    error: { code: errorCode, message: expect.any(String) },
+  });
+}
+
+describe("error and exit-code table", () => {
+  it.each([
+    { name: "unknown command", args: ["frobnicate"], exitCode: 2, errorCode: "USAGE" },
+    { name: "missing required lease flags", args: ["lease"], exitCode: 2, errorCode: "USAGE" },
+    {
+      name: "empty --agent-id",
+      args: ["lease", "--platform", "ios", "--device", "iPhone 16", "--agent-id", ""],
+      exitCode: 2,
+      errorCode: "USAGE",
+    },
+    {
+      name: "--json on an already-JSON-only command",
+      args: ["list", "--json"],
+      exitCode: 2,
+      errorCode: "USAGE",
+    },
+  ])("$name -> exit $exitCode ($errorCode)", async ({ args, exitCode, errorCode }) => {
+    const env = await withDaemon();
+    const result = await env.cli(args);
+    expectStructuredFailure(result, exitCode, errorCode);
+  });
+
+  it("UNKNOWN_MODEL -> exit 12", async () => {
+    const env = await withDaemon();
+    await env.driverScript.set({
+      ios: { failures: { resolveSpec: { type: "UnknownModelError", model: "Bogus Phone" } } },
+    });
+
+    const result = await env.cli([
+      "lease",
+      "--platform",
+      "ios",
+      "--device",
+      "Bogus Phone",
+      "--detach",
+    ]);
+    expectStructuredFailure(result, 12, "UNKNOWN_MODEL");
+  });
+
+  it("RUNTIME_MISSING without --allow-download -> exit 12, and never attempts a download", async () => {
+    const env = await withDaemon();
+    await env.driverScript.set({
+      ios: { failures: { resolveSpec: { type: "RuntimeMissingError", osVersion: "999.0" } } },
+    });
+    await env.driverLog.clear();
+
+    const result = await env.cli([
+      "lease",
+      "--platform",
+      "ios",
+      "--device",
+      "iPhone 16",
+      "--os",
+      "999.0",
+      "--detach",
+    ]);
+    expectStructuredFailure(result, 12, "RUNTIME_MISSING");
+
+    const calls = await env.driverLog.calls();
+    expect(calls.some((call) => call.operation === "resolveSpec")).toBe(true);
+    expect(calls.some((call) => call.operation === "provision")).toBe(false);
+  });
+
+  it("UNKNOWN_LEASE (lease renew on an unknown id) -> falls back to exit 1", async () => {
+    const env = await withDaemon();
+    const result = await env.cli(["lease", "renew", "lse_does-not-exist"]);
+    expectStructuredFailure(result, 1, "UNKNOWN_LEASE");
+  });
+
+  it("HELD_LEASE_RENEWAL (renewing a held-mode lease) -> falls back to exit 1", async () => {
+    const env = await withDaemon();
+    await env.driverScript.set({
+      ios: { knownModels: ["iPhone 16"], availableOsVersions: ["18.4"] },
+    });
+
+    const held = env.cliBackground([
+      "lease",
+      "--platform",
+      "ios",
+      "--device",
+      "iPhone 16",
+      "--os",
+      "18.4",
+      "--agent-id",
+      "flow4-held",
+    ]);
+    const grant = JSON.parse(await held.firstStdoutLine()) as { lease: string };
+
+    try {
+      const result = await env.cli(["lease", "renew", grant.lease]);
+      expectStructuredFailure(result, 1, "HELD_LEASE_RENEWAL");
+    } finally {
+      held.kill("SIGTERM");
+      await held.waitForExit(15_000);
+    }
+  });
+});

--- a/e2e/fake-driver/fake-driver.ts
+++ b/e2e/fake-driver/fake-driver.ts
@@ -1,0 +1,317 @@
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import {
+  BootTimeoutError,
+  DriverCrashError,
+  RuntimeMissingError,
+  UnknownModelError,
+  type DeviceRequest,
+  type Driver,
+  type DriverCatalogEntry,
+  type DriverDevice,
+  type DriverReality,
+  type ObservedMark,
+  type ObservedRunState,
+} from "../../dist/core/driver.js";
+import type { DeviceSpec, Platform } from "../../dist/core/domain.js";
+import type {
+  FakeDriverErrorSpec,
+  FakeDriverOperation,
+  FakeDriverPlatformScript,
+  FakeDriverScript,
+  ScriptedObservedDevice,
+  ScriptedProcessEntry,
+} from "./types.js";
+
+/** Minimal clock contract this driver needs -- kept local so it stays type-only-decoupled. */
+export interface FakeDriverClock {
+  now(): number;
+  setTimer(delayMs: number, callback: () => void): unknown;
+}
+
+export interface OutOfProcessFakeDriverOptions {
+  readonly clock: FakeDriverClock;
+  readonly logPath: string | undefined;
+  readonly platform: Platform;
+  readonly scriptPath: string | undefined;
+}
+
+const DEFAULT_SCRIPT: FakeDriverPlatformScript = {
+  availableOsVersions: ["18.0"],
+};
+
+/**
+ * Driver implementation for the daemon-spawned process the e2e suite drives out of
+ * band. Every behaviour lives in a JSON script file re-read on each operation (env
+ * var `PITLANE_FAKE_DRIVER_SCRIPT`), and every call is appended as a JSON line to a
+ * log file (env var `PITLANE_FAKE_DRIVER_LOG`) so a test can assert what the daemon
+ * did and did not do. A missing script file falls back to permissive defaults --
+ * never a crash, per the safety rule that a broken test harness should not look like
+ * a broken daemon.
+ */
+export class OutOfProcessFakeDriver implements Driver {
+  readonly platform: Platform;
+  readonly #clock: FakeDriverClock;
+  readonly #logPath: string | undefined;
+  readonly #scriptPath: string | undefined;
+  readonly #devices = new Map<string, "provisioned" | "ready" | "shutdown">();
+  #lastKnownEstimateMs: FakeDriverPlatformScript["estimateMs"];
+  #nextDeviceNumber = 1;
+
+  constructor(options: OutOfProcessFakeDriverOptions) {
+    this.platform = options.platform;
+    this.#clock = options.clock;
+    this.#logPath = options.logPath;
+    this.#scriptPath = options.scriptPath;
+  }
+
+  async resolveSpec(
+    request: DeviceRequest,
+    options: { readonly allowDownload: boolean },
+  ): Promise<DeviceSpec> {
+    const script = await this.#beforeCall("resolveSpec", [request, options]);
+    this.#assertKnownModel(request.model, script);
+    const osVersion = this.#resolveOsVersion(request.osVersion, script, options.allowDownload);
+    return { model: request.model, osVersion, platform: this.platform };
+  }
+
+  #assertKnownModel(model: string, script: FakeDriverPlatformScript): void {
+    if (script.knownModels !== undefined && !script.knownModels.includes(model)) {
+      throw new UnknownModelError(this.platform, model);
+    }
+  }
+
+  /** Defaults to the newest scripted runtime; a missing/undownloadable one fails loudly. */
+  #resolveOsVersion(
+    requested: string | undefined,
+    script: FakeDriverPlatformScript,
+    allowDownload: boolean,
+  ): string {
+    const available = script.availableOsVersions ?? DEFAULT_SCRIPT.availableOsVersions ?? [];
+    const osVersion = requested ?? newestVersion(available);
+    if (osVersion === undefined) {
+      throw new RuntimeMissingError(this.platform, "default");
+    }
+    this.#assertOsVersionAvailable(osVersion, available, allowDownload);
+    return osVersion;
+  }
+
+  #assertOsVersionAvailable(
+    osVersion: string,
+    available: readonly string[],
+    allowDownload: boolean,
+  ): void {
+    if (!available.includes(osVersion) && !allowDownload) {
+      throw new RuntimeMissingError(this.platform, osVersion);
+    }
+  }
+
+  async provision(spec: DeviceSpec): Promise<DriverDevice> {
+    await this.#beforeCall("provision", [spec]);
+    const deviceId = `fake-${this.platform}-${this.#nextDeviceNumber}`;
+    this.#nextDeviceNumber += 1;
+    this.#devices.set(deviceId, "provisioned");
+    return { deviceId, driverData: { fakeDeviceId: deviceId } };
+  }
+
+  async makeReady(device: DriverDevice): Promise<void> {
+    await this.#beforeCall("makeReady", [device]);
+    this.#devices.set(device.deviceId, "ready");
+  }
+
+  async reclaim(
+    device: DriverDevice,
+    options: { readonly clean: "standard" | "full" },
+  ): Promise<{
+    readonly state: "ready" | "shutdown";
+    readonly strategy: "erase" | "snapshot" | "wipe";
+  }> {
+    const script = await this.#beforeCall("reclaim", [device, options]);
+    const state = script.reclaimResult ?? "ready";
+    const strategy = script.reclaimStrategy ?? "erase";
+    this.#devices.set(device.deviceId, state);
+    return { state, strategy };
+  }
+
+  reclaimStrategy(_options: {
+    readonly clean: "standard" | "full";
+  }): "erase" | "snapshot" | "wipe" {
+    return "erase";
+  }
+
+  async shutdown(device: DriverDevice): Promise<void> {
+    await this.#beforeCall("shutdown", [device]);
+    this.#devices.set(device.deviceId, "shutdown");
+  }
+
+  async destroy(device: DriverDevice): Promise<void> {
+    await this.#beforeCall("destroy", [device]);
+    this.#devices.delete(device.deviceId);
+  }
+
+  async listManaged(): Promise<DriverReality> {
+    const script = await this.#beforeCall("listManaged", []);
+    const overridden = script.managedReality;
+    if (overridden !== undefined) {
+      return {
+        devices: (overridden.devices ?? []).map(toObservedDevice),
+        processes: (overridden.processes ?? []).map(toManagedProcess),
+      };
+    }
+
+    return {
+      devices: [...this.#devices.entries()].map(([deviceId, status]) => ({
+        deviceId,
+        driverData: { fakeDeviceId: deviceId },
+        runState: runStateFor(status),
+      })),
+      processes: [],
+    };
+  }
+
+  async listCatalog(): Promise<DriverCatalogEntry> {
+    const script = await this.#beforeCall("listCatalog", []);
+    const runtimes = [...(script.availableOsVersions ?? DEFAULT_SCRIPT.availableOsVersions ?? [])];
+    return {
+      defaultRuntime: newestVersion(runtimes),
+      models: script.knownModels === undefined ? [] : [...script.knownModels],
+      runtimes: [...runtimes].sort(compareVersions),
+    };
+  }
+
+  estimate(operation: "provision" | "boot" | "reclaim", _spec: DeviceSpec): number {
+    // estimate() is synchronous in the Driver interface, so it reads the script
+    // synchronously best-effort; a stale/missing read just falls back to 0.
+    return this.#lastKnownEstimateMs?.[operation] ?? 0;
+  }
+
+  async #beforeCall(
+    operation: FakeDriverOperation,
+    arguments_: readonly unknown[],
+  ): Promise<FakeDriverPlatformScript> {
+    const script = await this.#readScript();
+    this.#lastKnownEstimateMs = script.estimateMs;
+    await this.#appendLog(operation, arguments_);
+
+    const latency = script.latencyMs?.[operation] ?? 0;
+    if (latency > 0) {
+      await new Promise<void>((resolve) => {
+        this.#clock.setTimer(latency, resolve);
+      });
+    }
+
+    const failure = script.failures?.[operation];
+    if (failure !== undefined) {
+      throw toError(this.platform, failure);
+    }
+
+    return script;
+  }
+
+  async #readScript(): Promise<FakeDriverPlatformScript> {
+    if (this.#scriptPath === undefined) {
+      return DEFAULT_SCRIPT;
+    }
+    try {
+      const raw = await readFile(this.#scriptPath, "utf8");
+      const parsed = JSON.parse(raw) as FakeDriverScript;
+      return parsed[this.platform] ?? DEFAULT_SCRIPT;
+    } catch {
+      // Missing file, invalid JSON, or a race with a test rewriting it mid-flight:
+      // fall back to defaults rather than making the fake driver itself flaky.
+      return DEFAULT_SCRIPT;
+    }
+  }
+
+  async #appendLog(operation: FakeDriverOperation, arguments_: readonly unknown[]): Promise<void> {
+    if (this.#logPath === undefined) {
+      return;
+    }
+    const line = `${JSON.stringify({
+      timestampMs: this.#clock.now(),
+      platform: this.platform,
+      operation,
+      arguments: arguments_,
+    })}\n`;
+    try {
+      await appendFile(this.#logPath, line, "utf8");
+    } catch {
+      await mkdir(dirname(this.#logPath), { recursive: true });
+      await appendFile(this.#logPath, line, "utf8");
+    }
+  }
+}
+
+function toObservedDevice(device: ScriptedObservedDevice): DriverReality["devices"][number] {
+  return {
+    deviceId: device.deviceId,
+    driverData: { fakeDeviceId: device.deviceId },
+    runState: device.runState as ObservedRunState,
+    ...(device.mark === undefined ? {} : { mark: toObservedMark(device.mark) }),
+  };
+}
+
+function toObservedMark(mark: NonNullable<ScriptedObservedDevice["mark"]>): ObservedMark {
+  return {
+    durable: mark.durable,
+    erasable: mark.erasable,
+    erasableReadable: mark.erasableReadable ?? true,
+  };
+}
+
+function toManagedProcess(process: ScriptedProcessEntry): DriverDevice {
+  return { deviceId: process.deviceId, driverData: { fakeDeviceId: process.deviceId } };
+}
+
+function runStateFor(status: "provisioned" | "ready" | "shutdown"): ObservedRunState {
+  switch (status) {
+    case "ready":
+      return "running";
+    case "shutdown":
+      return "stopped";
+    case "provisioned":
+      return "transitioning";
+  }
+}
+
+/** One factory per `FakeDriverErrorSpec["type"]` -- a lookup table instead of a
+ *  branching switch, so adding an error kind never raises `toError`'s complexity. */
+const ERROR_FACTORIES: {
+  readonly [Type in FakeDriverErrorSpec["type"]]: (
+    spec: Extract<FakeDriverErrorSpec, { readonly type: Type }>,
+    platform: Platform,
+  ) => Error;
+} = {
+  RuntimeMissingError: (spec, platform) =>
+    new RuntimeMissingError(platform, spec.osVersion ?? "unknown"),
+  UnknownModelError: (spec, platform) => new UnknownModelError(platform, spec.model ?? "unknown"),
+  BootTimeoutError: (spec) => new BootTimeoutError(spec.deviceId ?? "unknown"),
+  DriverCrashError: (spec) => new DriverCrashError(spec.message ?? "Scripted driver crash"),
+  generic: (spec) => new Error(spec.message ?? "Scripted fake driver failure"),
+};
+
+function toError(platform: Platform, spec: FakeDriverErrorSpec): Error {
+  const factory = ERROR_FACTORIES[spec.type] as (
+    spec: FakeDriverErrorSpec,
+    platform: Platform,
+  ) => Error;
+  return factory(spec, platform);
+}
+
+function newestVersion(versions: readonly string[]): string | undefined {
+  return [...versions].sort(compareVersions).at(-1);
+}
+
+function compareVersions(left: string, right: string): number {
+  const leftParts = left.split(".").map(Number);
+  const rightParts = right.split(".").map(Number);
+  const length = Math.max(leftParts.length, rightParts.length);
+  for (let index = 0; index < length; index += 1) {
+    const difference = (leftParts[index] ?? 0) - (rightParts[index] ?? 0);
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+  return left.localeCompare(right);
+}

--- a/e2e/fake-driver/index.ts
+++ b/e2e/fake-driver/index.ts
@@ -1,0 +1,19 @@
+import type { Driver } from "../../dist/core/driver.js";
+import { OutOfProcessFakeDriver, type FakeDriverClock } from "./fake-driver.js";
+import { DEFAULT_LOG_ENV, DEFAULT_SCRIPT_ENV } from "./types.js";
+
+/**
+ * The `PITLANE_DRIVERS_MODULE` entry point: substitutes real driver discovery in a
+ * daemon process spawned by the e2e suite. Reads `PITLANE_FAKE_DRIVER_SCRIPT` and
+ * `PITLANE_FAKE_DRIVER_LOG` from the environment and hands both fake drivers
+ * (ios + android) the same paths, so one script file and one call log cover a whole
+ * daemon instance regardless of which platform a test leases against.
+ */
+export function createDrivers(context: { readonly clock: FakeDriverClock }): Driver[] {
+  const scriptPath = process.env[DEFAULT_SCRIPT_ENV];
+  const logPath = process.env[DEFAULT_LOG_ENV];
+  return [
+    new OutOfProcessFakeDriver({ clock: context.clock, logPath, platform: "ios", scriptPath }),
+    new OutOfProcessFakeDriver({ clock: context.clock, logPath, platform: "android", scriptPath }),
+  ];
+}

--- a/e2e/fake-driver/tsconfig.json
+++ b/e2e/fake-driver/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "../../dist/e2e",
+    "types": ["node"]
+  },
+  "include": ["*.ts"]
+}

--- a/e2e/fake-driver/types.ts
+++ b/e2e/fake-driver/types.ts
@@ -1,0 +1,79 @@
+// Shapes shared by the scriptable fake driver, its script file, and its call log.
+// These are hand-declared rather than imported from src/core/driver.ts because the
+// structural pieces (ObservedDevice, DriverReality, ...) are simple enough to duplicate
+// and doing so keeps this file free of any value-level coupling to the src tree beyond
+// the four error classes declared in driver-errors.d.ts. Type-only imports would also
+// work, but duplicating here makes it obvious at a glance what the JSON script format is.
+
+export type FakeDriverPlatform = "ios" | "android";
+
+export type FakeDriverOperation =
+  | "resolveSpec"
+  | "provision"
+  | "makeReady"
+  | "reclaim"
+  | "shutdown"
+  | "destroy"
+  | "listManaged"
+  | "listCatalog";
+
+export type FakeDriverEstimateOperation = "provision" | "boot" | "reclaim";
+
+/** A forced failure for one operation. `type: "generic"` throws a plain Error. */
+export type FakeDriverErrorSpec =
+  | { readonly type: "RuntimeMissingError"; readonly osVersion?: string }
+  | { readonly type: "UnknownModelError"; readonly model?: string }
+  | { readonly type: "BootTimeoutError"; readonly deviceId?: string }
+  | { readonly type: "DriverCrashError"; readonly message?: string }
+  | { readonly type: "generic"; readonly message?: string };
+
+export type ScriptedRunState = "running" | "stopped" | "transitioning";
+
+export interface ScriptedMark {
+  readonly durable?: string;
+  readonly erasable?: string;
+  readonly erasableReadable?: boolean;
+}
+
+export interface ScriptedObservedDevice {
+  readonly deviceId: string;
+  readonly runState: ScriptedRunState;
+  readonly mark?: ScriptedMark;
+}
+
+export interface ScriptedProcessEntry {
+  readonly deviceId: string;
+}
+
+/** Overrides `listManaged()` so doctor drift (unknown/vanished devices) can be staged. */
+export interface ScriptedManagedReality {
+  readonly devices?: readonly ScriptedObservedDevice[];
+  readonly processes?: readonly ScriptedProcessEntry[];
+}
+
+export interface FakeDriverPlatformScript {
+  readonly knownModels?: readonly string[];
+  readonly availableOsVersions?: readonly string[];
+  readonly latencyMs?: Partial<Record<FakeDriverOperation, number>>;
+  readonly estimateMs?: Partial<Record<FakeDriverEstimateOperation, number>>;
+  readonly reclaimResult?: "ready" | "shutdown";
+  readonly reclaimStrategy?: "erase" | "snapshot" | "wipe";
+  readonly failures?: Partial<Record<FakeDriverOperation, FakeDriverErrorSpec>>;
+  readonly managedReality?: ScriptedManagedReality;
+}
+
+/** Top-level script file shape, read fresh on every driver operation. */
+export interface FakeDriverScript {
+  readonly ios?: FakeDriverPlatformScript;
+  readonly android?: FakeDriverPlatformScript;
+}
+
+export interface FakeDriverLogEntry {
+  readonly timestampMs: number;
+  readonly platform: FakeDriverPlatform;
+  readonly operation: FakeDriverOperation;
+  readonly arguments: readonly unknown[];
+}
+
+export const DEFAULT_SCRIPT_ENV = "PITLANE_FAKE_DRIVER_SCRIPT";
+export const DEFAULT_LOG_ENV = "PITLANE_FAKE_DRIVER_LOG";

--- a/e2e/heartbeat-ttl.test.ts
+++ b/e2e/heartbeat-ttl.test.ts
@@ -1,0 +1,127 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+import { waitFor, withDaemon } from "./helpers/index.js";
+
+interface LeaseRow {
+  readonly id: string;
+  readonly requesterId: string;
+  readonly ttlDeadline: number;
+  readonly lastHeartbeatAt?: number;
+}
+
+async function leaseRows(env: Awaited<ReturnType<typeof withDaemon>>): Promise<LeaseRow[]> {
+  const result = await env.cli(["list", "--leases"]);
+  if (result.code !== 0) throw new Error(`pitlane list --leases failed: ${result.stderr}`);
+  return result.json as LeaseRow[];
+}
+
+describe("sliding TTL and heartbeat", () => {
+  it("refuses to start with a heartbeat interval that isn't at most backstop / 4, naming the key", async () => {
+    const env = await withDaemon({
+      mode: "auto",
+      configOverrides: { lease: { heldTtlBackstopMs: 4_000, heartbeatIntervalMs: 2_000 } },
+    });
+
+    // Every command auto-starts on demand; the daemon process crashes on the bad
+    // config before it ever opens its socket, so the CLI retries for its startup
+    // window and then gives up -- surfaced as an INTERNAL timeout, not a specific
+    // config error code (the CLI never got a response to relay).
+    const result = await env.cli(["catalog", "--json"], { timeout: 15_000 });
+    expect(result.code).toBe(1);
+    expect(result.error?.code).toBe("INTERNAL");
+
+    await waitFor(
+      async () => {
+        try {
+          const log = await readFile(env.logPath, "utf8");
+          return log.includes("lease.heartbeatIntervalMs");
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 10_000, label: "daemon.log names the offending config key" },
+    );
+  });
+
+  it("slides a heartbeat-capable (MCP) lease past the backstop while a non-capable (CLI) lease expires at it", async () => {
+    const env = await withDaemon({
+      configOverrides: { lease: { heldTtlBackstopMs: 4_000, heartbeatIntervalMs: 800 } },
+    });
+    await env.driverScript.set({
+      ios: { knownModels: ["iPhone 16"], availableOsVersions: ["18.4"] },
+    });
+
+    const mcp = await env.mcpClient({ env: { PITLANE_AGENT_ID: "flow6-mcp" } });
+    const cliHeld = env.cliBackground([
+      "lease",
+      "--platform",
+      "ios",
+      "--device",
+      "iPhone 16",
+      "--os",
+      "18.4",
+      "--agent-id",
+      "flow6-cli",
+    ]);
+
+    try {
+      const leaseResult = await mcp.client.callTool({
+        name: "lease_simulator",
+        arguments: { platform: "ios", device: "iPhone 16", os: "18.4" },
+      });
+      const mcpLease = leaseResult.structuredContent as { lease_id: string; expires_at_ms: number };
+
+      const cliGrant = JSON.parse(await cliHeld.firstStdoutLine()) as { lease: string };
+
+      // The CLI lease deliberately never declares the heartbeat capability, so its
+      // backstop deadline never moves and it expires exactly at the original grant
+      // + heldTtlBackstopMs; the MCP lease, which does declare it, should still be
+      // alive well past that point with an advancing deadline and heartbeat marker.
+      await waitFor(
+        async () => {
+          const rows = await leaseRows(env);
+          const cliRow = rows.find((row) => row.id === cliGrant.lease);
+          return cliRow === undefined;
+        },
+        { timeout: 15_000, label: "CLI (non-heartbeating) lease expires at the backstop" },
+      );
+
+      const rowsAfterCliExpiry = await leaseRows(env);
+      const mcpRow = rowsAfterCliExpiry.find((row) => row.id === mcpLease.lease_id);
+      expect(mcpRow, "MCP lease should have survived past the CLI lease's expiry").toBeDefined();
+      expect(mcpRow?.ttlDeadline).toBeGreaterThan(mcpLease.expires_at_ms);
+      expect(mcpRow?.lastHeartbeatAt).toBeGreaterThan(0);
+
+      const statusResult = await mcp.client.callTool({ name: "lease_status", arguments: {} });
+      const statusExpiry = (statusResult.structuredContent as { expires_at_ms: number })
+        .expires_at_ms;
+      expect(statusExpiry).toBeGreaterThan(mcpLease.expires_at_ms);
+
+      const recorded = await env.events();
+      expect(
+        recorded.filter(
+          (entry) =>
+            entry.event === "lease.renewed" &&
+            (entry.payload as { leaseId?: string }).leaseId === mcpLease.lease_id,
+        ).length,
+        "expected repeated lease.renewed events for the heartbeating MCP lease",
+      ).toBeGreaterThan(1);
+      expect(recorded).toContainEqual(
+        expect.objectContaining({
+          event: "lease.expired",
+          payload: expect.objectContaining({ leaseId: cliGrant.lease }),
+        }),
+      );
+
+      await mcp.client.callTool({
+        name: "release_simulator",
+        arguments: { lease_id: mcpLease.lease_id },
+      });
+    } finally {
+      cliHeld.kill("SIGKILL");
+      await cliHeld.waitForExit(15_000).catch(() => undefined);
+      await mcp.close();
+    }
+  });
+});

--- a/e2e/held-lease-liveness.test.ts
+++ b/e2e/held-lease-liveness.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import { waitForDeviceState, waitForLeaseCount, withDaemon } from "./helpers/index.js";
+
+describe("held-lease liveness & restart", () => {
+  it("killing the held CLI process releases its lease", async () => {
+    const env = await withDaemon();
+    await env.driverScript.set({
+      ios: { knownModels: ["iPhone 16"], availableOsVersions: ["18.4"] },
+    });
+
+    const held = env.cliBackground([
+      "lease",
+      "--platform",
+      "ios",
+      "--device",
+      "iPhone 16",
+      "--os",
+      "18.4",
+      "--agent-id",
+      "flow5-killed",
+    ]);
+    const grant = JSON.parse(await held.firstStdoutLine()) as { lease: string; udid: string };
+    await waitForLeaseCount(env, 1);
+
+    held.kill("SIGKILL");
+    await held.waitForExit(15_000);
+
+    await waitForLeaseCount(env, 0);
+    await waitForDeviceState(env, grant.udid, "ready");
+    await env.expectEvents(["lease.granted", "lease.released"]);
+  });
+
+  it("orphan-sweeps a held lease still persisted across a daemon restart", async () => {
+    const env = await withDaemon();
+    await env.driverScript.set({
+      ios: { knownModels: ["iPhone 16"], availableOsVersions: ["18.4"] },
+    });
+
+    const held = env.cliBackground([
+      "lease",
+      "--platform",
+      "ios",
+      "--device",
+      "iPhone 16",
+      "--os",
+      "18.4",
+      "--agent-id",
+      "flow5-orphaned",
+    ]);
+    const grant = JSON.parse(await held.firstStdoutLine()) as { lease: string; udid: string };
+    await waitForLeaseCount(env, 1);
+
+    // Kill the daemon out from under the holder (not a graceful `daemon stop`) so the
+    // lease is left `held` in the persisted registry with no live connection --
+    // exactly the case StartupConverger's orphan sweep exists for.
+    await env.killDaemon("SIGKILL");
+    await env.startDaemon();
+
+    await waitForLeaseCount(env, 0);
+    await waitForDeviceState(env, grant.udid, "ready");
+
+    const recorded = await env.events();
+    expect(recorded).toContainEqual(
+      expect.objectContaining({
+        event: "lease.released",
+        payload: expect.objectContaining({ leaseId: grant.lease, reason: "orphaned" }),
+      }),
+    );
+
+    held.kill("SIGKILL");
+    await held.waitForExit(15_000).catch(() => undefined);
+  });
+
+  it("a detached lease survives a restart with its TTL timer restored", async () => {
+    const env = await withDaemon({
+      // Generous relative to the default (900_000ms) but still short enough to keep the
+      // test fast; needs enough headroom that a restart (which now waits, best-effort,
+      // for the previous daemon process to fully exit -- see helpers/env.ts) can't
+      // itself eat into the TTL window before the "still there right after restart"
+      // check below runs.
+      configOverrides: { lease: { detachedTtlMs: 15_000, heartbeatIntervalMs: 500 } },
+    });
+    await env.driverScript.set({
+      ios: { knownModels: ["iPhone 16"], availableOsVersions: ["18.4"] },
+    });
+
+    const lease = await env.cli([
+      "lease",
+      "--platform",
+      "ios",
+      "--device",
+      "iPhone 16",
+      "--os",
+      "18.4",
+      "--agent-id",
+      "flow5-detached",
+      "--detach",
+    ]);
+    expect(lease.code).toBe(0);
+    const grant = lease.json as { lease: string; udid: string };
+
+    // The event ring buffer resets on restart (documented behaviour, ARCHITECTURE.md),
+    // so check "granted" happened before the restart wipes it, and only look for
+    // "expired" afterwards.
+    await env.expectEvents(["lease.requested", "lease.granted"]);
+
+    await env.restartDaemon();
+
+    // Still there immediately after restart -- the lease was not dropped.
+    const leasesAfterRestart = await env.cli(["list", "--leases"]);
+    expect(leasesAfterRestart.json).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: grant.lease })]),
+    );
+
+    // If the TTL timer were not restored (rather than merely the lease record
+    // persisting), it would never expire and this would time out.
+    await waitForLeaseCount(env, 0, { timeout: 30_000 });
+    await waitForDeviceState(env, grant.udid, "ready");
+
+    await env.expectEvents(["lease.expired"]);
+  });
+});

--- a/e2e/helpers/cli.ts
+++ b/e2e/helpers/cli.ts
@@ -1,0 +1,199 @@
+import { spawn } from "node:child_process";
+import { join } from "node:path";
+
+import { REPO_ROOT } from "./repo-root.js";
+
+const CLI_ENTRY = join(REPO_ROOT, "dist/cli/main.js");
+
+export interface CliOptions {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly input?: string;
+  readonly timeout?: number;
+}
+
+export interface CliError {
+  readonly code: string;
+  readonly message: string;
+}
+
+export interface CliResult {
+  readonly code: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+  /** Parsed stdout, when it is exactly one line of JSON (most commands' success output). */
+  readonly json: unknown;
+  /** Parsed `{"error":{code,message}}` stderr line -- the CLI's documented failure contract. */
+  readonly error: CliError | undefined;
+}
+
+/**
+ * Runs one `pitlane` CLI invocation to completion. Exit-code and structured-error
+ * assertions read as one-liners: `expect((await cli(env, [...])).code).toBe(13)`.
+ */
+export function cli(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+  options: CliOptions = {},
+): Promise<CliResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI_ENTRY, ...args], {
+      env: { ...env, ...options.env },
+    });
+    let stdout = "";
+    let stderr = "";
+    const timer =
+      options.timeout === undefined
+        ? undefined
+        : setTimeout(() => {
+            child.kill("SIGKILL");
+            reject(new Error(`pitlane ${args.join(" ")} timed out after ${options.timeout}ms`));
+          }, options.timeout);
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    if (options.input !== undefined) {
+      child.stdin.write(options.input);
+      child.stdin.end();
+    }
+    child.once("error", (error) => {
+      if (timer !== undefined) clearTimeout(timer);
+      reject(error);
+    });
+    child.once("close", (code) => {
+      if (timer !== undefined) clearTimeout(timer);
+      resolve({ code, stdout, stderr, ...parseOutputs(stdout, stderr) });
+    });
+  });
+}
+
+export interface CliBackgroundHandle {
+  /** Resolves with the first stdout line -- the lease grant JSON in held mode. */
+  firstStdoutLine(timeout?: number): Promise<string>;
+  /** The stderr progress JSON lines observed so far, in order. */
+  progressEvents(): readonly unknown[];
+  waitForExit(timeout?: number): Promise<CliResult>;
+  kill(signal?: NodeJS.Signals): void;
+  readonly pid: number | undefined;
+}
+
+/**
+ * Starts a `pitlane` invocation that stays running (held-mode `lease`), for tests
+ * that need to observe progress, kill the process, or hold a lease across other
+ * assertions.
+ */
+export function cliBackground(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+  options: CliOptions = {},
+): CliBackgroundHandle {
+  const child = spawn(process.execPath, [CLI_ENTRY, ...args], {
+    env: { ...env, ...options.env },
+  });
+  let stdout = "";
+  let stderr = "";
+  const progress: unknown[] = [];
+  const stdoutWaiters: ((line: string) => void)[] = [];
+  let firstLineSeen: string | undefined;
+
+  child.stdout.on("data", (chunk: Buffer) => {
+    stdout += chunk.toString("utf8");
+    if (firstLineSeen === undefined && stdout.includes("\n")) {
+      firstLineSeen = stdout.slice(0, stdout.indexOf("\n"));
+      for (const waiter of stdoutWaiters.splice(0)) waiter(firstLineSeen);
+    }
+  });
+  child.stderr.on("data", (chunk: Buffer) => {
+    stderr += chunk.toString("utf8");
+    for (const line of chunk.toString("utf8").split("\n")) {
+      if (line.trim() === "") continue;
+      try {
+        progress.push(JSON.parse(line));
+      } catch {
+        // Non-JSON stderr noise is preserved in `stderr` but not treated as progress.
+      }
+    }
+  });
+
+  let exited: Promise<CliResult> | undefined;
+  const exit = (): Promise<CliResult> => {
+    exited ??= new Promise((resolve) => {
+      child.once("close", (code) => {
+        resolve({ code, stdout, stderr, ...parseOutputs(stdout, stderr) });
+      });
+    });
+    return exited;
+  };
+
+  return {
+    pid: child.pid,
+    async firstStdoutLine(timeout = 30_000) {
+      if (firstLineSeen !== undefined) return firstLineSeen;
+      return new Promise<string>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          reject(new Error(`Timed out after ${timeout}ms waiting for first stdout line`));
+        }, timeout);
+        stdoutWaiters.push((line) => {
+          clearTimeout(timer);
+          resolve(line);
+        });
+      });
+    },
+    progressEvents: () => [...progress],
+    async waitForExit(timeout = 30_000) {
+      return Promise.race([
+        exit(),
+        new Promise<CliResult>((_resolve, reject) => {
+          setTimeout(
+            () => reject(new Error(`Timed out after ${timeout}ms waiting for exit`)),
+            timeout,
+          );
+        }),
+      ]);
+    },
+    kill(signal: NodeJS.Signals = "SIGTERM") {
+      child.kill(signal);
+    },
+  };
+}
+
+function parseOutputs(
+  stdout: string,
+  stderr: string,
+): { json: unknown; error: CliError | undefined } {
+  const json = parseSoleJsonLine(stdout);
+  // A failing command's stderr is documented to carry exactly one structured error
+  // line, but a request that got as far as queueing/provisioning first writes
+  // progress lines on the same stream -- so search all lines, not just a sole one,
+  // and prefer the last match (the final error, after any progress).
+  const error = stderr
+    .split("\n")
+    .map((line) => parseJsonLine(line))
+    .filter((value): value is Record<string, unknown> => isErrorEnvelope(value))
+    .map((envelope) => envelope.error as CliError)
+    .at(-1);
+  return { json, error };
+}
+
+function parseSoleJsonLine(text: string): unknown {
+  const trimmed = text.trim();
+  if (trimmed === "" || trimmed.includes("\n")) return undefined;
+  return parseJsonLine(trimmed);
+}
+
+function parseJsonLine(line: string): unknown {
+  const trimmed = line.trim();
+  if (trimmed === "") return undefined;
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function isErrorEnvelope(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && "error" in value;
+}

--- a/e2e/helpers/driver-script.ts
+++ b/e2e/helpers/driver-script.ts
@@ -1,0 +1,74 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import type { FakeDriverLogEntry, FakeDriverScript } from "../fake-driver/types.js";
+
+/** Mutates the fake driver's JSON script file; the daemon re-reads it on every call. */
+export interface DriverScriptControl {
+  /** Replaces the whole script (both platforms). */
+  set(script: FakeDriverScript): Promise<void>;
+  /** Shallow-merges into whichever platform keys are present, leaving others untouched. */
+  merge(script: FakeDriverScript): Promise<void>;
+  /** Deletes the script file so the driver falls back to defaults. */
+  clear(): Promise<void>;
+  get(): Promise<FakeDriverScript>;
+  readonly path: string;
+}
+
+/** Reads the fake driver's append-only JSON-lines call log. */
+export interface DriverLogControl {
+  calls(): Promise<FakeDriverLogEntry[]>;
+  clear(): Promise<void>;
+  readonly path: string;
+}
+
+export function driverScriptControl(scriptPath: string): DriverScriptControl {
+  return {
+    path: scriptPath,
+    async set(script) {
+      await mkdir(dirname(scriptPath), { recursive: true });
+      await writeFile(scriptPath, JSON.stringify(script, null, 2), "utf8");
+    },
+    async merge(script) {
+      const current = await this.get();
+      const ios = script.ios === undefined ? current.ios : { ...current.ios, ...script.ios };
+      const android =
+        script.android === undefined ? current.android : { ...current.android, ...script.android };
+      await this.set({
+        ...(ios === undefined ? {} : { ios }),
+        ...(android === undefined ? {} : { android }),
+      });
+    },
+    async clear() {
+      await rm(scriptPath, { force: true });
+    },
+    async get() {
+      try {
+        return JSON.parse(await readFile(scriptPath, "utf8")) as FakeDriverScript;
+      } catch {
+        return {};
+      }
+    },
+  };
+}
+
+export function driverLogControl(logPath: string): DriverLogControl {
+  return {
+    path: logPath,
+    async calls() {
+      let contents: string;
+      try {
+        contents = await readFile(logPath, "utf8");
+      } catch {
+        return [];
+      }
+      return contents
+        .split("\n")
+        .filter((line) => line.trim() !== "")
+        .map((line) => JSON.parse(line) as FakeDriverLogEntry);
+    },
+    async clear() {
+      await rm(logPath, { force: true });
+    },
+  };
+}

--- a/e2e/helpers/env.ts
+++ b/e2e/helpers/env.ts
@@ -1,0 +1,364 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach } from "vitest";
+
+import {
+  cli,
+  cliBackground,
+  type CliBackgroundHandle,
+  type CliOptions,
+  type CliResult,
+} from "./cli.js";
+import {
+  driverLogControl,
+  driverScriptControl,
+  type DriverLogControl,
+  type DriverScriptControl,
+} from "./driver-script.js";
+import { events, expectEvents, type RecordedEvent } from "./events.js";
+import { mcpClient, type McpClientHandle, type McpClientOptions } from "./mcp.js";
+import { REPO_ROOT } from "./repo-root.js";
+import { waitFor } from "./wait.js";
+
+const execFileAsync = promisify(execFile);
+
+const FAKE_DRIVER_MODULE = join(REPO_ROOT, "dist/e2e/index.js");
+
+/**
+ * Envs created by `withDaemon()` during the *currently running* test, torn down by
+ * the single `afterEach` below.
+ *
+ * Why a module-level registry instead of each `withDaemon()` call registering its
+ * own `afterEach`: vitest resolves hooks from the synchronous call stack active
+ * during test *collection*, not test *execution*. `withDaemon()` is only ever called
+ * from inside a running `it()` body (after collection has already finished), so an
+ * `afterEach()` call made there never attaches to anything -- confirmed directly: it
+ * silently never fires, for a hook registered synchronously as literally the first
+ * statement of an async function just as much as one registered after several
+ * `await`s. (This cost real debugging time: dozens of "green" runs were quietly
+ * leaking daemon processes because teardown was never actually running -- passing a
+ * test never depended on it.) Registering `afterEach` once here, at module top
+ * level, happens during collection (this module is imported at each test file's own
+ * top level), so it is a real, firing hook; it just needs to know which envs to tear
+ * down, which is what this registry is for.
+ */
+const activeEnvs = new Set<TeardownState>();
+
+afterEach(async () => {
+  const states = [...activeEnvs];
+  activeEnvs.clear();
+  const results = await Promise.allSettled(states.map((state) => teardown(state)));
+  const failures = results.filter(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  if (failures.length > 0) {
+    throw new Error(failures.map((failure) => errorMessage(failure.reason)).join("; "));
+  }
+});
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export interface WithDaemonOptions {
+  /**
+   * "running" (default) starts the daemon explicitly before returning, so the
+   * first test action talks to an already-live daemon. "auto" leaves the daemon
+   * unstarted so the test can exercise CLI/MCP auto-start and stale-socket
+   * recovery itself.
+   */
+  readonly mode?: "running" | "auto";
+  /** Seeded into config.json before the daemon (if any) starts. */
+  readonly configOverrides?: Record<string, unknown>;
+  readonly agentId?: string;
+  /**
+   * "fake" (default) wires `PITLANE_DRIVERS_MODULE` at the scriptable out-of-process
+   * fake driver. "real" leaves driver discovery alone -- the daemon finds the real
+   * iOS/Android drivers exactly as it would in production -- for the slow, real-SDK
+   * lane; `driverScript`/`driverLog` are inert in that mode (nothing reads them).
+   */
+  readonly driver?: "fake" | "real";
+}
+
+export interface TestEnv {
+  readonly home: string;
+  readonly socketPath: string;
+  readonly logPath: string;
+  readonly configPath: string;
+  /** Environment to pass to any spawned pitlane process (CLI, MCP, or the daemon). */
+  readonly env: NodeJS.ProcessEnv;
+  readonly driverScript: DriverScriptControl;
+  readonly driverLog: DriverLogControl;
+  cli(args: readonly string[], options?: CliOptions): Promise<CliResult>;
+  cliBackground(args: readonly string[], options?: CliOptions): CliBackgroundHandle;
+  mcpClient(options?: McpClientOptions): Promise<McpClientHandle>;
+  events(since?: string): Promise<RecordedEvent[]>;
+  expectEvents(
+    names: readonly string[],
+    options?: { readonly since?: string; readonly timeout?: number },
+  ): Promise<RecordedEvent[]>;
+  /** Starts the daemon explicitly (`pitlane daemon start`); a no-op if already running. */
+  startDaemon(): Promise<CliResult>;
+  /** Stops the daemon gracefully (`pitlane daemon stop`), then restarts it explicitly. */
+  restartDaemon(): Promise<void>;
+  /** Sends the given signal directly to the daemon process (default SIGKILL), for
+   *  stale-socket-recovery and orphan-sweep tests. Resolves once the process is gone. */
+  killDaemon(signal?: NodeJS.Signals): Promise<void>;
+  /** Writes config.json keys, restarts the daemon, runs `fn`, then restores the
+   *  original config.json and restarts again. */
+  withConfig<T>(overrides: Record<string, unknown>, fn: () => Promise<T>): Promise<T>;
+}
+
+/**
+ * Allocates an isolated `PITLANE_HOME`, wires the fake driver in, and returns a
+ * `TestEnv`. Registers itself with the module-level `activeEnvs` registry so the one
+ * real `afterEach` above tears it down at the end of the current test: kills any
+ * backgrounded CLI/MCP processes this env spawned, gracefully stops the daemon, then
+ * verifies the pids that were observed holding the socket before that stop actually
+ * exited (not just that the socket file is gone -- see `isProcessAlive`),
+ * force-killing and failing the test if any survived. It does not independently
+ * assert lease/device state is clean on exit; a flow that cares about that asserts
+ * it itself (e.g. `waitForLeaseCount(env, 0)`).
+ */
+export async function withDaemon(options: WithDaemonOptions = {}): Promise<TestEnv> {
+  const home = await mkdtemp(join(tmpdir(), "pitlane-e2e-"));
+  const socketPath = join(home, "daemon.sock");
+  const logPath = join(home, "daemon.log");
+  const configPath = join(home, "config.json");
+  const scriptPath = join(home, "fake-driver-script.json");
+  const logCallPath = join(home, "fake-driver-calls.jsonl");
+
+  const useFakeDriver = options.driver !== "real";
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    PITLANE_HOME: home,
+    ...(useFakeDriver
+      ? {
+          PITLANE_DRIVERS_MODULE: FAKE_DRIVER_MODULE,
+          PITLANE_FAKE_DRIVER_SCRIPT: scriptPath,
+          PITLANE_FAKE_DRIVER_LOG: logCallPath,
+        }
+      : {}),
+    ...(options.agentId === undefined ? {} : { PITLANE_AGENT_ID: options.agentId }),
+  };
+
+  if (options.configOverrides !== undefined) {
+    await writeFile(configPath, `${JSON.stringify(options.configOverrides, null, 2)}\n`, "utf8");
+  }
+
+  const backgroundProcesses = new Set<CliBackgroundHandle>();
+  const mcpClients = new Set<McpClientHandle>();
+
+  const testEnv: TestEnv = {
+    home,
+    socketPath,
+    logPath,
+    configPath,
+    env,
+    driverScript: driverScriptControl(scriptPath),
+    driverLog: driverLogControl(logCallPath),
+    cli: (args, cliOptions) => cli(args, env, cliOptions),
+    cliBackground: (args, cliOptions) => {
+      const handle = cliBackground(args, env, cliOptions);
+      backgroundProcesses.add(handle);
+      return handle;
+    },
+    mcpClient: async (mcpOptions) => {
+      const handle = await mcpClient(env, mcpOptions);
+      mcpClients.add(handle);
+      return handle;
+    },
+    events: (since) => events(env, since),
+    expectEvents: (names, expectOptions) => expectEvents(env, names, expectOptions),
+    async startDaemon() {
+      return cli(["daemon", "start"], env);
+    },
+    async restartDaemon() {
+      // Wait for the *process* to actually exit, not just its socket file to
+      // disappear -- `daemon.stop()` unlinks the socket as part of shutdown, which
+      // can land slightly before the process fully drains its event loop. Starting
+      // a new daemon while the old one is still mid-exit was a real, reproduced
+      // source of leaked daemon processes (see the module doc above `activeEnvs`).
+      const pidsBeforeStop = await pidsHoldingSocket(socketPath);
+      await cli(["daemon", "stop"], env);
+      await waitFor(() => !existsSync(socketPath), {
+        timeout: 10_000,
+        label: "daemon socket removed",
+      });
+      // Best-effort: under heavy system load a still-exiting process can
+      // legitimately take a while, and `teardown()`'s own grace-period check is the
+      // real backstop for a genuine leak -- this just reduces (not guarantees
+      // against) the ordinary-case race, so a timeout here must not abort the
+      // restart itself.
+      await waitFor(
+        async () => {
+          const stillAlive = await Promise.all(pidsBeforeStop.map((pid) => isProcessAlive(pid)));
+          return !stillAlive.some(Boolean);
+        },
+        { timeout: 10_000, label: "previous daemon process actually exited" },
+      ).catch(() => undefined);
+      await cli(["daemon", "start"], env);
+    },
+    async killDaemon(signal: NodeJS.Signals = "SIGKILL") {
+      const pids = await pidsHoldingSocket(socketPath);
+      for (const pid of pids) {
+        try {
+          process.kill(pid, signal);
+        } catch {
+          // Already gone.
+        }
+      }
+      await waitFor(async () => (await pidsHoldingSocket(socketPath)).length === 0, {
+        timeout: 10_000,
+        label: "daemon process exited after signal",
+      });
+    },
+    async withConfig(overrides, fn) {
+      const previous = existsSync(configPath) ? await readFileIfExists(configPath) : undefined;
+      const merged = mergeDeep(
+        previous === undefined ? {} : (JSON.parse(previous) as Record<string, unknown>),
+        overrides,
+      );
+      await writeFile(configPath, `${JSON.stringify(merged, null, 2)}\n`, "utf8");
+      await testEnv.restartDaemon();
+      try {
+        return await fn();
+      } finally {
+        if (previous === undefined) await rm(configPath, { force: true });
+        else await writeFile(configPath, previous, "utf8");
+        await testEnv.restartDaemon();
+      }
+    },
+  };
+
+  if (options.mode !== "auto") {
+    await testEnv.startDaemon();
+  }
+
+  activeEnvs.add({ backgroundProcesses, env, home, mcpClients, socketPath });
+  return testEnv;
+}
+
+interface TeardownState {
+  readonly backgroundProcesses: ReadonlySet<CliBackgroundHandle>;
+  readonly env: NodeJS.ProcessEnv;
+  readonly home: string;
+  readonly mcpClients: ReadonlySet<McpClientHandle>;
+  readonly socketPath: string;
+}
+
+async function teardown(state: TeardownState): Promise<void> {
+  const { backgroundProcesses, env, home, mcpClients, socketPath } = state;
+  for (const client of mcpClients) {
+    await client.close().catch(() => undefined);
+  }
+  for (const handle of backgroundProcesses) {
+    handle.kill("SIGKILL");
+  }
+  await Promise.all(
+    [...backgroundProcesses].map((handle) => handle.waitForExit(10_000).catch(() => undefined)),
+  );
+
+  // Capture who (if anyone) is holding the socket *before* the graceful stop, so
+  // we can verify those specific pids actually exit -- checking only "is the
+  // socket file still there" after `daemon stop` would miss a process that
+  // unlinked its socket on the way out but never actually terminated.
+  const pidsBeforeStop = await pidsHoldingSocket(socketPath);
+  await cli(["daemon", "stop"], env).catch(() => undefined);
+  await waitFor(() => !existsSync(socketPath), { timeout: 5_000 }).catch(() => undefined);
+
+  // A process can keep running for a little while after its socket is unlinked
+  // (event-loop drain, especially under load) -- give `pidsBeforeStop` a real grace
+  // window rather than a single point-in-time check, so a merely-slow exit is not
+  // mistaken for a genuine leak.
+  await waitFor(
+    async () => {
+      const alive = await Promise.all(pidsBeforeStop.map((pid) => isProcessAlive(pid)));
+      return !alive.some(Boolean);
+    },
+    { timeout: 20_000, interval: 100 },
+  ).catch(() => undefined);
+
+  const stillHoldingSocket = await pidsHoldingSocket(socketPath);
+  const stillAlive = (
+    await Promise.all(
+      pidsBeforeStop.map(async (pid) => ((await isProcessAlive(pid)) ? pid : undefined)),
+    )
+  ).filter((pid): pid is number => pid !== undefined);
+  const strayPids = [...new Set([...stillHoldingSocket, ...stillAlive])];
+  for (const pid of strayPids) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // Already gone.
+    }
+  }
+
+  await rm(home, { force: true, recursive: true });
+
+  if (strayPids.length > 0) {
+    throw new Error(
+      `withDaemon teardown found stray daemon process(es) that outlived \`daemon stop\` for ${socketPath}: ${strayPids.join(", ")}`,
+    );
+  }
+}
+
+/**
+ * Signal-0 liveness probe: sends no actual signal, just asks the kernel whether
+ * `pid` exists and is ours to signal. Throws ESRCH (gone) or EPERM (exists, not
+ * ours -- treated as alive since it did not exit) otherwise.
+ */
+async function isProcessAlive(pid: number): Promise<boolean> {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error: unknown) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+/** Finds pids with an open file descriptor on `socketPath` (macOS/Linux via lsof). */
+async function pidsHoldingSocket(socketPath: string): Promise<number[]> {
+  if (!existsSync(socketPath)) return [];
+  try {
+    const { stdout } = await execFileAsync("lsof", ["-t", socketPath]);
+    return stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line !== "")
+      .map(Number)
+      .filter((pid) => Number.isInteger(pid));
+  } catch {
+    // lsof exits non-zero when nothing holds the file, or may be unavailable.
+    return [];
+  }
+}
+
+async function readFileIfExists(path: string): Promise<string | undefined> {
+  try {
+    return await readFile(path, "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+function mergeDeep(
+  base: Record<string, unknown>,
+  overrides: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(overrides)) {
+    const existing = result[key];
+    result[key] =
+      isPlainObject(value) && isPlainObject(existing) ? mergeDeep(existing, value) : value;
+  }
+  return result;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/e2e/helpers/env.ts
+++ b/e2e/helpers/env.ts
@@ -64,6 +64,31 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+/**
+ * Capacity inputs the fake-driver lane pins so a flow's device budget comes from the
+ * flow, never from the machine running it. `defaultConfig` derives the per-platform
+ * device limits from `availableParallelism()` (a 2-core runner yields exactly one iOS
+ * device), and `capacity.ts` independently gates on `totalmem()` minus a 4 GiB OS
+ * reserve at 1.5 GiB per iOS device (a 7 GiB runner therefore admits two, whatever
+ * `limits` says). A flow needing more concurrent devices than that passes on a dev
+ * machine and wedges on a small CI runner -- the extra lease simply queues until the
+ * test's own timeout, which reads as a hang rather than as "capacity refused".
+ *
+ * Fake devices are JSON in a file and consume no real RAM, so the per-device budget is
+ * pinned to a nominal 1 MiB, which keeps the RAM gate from binding while leaving it
+ * wired. Flows that exercise capacity itself override `limits` on top of this. The real
+ * -SDK lane deliberately does not get this treatment: there the host's RAM is a real
+ * constraint and the production defaults are what should apply.
+ */
+const FAKE_LANE_BASE_CONFIG: Record<string, unknown> = {
+  limits: {
+    maxRunning: 8,
+    ios: { maxDevices: 8, maxRunning: 8 },
+    android: { maxDevices: 8, maxRunning: 8 },
+  },
+  ramBudget: { iosBytesPerDevice: 1024 * 1024, androidBytesPerDevice: 1024 * 1024 },
+};
+
 export interface WithDaemonOptions {
   /**
    * "running" (default) starts the daemon explicitly before returning, so the
@@ -146,8 +171,11 @@ export async function withDaemon(options: WithDaemonOptions = {}): Promise<TestE
     ...(options.agentId === undefined ? {} : { PITLANE_AGENT_ID: options.agentId }),
   };
 
-  if (options.configOverrides !== undefined) {
-    await writeFile(configPath, `${JSON.stringify(options.configOverrides, null, 2)}\n`, "utf8");
+  const seededConfig = useFakeDriver
+    ? mergeDeep(FAKE_LANE_BASE_CONFIG, options.configOverrides ?? {})
+    : options.configOverrides;
+  if (seededConfig !== undefined) {
+    await writeFile(configPath, `${JSON.stringify(seededConfig, null, 2)}\n`, "utf8");
   }
 
   const backgroundProcesses = new Set<CliBackgroundHandle>();

--- a/e2e/helpers/events.ts
+++ b/e2e/helpers/events.ts
@@ -1,0 +1,64 @@
+import { cli } from "./cli.js";
+import { waitFor } from "./wait.js";
+
+export interface RecordedEvent {
+  readonly timestamp: number;
+  readonly event: string;
+  readonly payload: unknown;
+  readonly module: string;
+}
+
+/** Replays the business-event ring buffer via `pitlane events --since`, parsed. */
+export async function events(env: NodeJS.ProcessEnv, since = "1h"): Promise<RecordedEvent[]> {
+  const result = await cli(["events", "--since", since], env);
+  if (result.code !== 0) {
+    throw new Error(`pitlane events failed (exit ${String(result.code)}): ${result.stderr}`);
+  }
+  return result.stdout
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .map((line) => JSON.parse(line) as RecordedEvent);
+}
+
+/**
+ * Asserts that `expectedNames` appear, in order, as a (not necessarily contiguous)
+ * subsequence of the recorded event names -- this is what "the documented sequence"
+ * checks in the flows mean: the daemon did these things in this order, extra events
+ * from unrelated activity are fine.
+ */
+export async function expectEvents(
+  env: NodeJS.ProcessEnv,
+  expectedNames: readonly string[],
+  options: { readonly since?: string; readonly timeout?: number } = {},
+): Promise<RecordedEvent[]> {
+  let recorded: RecordedEvent[] = [];
+  await waitFor(
+    async () => {
+      recorded = await events(env, options.since);
+      return containsOrderedSubsequence(
+        recorded.map((entry) => entry.event),
+        expectedNames,
+      );
+    },
+    {
+      timeout: options.timeout ?? 15_000,
+      label: () =>
+        `expected event sequence [${expectedNames.join(", ")}], last saw [${recorded
+          .map((entry) => entry.event)
+          .join(", ")}]`,
+    },
+  );
+  return recorded;
+}
+
+function containsOrderedSubsequence(
+  haystack: readonly string[],
+  needle: readonly string[],
+): boolean {
+  let index = 0;
+  for (const name of haystack) {
+    if (index >= needle.length) break;
+    if (name === needle[index]) index += 1;
+  }
+  return index === needle.length;
+}

--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -1,0 +1,8 @@
+// Public surface for flow test files. Kept to exactly what a flow currently imports
+// through this barrel -- add an export here (from its owning helper module) the
+// moment a flow needs it, rather than pre-declaring the full internal surface, so an
+// unused re-export is always a real signal.
+export { withDaemon } from "./env.js";
+export { waitFor } from "./wait.js";
+export { waitForDeviceState, waitForLeaseCount } from "./status.js";
+export type { CliResult } from "./cli.js";

--- a/e2e/helpers/mcp.ts
+++ b/e2e/helpers/mcp.ts
@@ -1,0 +1,149 @@
+import { join } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import {
+  LoggingMessageNotificationSchema,
+  ProgressNotificationSchema,
+  type LoggingMessageNotification,
+  type ProgressNotification,
+} from "@modelcontextprotocol/sdk/types.js";
+
+import { REPO_ROOT } from "./repo-root.js";
+
+const CLI_ENTRY = join(REPO_ROOT, "dist/cli/main.js");
+
+export interface McpClientOptions {
+  readonly env?: NodeJS.ProcessEnv;
+}
+
+export interface McpClientHandle {
+  readonly client: Client;
+  /** `notifications/progress` frames received so far, in order. */
+  progressNotifications(): readonly ProgressNotification["params"][];
+  /** `notifications/message` (logging) frames received so far, in order. */
+  loggingNotifications(): readonly LoggingMessageNotification["params"][];
+  waitForNotification<T>(
+    predicate: (
+      notification:
+        | { readonly kind: "progress"; readonly params: ProgressNotification["params"] }
+        | { readonly kind: "logging"; readonly params: LoggingMessageNotification["params"] },
+    ) => T | undefined,
+    timeout?: number,
+  ): Promise<T>;
+  /**
+   * The `pitlane mcp` subprocess's stderr captured so far. Piped (not inherited) so a
+   * subprocess shutdown quirk (see the flow-2 report note on a stack-overflow logged
+   * during teardown) does not spam the test runner's own output; available here for
+   * a test that needs to inspect it.
+   */
+  stderrOutput(): string;
+  close(): Promise<void>;
+}
+
+/**
+ * Spawns `node dist/cli/main.js mcp` and connects a real SDK `Client` over stdio,
+ * with progress/logging notification sinks pre-wired so tests can assert MCP
+ * framing in one place instead of re-registering handlers per test.
+ */
+export async function mcpClient(
+  env: NodeJS.ProcessEnv,
+  options: McpClientOptions = {},
+): Promise<McpClientHandle> {
+  let stderrOutput = "";
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [CLI_ENTRY, "mcp"],
+    // StdioClientTransport only inherits a safe-listed subset of process.env by
+    // default (DEFAULT_INHERITED_ENV_VARS) -- explicit here so PITLANE_HOME /
+    // PITLANE_DRIVERS_MODULE / PITLANE_AGENT_ID actually reach the spawned process.
+    env: toStringEnv({ ...env, ...options.env }),
+    // Piped (not the default "inherit") so a subprocess shutdown quirk doesn't spam
+    // the test runner's own stderr; captured instead, see `stderrOutput()`.
+    stderr: "pipe",
+  });
+  transport.stderr?.on("data", (chunk: Buffer) => {
+    stderrOutput += chunk.toString("utf8");
+  });
+  const client = new Client({ name: "pitlane-e2e", version: "0.0.0" });
+
+  const progress: ProgressNotification["params"][] = [];
+  const logging: LoggingMessageNotification["params"][] = [];
+  const waiters: {
+    predicate: (notification: { kind: "progress" | "logging"; params: unknown }) => unknown;
+    resolve: (value: unknown) => void;
+  }[] = [];
+
+  function dispatch(notification: { kind: "progress" | "logging"; params: unknown }): void {
+    for (let index = waiters.length - 1; index >= 0; index -= 1) {
+      const waiter = waiters[index];
+      if (waiter === undefined) continue;
+      const result = waiter.predicate(notification);
+      if (result !== undefined) {
+        waiters.splice(index, 1);
+        waiter.resolve(result);
+      }
+    }
+  }
+
+  client.setNotificationHandler(ProgressNotificationSchema, (notification) => {
+    progress.push(notification.params);
+    dispatch({ kind: "progress", params: notification.params });
+  });
+  client.setNotificationHandler(LoggingMessageNotificationSchema, (notification) => {
+    logging.push(notification.params);
+    dispatch({ kind: "logging", params: notification.params });
+  });
+
+  await client.connect(transport);
+  let closed = false;
+
+  return {
+    client,
+    progressNotifications: () => [...progress],
+    loggingNotifications: () => [...logging],
+    stderrOutput: () => stderrOutput,
+    waitForNotification(predicate, timeout = 30_000) {
+      // Check what has already arrived first -- a notification can beat the caller
+      // to `waitForNotification` (e.g. the action that triggers it and the call to
+      // this method are two separate awaits), and only dispatching to *future*
+      // arrivals would make that a race instead of a wait.
+      for (const params of progress) {
+        const result = predicate({ kind: "progress", params });
+        if (result !== undefined) return Promise.resolve(result as never);
+      }
+      for (const params of logging) {
+        const result = predicate({ kind: "logging", params });
+        if (result !== undefined) return Promise.resolve(result as never);
+      }
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          const index = waiters.findIndex((waiter) => waiter.resolve === resolve);
+          if (index >= 0) waiters.splice(index, 1);
+          reject(new Error(`Timed out after ${timeout}ms waiting for a matching MCP notification`));
+        }, timeout);
+        waiters.push({
+          predicate: (notification) => predicate(notification as never),
+          resolve: (value) => {
+            clearTimeout(timer);
+            resolve(value as never);
+          },
+        });
+      });
+    },
+    async close() {
+      // Idempotent: both a test's own cleanup and TestEnv's teardown safety net may
+      // call this on the same handle.
+      if (closed) return;
+      closed = true;
+      await client.close();
+    },
+  };
+}
+
+function toStringEnv(env: NodeJS.ProcessEnv): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (value !== undefined) result[key] = value;
+  }
+  return result;
+}

--- a/e2e/helpers/repo-root.ts
+++ b/e2e/helpers/repo-root.ts
@@ -1,0 +1,10 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * The repository root, derived from this file's own location rather than
+ * `process.cwd()` -- so the suite doesn't depend on the directory vitest happened
+ * to be invoked from. This file lives at `e2e/helpers/repo-root.ts`, two levels
+ * below the root.
+ */
+export const REPO_ROOT: string = join(dirname(fileURLToPath(import.meta.url)), "../..");

--- a/e2e/helpers/setup.ts
+++ b/e2e/helpers/setup.ts
@@ -1,0 +1,23 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import { REPO_ROOT } from "./repo-root.js";
+
+// Fails fast with an actionable message instead of a confusing ENOENT from the first
+// spawned `node dist/cli/main.js` if someone runs `vitest run --project e2e` directly
+// without going through `pnpm run test:e2e` (which builds first).
+const requiredBuildOutputs = [
+  "dist/cli/main.js",
+  "dist/daemon/main.js",
+  "dist/mcp/main.js",
+  "dist/e2e/index.js",
+];
+
+for (const relativePath of requiredBuildOutputs) {
+  if (!existsSync(join(REPO_ROOT, relativePath))) {
+    throw new Error(
+      `e2e setup: missing build output ${relativePath}. Run \`pnpm run build && pnpm run build:e2e\` ` +
+        "(or use `pnpm run test:e2e`, which does this for you) before running the e2e project.",
+    );
+  }
+}

--- a/e2e/helpers/status.ts
+++ b/e2e/helpers/status.ts
@@ -1,0 +1,67 @@
+import type { TestEnv } from "./env.js";
+import { waitFor } from "./wait.js";
+
+interface DeviceRecord {
+  readonly id: string;
+  readonly driverDeviceId: string;
+  readonly state: string;
+  readonly [key: string]: unknown;
+}
+
+interface LeaseRecord {
+  readonly id: string;
+  readonly requesterId: string;
+  readonly [key: string]: unknown;
+}
+
+async function listDevices(env: TestEnv): Promise<DeviceRecord[]> {
+  const result = await env.cli(["list", "--devices"]);
+  if (result.code !== 0) throw new Error(`pitlane list --devices failed: ${result.stderr}`);
+  return result.json as DeviceRecord[];
+}
+
+async function listLeases(env: TestEnv): Promise<LeaseRecord[]> {
+  const result = await env.cli(["list", "--leases"]);
+  if (result.code !== 0) throw new Error(`pitlane list --leases failed: ${result.stderr}`);
+  return result.json as LeaseRecord[];
+}
+
+/**
+ * Polls `pitlane list --devices` until the device identified by `driverDeviceId`
+ * (the driver-opaque id -- what a lease grant reports as `udid`/`device_id`, *not*
+ * pitlane's own registry device id) reaches `state`.
+ */
+export async function waitForDeviceState(
+  env: TestEnv,
+  driverDeviceId: string,
+  state: string,
+  options: { readonly timeout?: number } = {},
+): Promise<void> {
+  await waitFor(
+    async () =>
+      (await listDevices(env)).some(
+        (device) => device.driverDeviceId === driverDeviceId && device.state === state,
+      ),
+    {
+      timeout: options.timeout ?? 30_000,
+      label: `device ${driverDeviceId} reaches state ${state}`,
+    },
+  );
+}
+
+/** Polls `pitlane list --leases` until exactly `count` leases are active. */
+export async function waitForLeaseCount(
+  env: TestEnv,
+  count: number,
+  options: { readonly timeout?: number } = {},
+): Promise<LeaseRecord[]> {
+  let leases: LeaseRecord[] = [];
+  await waitFor(
+    async () => {
+      leases = await listLeases(env);
+      return leases.length === count;
+    },
+    { timeout: options.timeout ?? 30_000, label: `lease count reaches ${count}` },
+  );
+  return leases;
+}

--- a/e2e/helpers/wait.ts
+++ b/e2e/helpers/wait.ts
@@ -1,0 +1,43 @@
+/**
+ * The only timing primitive in this suite: no test or helper may `sleep`/fixed-delay.
+ * Everything that needs "wait until X" polls a predicate through this function.
+ */
+export async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  options: {
+    readonly timeout?: number;
+    readonly interval?: number;
+    /** Evaluated lazily, only on timeout, so it can report the real last-observed state. */
+    readonly label?: string | (() => string);
+  } = {},
+): Promise<void> {
+  const timeout = options.timeout ?? 30_000;
+  const interval = options.interval ?? 100;
+  const deadline = Date.now() + timeout;
+  let lastError: unknown;
+
+  for (;;) {
+    try {
+      if (await predicate()) return;
+      lastError = undefined;
+    } catch (error: unknown) {
+      lastError = error;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `waitFor timed out after ${timeout}ms${labelSuffix(options.label)}${causeSuffix(lastError)}`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+}
+
+function labelSuffix(label: string | (() => string) | undefined): string {
+  const resolved = typeof label === "function" ? label() : label;
+  return resolved === undefined ? "" : ` (${resolved})`;
+}
+
+function causeSuffix(error: unknown): string {
+  if (error === undefined) return "";
+  return `: ${error instanceof Error ? error.message : String(error)}`;
+}

--- a/e2e/lease-lifecycle.test.ts
+++ b/e2e/lease-lifecycle.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import { waitForDeviceState, withDaemon } from "./helpers/index.js";
+
+describe("lease lifecycle across both frontends", () => {
+  it("catalog -> lease --detach -> status/list agree -> release -> device returns to ready -> events", async () => {
+    const env = await withDaemon();
+    await env.driverScript.set({
+      ios: { knownModels: ["iPhone 16"], availableOsVersions: ["18.4"] },
+    });
+    const agentId = "flow2-cli-agent";
+
+    const catalogJson = await env.cli(["catalog", "--json"]);
+    expect(catalogJson.code).toBe(0);
+    expect(catalogJson.json).toMatchObject({
+      platforms: expect.arrayContaining([
+        expect.objectContaining({ platform: "ios", models: ["iPhone 16"], defaultRuntime: "18.4" }),
+      ]),
+    });
+
+    const catalogHuman = await env.cli(["catalog"]);
+    expect(catalogHuman.code).toBe(0);
+    expect(catalogHuman.stdout).toContain("iPhone 16");
+
+    const lease = await env.cli([
+      "lease",
+      "--platform",
+      "ios",
+      "--device",
+      "iPhone 16",
+      "--os",
+      "18.4",
+      "--agent-id",
+      agentId,
+      "--detach",
+    ]);
+    expect(lease.code).toBe(0);
+    const leaseGrant = lease.json as { lease: string; device: string; udid: string };
+    expect(leaseGrant.device).toBe("iPhone 16");
+
+    const statusJson = await env.cli(["status", "--json"]);
+    expect(statusJson.code).toBe(0);
+    expect(statusJson.json).toMatchObject({
+      leases: expect.arrayContaining([
+        expect.objectContaining({ id: leaseGrant.lease, requesterId: agentId }),
+      ]),
+    });
+
+    const listLeases = await env.cli(["list", "--leases"]);
+    expect(listLeases.code).toBe(0);
+    expect(listLeases.json).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: leaseGrant.lease, requesterId: agentId }),
+      ]),
+    );
+
+    const release = await env.cli(["release", leaseGrant.lease]);
+    expect(release.code).toBe(0);
+
+    await waitForDeviceState(env, leaseGrant.udid, "ready");
+
+    await env.expectEvents(["lease.requested", "lease.granted", "lease.released"]);
+  });
+
+  it("agrees with the CLI when the lease/release cycle runs through MCP", async () => {
+    const env = await withDaemon();
+    await env.driverScript.set({
+      ios: { knownModels: ["iPhone 16"], availableOsVersions: ["18.4"] },
+    });
+    const agentId = "flow2-mcp-agent";
+
+    const mcp = await env.mcpClient({ env: { PITLANE_AGENT_ID: agentId } });
+    try {
+      const leaseResult = await mcp.client.callTool({
+        name: "lease_simulator",
+        arguments: { platform: "ios", device: "iPhone 16", os: "18.4" },
+      });
+      const leased = leaseResult.structuredContent as {
+        lease_id: string;
+        device_id: string;
+        device: string;
+        platform: string;
+      };
+      expect(leased.device).toBe("iPhone 16");
+
+      const statusResult = await mcp.client.callTool({ name: "lease_status", arguments: {} });
+      expect(statusResult.structuredContent).toMatchObject({
+        held: true,
+        lease_id: leased.lease_id,
+        device_id: leased.device_id,
+      });
+
+      // The CLI frontend must see the exact same lease, keyed by the same requester id.
+      const cliLeases = await env.cli(["list", "--leases"]);
+      expect(cliLeases.code).toBe(0);
+      expect(cliLeases.json).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: leased.lease_id, requesterId: agentId }),
+        ]),
+      );
+
+      const releaseResult = await mcp.client.callTool({
+        name: "release_simulator",
+        arguments: { lease_id: leased.lease_id },
+      });
+      expect(releaseResult.structuredContent).toMatchObject({
+        lease_id: leased.lease_id,
+        released: true,
+      });
+
+      await waitForDeviceState(env, leased.device_id, "ready");
+
+      const cliLeasesAfter = await env.cli(["list", "--leases"]);
+      expect(cliLeasesAfter.json).toEqual([]);
+    } finally {
+      await mcp.close();
+    }
+  });
+});

--- a/e2e/mcp-session.test.ts
+++ b/e2e/mcp-session.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+
+import { withDaemon } from "./helpers/index.js";
+
+interface McpErrorPayload {
+  readonly code: string;
+  readonly message: string;
+}
+
+describe("MCP session semantics", () => {
+  it("exercises all four tools, and streams strictly increasing progress with human messages", async () => {
+    const env = await withDaemon();
+    await env.driverScript.set({
+      ios: { knownModels: ["iPhone 16"], availableOsVersions: ["18.4"] },
+      android: { knownModels: ["Pixel 8"], availableOsVersions: ["34"] },
+    });
+    const mcp = await env.mcpClient({ env: { PITLANE_AGENT_ID: "flow7-tools" } });
+
+    try {
+      const devicesBefore = await mcp.client.callTool({ name: "list_devices", arguments: {} });
+      expect(devicesBefore.structuredContent).toMatchObject({
+        platforms: expect.arrayContaining([
+          expect.objectContaining({ platform: "ios", models: ["iPhone 16"] }),
+        ]),
+      });
+
+      const statusBefore = await mcp.client.callTool({ name: "lease_status", arguments: {} });
+      expect(statusBefore.structuredContent).toEqual({ held: false });
+
+      const leaseResult = await mcp.client.callTool({
+        name: "lease_simulator",
+        arguments: { platform: "ios", device: "iPhone 16", os: "18.4" },
+        _meta: { progressToken: "flow7-token" },
+      });
+      const leased = leaseResult.structuredContent as { lease_id: string; device_id: string };
+
+      const progress = mcp.progressNotifications();
+      expect(progress.length, "expected at least one notifications/progress frame").toBeGreaterThan(
+        0,
+      );
+      for (const [index, frame] of progress.entries()) {
+        expect(frame.progressToken).toBe("flow7-token");
+        expect(typeof frame.message).toBe("string");
+        expect((frame.message as string).length).toBeGreaterThan(0);
+        if (index > 0) {
+          expect(frame.progress).toBeGreaterThan(progress[index - 1]?.progress as number);
+        }
+      }
+
+      const statusAfter = await mcp.client.callTool({ name: "lease_status", arguments: {} });
+      expect(statusAfter.structuredContent).toMatchObject({
+        held: true,
+        lease_id: leased.lease_id,
+      });
+
+      const released = await mcp.client.callTool({
+        name: "release_simulator",
+        arguments: { lease_id: leased.lease_id },
+      });
+      expect(released.structuredContent).toEqual({ lease_id: leased.lease_id, released: true });
+    } finally {
+      await mcp.close();
+    }
+  });
+
+  it("relays a force-release from the CLI as a logging warning, then LEASE_NOT_OWNED is a clean tool error, and the server stays usable", async () => {
+    const env = await withDaemon();
+    await env.driverScript.set({
+      ios: { knownModels: ["iPhone 16"], availableOsVersions: ["18.4"] },
+    });
+    const mcp = await env.mcpClient({ env: { PITLANE_AGENT_ID: "flow7-force-release" } });
+
+    try {
+      const leaseResult = await mcp.client.callTool({
+        name: "lease_simulator",
+        arguments: { platform: "ios", device: "iPhone 16", os: "18.4" },
+      });
+      const leased = leaseResult.structuredContent as { lease_id: string; device_id: string };
+
+      const forceRelease = await env.cli(["release", "--all", "--yes"]);
+      expect(forceRelease.code).toBe(0);
+
+      const warning = await mcp.waitForNotification((notification) => {
+        if (notification.kind !== "logging") return undefined;
+        const data = notification.params.data as
+          | { lease_id?: string; device_id?: string; reason?: string }
+          | undefined;
+        return data?.lease_id === leased.lease_id ? notification.params : undefined;
+      });
+      expect(warning.logger).toBe("pitlane");
+      expect(warning.level).toBe("warning");
+      // The daemon push carries its own internal registry device id, not the
+      // driver-opaque `device_id` (udid) the MCP lease result reports -- only assert
+      // it names *a* device, plus the lease id and reason, which do match exactly.
+      expect(warning.data).toMatchObject({
+        lease_id: leased.lease_id,
+        device_id: expect.any(String),
+        reason: "explicit",
+      });
+
+      const statusAfter = await mcp.client.callTool({ name: "lease_status", arguments: {} });
+      expect(statusAfter.structuredContent).toEqual({ held: false });
+
+      const staleRelease = await mcp.client.callTool({
+        name: "release_simulator",
+        arguments: { lease_id: leased.lease_id },
+      });
+      expect(staleRelease.isError).toBe(true);
+      const errorPayload = JSON.parse(
+        (staleRelease.content as { text: string }[])[0]?.text ?? "{}",
+      ) as McpErrorPayload;
+      expect(errorPayload.code).toBe("LEASE_NOT_OWNED");
+
+      // Still usable: a clean tool error must not have wedged the session/transport.
+      const devices = await mcp.client.callTool({ name: "list_devices", arguments: {} });
+      expect(devices.isError).toBeFalsy();
+    } finally {
+      await mcp.close();
+    }
+  });
+
+  // Regression for PR #35 ("reconnect the session after a daemon restart"): before
+  // that fix, an MCP server whose daemon connection died mid-session would surface
+  // the *next* tool call as an opaque INTERNAL error instead of transparently
+  // reconnecting.
+  it("reconnects after the daemon restarts under a live MCP server process (PR #35)", async () => {
+    const env = await withDaemon();
+    await env.driverScript.set({
+      ios: { knownModels: ["iPhone 16"], availableOsVersions: ["18.4"] },
+    });
+    const mcp = await env.mcpClient({ env: { PITLANE_AGENT_ID: "flow7-restart" } });
+
+    try {
+      const leaseResult = await mcp.client.callTool({
+        name: "lease_simulator",
+        arguments: { platform: "ios", device: "iPhone 16", os: "18.4" },
+      });
+      const leased = leaseResult.structuredContent as { lease_id: string };
+
+      const lostNotice = mcp.waitForNotification((notification) => {
+        if (notification.kind !== "logging") return undefined;
+        const data = notification.params.data as { lease_id?: string; reason?: string } | undefined;
+        return data?.lease_id === leased.lease_id ? data.reason : undefined;
+      });
+
+      await env.restartDaemon();
+      expect(await lostNotice).toBe("daemon-connection-lost");
+
+      const statusAfterRestart = await mcp.client.callTool({ name: "lease_status", arguments: {} });
+      expect(statusAfterRestart.isError).toBeFalsy();
+      expect(statusAfterRestart.structuredContent).toEqual({ held: false });
+
+      const devices = await mcp.client.callTool({ name: "list_devices", arguments: {} });
+      expect(devices.isError, "expected a clean reconnect, not an INTERNAL error").toBeFalsy();
+      expect(devices.structuredContent).toMatchObject({ platforms: expect.any(Array) });
+    } finally {
+      await mcp.close();
+    }
+  });
+});

--- a/e2e/parallel-contention.test.ts
+++ b/e2e/parallel-contention.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { withDaemon } from "./helpers/index.js";
+import { waitForLeaseCount } from "./helpers/status.js";
+
+const AGENT_IDS = Array.from({ length: 8 }, (_, index) => `parallel-agent-${index}`);
+
+interface LeaseRow {
+  readonly id: string;
+  readonly deviceId: string;
+  readonly requesterId: string;
+}
+
+describe("parallel contention invariant", () => {
+  it("never over-grants capacity or double-grants a device, and eventually serves every requester", async () => {
+    const env = await withDaemon({
+      configOverrides: { limits: { maxRunning: 2, ios: { maxDevices: 2, maxRunning: 2 } } },
+    });
+    await env.driverScript.set({
+      ios: { knownModels: ["iPhone 16"], availableOsVersions: ["18.4"] },
+    });
+
+    const handles = AGENT_IDS.map((agentId) =>
+      env.cliBackground([
+        "lease",
+        "--platform",
+        "ios",
+        "--device",
+        "iPhone 16",
+        "--os",
+        "18.4",
+        "--agent-id",
+        agentId,
+      ]),
+    );
+
+    const servedDeviceByAgent = new Map<string, string>();
+
+    // As soon as each holder is granted, immediately kill it -- releasing capacity so
+    // the remaining queued agents can be served in turn. All eight are started
+    // concurrently; none is awaited before the next starts.
+    const releaseChains = handles.map(async (handle, index) => {
+      const line = await handle.firstStdoutLine(60_000);
+      const grant = JSON.parse(line) as { lease: string; udid: string };
+      servedDeviceByAgent.set(AGENT_IDS[index] as string, grant.udid);
+      handle.kill("SIGKILL");
+      await handle.waitForExit(15_000).catch(() => undefined);
+    });
+
+    let maxObservedLeaseCount = 0;
+    let duplicateDeviceObservation: LeaseRow[] | undefined;
+    const invariantPoll = (async () => {
+      while (servedDeviceByAgent.size < AGENT_IDS.length) {
+        const result = await env.cli(["list", "--leases"]);
+        if (result.code === 0) {
+          const rows = result.json as LeaseRow[];
+          maxObservedLeaseCount = Math.max(maxObservedLeaseCount, rows.length);
+          const deviceIds = rows.map((row) => row.deviceId);
+          if (new Set(deviceIds).size !== deviceIds.length) duplicateDeviceObservation = rows;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+    })();
+
+    await Promise.all([...releaseChains, invariantPoll]);
+
+    expect(
+      maxObservedLeaseCount,
+      "never observed more than the configured maxRunning=2 leases active at once",
+    ).toBeLessThanOrEqual(2);
+    expect(
+      duplicateDeviceObservation,
+      `a device was observed granted to two leases at once: ${JSON.stringify(duplicateDeviceObservation)}`,
+    ).toBeUndefined();
+    expect(servedDeviceByAgent.size, "every requester was eventually served").toBe(
+      AGENT_IDS.length,
+    );
+
+    await waitForLeaseCount(env, 0);
+    const finalStatus = await env.cli(["status", "--json"]);
+    expect(finalStatus.code).toBe(0);
+    expect((finalStatus.json as { health: string }).health).toBe("running");
+  });
+});

--- a/e2e/slow-android-smoke.test.ts
+++ b/e2e/slow-android-smoke.test.ts
@@ -1,0 +1,148 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+import { withDaemon } from "./helpers/index.js";
+import { waitFor } from "./helpers/wait.js";
+
+const execFileAsync = promisify(execFile);
+const ANDROID_HOME =
+  process.env.ANDROID_HOME ??
+  process.env.ANDROID_SDK_ROOT ??
+  join(homedir(), "Library/Android/sdk");
+const hasAndroidSdk =
+  existsSync(ANDROID_HOME) && existsSync(join(ANDROID_HOME, "platform-tools", "adb"));
+
+async function adbDevices(): Promise<string[]> {
+  const adb = join(ANDROID_HOME, "platform-tools", "adb");
+  const { stdout } = await execFileAsync(adb, ["devices"]).catch(() => ({ stdout: "" }));
+  return stdout
+    .split("\n")
+    .slice(1)
+    .map((line) => line.trim())
+    .filter((line) => line.endsWith("device"))
+    .map((line) => line.split(/\s+/)[0] as string);
+}
+
+async function avdManagerList(): Promise<string[]> {
+  const avdmanager = join(ANDROID_HOME, "cmdline-tools", "latest", "bin", "avdmanager");
+  const binary = existsSync(avdmanager)
+    ? avdmanager
+    : join(ANDROID_HOME, "tools", "bin", "avdmanager");
+  const { stdout } = await execFileAsync(binary, ["list", "avd"]).catch(() => ({ stdout: "" }));
+  return [...stdout.matchAll(/Name:\s*(\S+)/g)].map((match) => match[1] as string);
+}
+
+// Real emulator boots are slow and this SDK layout is host-specific, so this lane is
+// gated on an actually-discoverable Android SDK rather than just `process.platform`.
+describe.skipIf(!hasAndroidSdk)(
+  "Android smoke (real emulator/adb)",
+  { tags: ["slow", "android"] },
+  () => {
+    it(
+      "catalog agrees with the SDK, a cold lease boots a real emulator, and a shut-down emulator reports erasableReadable:false with no crash or false provenance finding",
+      { timeout: 420_000 },
+      async () => {
+        const env = await withDaemon({
+          driver: "real",
+          configOverrides: { idle: { shutdownAfterMs: 300 } },
+        });
+        try {
+          const catalog = await env.cli(["catalog", "--json", "--platform", "android"]);
+          expect(catalog.code).toBe(0);
+          const platforms = (
+            catalog.json as { platforms: { platform: string; models: string[] }[] }
+          ).platforms;
+          const androidCatalog = platforms.find((platform) => platform.platform === "android");
+          expect(
+            androidCatalog,
+            "pitlane catalog reported no android platform -- SDK discovery failed",
+          ).toBeDefined();
+          expect(androidCatalog?.models.length ?? 0).toBeGreaterThan(0);
+          const model = androidCatalog?.models[0] as string;
+
+          const lease = await env.cli(
+            [
+              "lease",
+              "--platform",
+              "android",
+              "--device",
+              model,
+              "--agent-id",
+              "android-smoke",
+              "--detach",
+            ],
+            { timeout: 240_000 },
+          );
+          expect(lease.code, `lease failed: ${lease.stderr}`).toBe(0);
+          const grant = lease.json as { lease: string; udid: string };
+
+          // The adb serial (e.g. "emulator-5554") is a driver-internal detail pitlane
+          // deliberately keeps opaque outside drivers/android (architecture.md #2) --
+          // `grant.udid` is pitlane's own AVD name, not the adb serial, so this only
+          // asserts that *an* emulator is actually online, not which one by serial.
+          const onlineSerials = await adbDevices();
+          expect(
+            onlineSerials.length,
+            "expected at least one booted emulator visible to adb",
+          ).toBeGreaterThan(0);
+
+          const avdNames = await avdManagerList();
+          expect(
+            avdNames.some((name) => name.startsWith("pitlane_")),
+            "expected a pitlane_-prefixed AVD",
+          ).toBe(true);
+
+          await env.cli(["release", grant.lease]);
+
+          // Force the idle-shutdown rule (see flow 9) rather than waiting on the slow
+          // periodic tick, so the emulator process actually stops.
+          await waitFor(
+            async () => {
+              await env.cli(["cleanup"]);
+              const rows = (await env.cli(["list", "--devices"])).json as {
+                driverDeviceId: string;
+                state: string;
+              }[];
+              return rows.some(
+                (row) => row.driverDeviceId === grant.udid && row.state === "shutdown",
+              );
+            },
+            { timeout: 60_000, interval: 500, label: "device demoted to shutdown" },
+          );
+
+          // With the emulator process stopped, the on-device erasable mark is
+          // unreachable -- `doctor` must not crash on that, must not report it as an
+          // erase (unreadable is not the same as absent), and `list` must render fine.
+          const doctorReport = await env.cli(["doctor"]);
+          expect(doctorReport.code).toBe(0);
+          const findings = (
+            doctorReport.json as { findings: { kind: string; deviceId?: string }[] }
+          ).findings;
+          const devices = (await env.cli(["list", "--devices"])).json as {
+            id: string;
+            driverDeviceId: string;
+          }[];
+          const registryId = devices.find((device) => device.driverDeviceId === grant.udid)?.id;
+          expect(
+            findings.some(
+              (finding) =>
+                finding.kind === "foreign-provenance-change" && finding.deviceId === registryId,
+            ),
+            "a stopped emulator's unreadable mark must not be reported as a foreign-provenance-change",
+          ).toBe(false);
+
+          const list = await env.cli(["list", "--devices"]);
+          expect(list.code).toBe(0);
+        } finally {
+          await env
+            .cli(["nuke", "--delete-devices", "--yes"], { timeout: 120_000 })
+            .catch(() => undefined);
+        }
+      },
+    );
+  },
+);

--- a/e2e/slow-ios-smoke.test.ts
+++ b/e2e/slow-ios-smoke.test.ts
@@ -1,0 +1,155 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+import { withDaemon } from "./helpers/index.js";
+import { waitFor } from "./helpers/wait.js";
+
+const execFileAsync = promisify(execFile);
+
+interface SimctlDevice {
+  readonly udid: string;
+  readonly name: string;
+  readonly state: string;
+}
+
+async function simctlDevices(): Promise<SimctlDevice[]> {
+  const { stdout } = await execFileAsync("xcrun", ["simctl", "list", "devices", "-j"]);
+  const parsed = JSON.parse(stdout) as { devices: Record<string, SimctlDevice[]> };
+  return Object.values(parsed.devices).flat();
+}
+
+async function simctlRuntimes(): Promise<string[]> {
+  const { stdout } = await execFileAsync("xcrun", ["simctl", "list", "runtimes", "-j"]);
+  const parsed = JSON.parse(stdout) as {
+    runtimes: { name: string; version: string; isAvailable: boolean }[];
+  };
+  return parsed.runtimes.filter((runtime) => runtime.isAvailable).map((runtime) => runtime.version);
+}
+
+async function deleteStrayPitlaneSimulators(): Promise<void> {
+  const devices = await simctlDevices();
+  for (const device of devices) {
+    if (device.name.startsWith("pitlane-")) {
+      await execFileAsync("xcrun", ["simctl", "delete", device.udid]).catch(() => undefined);
+    }
+  }
+}
+
+// This lane needs the real simctl toolchain, hence darwin-only and gated on an
+// installed runtime -- it never installs one itself (no --allow-download).
+describe.skipIf(process.platform !== "darwin")(
+  "iOS smoke (real simctl)",
+  { tags: ["slow", "ios"] },
+  () => {
+    it(
+      "catalog agrees with simctl, a cold lease boots a real Booted simulator with matching provenance, release keeps it warm, and nuke leaves no pitlane- simulator",
+      { timeout: 300_000 },
+      async () => {
+        const availableRuntimes = await simctlRuntimes();
+        if (availableRuntimes.length === 0) {
+          throw new Error("No installed, available iOS runtime -- cannot run the iOS smoke lane");
+        }
+
+        const env = await withDaemon({ driver: "real" });
+        try {
+          const catalog = await env.cli(["catalog", "--json", "--platform", "ios"]);
+          expect(catalog.code).toBe(0);
+          const platforms = (
+            catalog.json as {
+              platforms: { platform: string; models: string[]; runtimes: string[] }[];
+            }
+          ).platforms;
+          const iosCatalog = platforms.find((platform) => platform.platform === "ios");
+          expect(iosCatalog, "pitlane catalog reported no iOS platform").toBeDefined();
+          expect(
+            iosCatalog?.models.length ?? 0,
+            "pitlane catalog reported no iOS models",
+          ).toBeGreaterThan(0);
+          for (const runtime of iosCatalog?.runtimes ?? []) {
+            expect(
+              availableRuntimes,
+              "pitlane catalog's runtimes must agree with real simctl",
+            ).toContain(runtime);
+          }
+          const model = iosCatalog?.models[0] as string;
+
+          const lease = await env.cli(
+            [
+              "lease",
+              "--platform",
+              "ios",
+              "--device",
+              model,
+              "--agent-id",
+              "ios-smoke",
+              "--detach",
+            ],
+            { timeout: 120_000 },
+          );
+          expect(lease.code, `lease failed: ${lease.stderr}`).toBe(0);
+          const grant = lease.json as { lease: string; udid: string; device: string };
+
+          const booted = await simctlDevices();
+          const bootedDevice = booted.find((device) => device.udid === grant.udid);
+          expect(bootedDevice, `simctl does not know about udid ${grant.udid}`).toBeDefined();
+          expect(bootedDevice?.state).toBe("Booted");
+          expect(
+            bootedDevice?.name.startsWith("pitlane-"),
+            "device name must carry the pitlane- prefix",
+          ).toBe(true);
+
+          // Provenance: both marks exist with the same token. `doctor` is the
+          // documented way to observe this -- a foreign-provenance-change finding
+          // for this device would mean the marks disagree or are missing.
+          const doctorReport = await env.cli(["doctor"]);
+          expect(doctorReport.code).toBe(0);
+          const findings = (
+            doctorReport.json as { findings: { kind: string; deviceId?: string }[] }
+          ).findings;
+          const devices = (await env.cli(["list", "--devices"])).json as {
+            id: string;
+            driverDeviceId: string;
+          }[];
+          const registryId = devices.find((device) => device.driverDeviceId === grant.udid)?.id;
+          expect(
+            findings.some(
+              (finding) =>
+                finding.kind === "foreign-provenance-change" && finding.deviceId === registryId,
+            ),
+            "expected no provenance drift for a device pitlane just created",
+          ).toBe(false);
+
+          const release = await env.cli(["release", grant.lease]);
+          expect(release.code).toBe(0);
+
+          // Still Booted: the warm pool only demotes after idle.shutdownAfterMs,
+          // which defaults far longer than this test.
+          await waitFor(
+            async () => {
+              const rows = (await env.cli(["list", "--devices"])).json as {
+                driverDeviceId: string;
+                state: string;
+              }[];
+              return rows.some((row) => row.driverDeviceId === grant.udid && row.state === "ready");
+            },
+            { timeout: 60_000, label: "device returns to ready after release" },
+          );
+          const stillBooted = await simctlDevices();
+          expect(stillBooted.find((device) => device.udid === grant.udid)?.state).toBe("Booted");
+
+          const nuke = await env.cli(["nuke", "--delete-devices", "--yes"], { timeout: 60_000 });
+          expect(nuke.code).toBe(0);
+
+          await waitFor(
+            async () =>
+              !(await simctlDevices()).some((device) => device.name.startsWith("pitlane-")),
+            { timeout: 60_000, label: "no pitlane- simulator remains after nuke --delete-devices" },
+          );
+        } finally {
+          await deleteStrayPitlaneSimulators();
+        }
+      },
+    );
+  },
+);

--- a/e2e/slow-no-implicit-download.test.ts
+++ b/e2e/slow-no-implicit-download.test.ts
@@ -1,0 +1,93 @@
+import { execFile } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+import { withDaemon } from "./helpers/index.js";
+
+const execFileAsync = promisify(execFile);
+const ANDROID_HOME =
+  process.env.ANDROID_HOME ??
+  process.env.ANDROID_SDK_ROOT ??
+  join(homedir(), "Library/Android/sdk");
+const hasAndroidSdk = existsSync(ANDROID_HOME);
+
+async function simctlRuntimeNames(): Promise<string[]> {
+  const { stdout } = await execFileAsync("xcrun", ["simctl", "list", "runtimes", "-j"]);
+  const parsed = JSON.parse(stdout) as { runtimes: { name: string }[] };
+  return parsed.runtimes.map((runtime) => runtime.name).sort();
+}
+
+function androidSystemImages(): string[] {
+  const root = join(ANDROID_HOME, "system-images");
+  if (!existsSync(root)) return [];
+  return readdirSync(root).sort();
+}
+
+/**
+ * safety.md #4: missing runtimes / system images fail the request unless
+ * `--allow-download` was explicitly passed. This flow never passes it, and asserts
+ * the installed-runtime inventory is byte-for-byte the same before and after --
+ * the strongest evidence available short of an actual network-activity monitor that
+ * nothing multi-GB was pulled down as a side effect of any command this suite ran.
+ */
+describe.skipIf(process.platform !== "darwin")(
+  "no-implicit-download invariant",
+  { tags: ["slow", "ios", "android"] },
+  () => {
+    it(
+      "leaves installed iOS runtimes and Android system images unchanged across a normal lease/release/doctor/cleanup/nuke cycle",
+      { timeout: 300_000 },
+      async () => {
+        const iosRuntimesBefore = await simctlRuntimeNames();
+        const androidImagesBefore = androidSystemImages();
+
+        const env = await withDaemon({ driver: "real" });
+        try {
+          const catalog = await env.cli(["catalog", "--json"]);
+          expect(catalog.code).toBe(0);
+          const platforms = (
+            catalog.json as { platforms: { platform: string; models: string[] }[] }
+          ).platforms;
+          const ios = platforms.find((platform) => platform.platform === "ios");
+
+          if (ios !== undefined && ios.models.length > 0) {
+            const lease = await env.cli(
+              [
+                "lease",
+                "--platform",
+                "ios",
+                "--device",
+                ios.models[0] as string,
+                "--agent-id",
+                "no-download",
+                "--detach",
+              ],
+              { timeout: 120_000 },
+            );
+            expect(lease.code, `lease failed: ${lease.stderr}`).toBe(0);
+            const grant = lease.json as { lease: string };
+            await env.cli(["release", grant.lease]);
+          }
+
+          await env.cli(["doctor"]);
+          await env.cli(["cleanup", "--dry-run"]);
+          await env.cli(["nuke", "--delete-devices", "--yes"], { timeout: 60_000 });
+        } finally {
+          // No cleanup beyond nuke above: this flow must never touch anything besides
+          // what pitlane itself created and already destroyed.
+        }
+
+        const iosRuntimesAfter = await simctlRuntimeNames();
+        expect(iosRuntimesAfter).toEqual(iosRuntimesBefore);
+
+        if (hasAndroidSdk) {
+          const androidImagesAfter = androidSystemImages();
+          expect(androidImagesAfter).toEqual(androidImagesBefore);
+        }
+      },
+    );
+  },
+);

--- a/e2e/tsconfig.typecheck.json
+++ b/e2e/tsconfig.typecheck.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "outDir": "../dist/e2e-typecheck-tmp",
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -11,14 +11,18 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "test": "vitest run src",
+    "build:e2e": "tsc -p e2e/fake-driver/tsconfig.json",
+    "test": "vitest run --project unit",
+    "test:e2e": "pnpm run build && pnpm run build:e2e && vitest run --project e2e --tags-filter='!slow'",
+    "test:e2e:slow": "pnpm run build && pnpm run build:e2e && vitest run --project e2e",
     "typecheck": "tsc --noEmit",
-    "lint": "oxlint src",
+    "typecheck:e2e": "pnpm run build && tsc -p e2e/tsconfig.typecheck.json",
+    "lint": "oxlint src e2e",
     "fallow": "fallow",
     "format": "oxfmt --write .",
     "format:check": "oxfmt --check .",
     "prepare": "lefthook install",
-    "check": "pnpm run typecheck && pnpm run lint && pnpm run format:check && pnpm run test",
+    "check": "pnpm run typecheck && pnpm run typecheck:e2e && pnpm run lint && pnpm run format:check && pnpm run test && pnpm run test:e2e",
     "release": "release-it"
   },
   "dependencies": {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,4 +1,3 @@
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
@@ -7,6 +6,7 @@ import {
   NodeDaemonLauncher,
   NodeFilesystem,
   NodeIpcTransport,
+  resolvePitlaneHome,
   SystemClock,
   type Filesystem,
 } from "../ports/index.js";
@@ -92,7 +92,7 @@ export function fallbackRequesterId(env: NodeJS.ProcessEnv): string {
 }
 
 function defaultCliEnvironment(env: NodeJS.ProcessEnv = process.env): CliEnvironment {
-  const dataDirectory = join(homedir(), ".pitlane");
+  const dataDirectory = resolvePitlaneHome(env);
   const filesystem = new NodeFilesystem();
   const clock = new SystemClock();
   const ipc = new NodeIpcTransport();

--- a/src/daemon/main.test.ts
+++ b/src/daemon/main.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -96,5 +96,87 @@ describe("discoverDrivers", () => {
         module: "daemon.driver-discovery",
       }),
     );
+  });
+});
+
+describe("discoverDrivers with PITLANE_DRIVERS_MODULE", () => {
+  const previousModule = process.env.PITLANE_DRIVERS_MODULE;
+
+  afterEach(() => {
+    if (previousModule === undefined) {
+      delete process.env.PITLANE_DRIVERS_MODULE;
+    } else {
+      process.env.PITLANE_DRIVERS_MODULE = previousModule;
+    }
+  });
+
+  async function writeModule(contents: string): Promise<string> {
+    const directory = await mkdtemp(join(tmpdir(), "pitlane-drivers-module-"));
+    temporaryDirectories.push(directory);
+    const modulePath = join(directory, "drivers.mjs");
+    await writeFile(modulePath, contents, "utf8");
+    return modulePath;
+  }
+
+  async function discover(sink: MemoryLogSink) {
+    const logger = new JsonLinesLogger({ clock: new FakeClock(), level: "debug", sink });
+    return discoverDrivers({
+      clock: new FakeClock(),
+      filesystem: new MemoryFilesystem(),
+      idGenerator: new CryptoIdGenerator(),
+      logger,
+      processRunner: new ScriptedProcessRunner([]),
+    });
+  }
+
+  it("substitutes discovery with the module's createDrivers(context), logging the substitution", async () => {
+    process.env.PITLANE_DRIVERS_MODULE = await writeModule(
+      `export function createDrivers(context) {
+         return [{ platform: "ios", fromModule: true, sawContext: typeof context.logger === "object" }];
+       }`,
+    );
+    const sink = new MemoryLogSink();
+
+    const drivers = await discover(sink);
+
+    expect(drivers).toEqual([{ platform: "ios", fromModule: true, sawContext: true }]);
+    expect(sink.records).toContainEqual(
+      expect.objectContaining({
+        level: "info",
+        message: "Substituting driver discovery via PITLANE_DRIVERS_MODULE",
+        module: "daemon.driver-discovery",
+      }),
+    );
+    expect(sink.records).toContainEqual(
+      expect.objectContaining({
+        level: "info",
+        message: "Loaded drivers from PITLANE_DRIVERS_MODULE",
+        module: "daemon.driver-discovery",
+        fields: expect.objectContaining({ count: 1 }),
+      }),
+    );
+  });
+
+  it("supports a synchronous createDrivers returning an array directly", async () => {
+    process.env.PITLANE_DRIVERS_MODULE = await writeModule(
+      `export function createDrivers() { return []; }`,
+    );
+
+    await expect(discover(new MemoryLogSink())).resolves.toEqual([]);
+  });
+
+  it("fails loudly when the module has no createDrivers export", async () => {
+    process.env.PITLANE_DRIVERS_MODULE = await writeModule(`export const nope = 1;`);
+
+    await expect(discover(new MemoryLogSink())).rejects.toThrow(/createDrivers/);
+  });
+
+  it("fails loudly when the module cannot be imported", async () => {
+    process.env.PITLANE_DRIVERS_MODULE = join(
+      tmpdir(),
+      "pitlane-drivers-module-does-not-exist.mjs",
+    );
+
+    await expect(discover(new MemoryLogSink())).rejects.toThrow();
   });
 });

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { EventBus } from "../bus/index.js";
@@ -29,6 +29,7 @@ import {
   NodeIpcTransport,
   NodeProcessRunner,
   NodeSystemStats,
+  resolvePitlaneHome,
   SystemClock,
   type SystemStats,
   type ProcessRunner,
@@ -57,7 +58,7 @@ export interface StartDaemonOptions {
 /** Constructs the daemon's real adapters once; all state remains in the daemon. */
 // fallow-ignore-next-line complexity -- explicit production composition necessarily wires all external ports.
 export async function startDaemon(options: StartDaemonOptions = {}): Promise<DaemonServer> {
-  const dataDirectory = options.dataDirectory ?? join(homedir(), ".pitlane");
+  const dataDirectory = options.dataDirectory ?? resolvePitlaneHome();
   const filesystem = options.filesystem ?? new NodeFilesystem();
   const clock = options.clock ?? new SystemClock();
   const systemStats = options.systemStats ?? new NodeSystemStats();
@@ -138,15 +139,22 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
   return daemon;
 }
 
-export async function discoverDrivers(options: {
+export interface DriverDiscoveryContext {
   readonly clock: Clock;
   readonly filesystem: Filesystem;
   readonly idGenerator: IdGenerator;
   readonly logger: Logger;
   readonly processRunner: ProcessRunner;
-}): Promise<Driver[]> {
-  const drivers: Driver[] = [];
+}
+
+export async function discoverDrivers(options: DriverDiscoveryContext): Promise<Driver[]> {
   const logger = options.logger.child("driver-discovery");
+  const driversModule = process.env.PITLANE_DRIVERS_MODULE;
+  if (driversModule !== undefined) {
+    return loadDriversModule(driversModule, options, logger);
+  }
+
+  const drivers: Driver[] = [];
   if (process.platform === "darwin") {
     drivers.push(
       new IosSimctlDriver({
@@ -181,16 +189,51 @@ export async function discoverDrivers(options: {
 }
 
 /**
+ * Testing/advanced hook: substitutes real driver discovery with a module supplied via
+ * `PITLANE_DRIVERS_MODULE`. The daemon always runs as a separately spawned process, so
+ * the module is resolved as a file path (relative to `process.cwd()`) and dynamically
+ * imported -- this is how the e2e suite injects a scriptable fake driver without the
+ * daemon ever knowing it isn't talking to real hardware. A missing module, an import
+ * error, or a module without a `createDrivers` export fails daemon startup loudly
+ * rather than silently falling back to real discovery.
+ */
+async function loadDriversModule(
+  modulePath: string,
+  context: DriverDiscoveryContext,
+  logger: Logger,
+): Promise<Driver[]> {
+  logger.info("Substituting driver discovery via PITLANE_DRIVERS_MODULE", {
+    module: modulePath,
+  });
+  const moduleUrl = pathToFileURL(resolve(modulePath)).href;
+  const imported = (await import(moduleUrl)) as {
+    createDrivers?: (context: DriverDiscoveryContext) => Promise<Driver[]> | Driver[];
+  };
+  if (typeof imported.createDrivers !== "function") {
+    throw new Error(
+      `PITLANE_DRIVERS_MODULE ${modulePath} does not export a createDrivers(context) function`,
+    );
+  }
+  const drivers = await imported.createDrivers(context);
+  logger.info("Loaded drivers from PITLANE_DRIVERS_MODULE", {
+    count: drivers.length,
+    module: modulePath,
+    platforms: drivers.map((driver) => driver.platform),
+  });
+  return drivers;
+}
+
+/**
  * Best-effort logger for the fatal startup handler below. It cannot depend on the
  * daemon's own `Config` — that is exactly what may have failed to load — so it always
  * writes to the default log location at a fixed level.
  */
-export function createFatalLogger(): Logger {
+function createFatalLogger(): Logger {
   return new JsonLinesLogger({
     clock: new SystemClock(),
     level: "error",
     module: "daemon",
-    sink: new NodeFileLogSink({ path: join(homedir(), ".pitlane", "daemon.log") }),
+    sink: new NodeFileLogSink({ path: join(resolvePitlaneHome(), "daemon.log") }),
   });
 }
 

--- a/src/mcp/main.test.ts
+++ b/src/mcp/main.test.ts
@@ -28,6 +28,31 @@ describe("MCP stdio lifecycle", () => {
     expect(signals.listeners.size).toBe(0);
   });
 
+  // Regression for a real reentrancy bug: the SDK's transport.close() can invoke
+  // `onclose` *synchronously*, inside the same call stack `shutdown()` is already
+  // running in (via `server.close()` -> `transport.close()`). A `shutdownPromise ??=
+  // (async () => {...})()` guard alone does not close that window -- the assignment
+  // to `shutdownPromise` only happens after the async IIFE returns a promise, so a
+  // synchronous re-entrant call still sees it as `undefined` and recurses. Left
+  // unfixed this recurses until the stack overflows (observed via a real MCP client
+  // round trip through @modelcontextprotocol/sdk's stdio transport).
+  it("does not recurse when the transport's close() synchronously re-triggers onclose", async () => {
+    const transport = new SynchronouslyReentrantTransport();
+    const server = new FakeServer();
+    const runner = await startMcpStdio({
+      createServer: () => server as unknown as McpServer,
+      createTransport: () => transport,
+      signals: new FakeSignals(),
+    });
+
+    // This must not throw RangeError: Maximum call stack size exceeded.
+    transport.onclose?.();
+    await runner.finished;
+
+    expect(server.closeCalls).toBe(1);
+    expect(transport.closeCalls).toBe(1);
+  });
+
   it("cleans up after startup failure", async () => {
     const transport = new FakeTransport();
     const server = new FakeServer(new Error("startup failed"));
@@ -187,6 +212,20 @@ class FakeTransport implements McpTransport {
   onclose?: () => void;
   async close(): Promise<void> {
     this.closeCalls += 1;
+  }
+}
+
+/**
+ * Mirrors the real @modelcontextprotocol/sdk stdio transport's observed shutdown
+ * behaviour: `close()` invokes `onclose` synchronously (before its own first await),
+ * from inside the same call stack a caller's `await transport.close()` is in.
+ */
+class SynchronouslyReentrantTransport implements McpTransport {
+  closeCalls = 0;
+  onclose?: () => void;
+  async close(): Promise<void> {
+    this.closeCalls += 1;
+    this.onclose?.();
   }
 }
 

--- a/src/mcp/main.ts
+++ b/src/mcp/main.ts
@@ -1,10 +1,14 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { NodeDaemonLauncher, NodeIpcTransport, SystemClock } from "../ports/index.js";
+import {
+  NodeDaemonLauncher,
+  NodeIpcTransport,
+  resolvePitlaneHome,
+  SystemClock,
+} from "../ports/index.js";
 import { connectDaemon } from "../daemon-client/client.js";
 import type { DaemonConnection } from "../daemon-client/protocol.js";
 import { McpSession } from "./session.js";
@@ -73,6 +77,16 @@ export async function startMcpStdio(
     resolveFinished = resolve;
   });
   let shutdownPromise: Promise<void> | undefined;
+  // Guards synchronous re-entrancy, not just repeated calls after the fact: the SDK's
+  // own transport.close() can invoke `onclose` synchronously, inside the same call
+  // stack that reaches it via `server.close()` below -- at that point `shutdownPromise
+  // ??= ...` has not finished assigning yet (the assignment happens only after the IIFE
+  // it calls returns a promise), so a plain `??=` guard re-enters and recurses until the
+  // stack overflows. Setting this flag as the very first synchronous statement closes
+  // that window: a re-entrant call sees it immediately and returns `shutdownPromise` as
+  // it stands (possibly still `undefined` at that exact instant, which is fine -- the
+  // caller that reached us via `onclose` doesn't await the result).
+  let shuttingDown = false;
   let serverConnectStarted = false;
 
   const onSignal = () => {
@@ -87,7 +101,9 @@ export async function startMcpStdio(
     void shutdown();
   };
   const shutdown = (): Promise<void> => {
-    shutdownPromise ??= (async () => {
+    if (shuttingDown) return shutdownPromise ?? Promise.resolve();
+    shuttingDown = true;
+    shutdownPromise = (async () => {
       signals.off("SIGINT", onSignal);
       signals.off("SIGTERM", onSignal);
       stdin.off("end", onStdinEnd);
@@ -122,7 +138,7 @@ export async function startMcpStdio(
 }
 
 function defaultEnvironment(): Required<Pick<McpStdioEnvironment, "connect" | "createTransport">> {
-  const dataDirectory = join(homedir(), ".pitlane");
+  const dataDirectory = resolvePitlaneHome();
   const clock = new SystemClock();
   const ipc = new NodeIpcTransport();
   const socketPath = join(dataDirectory, "daemon.sock");

--- a/src/ports/daemon-launcher.ts
+++ b/src/ports/daemon-launcher.ts
@@ -22,6 +22,10 @@ export class NodeDaemonLauncher implements DaemonLauncher {
     try {
       const child = spawn(this.options.command, this.options.args, {
         detached: true,
+        // Explicit rather than relying on spawn's default: the daemon must inherit
+        // overrides like PITLANE_HOME and PITLANE_DRIVERS_MODULE from whichever
+        // frontend (CLI/MCP) auto-launched it.
+        env: process.env,
         stdio: ["ignore", log.fd, log.fd],
       });
       await new Promise<void>((resolve, reject) => {

--- a/src/ports/index.ts
+++ b/src/ports/index.ts
@@ -1,4 +1,5 @@
 export { type Filesystem, MemoryFilesystem, NodeFilesystem } from "./filesystem.js";
+export { resolvePitlaneHome } from "./paths.js";
 export { type DaemonLauncher, FakeDaemonLauncher, NodeDaemonLauncher } from "./daemon-launcher.js";
 export {
   type IpcConnection,

--- a/src/ports/paths.test.ts
+++ b/src/ports/paths.test.ts
@@ -1,0 +1,15 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { resolvePitlaneHome } from "./paths.js";
+
+describe("resolvePitlaneHome", () => {
+  it("defaults to ~/.pitlane when PITLANE_HOME is unset", () => {
+    expect(resolvePitlaneHome({})).toBe(join(homedir(), ".pitlane"));
+  });
+
+  it("uses PITLANE_HOME when set", () => {
+    expect(resolvePitlaneHome({ PITLANE_HOME: "/tmp/custom-home" })).toBe("/tmp/custom-home");
+  });
+});

--- a/src/ports/paths.ts
+++ b/src/ports/paths.ts
@@ -1,0 +1,12 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Resolves pitlane's data directory (config.json, state.json, daemon.sock, daemon.log).
+ * `PITLANE_HOME` overrides the default `~/.pitlane` -- used by tests that need an
+ * isolated data directory per daemon instance, and by anyone running multiple
+ * independent pitlane installs on one machine.
+ */
+export function resolvePitlaneHome(env: NodeJS.ProcessEnv = process.env): string {
+  return env.PITLANE_HOME ?? join(homedir(), ".pitlane");
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
+    "declaration": true,
     "outDir": "dist",
     "rootDir": "src",
     "types": ["node"]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // strictTags (default in vitest 4.1) rejects any tag not declared here or on a
+    // project. Declared once at the root so both projects inherit the vocabulary.
+    tags: [{ name: "slow" }, { name: "ios" }, { name: "android" }],
+    projects: [
+      {
+        test: {
+          name: "unit",
+          include: ["src/**/*.test.ts"],
+        },
+      },
+      {
+        test: {
+          name: "e2e",
+          include: ["e2e/**/*.test.ts"],
+          setupFiles: ["e2e/helpers/setup.ts"],
+          // The daemon owns real OS resources (sockets, spawned processes); running
+          // flows concurrently would make failures nondeterministic and hard to
+          // attribute to the right flow.
+          fileParallelism: false,
+          // Individual slow real-SDK flows (tagged "slow") set their own longer
+          // per-test timeout -- a hang in the fast fake-driver lane should fail in
+          // ~2 minutes, not stall CI for ten.
+          testTimeout: 120_000,
+          hookTimeout: 60_000,
+        },
+      },
+    ],
+  },
+});


### PR DESCRIPTION
Turns the agent-driven manual verification in `TESTS.md` into a suite a test runner executes, so a release gate stops depending on an agent remembering to check something.

## What runs

| Lane | Command | Uses | When |
|---|---|---|---|
| fast | `pnpm run test:e2e` | scriptable fake driver, no SDKs | part of `pnpm run check` |
| slow | `pnpm run test:e2e:slow` | real `simctl` / `adb` / emulators | manual, pre-release |

Ten fast flows spawn the real daemon, run the CLI as a subprocess, and drive the MCP server with a real `@modelcontextprotocol/sdk` client over a real unix socket — but against a fake driver injected via `PITLANE_DRIVERS_MODULE`, so no simulator or emulator is involved and the lane finishes in ~115s:

daemon lifecycle & stale-socket recovery · lease lifecycle across CLI+MCP · contention & queueing · the documented exit-code table · held-lease liveness across restarts · sliding heartbeat TTL · MCP session semantics · doctor drift · capacity/cleanup/nuke · a parallel-contention invariant

They deliberately only assert what crosses a process boundary. Core logic stays unit-tested in-process.

Three real-SDK smoke flows are tagged `slow` and excluded from the fast lane.

## Why this is worth having over the agent sessions

Four things the manual runs structurally could not do, all now asserted:

- **MCP notification frames.** `TESTS.md` tests 5, 6 and 7 all record that `notifications/progress` and `notifications/message` were invisible to the harness, so the strongest assertions were downgraded to session-state proxies. A real SDK client sees every frame.
- **Concurrency.** `TESTS.md` notes all sub-agents share one MCP session, so contention could only be tested through the CLI. Flow 10 runs eight concurrent leases against a limit of two.
- **The sliding-TTL test.** Test 7 never finished — it needed a 3-minute wait and an app restart. With a 4s backstop it now runs in seconds.
- **Drift-free expectations.** Tests 2 and 5 recorded false failures from an underspecified plan and needed a supervisor to rewrite them. An assertion is the spec.

## Two new environment overrides

- **`PITLANE_HOME`** — repoints the data directory, resolved once instead of four hardcoded `homedir()` joins. Needed for per-test isolation; independently useful for running multiple instances.
- **`PITLANE_DRIVERS_MODULE`** — substitutes driver discovery with your own module. This is what lets the daemon run against a scripted driver; it fails loudly rather than falling back.

Both documented in `docs/CLI.md`.

## One product fix included

`fix(mcp)`: the stdio transport calls `onclose` **synchronously** from inside the same stack `shutdown()` runs in via `server.close()`. The `shutdownPromise ??= (async () => {…})()` guard didn't cover that — the assignment only happens after the IIFE returns, so the re-entrant call saw `undefined` and recursed to stack overflow. Every MCP client disconnect after a lease round trip hit it. Fixed with a flag set as the first synchronous statement, plus a regression test using a transport that calls `onclose` before returning.

## Findings, not fixed here

1. **`pitlane daemon status` ignores `--json`.** The running branch always calls `writeResult` (raw JSON) while its `start`/`stop` siblings and its own stopped-fallback branch on `values.json`, contradicting `docs/CLI.md`. Left alone deliberately — changing a shipped command's default output is a call for the owner, not a side effect of a test PR. Documented by an `it.fails` in `daemon-lifecycle.test.ts`, which will fail loudly if someone fixes the bug.
2. **The slow lane does not pass as a whole run.** Each of the three flows passes individually (iOS 67s, Android 48s, no-download 68s), but every combined run has failed: a daemon occasionally outlives `daemon stop` and trips teardown's stray-process assertion, and the no-implicit-download flow hit its 300s timeout. This reproduced on an idle machine, so it is not merely load. Not root-caused, not distinguished from the reclaim stall in `docs/known-pitfalls.md`. Recorded in `e2e/README.md`; the lane is opt-in and not part of `check`.
3. **Daemons that lose the socket race may not exit.** After a clean, fully green fast-lane run, two daemon processes from the same test home (started 10s apart) were still alive holding no socket. Teardown kills the pid that held the socket, so these slip past. Suspected: a daemon that loses the endpoint claim keeps running instead of exiting. Worth its own investigation.

## Notes for the reviewer

- **`check` now includes the fast lane** (~115s, and it spawns subprocesses and shells out to `lsof`). If that's the wrong trade for a pre-release gate, dropping `test:e2e` from `check` is a one-line revert; CI can run it as its own job.
- `tsconfig.json` gains `declaration: true` so the out-of-process fake driver can import the real `Driver` types and error classes from `dist/` instead of a hand-synced copy — that duplication existed in an earlier draft and was deliberately removed.
- `.fallowrc.json` gains the e2e entry points (`e2e/**/*.test.ts`, plus `e2e/fake-driver/index.ts` as dynamically loaded) — without them fallow sees the whole suite as dead code.
- Verified on this machine: `pnpm run check` green; fast lane green on four separate runs; `fallow audit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
