### PR TITLE
fix(ports): settle ProcessHandle.wait() on exit, not stdio EOF

### DIFF
--- a/src/drivers/android/index.ts
+++ b/src/drivers/android/index.ts
@@ -29,6 +29,10 @@ const PORT_MAX = 5682;
 const PORT_MIN = 5554;
 const PORT_POLL_INTERVAL_MS = 2_000;
 const SDK_DOWNLOAD_TIMEOUT_MS = 20 * 60_000;
+// A defense-in-depth bound on the wait that follows a SIGKILL: NodeProcessHandle#wait
+// already settles shortly after `exit`, but this keeps a pathologically slow reap
+// from ever turning a "we already killed it" cleanup into an unbounded await.
+const SIGKILL_REAP_TIMEOUT_MS = 5_000;
 const SNAPSHOT_BOOT_ESTIMATE_MS = 4_000;
 const CLEAN_BASELINE = "pitlane_clean_baseline";
 const DURABLE_MARK_KEY = "pitlane.mark";
@@ -705,7 +709,7 @@ export class AndroidDriver implements Driver {
       await this.#waitForReadiness(data, startedAt);
     } catch (error: unknown) {
       handle.kill("SIGKILL");
-      await handle.wait();
+      await this.#waitForExit(handle, SIGKILL_REAP_TIMEOUT_MS);
       state.handle = undefined;
       throw error;
     }
@@ -775,7 +779,7 @@ export class AndroidDriver implements Driver {
     const exited = await this.#waitForExit(handle, this.#readinessTimeoutMs);
     if (!exited) {
       handle.kill("SIGKILL");
-      await handle.wait();
+      await this.#waitForExit(handle, SIGKILL_REAP_TIMEOUT_MS);
     }
     state.handle = undefined;
   }

--- a/src/ports/process-runner.test.ts
+++ b/src/ports/process-runner.test.ts
@@ -145,4 +145,54 @@ describe("NodeProcessRunner", () => {
       }
     }
   }, 4_000);
+
+  it("keeps waiting while output is still arriving after the process exits", async () => {
+    const runner = new NodeProcessRunner();
+    // Same shape as above, but the pipe is still delivering when the process goes:
+    // the grandchild emits a chunk every 200ms for well over a grace window, then
+    // goes quiet. Settling on a bare post-exit timer would cut the capture off at
+    // the first chunk -- a truncated capture surfaces later as a parse error, far
+    // from its cause -- so the window has to restart while output keeps arriving.
+    const handle = runner.spawn(process.execPath, [
+      "-e",
+      `
+          const { spawn } = require("node:child_process");
+          const grandchild = spawn(
+            process.execPath,
+            [
+              "-e",
+              // console.log appends its own newline, which keeps this three-deep
+              // nested source free of escape sequences that have to survive two
+              // rounds of string parsing on the way down.
+              "let n = 0; const t = setInterval(() => { console.log('chunk-' + n); if (++n === 6) { clearInterval(t); setTimeout(() => {}, 3_000); } }, 200);",
+            ],
+            { detached: true, stdio: "inherit" },
+          );
+          grandchild.unref();
+          require("node:fs").writeSync(1, String(grandchild.pid) + "\\n");
+          process.exit(0);
+        `,
+    ]);
+
+    let grandchildPid: number | undefined;
+    try {
+      const lines = handle.stdout[Symbol.asyncIterator]();
+      grandchildPid = Number((await lines.next()).value);
+
+      const result = await handle.wait();
+
+      expect(result.code).toBe(0);
+      expect(result.stdout, "capture was cut off while the pipe was still delivering").toContain(
+        "chunk-5",
+      );
+    } finally {
+      if (grandchildPid !== undefined) {
+        try {
+          process.kill(grandchildPid, "SIGKILL");
+        } catch {
+          // Already gone by the time we get here.
+        }
+      }
+    }
+  }, 8_000);
 });

--- a/src/ports/process-runner.test.ts
+++ b/src/ports/process-runner.test.ts
@@ -96,4 +96,53 @@ describe("NodeProcessRunner", () => {
       }),
     ).resolves.toEqual({ code: null, stderr: "", stdout: "" });
   });
+
+  it("settles wait() when a detached grandchild keeps the stdio pipe open after the process exits", async () => {
+    const runner = new NodeProcessRunner();
+    // The child forks its own detached grandchild that inherits our pipe's write
+    // end, prints the grandchild's pid, then exits immediately -- reproducing the
+    // real defect, where a surviving grandchild silences `close` even though the
+    // process wait() is meant to be waiting for is already gone.
+    const handle = runner.spawn(process.execPath, [
+      "-e",
+      `
+          const { spawn } = require("node:child_process");
+          const grandchild = spawn(process.execPath, ["-e", "setInterval(() => {}, 1_000)"], {
+            detached: true,
+            stdio: "inherit",
+          });
+          grandchild.unref();
+          require("node:fs").writeSync(1, String(grandchild.pid) + "\\n");
+          process.exit(3);
+        `,
+    ]);
+
+    let grandchildPid: number | undefined;
+    try {
+      const lines = handle.stdout[Symbol.asyncIterator]();
+      grandchildPid = Number((await lines.next()).value);
+
+      // Race a generous but bounded timeout so a regression here fails as a clear
+      // assertion instead of vitest's own suite-wide test timeout.
+      const result = await Promise.race([
+        handle.wait(),
+        new Promise<never>((_resolve, reject) => {
+          setTimeout(
+            () => reject(new Error("wait() did not settle while a grandchild held stdio open")),
+            2_000,
+          ).unref();
+        }),
+      ]);
+
+      expect(result.code).toBe(3);
+    } finally {
+      if (grandchildPid !== undefined) {
+        try {
+          process.kill(grandchildPid, "SIGKILL");
+        } catch {
+          // Already gone by the time we get here.
+        }
+      }
+    }
+  }, 4_000);
 });

--- a/src/ports/process-runner.ts
+++ b/src/ports/process-runner.ts
@@ -1,5 +1,16 @@
 import { spawn as spawnChildProcess, type ChildProcess } from "node:child_process";
 
+// `close` normally follows `exit` within the same tick, once the child's own stdio
+// pipes report EOF. But children are spawned `detached: true`, so a process that
+// forks a grandchild before it dies can leave that grandchild holding the inherited
+// write end of our pipe open -- `close` then never fires even though the process we
+// actually care about is long gone. This grace window bounds how long `wait()` keeps
+// deferring to `close` for the fully-flushed output before it settles from `exit`
+// with whatever was captured so far. It only needs to cover ordinary EOF propagation
+// latency (effectively instant), not an orphaned grandchild's lifetime, so it is kept
+// short rather than sized like a real operation timeout.
+const EXIT_TO_CLOSE_GRACE_MS = 1_000;
+
 export interface ProcessRunOptions {
   readonly timeoutMs?: number;
   readonly env?: NodeJS.ProcessEnv;
@@ -90,8 +101,23 @@ class NodeProcessHandle implements ProcessHandle {
     captureLines(child.stderr, this.stderr, this.#stderrChunks);
     this.#result = new Promise<ProcessResult>((resolve, reject) => {
       child.once("error", reject);
-      child.once("close", (code) => {
+
+      let settled = false;
+      const settle = (code: number | null): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
         resolve({ code, stderr: this.#stderrChunks.join(""), stdout: this.#stdoutChunks.join("") });
+      };
+
+      child.once("close", (code) => {
+        settle(code);
+      });
+      child.once("exit", (code) => {
+        const timer = setTimeout(() => settle(code), EXIT_TO_CLOSE_GRACE_MS);
+        // A pending grace timer must never keep the Node process alive on its own.
+        timer.unref();
       });
     });
   }

--- a/src/ports/process-runner.ts
+++ b/src/ports/process-runner.ts
@@ -4,12 +4,21 @@ import { spawn as spawnChildProcess, type ChildProcess } from "node:child_proces
 // pipes report EOF. But children are spawned `detached: true`, so a process that
 // forks a grandchild before it dies can leave that grandchild holding the inherited
 // write end of our pipe open -- `close` then never fires even though the process we
-// actually care about is long gone. This grace window bounds how long `wait()` keeps
-// deferring to `close` for the fully-flushed output before it settles from `exit`
-// with whatever was captured so far. It only needs to cover ordinary EOF propagation
-// latency (effectively instant), not an orphaned grandchild's lifetime, so it is kept
-// short rather than sized like a real operation timeout.
+// actually care about is long gone. After `exit`, `wait()` therefore stops waiting
+// for `close` once the pipes have gone quiet for this long.
+//
+// Quiet, not merely elapsed: settling on a bare timer would truncate the output of a
+// process that exited while its pipe was still draining (a large `simctl list --json`
+// under a loaded event loop), and a truncated capture surfaces as a parse error far
+// from its cause. So the window restarts whenever more output arrives, which
+// distinguishes "still draining" from "held open by something that has nothing to
+// say" -- the only case this needs to escape.
 const EXIT_TO_CLOSE_GRACE_MS = 1_000;
+
+// A grandchild that inherits the pipe *and* chatters on it would otherwise restart the
+// grace window forever, so the deferral is capped. Reaching this cap means the output
+// may be incomplete; nothing else is waiting on it by then.
+const EXIT_TO_CLOSE_MAX_DEFERRAL_MS = 5_000;
 
 export interface ProcessRunOptions {
   readonly timeoutMs?: number;
@@ -115,9 +124,20 @@ class NodeProcessHandle implements ProcessHandle {
         settle(code);
       });
       child.once("exit", (code) => {
-        const timer = setTimeout(() => settle(code), EXIT_TO_CLOSE_GRACE_MS);
-        // A pending grace timer must never keep the Node process alive on its own.
-        timer.unref();
+        const deadline = Date.now() + EXIT_TO_CLOSE_MAX_DEFERRAL_MS;
+        const capturedSoFar = (): number => this.#stdoutChunks.length + this.#stderrChunks.length;
+        const armGrace = (chunksAtArm: number): void => {
+          const timer = setTimeout(() => {
+            if (capturedSoFar() !== chunksAtArm && Date.now() < deadline) {
+              armGrace(capturedSoFar());
+              return;
+            }
+            settle(code);
+          }, EXIT_TO_CLOSE_GRACE_MS);
+          // A pending grace timer must never keep the Node process alive on its own.
+          timer.unref();
+        };
+        armGrace(capturedSoFar());
       });
     });
   }


### PR DESCRIPTION
Closes the `ProcessHandle.wait()` half of #37. The stalled-transition half (doctor finding, transition age in `status` / `list --devices`, the safe `--fix`) is deliberately **not** here — it needs the "present, counts against capacity, not grantable" disposition that #21 is defining, so it should follow that.

## The defect

`NodeProcessHandle` settled `wait()` from the child's `close` event — stdio EOF, not process exit:

```ts
child.once("close", (code) => { resolve({ code, stderr: …, stdout: … }); });
```

Children are spawned `detached: true` with `stdio: "pipe"`, so a grandchild that inherits the pipe's write end keeps `close` from ever firing. `wait()` then never settles even though the process it is waiting for is gone.

In the Android driver that became an unbounded await *after* a SIGKILL, in both kill paths (`#startEmulator`'s boot-readiness failure and `#shutdown`) — a bounded wait followed by an unbounded one.

## The fix

`wait()` still prefers `close`, so the fully-flushed output stays intact in the normal case. After `exit`, it stops deferring to `close` once the pipes have gone **quiet** for `EXIT_TO_CLOSE_GRACE_MS` (1s).

Quiet rather than merely elapsed, and that distinction is the substance of the change. Settling on a bare post-exit timer swaps one silent failure for another: a process that exits while its pipe is still draining — a large `simctl list --json` under a loaded event loop — would have its capture truncated, and a truncated capture surfaces as a parse error far from its cause. Restarting the window whenever more output arrives separates "still draining" from "held open by something with nothing to say", which is the only case that needs escaping. A chattering grandchild would restart it forever, so total deferral is capped at 5s.

The grace timer is `unref()`d, so a pending one can never hold the process open by itself.

Both Android post-SIGKILL waits are now bounded (5s) through the driver's existing `#waitForExit` race helper rather than a second mechanism — defence in depth on top of the ports-level fix.

## Tests

Two regression tests, both verified to fail against the code they guard (not just to pass against the fix):

- **Grandchild holds the pipe open.** A child forks a `detached` grandchild inheriting its stdio, prints the grandchild's pid, and exits 3. `close` never fires. Reverting `process-runner.ts` makes it fail on its own assertion rather than a suite timeout; the grandchild is SIGKILLed in a `finally` so nothing leaks into the e2e lane's stray-process teardown.
- **Pipe still delivering after exit.** Same shape, but the grandchild emits every 200ms for well past one window. On a bare grace timer the capture stops at the first chunk and the test fails; on quiet-based deferral the whole stream is captured.

`ProcessResult.code` stays correct on both paths — `exit` reports `code === null` for a signalled process exactly as `close` does, which the existing timeout test (expecting `code: null`) still covers.

## Verification

`pnpm run check` green (505 unit tests, 28 e2e); `fallow audit` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbpHvzYe8vEs71QHbpAhyT)_