### PR TITLE
Rewrite README in cordierite style, add docs/CONFIGURATION.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ after a longer one to reclaim disk — automatically, in tiers.
 
 **It's advisory, not a sandbox.** Pitlane doesn't wrap or intercept
 `simctl` / `avdmanager` — it works because agents are instructed to only use
-devices handed to them by a lease. What it *does* enforce is its own blast
+devices handed to them by a lease. What it _does_ enforce is its own blast
 radius: Pitlane only ever shuts down, erases, or deletes devices it created
 itself. Everything else on the machine is read-only to it.
 
@@ -43,7 +43,14 @@ pitlane lease --platform ios --device "iPhone 16" --detach
 ```
 
 ```json
-{"lease":"lse_9f2c","platform":"ios","device":"iPhone 16","os":"18.4","udid":"ABCD-...","state":"leased"}
+{
+  "lease": "lse_9f2c",
+  "platform": "ios",
+  "device": "iPhone 16",
+  "os": "18.4",
+  "udid": "ABCD-...",
+  "state": "leased"
+}
 ```
 
 That's the whole interaction: ask for a platform and a device model, get
@@ -61,7 +68,14 @@ the lease result lands on stdout the moment the new device is ready:
 ```
 
 ```json
-{"lease":"lse_a731","platform":"ios","device":"iPhone 16","os":"18.4","udid":"EFGH-...","state":"leased"}
+{
+  "lease": "lse_a731",
+  "platform": "ios",
+  "device": "iPhone 16",
+  "os": "18.4",
+  "udid": "EFGH-...",
+  "state": "leased"
+}
 ```
 
 No manual bookkeeping, no "device busy" error to handle — just a second

--- a/README.md
+++ b/README.md
@@ -50,6 +50,27 @@ That's the whole interaction: ask for a platform and a device model, get
 back an identified, ready-to-use device. Release it explicitly, or let its
 TTL expire.
 
+Now say a second agent asks for the same `iPhone 16` a moment later. It's
+already leased to the first agent — no problem, Pitlane just provisions
+another one. Progress streams as JSON lines on stderr while it happens, and
+the lease result lands on stdout the moment the new device is ready:
+
+```json
+{"event":"provisioning","eta_seconds":5}
+{"event":"booting","eta_seconds":30}
+```
+
+```json
+{"lease":"lse_a731","platform":"ios","device":"iPhone 16","os":"18.4","udid":"EFGH-...","state":"leased"}
+```
+
+No manual bookkeeping, no "device busy" error to handle — just a second
+device, a few seconds later. That keeps up until the machine's capacity
+limit is reached (derived from its CPU and RAM, or set explicitly in
+[docs/CONFIGURATION.md](docs/CONFIGURATION.md)); after that, further
+requests wait in a fair queue instead of failing, with `--timeout` and
+`--no-wait` for callers that want different behavior.
+
 Agents that speak the Model Context Protocol can skip the CLI entirely and
 get the same lease/release workflow as tools, through a local stdio server:
 

--- a/README.md
+++ b/README.md
@@ -1,47 +1,69 @@
-# Pitlane
+### A control plane so parallel coding agents stop fighting over the same simulator
 
-Pitlane is a control plane for iOS simulators and Android emulators, built
-for environments where multiple coding agents run in parallel on one
-machine.
+Pitlane is a CLI-first control plane for iOS simulators and Android
+emulators, built for environments where multiple coding agents run on one
+machine at the same time. Agents don't touch `simctl` or `avdmanager`
+directly — they ask Pitlane for a device and get one back, booted and
+health-checked, that no other agent will touch until they're done with it.
 
-## The problem
+## Why you'd want this
 
-Agents that need a simulator grab whatever `simctl` / `avdmanager` shows
-them. Two agents that pick the same device start fighting over it —
-booting, erasing, and installing over each other — without ever knowing the
-other exists.
+**Two agents, one simulator, zero coordination.** Left to themselves, agents
+that need a device grab whatever `simctl` / `avdmanager` happens to show
+them. Two agents that pick the same one start booting, erasing, and
+installing over each other — without either ever knowing the other exists.
+Pitlane gives them a single primitive instead: **lease a device**.
 
-## The solution
+**You don't provision devices by hand.** If nothing matching is free,
+Pitlane provisions one itself, up to a capacity limit it derives from the
+machine's CPU and RAM. Once that limit is reached, further requests block
+and wait in a fair queue rather than failing outright, with `--timeout` and
+`--no-wait` escape hatches for callers that want different behavior.
 
-Pitlane is a CLI-first control plane (backed by a local daemon) that works the
-same way for both platforms and gives agents one primitive: **lease a device**.
-Agents that support the Model Context Protocol (MCP) can optionally use the
-same lease workflow through a local stdio server.
+**Idle devices don't sit there burning RAM and disk.** A device nobody's
+using is shut down after a short idle period to reclaim RAM, then deleted
+after a longer one to reclaim disk — automatically, in tiers.
 
-## Features
+**It's advisory, not a sandbox.** Pitlane doesn't wrap or intercept
+`simctl` / `avdmanager` — it works because agents are instructed to only use
+devices handed to them by a lease. What it *does* enforce is its own blast
+radius: Pitlane only ever shuts down, erases, or deletes devices it created
+itself. Everything else on the machine is read-only to it.
 
-- **Lease, don't grab.** `pitlane lease` hands back a device — booted and
-  health-checked — that no other agent will touch for the duration of the
-  lease.
-- **Auto-provisioning.** If no matching device is free, Pitlane provisions
-  one, up to a capacity limit derived from the machine's CPU and RAM.
-- **Fair queueing.** Once the limit is reached, requests block and wait in a
-  fair queue until a device frees up, with `--timeout` and `--no-wait`
-  escape hatches.
-- **Tiered idle cleanup.** Devices that sit unused are shut down after a
-  short idle period to reclaim RAM, then deleted after a longer one to
-  reclaim disk.
-- **Advisory coordination.** Pitlane doesn't sandbox anything — it works
-  because agents are instructed to only use devices handed to them by a
-  lease, never to call `simctl` / `avdmanager` directly.
-- **Managed-device registry.** Pitlane only ever shuts down, erases, or
-  deletes devices it created itself. Everything else on the machine is
-  read-only to it.
-- **Agent-first output.** CLI lease results are one JSON line on stdout;
-  progress (e.g. provisioning ETAs) streams as JSON lines on stderr. The
-  optional MCP server reserves stdout for MCP JSON-RPC.
-- **Optional MCP integration.** A local stdio MCP server gives agent clients
-  the lease and release workflow without replacing the CLI operator interface.
+**Built for agents first, humans second.** Lease results are one JSON line
+on stdout; progress (queueing, provisioning ETAs, boot) streams as JSON
+lines on stderr. Status and other operator-facing commands default to a
+human-readable view and take `--json` when a script wants the structured
+form instead.
+
+## What it looks like
+
+```sh
+pitlane lease --platform ios --device "iPhone 16" --detach
+```
+
+```json
+{"lease":"lse_9f2c","platform":"ios","device":"iPhone 16","os":"18.4","udid":"ABCD-...","state":"leased"}
+```
+
+That's the whole interaction: ask for a platform and a device model, get
+back an identified, ready-to-use device. Release it explicitly, or let its
+TTL expire.
+
+Agents that speak the Model Context Protocol can skip the CLI entirely and
+get the same lease/release workflow as tools, through a local stdio server:
+
+```json
+{
+  "mcpServers": {
+    "pitlane": {
+      "command": "pitlane",
+      "args": ["mcp"],
+      "env": { "PITLANE_AGENT_ID": "agent-1" }
+    }
+  }
+}
+```
 
 ## Getting started
 
@@ -52,134 +74,53 @@ pitlane lease --platform ios --device "iPhone 16" --detach
 pitlane status --json
 ```
 
-The daemon starts on demand — no separate setup step is needed. Use
+The daemon starts on demand — there's no separate setup step. Use
 `pitlane doctor` to reconcile managed state with reality, and
 `pitlane nuke --yes --delete-devices` only for an emergency reset of
 Pitlane-managed devices.
 
-See [docs/CLI.md](docs/CLI.md) for the full command reference.
+See [docs/CLI.md](docs/CLI.md) for the full command reference and
+[docs/CLI.md#mcp-integration-optional](docs/CLI.md) or the [README section
+below](#mcp-integration-optional) for wiring up an MCP client.
 
 ## MCP integration (optional)
 
-The CLI remains Pitlane's primary, full operator interface. MCP is a focused
-agent integration: it intentionally exposes neither status, configuration,
-events, lease renewal, nor destructive or other operator commands.
+The CLI remains Pitlane's primary, full operator interface. MCP is a
+narrower, agent-focused integration: it intentionally exposes neither
+status, configuration, events, lease renewal, nor destructive or other
+operator commands. Start it with `pitlane mcp` — it reserves stdout for MCP
+JSON-RPC, so lease results never mix with protocol framing.
 
-Start the local stdio server with:
+`PITLANE_AGENT_ID` sets the server's stable requester identity. Pitlane
+allows at most one active lease per identity, so give each agent session a
+distinct, stable id — run one MCP server process per agent session, each
+with its own id.
 
-```sh
-pitlane mcp
-```
+The server exposes exactly four tools: `list_devices` (read-only catalog of
+what can be leased), `lease_simulator`, `release_simulator`, and
+`lease_status` (cheap, safe to poll after a context compaction to check
+whether a device is still held). Full tool contracts, progress reporting,
+and lease-loss notifications are documented in
+[docs/CLI.md](docs/CLI.md#pitlane-mcp).
 
-Configure an MCP client to spawn it with this generic configuration:
+## Documentation
 
-```json
-{
-  "mcpServers": {
-    "pitlane": {
-      "command": "pitlane",
-      "args": ["mcp"],
-      "env": {
-        "PITLANE_AGENT_ID": "agent-1"
-      }
-    }
-  }
-}
-```
+- [docs/ABOUT.md](docs/ABOUT.md) — what the tool is and the problem it solves, in short form
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — how the daemon, drivers, and frontends fit together
+- [docs/CLI.md](docs/CLI.md) — the full command reference
+- [docs/CONFIGURATION.md](docs/CONFIGURATION.md) — every config key, its default, and how limits interact
+- [docs/EVENTS.md](docs/EVENTS.md) — catalog of business events on `pitlane events`
+- [docs/known-pitfalls.md](docs/known-pitfalls.md) — accepted gaps and their planned fixes
+- [docs/IDEAS.md](docs/IDEAS.md) — post-v1 ideas, not yet built
 
-GUI-launched MCP clients may not inherit your shell `PATH`; in that case,
-replace `pitlane` with its absolute path.
+## Made with ❤️ at Callstack
 
-`PITLANE_AGENT_ID` sets this server's stable requester identity — Pitlane
-allows at most one active lease per identity, so **give each agent session a
-distinct, stable id** (falling back to a pid-derived value otherwise, which
-does not survive a process restart). This is also the id shown as the
-requester in `pitlane status` / `pitlane list --leases`; see
-[docs/CLI.md](docs/CLI.md#agent-identity) for the full precedence, including
-the CLI's `--agent-id` flag.
+`pitlane` is an open source project and will always remain free to use. If
+you think it's cool, please star it 🌟. [Callstack][callstack-readme-with-love]
+is a group of React and React Native geeks, contact us at
+[hello@callstack.com](mailto:hello@callstack.com) if you need any help with
+these or just want to say hi!
 
-The server provides exactly four tools:
+Like the project? ⛸️ [Join the team](https://callstack.com/careers/?utm_campaign=Senior_RN&utm_source=github&utm_medium=readme) who does amazing stuff for clients and drives React Native Open Source! 🔥
 
-- `list_devices` returns, per available platform, the resolvable device
-  models, the runtimes / system images already installed, and which
-  installed runtime is the default (the newest). An optional `platform`
-  (`ios` or `android`) narrows the result. It is read-only — it never
-  downloads a runtime or system image — so call it once to pick a valid
-  `device`/`os` before `lease_simulator` instead of guessing.
-- `lease_simulator` requires `platform` (`ios` or `android`) and `device`.
-  `os` is optional and otherwise selects the newest installed runtime.
-  `no_wait` defaults to `false`; `timeout_seconds` optionally limits queue
-  waiting. `allow_download` defaults to `false` and must be explicitly `true`
-  before a missing runtime or system image may be downloaded.
-- `release_simulator` requires the `lease_id` returned by the lease tool and
-  releases only that MCP session's lease.
-- `lease_status` is read-only and takes no input. It reports this session's
-  current lease (`lease_id`, `device`, `os`, `platform`, `device_id`,
-  `expires_at_ms`, `state`), or `{ "held": false }` if the session holds
-  nothing. It is cheap, local, and safe to call repeatedly — e.g. after a
-  context compaction, to check whether a device is still held.
-
-All four tools return structured results as well as JSON text content, so
-MCP clients can reliably consume the device catalog, leased device details,
-release confirmation, or status. An MCP lease is held by the server process's
-daemon connection: release it explicitly when work is done; it is also
-released when that MCP process disconnects. Run one MCP server process per
-agent session, each with its own `PITLANE_AGENT_ID`.
-
-If a held lease ends elsewhere — it expires, or is force-released by
-`pitlane release --all`, `pitlane nuke`, or doctor expiry — the daemon pushes
-a lease-ended fact to this session, which forgets that lease and relays it to
-the MCP client as a `notifications/message` logging notification (level
-`warning`, `logger: "pitlane"`) carrying `lease_id`, `device_id`, and
-`reason`. A well-behaved agent should treat this as "the device is gone" and
-call `lease_simulator` again rather than keep operating on it; a subsequent
-`release_simulator` for that lease id fails with `LEASE_NOT_OWNED` instead of
-succeeding.
-
-If the `lease_simulator` call's request carries a `_meta.progressToken`, a
-cold provision — waiting in the queue, provisioning, booting, or reclaiming a
-device — is reported as MCP `notifications/progress` for that request, each
-carrying a human-readable `message` (e.g. queue position, or an ETA in
-seconds) and a `progress` value that only increases. Clients that don't
-supply a progress token see no change: the tool call behaves exactly as
-before, just blocking until it resolves.
-
-## Configuration
-
-Pitlane reads `~/.pitlane/config.json` and merges it over built-in
-defaults. Only the keys below are recognized; unknown keys are ignored with
-a warning. Inspect the effective, merged configuration at any time with
-`pitlane config`.
-
-| Property                          | Description                                                                                                                                                                                                                  | Default                                                        |
-| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| `limits.maxRunning`               | Global cap on devices running at once, across both platforms.                                                                                                                                                                | Sum of `limits.ios.maxDevices` and `limits.android.maxDevices` |
-| `limits.ios.maxDevices`           | Max number of iOS simulators Pitlane will manage at once.                                                                                                                                                                    | `max(1, cpuCount / 2)`                                         |
-| `limits.ios.maxRunning`           | Max number of iOS simulators running at once.                                                                                                                                                                                | Same as `limits.ios.maxDevices`                                |
-| `limits.android.maxDevices`       | Max number of Android emulators Pitlane will manage at once.                                                                                                                                                                 | `max(1, min(cpuCount / 4, totalRamGb / 8))`                    |
-| `limits.android.maxRunning`       | Max number of Android emulators running at once.                                                                                                                                                                             | Same as `limits.android.maxDevices`                            |
-| `ramBudget.iosBytesPerDevice`     | RAM reserved per iOS simulator when computing capacity.                                                                                                                                                                      | `1.5 GiB`                                                      |
-| `ramBudget.androidBytesPerDevice` | RAM reserved per Android emulator when computing capacity.                                                                                                                                                                   | `4 GiB`                                                        |
-| `idle.shutdownAfterMs`            | How long an unused device sits idle before Pitlane shuts it down (tier 1, reclaims RAM).                                                                                                                                     | `10 minutes`                                                   |
-| `idle.deleteAfterMs`              | How long a shut-down device sits idle before Pitlane deletes it (tier 2, reclaims disk).                                                                                                                                     | `1 hour`                                                       |
-| `lease.heldTtlBackstopMs`         | Backstop TTL for held-mode leases, in case the holding process dies without releasing.                                                                                                                                       | `1 hour`                                                       |
-| `lease.detachedTtlMs`             | TTL for detached-mode leases before they must be renewed with `pitlane lease renew`.                                                                                                                                         | `15 minutes`                                                   |
-| `lease.heartbeatIntervalMs`       | How often the daemon pings a held-mode connection that declared the `heartbeat` capability; each pong slides that connection's leases' TTL back out to a full `heldTtlBackstopMs`. Must be `<= lease.heldTtlBackstopMs / 4`. | `5 minutes`                                                    |
-| `diskPressure.freeBytesThreshold` | Free disk space below which Pitlane treats the machine as under disk pressure.                                                                                                                                               | `10 GiB`                                                       |
-| `eventBuffer.capacity`            | Number of business events kept in the in-memory ring buffer (see `pitlane events`).                                                                                                                                          | `1000`                                                         |
-
-All limit values must be positive integers; all durations and byte sizes
-must be non-negative numbers (milliseconds and bytes, respectively).
-Running limits are independent of managed-device limits — an omitted
-`maxRunning` defaults to its corresponding `maxDevices` value (and, at the
-global level, to their sum):
-
-```json
-{
-  "limits": {
-    "maxRunning": 3,
-    "ios": { "maxDevices": 4, "maxRunning": 2 },
-    "android": { "maxDevices": 2, "maxRunning": 2 }
-  }
-}
-```
+[callstack-readme-with-love]: https://callstack.com/?utm_source=github.com&utm_medium=referral&utm_campaign=pitlane&utm_term=readme-with-love

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,42 @@
+# Configuration
+
+Pitlane reads `~/.pitlane/config.json` and merges it over built-in
+defaults. Only the keys below are recognized; unknown keys are ignored with
+a warning. Inspect the effective, merged configuration at any time with
+`pitlane config`.
+
+| Property                          | Description                                                                                                                                                                                                                  | Default                                                        |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `limits.maxRunning`               | Global cap on devices running at once, across both platforms.                                                                                                                                                                | Sum of `limits.ios.maxDevices` and `limits.android.maxDevices` |
+| `limits.ios.maxDevices`           | Max number of iOS simulators Pitlane will manage at once.                                                                                                                                                                    | `max(1, cpuCount / 2)`                                         |
+| `limits.ios.maxRunning`           | Max number of iOS simulators running at once.                                                                                                                                                                                | Same as `limits.ios.maxDevices`                                |
+| `limits.android.maxDevices`       | Max number of Android emulators Pitlane will manage at once.                                                                                                                                                                 | `max(1, min(cpuCount / 4, totalRamGb / 8))`                    |
+| `limits.android.maxRunning`       | Max number of Android emulators running at once.                                                                                                                                                                             | Same as `limits.android.maxDevices`                            |
+| `ramBudget.iosBytesPerDevice`     | RAM reserved per iOS simulator when computing capacity.                                                                                                                                                                      | `1.5 GiB`                                                       |
+| `ramBudget.androidBytesPerDevice` | RAM reserved per Android emulator when computing capacity.                                                                                                                                                                   | `4 GiB`                                                         |
+| `idle.shutdownAfterMs`            | How long an unused device sits idle before Pitlane shuts it down (tier 1, reclaims RAM).                                                                                                                                     | `10 minutes`                                                    |
+| `idle.deleteAfterMs`              | How long a shut-down device sits idle before Pitlane deletes it (tier 2, reclaims disk).                                                                                                                                     | `1 hour`                                                        |
+| `lease.heldTtlBackstopMs`         | Backstop TTL for held-mode leases, in case the holding process dies without releasing.                                                                                                                                       | `1 hour`                                                        |
+| `lease.detachedTtlMs`             | TTL for detached-mode leases before they must be renewed with `pitlane lease renew`.                                                                                                                                         | `15 minutes`                                                    |
+| `lease.heartbeatIntervalMs`       | How often the daemon pings a held-mode connection that declared the `heartbeat` capability; each pong slides that connection's leases' TTL back out to a full `heldTtlBackstopMs`. Must be `<= lease.heldTtlBackstopMs / 4`. | `5 minutes`                                                     |
+| `diskPressure.freeBytesThreshold` | Free disk space below which Pitlane treats the machine as under disk pressure.                                                                                                                                               | `10 GiB`                                                         |
+| `eventBuffer.capacity`            | Number of business events kept in the in-memory ring buffer (see `pitlane events`).                                                                                                                                          | `1000`                                                           |
+
+All limit values must be positive integers; all durations and byte sizes
+must be non-negative numbers (milliseconds and bytes, respectively).
+Running limits are independent of managed-device limits — an omitted
+`maxRunning` defaults to its corresponding `maxDevices` value (and, at the
+global level, to their sum):
+
+```json
+{
+  "limits": {
+    "maxRunning": 3,
+    "ios": { "maxDevices": 4, "maxRunning": 2 },
+    "android": { "maxDevices": 2, "maxRunning": 2 }
+  }
+}
+```
+
+See [CLI.md](CLI.md#pitlane-config-get-keyset-key-value) for the
+`pitlane config` command itself.


### PR DESCRIPTION
## Summary
- Rewrites `README.md` in the style of [cordierite](https://github.com/callstackincubator/cordierite)'s README: problem/solution framing, a short "what it looks like" example, a getting-started guide, and links out to the docs.
- Moves the full configuration key reference out of the README into a new `docs/CONFIGURATION.md`, linked from the README and from `docs/CLI.md`.
- Keeps the "Made with ❤️ at Callstack" footer, with tracking query params adjusted for `pitlane` instead of `cordierite`.

## Test plan
- [x] Verified internal doc links (`docs/CLI.md#pitlane-mcp`, `docs/CONFIGURATION.md`, etc.) resolve to existing anchors/files.
- [ ] Visual read-through on GitHub once the PR is open.

---
_Generated by [Claude Code](https://claude.ai/code/session_016zAiFcFQoU7ffb6sZ4GPu9)_