### PR TITLE
feat(cli): add `pitlane top` live terminal dashboard

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -209,6 +209,19 @@ registry-managed device. Never touches devices outside the registry.
 Stream the business-event ring buffer (see [EVENTS.md](EVENTS.md)) as JSON
 lines. `--follow` keeps streaming; `--since 1h` replays recent history.
 
+## `pitlane top`
+
+Live, read-only, full-screen terminal dashboard of daemon state: every
+managed device with its state/OS/agent/duration, a capacity meter, queue
+depth, and the most recent business event. Connects with the daemon's
+existing-connection path only — **it never auto-starts the daemon**; if it
+isn't running, `top` fails the same way every other command does (a
+structured stderr error line, non-zero exit). The view refreshes on every
+pushed event (debounced ~150ms) and on a 5s safety-net poll, so it stays
+correct without polling aggressively. `q`, `Esc`, or Ctrl+C quits cleanly.
+Exposes no destructive actions — no release/cleanup/doctor/nuke surface —
+by design; use the dedicated commands for those.
+
 ## `pitlane daemon <start|stop|status|logs>`
 
 Manage the daemon explicitly. Other commands auto-start it on demand;

--- a/package.json
+++ b/package.json
@@ -23,11 +23,14 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.29.0",
+    "ink": "^7.1.1",
+    "react": "^19.2.8",
     "zod": "^3.25.76"
   },
   "devDependencies": {
     "@release-it/conventional-changelog": "^11.0.1",
     "@types/node": "^26.1.1",
+    "@types/react": "^19.2.18",
     "fallow": "^3.6.0",
     "lefthook": "^2.1.10",
     "oxfmt": "^0.59.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,202 +1,3 @@
----
-lockfileVersion: '9.0'
-
-importers:
-
-  .:
-    configDependencies: {}
-    packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: ^11.9.0
-        version: 11.22.0
-      pnpm:
-        specifier: ^11.9.0
-        version: 11.22.0
-
-packages:
-
-  '@pnpm/exe@11.22.0':
-    resolution: {integrity: sha512-B1SGeKm+v9pX9YkzMmrnO2FbgBd8TDwzZ3jSj6J6ThxdyGvI4TsOfMeHARW4Wb25visPpmMDfIXrU76EZdJM4g==}
-    hasBin: true
-
-  '@pnpm/linux-arm64@11.22.0':
-    resolution: {integrity: sha512-xzzn3jYG9QaiFZPaHcWM3yX4Fm9UGz5E42mzpbvUEvXYf5O9fwNolenOhGLpRl2qS5u35fjZSvDZbWlOwHMcug==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@pnpm/linux-x64@11.22.0':
-    resolution: {integrity: sha512-isvaPctGinbsM2hsTtRsMarN8Sr5QhXDTNmn8Xv9Lp1PjincCvH2RBbhpo+xYIOxzgls1dtQSdgoORUbfRVALQ==}
-    cpu: [x64]
-    os: [linux]
-
-  '@pnpm/linuxstatic-arm64@11.22.0':
-    resolution: {integrity: sha512-i4J+AQWW0T3JBdXaLsvxu8ZmMG1HLS6JZQESdOR9uBv8Zumb4yg8GYT83eWRLacr6ngVdhEBiC3W4eOG64MFbA==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@pnpm/linuxstatic-x64@11.22.0':
-    resolution: {integrity: sha512-QYzk8jhSuSbVthW/OxEOhU3f3zhjpw4HqgedrlwbVNb7btCWn5del2Hb5PsYYka2PbmKq5EtF5IzYN8Yp1CfxQ==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@pnpm/macos-arm64@11.22.0':
-    resolution: {integrity: sha512-Io8Axk5kutPgMuAfOg1QGj3J0/KpLvH5iiPcmp7up8D4q7BNWT02ndQo3RyGWqrlkf5nwspM41GFpWTShrZ4Aw==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@pnpm/win-arm64@11.22.0':
-    resolution: {integrity: sha512-QgaRuKGQKov7xW2utPCgDT83fn/PU5cD6HFgib48oTslz7wv26E89d4jMCxL4GRmEL2YCfkYuj5ITj1oVWg5WQ==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@pnpm/win-x64@11.22.0':
-    resolution: {integrity: sha512-iWYsiSwpgxqur+TwsnSoPdOQaEfd4ygB84mb5tJUOgim6PHr1xhKJBndaQzH+At/WkLxLdYN+K8dYc4M7naezg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@reflink/reflink-darwin-arm64@0.1.19':
-    resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@reflink/reflink-darwin-x64@0.1.19':
-    resolution: {integrity: sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@reflink/reflink-linux-arm64-gnu@0.1.19':
-    resolution: {integrity: sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@reflink/reflink-linux-arm64-musl@0.1.19':
-    resolution: {integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@reflink/reflink-linux-x64-gnu@0.1.19':
-    resolution: {integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@reflink/reflink-linux-x64-musl@0.1.19':
-    resolution: {integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@reflink/reflink-win32-arm64-msvc@0.1.19':
-    resolution: {integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@reflink/reflink-win32-x64-msvc@0.1.19':
-    resolution: {integrity: sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@reflink/reflink@0.1.19':
-    resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
-    engines: {node: '>= 10'}
-
-  detect-libc@2.1.2:
-    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
-    engines: {node: '>=8'}
-
-  pnpm@11.22.0:
-    resolution: {integrity: sha512-H/hwxMYTPf2I+yr8Rt0T1H8JyXlLQ4xv20fKmMrzvBY4HuC+k6CRuOOCTPAfiJ9G19niCRD7C+GrD7W6qA3WIQ==}
-    engines: {node: '>=22.13'}
-    hasBin: true
-
-snapshots:
-
-  '@pnpm/exe@11.22.0':
-    dependencies:
-      '@reflink/reflink': 0.1.19
-      detect-libc: 2.1.2
-    optionalDependencies:
-      '@pnpm/linux-arm64': 11.22.0
-      '@pnpm/linux-x64': 11.22.0
-      '@pnpm/linuxstatic-arm64': 11.22.0
-      '@pnpm/linuxstatic-x64': 11.22.0
-      '@pnpm/macos-arm64': 11.22.0
-      '@pnpm/win-arm64': 11.22.0
-      '@pnpm/win-x64': 11.22.0
-
-  '@pnpm/linux-arm64@11.22.0':
-    optional: true
-
-  '@pnpm/linux-x64@11.22.0':
-    optional: true
-
-  '@pnpm/linuxstatic-arm64@11.22.0':
-    optional: true
-
-  '@pnpm/linuxstatic-x64@11.22.0':
-    optional: true
-
-  '@pnpm/macos-arm64@11.22.0':
-    optional: true
-
-  '@pnpm/win-arm64@11.22.0':
-    optional: true
-
-  '@pnpm/win-x64@11.22.0':
-    optional: true
-
-  '@reflink/reflink-darwin-arm64@0.1.19':
-    optional: true
-
-  '@reflink/reflink-darwin-x64@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-arm64-gnu@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-arm64-musl@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-x64-gnu@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-x64-musl@0.1.19':
-    optional: true
-
-  '@reflink/reflink-win32-arm64-msvc@0.1.19':
-    optional: true
-
-  '@reflink/reflink-win32-x64-msvc@0.1.19':
-    optional: true
-
-  '@reflink/reflink@0.1.19':
-    optionalDependencies:
-      '@reflink/reflink-darwin-arm64': 0.1.19
-      '@reflink/reflink-darwin-x64': 0.1.19
-      '@reflink/reflink-linux-arm64-gnu': 0.1.19
-      '@reflink/reflink-linux-arm64-musl': 0.1.19
-      '@reflink/reflink-linux-x64-gnu': 0.1.19
-      '@reflink/reflink-linux-x64-musl': 0.1.19
-      '@reflink/reflink-win32-arm64-msvc': 0.1.19
-      '@reflink/reflink-win32-x64-msvc': 0.1.19
-
-  detect-libc@2.1.2: {}
-
-  pnpm@11.22.0: {}
-
----
 lockfileVersion: '9.0'
 
 settings:
@@ -214,6 +15,12 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
         version: 1.29.0(zod@3.25.76)
+      ink:
+        specifier: ^7.1.1
+        version: 7.1.1(@types/react@19.2.18)(react@19.2.8)
+      react:
+        specifier: ^19.2.8
+        version: 19.2.8
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -224,6 +31,9 @@ importers:
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
+      '@types/react':
+        specifier: ^19.2.18
+        version: 19.2.18
       fallow:
         specifier: ^3.6.0
         version: 3.6.0
@@ -247,6 +57,10 @@ importers:
         version: 4.1.10(@types/node@26.1.1)(vite@8.1.4(@types/node@26.1.1)(jiti@2.7.0))
 
 packages:
+
+  '@alcalzone/ansi-tokenize@0.3.0':
+    resolution: {integrity: sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==}
+    engines: {node: '>=18'}
 
   '@conventional-changelog/git-client@2.7.0':
     resolution: {integrity: sha512-j7A8/LBEQ+3rugMzPXoKYzyUPpw/0CBQCyvtTR7Lmu4olG4yRC/Tfkq79Mr3yuPs0SUitlO2HwGP3gitMJnRFw==}
@@ -912,6 +726,9 @@ packages:
     resolution: {integrity: sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q==}
     deprecated: This is a stub types definition. parse-path provides its own type definitions, so you do not need this installed.
 
+  '@types/react@19.2.18':
+    resolution: {integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==}
+
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
     engines: {node: '>=16.20.0'}
@@ -1080,8 +897,16 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
   array-ify@1.0.0:
@@ -1097,6 +922,10 @@ packages:
 
   async-retry@1.3.3:
     resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
+
+  auto-bind@5.0.1:
+    resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   basic-ftp@5.3.1:
     resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
@@ -1161,6 +990,14 @@ packages:
   citty@0.2.2:
     resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
 
+  cli-boxes@4.0.1:
+    resolution: {integrity: sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==}
+    engines: {node: '>=18.20 <19 || >=20.10'}
+
+  cli-cursor@4.0.0:
+    resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
@@ -1169,9 +1006,17 @@ packages:
     resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
     engines: {node: '>=18.20'}
 
+  cli-truncate@6.1.1:
+    resolution: {integrity: sha512-06p9vyLahLa4zkGcgsGxU6iEkSOiuI4fhCH6Emhe2lPAcoUv73n72DnODsnHA+5wwXGnV0n9M9/qOQJSjYhFhw==}
+    engines: {node: '>=22'}
+
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
+
+  code-excerpt@4.0.0:
+    resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
@@ -1238,6 +1083,10 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  convert-to-spaces@2.0.1:
+    resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
@@ -1253,6 +1102,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   data-uri-to-buffer@7.0.0:
     resolution: {integrity: sha512-CuRUx0TXGSbbWdEci3VK/XOZGP3n0P4pIKpsqpVtBqaIIuj3GKK8H45oAqA4Rg8FHipc+CzRdUzmD4YQXxv66Q==}
@@ -1318,6 +1170,10 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -1333,8 +1189,15 @@ packages:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.51.0:
+    resolution: {integrity: sha512-zC2lQGkM7QX+Gm6iM3+WIdZJzthsEd14LvRNJneSO2hzyz/zNBENR8+YXWo1cKxgPBtV6ksPYHELbcwBRzmdCw==}
+
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
 
   escodegen@2.1.0:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
@@ -1509,8 +1372,25 @@ packages:
     resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
+  indent-string@5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ink@7.1.1:
+    resolution: {integrity: sha512-Y43xxa1ZSPvpmfLHcN5o+OdP8Rf8ykkNJEuKYOUNZKT8wXVNLFTtEm1nSDMQkfBH+YANF4Xuu0hhZ4ejqAtN2w==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@types/react': '>=19.2.0'
+      react: '>=19.2.0'
+      react-devtools-core: '>=6.1.2'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-devtools-core:
+        optional: true
 
   ip-address@10.5.0:
     resolution: {integrity: sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==}
@@ -1523,6 +1403,15 @@ packages:
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
+  is-in-ci@2.0.0:
+    resolution: {integrity: sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==}
+    engines: {node: '>=20'}
     hasBin: true
 
   is-in-ssh@1.0.0:
@@ -1767,6 +1656,10 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
@@ -1835,6 +1728,10 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
@@ -1897,6 +1794,10 @@ packages:
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  patch-console@2.0.0:
+    resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -1969,6 +1870,16 @@ packages:
   rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
 
+  react-reconciler@0.33.0:
+    resolution: {integrity: sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.2.0
+
+  react@19.2.8:
+    resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
+    engines: {node: '>=0.10.0'}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
@@ -1985,6 +1896,10 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  restore-cursor@4.0.0:
+    resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
@@ -2012,6 +1927,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -2061,9 +1979,16 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  slice-ansi@9.0.0:
+    resolution: {integrity: sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==}
+    engines: {node: '>=22'}
 
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -2097,6 +2022,10 @@ packages:
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -2121,6 +2050,14 @@ packages:
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
+
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
+  terminal-size@4.0.1:
+    resolution: {integrity: sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==}
+    engines: {node: '>=18'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -2155,6 +2092,10 @@ packages:
   type-fest@2.19.0:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
     engines: {node: '>=12.20'}
+
+  type-fest@5.8.0:
+    resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
+    engines: {node: '>=20'}
 
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
@@ -2299,6 +2240,10 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  widest-line@6.0.0:
+    resolution: {integrity: sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==}
+    engines: {node: '>=20'}
+
   wildcard-match@5.1.4:
     resolution: {integrity: sha512-wldeCaczs8XXq7hj+5d/F38JE2r7EXgb6WQDM84RVwxy81T/sxB5e9+uZLK9Q9oNz1mlvjut+QtvgaOQFPVq/g==}
 
@@ -2309,8 +2254,24 @@ packages:
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
+  wrap-ansi@10.0.1:
+    resolution: {integrity: sha512-M0N4xzyzosiIok3svYlEo1sdLZts/8FPgYH/GPC3wvlmPoRvnoManGMrE54waYj3tISA8w6lsdesfVv67qSr8Q==}
+    engines: {node: '>=20'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
@@ -2324,6 +2285,9 @@ packages:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
 
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
+
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
@@ -2333,6 +2297,11 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@alcalzone/ansi-tokenize@0.3.0':
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
 
   '@conventional-changelog/git-client@2.7.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)':
     dependencies:
@@ -2817,6 +2786,10 @@ snapshots:
     dependencies:
       parse-path: 7.1.0
 
+  '@types/react@19.2.18':
+    dependencies:
+      csstype: 3.2.3
+
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
 
@@ -2936,7 +2909,13 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
   ansi-regex@6.2.2: {}
+
+  ansi-styles@6.2.3: {}
 
   array-ify@1.0.0: {}
 
@@ -2949,6 +2928,8 @@ snapshots:
   async-retry@1.3.3:
     dependencies:
       retry: 0.13.1
+
+  auto-bind@5.0.1: {}
 
   basic-ftp@5.3.1: {}
 
@@ -3019,13 +3000,28 @@ snapshots:
 
   citty@0.2.2: {}
 
+  cli-boxes@4.0.1: {}
+
+  cli-cursor@4.0.0:
+    dependencies:
+      restore-cursor: 4.0.0
+
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
 
   cli-spinners@3.4.0: {}
 
+  cli-truncate@6.1.1:
+    dependencies:
+      slice-ansi: 9.0.0
+      string-width: 8.2.2
+
   cli-width@4.1.0: {}
+
+  code-excerpt@4.0.0:
+    dependencies:
+      convert-to-spaces: 2.0.1
 
   compare-func@2.0.0:
     dependencies:
@@ -3098,6 +3094,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  convert-to-spaces@2.0.1: {}
+
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
@@ -3112,6 +3110,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  csstype@3.2.3: {}
 
   data-uri-to-buffer@7.0.0: {}
 
@@ -3159,6 +3159,8 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
+  environment@1.1.0: {}
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
@@ -3169,7 +3171,11 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
+  es-toolkit@1.51.0: {}
+
   escape-html@1.0.3: {}
+
+  escape-string-regexp@2.0.0: {}
 
   escodegen@2.1.0:
     dependencies:
@@ -3394,13 +3400,55 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  indent-string@5.0.0: {}
+
   inherits@2.0.4: {}
+
+  ink@7.1.1(@types/react@19.2.18)(react@19.2.8):
+    dependencies:
+      '@alcalzone/ansi-tokenize': 0.3.0
+      ansi-escapes: 7.3.0
+      ansi-styles: 6.2.3
+      auto-bind: 5.0.1
+      chalk: 5.6.2
+      cli-boxes: 4.0.1
+      cli-cursor: 4.0.0
+      cli-truncate: 6.1.1
+      code-excerpt: 4.0.0
+      es-toolkit: 1.51.0
+      indent-string: 5.0.0
+      is-in-ci: 2.0.0
+      patch-console: 2.0.0
+      react: 19.2.8
+      react-reconciler: 0.33.0(react@19.2.8)
+      scheduler: 0.27.0
+      signal-exit: 3.0.7
+      slice-ansi: 9.0.0
+      stack-utils: 2.0.6
+      string-width: 8.2.2
+      terminal-size: 4.0.1
+      type-fest: 5.8.0
+      widest-line: 6.0.0
+      wrap-ansi: 10.0.1
+      ws: 8.21.3
+      yoga-layout: 3.2.1
+    optionalDependencies:
+      '@types/react': 19.2.18
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   ip-address@10.5.0: {}
 
   ipaddr.js@1.9.1: {}
 
   is-docker@3.0.0: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.6.0
+
+  is-in-ci@2.0.0: {}
 
   is-in-ssh@1.0.0: {}
 
@@ -3577,6 +3625,8 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  mimic-fn@2.1.0: {}
+
   mimic-function@5.0.1: {}
 
   minimist@1.2.8: {}
@@ -3626,6 +3676,10 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
 
   onetime@7.0.0:
     dependencies:
@@ -3732,6 +3786,8 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  patch-console@2.0.0: {}
+
   path-key@3.1.1: {}
 
   path-to-regexp@8.4.2: {}
@@ -3805,6 +3861,13 @@ snapshots:
       defu: 6.1.7
       destr: 2.0.5
 
+  react-reconciler@0.33.0(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      scheduler: 0.27.0
+
+  react@19.2.8: {}
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
@@ -3844,6 +3907,11 @@ snapshots:
       - supports-color
 
   require-from-string@2.0.2: {}
+
+  restore-cursor@4.0.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
 
   restore-cursor@5.1.0:
     dependencies:
@@ -3888,6 +3956,8 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
+
+  scheduler@0.27.0: {}
 
   semver@7.7.4: {}
 
@@ -3956,7 +4026,14 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@3.0.7: {}
+
   signal-exit@4.1.0: {}
+
+  slice-ansi@9.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
 
   smart-buffer@4.2.0: {}
 
@@ -3991,6 +4068,10 @@ snapshots:
 
   spdx-license-ids@3.0.23: {}
 
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
+
   stackback@0.0.2: {}
 
   statuses@2.0.2: {}
@@ -4011,6 +4092,10 @@ snapshots:
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
+
+  tagged-tag@1.0.0: {}
+
+  terminal-size@4.0.1: {}
 
   tinybench@2.9.0: {}
 
@@ -4035,6 +4120,10 @@ snapshots:
   tslib@2.8.1: {}
 
   type-fest@2.19.0: {}
+
+  type-fest@5.8.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   type-is@2.1.0:
     dependencies:
@@ -4139,6 +4228,10 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  widest-line@6.0.0:
+    dependencies:
+      string-width: 8.2.2
+
   wildcard-match@5.1.4: {}
 
   windows-release@7.1.1:
@@ -4147,7 +4240,14 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
+  wrap-ansi@10.0.1:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 8.2.2
+
   wrappy@1.0.2: {}
+
+  ws@8.21.3: {}
 
   wsl-utils@0.3.1:
     dependencies:
@@ -4157,6 +4257,8 @@ snapshots:
   yargs-parser@22.0.0: {}
 
   yoctocolors@2.1.2: {}
+
+  yoga-layout@3.2.1: {}
 
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -675,6 +675,82 @@ describe("CLI boundary", () => {
     await expect(runCli(["catalog", "--platform", "windows"], output.environment)).resolves.toBe(2);
     expect(output.stderr).toContain("--platform must be ios or android");
   });
+
+  it("prints top help without connecting to the daemon", async () => {
+    const output = outputCapture();
+
+    await expect(runCli(["top", "--help"], output.environment)).resolves.toBe(0);
+    expect(output.stdout).toBe("Usage: pitlane top\n");
+    expect(output.stderr).toBe("");
+  });
+
+  it("dispatches pitlane top to the injected loadTopUi frontend, connecting with connectExisting", async () => {
+    const output = outputCapture();
+    const connection = new StubConnection();
+    const runTopUi = vi.fn(async (_options: { readonly connection: DaemonConnection }) => 0);
+    const loadTopUi = vi.fn(async () => runTopUi);
+
+    await expect(
+      runCli(
+        ["top"],
+        output.environmentWith({
+          connect: async () => {
+            throw new Error("must not fall back to connect when connectExisting is provided");
+          },
+          connectExisting: async () => connection,
+          loadTopUi,
+        }),
+      ),
+    ).resolves.toBe(0);
+    expect(loadTopUi).toHaveBeenCalledTimes(1);
+    expect(runTopUi).toHaveBeenCalledTimes(1);
+    expect(runTopUi.mock.calls[0]?.[0]).toMatchObject({ connection });
+  });
+
+  it("falls back to connect for pitlane top when connectExisting is not provided", async () => {
+    const output = outputCapture();
+    const connection = new StubConnection();
+    const runTopUi = vi.fn(async () => 0);
+
+    await expect(
+      runCli(
+        ["top"],
+        output.environmentWith({
+          connect: async () => connection,
+          loadTopUi: async () => runTopUi,
+        }),
+      ),
+    ).resolves.toBe(0);
+    expect(runTopUi).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates a connection failure through the standard daemon-error stderr path, never loading the Ink frontend", async () => {
+    const output = outputCapture();
+    const loadTopUi = vi.fn(async () => vi.fn(async () => 0));
+
+    await expect(
+      runCli(
+        ["top"],
+        output.environmentWith({
+          connectExisting: async () => {
+            throw new DaemonClientError("DAEMON_UNAVAILABLE", "Daemon is not running");
+          },
+          loadTopUi,
+        }),
+      ),
+    ).resolves.toBe(1);
+    expect(loadTopUi).not.toHaveBeenCalled();
+    expect(JSON.parse(output.stderr)).toEqual({
+      error: { code: "DAEMON_UNAVAILABLE", message: "Daemon is not running" },
+    });
+  });
+
+  it("rejects unexpected top input", async () => {
+    const output = outputCapture();
+
+    await expect(runCli(["top", "unexpected"], output.environment)).resolves.toBe(2);
+    expect(JSON.parse(output.stderr)).toMatchObject({ error: { code: "USAGE" } });
+  });
 });
 
 class StubConnection implements DaemonConnection {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,6 +13,8 @@ import {
 import { connectDaemon, connectExistingDaemon } from "../daemon-client/client.js";
 import { parseRawLeaseGrant } from "../daemon-client/contracts.js";
 import { DaemonClientError, type DaemonConnection } from "../daemon-client/protocol.js";
+// Type-only: erased at compile time, so this never triggers Ink's real (eager) module load.
+import type { TopUiRunner } from "./top/ui.js";
 
 export { DaemonClientError, type DaemonConnection } from "../daemon-client/protocol.js";
 
@@ -21,6 +23,7 @@ const USAGE = `Usage: pitlane <command> [options]
 Commands:
   lease, release, status, list, catalog, cleanup, doctor, nuke, events,
   daemon, config
+  top                         Live read-only terminal dashboard
   mcp                         Start the stdio MCP server
 Run 'pitlane <command> --help' for command usage.`;
 
@@ -74,6 +77,8 @@ export interface CliEnvironment {
   /** Loads the MCP frontend only when the `mcp` command is dispatched. */
   readonly loadMcpStdio?: () => Promise<McpStdioRunner>;
   readonly runMcpStdio?: () => Promise<void>;
+  /** Loads the Ink dashboard frontend only when the `top` command is dispatched. */
+  readonly loadTopUi?: () => Promise<TopUiRunner>;
   readonly signals: Signals;
   readonly stderr: Output;
   readonly stdout: Output;
@@ -135,6 +140,10 @@ async function loadDefaultMcpStdio(): Promise<McpStdioRunner> {
   return (await import("../mcp/main.js")).runMcpStdio;
 }
 
+async function loadDefaultTopUi(): Promise<TopUiRunner> {
+  return (await import("./top/ui.js")).runTopUi;
+}
+
 export async function runCli(
   argv: readonly string[],
   environment: CliEnvironment = defaultCliEnvironment(),
@@ -167,6 +176,8 @@ export async function runCli(
         return await runDaemon(argv.slice(1), environment);
       case "config":
         return await runConfig(argv.slice(1), environment);
+      case "top":
+        return await runTop(argv.slice(1), environment);
       case "mcp":
         return await runMcp(argv.slice(1), environment);
       default:
@@ -195,6 +206,28 @@ function cliErrorCode(error: unknown): string {
   if (error instanceof UsageError) return "USAGE";
   if (error instanceof DaemonClientError) return error.code;
   return "INTERNAL";
+}
+
+/**
+ * Live read-only dashboard. Connects with `connectExisting` (never
+ * `connect`) so a dashboard can never silently boot the daemon — if it
+ * isn't running, `connectExisting` throws and the usual `DaemonClientError`
+ * path in `runCli`'s catch reports it; there is no special-casing here.
+ */
+async function runTop(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+  const values = commandArgs(argv, { help: { type: "boolean", short: "h" } });
+  if (values.help) {
+    environment.stdout.write("Usage: pitlane top\n");
+    return 0;
+  }
+  if (values.positionals.length > 0) throw new UsageError("top accepts no arguments");
+  const connection = await (environment.connectExisting ?? environment.connect)();
+  const runTopUi = await (environment.loadTopUi ?? loadDefaultTopUi)();
+  return await runTopUi({
+    connection,
+    now: environment.now ?? Date.now,
+    signals: environment.signals,
+  });
 }
 
 async function runMcp(argv: readonly string[], environment: CliEnvironment): Promise<number> {

--- a/src/cli/top/ui.tsx
+++ b/src/cli/top/ui.tsx
@@ -1,0 +1,569 @@
+/**
+ * `pitlane top`: a live, read-only Ink dashboard over daemon state.
+ *
+ * This module is loaded lazily (see `loadDefaultTopUi` in `../index.ts`), the
+ * same way `loadMcpStdio` lazily loads the MCP frontend, so every other
+ * command never pays React/Ink's import cost. Nothing in here is unit
+ * tested directly — the parsing and derivation logic it renders lives in
+ * `./view-model.ts`, which is pure and fully tested; this file is the thin,
+ * un-tested rendering layer on top of it.
+ */
+import { Box, render, Text, useApp, useInput, useStdin, useStdout } from "ink";
+import React, { useEffect, useSyncExternalStore } from "react";
+
+import { DaemonClientError, type DaemonConnection } from "../../daemon-client/protocol.js";
+import {
+  buildMeter,
+  formatCoarseDuration,
+  formatDuration,
+  formatRelativeAge,
+  parseIdleShutdownAfterMs,
+  parseStatus,
+  resolveWidth,
+  meterLayout,
+  summarizeEvent,
+  type DeviceRow,
+  type EventSummary,
+  type RowState,
+  type TopViewModel,
+} from "./view-model.js";
+
+interface Signals {
+  on(signal: "SIGINT" | "SIGTERM", listener: () => void): unknown;
+  off(signal: "SIGINT" | "SIGTERM", listener: () => void): unknown;
+}
+
+export interface TopRunOptions {
+  readonly connection: DaemonConnection;
+  readonly now: () => number;
+  readonly signals: Signals;
+}
+
+export type TopUiRunner = (options: TopRunOptions) => Promise<number>;
+
+const REFRESH_DEBOUNCE_MS = 150;
+const POLL_INTERVAL_MS = 5_000;
+const METER_WIDTH = 20;
+
+/**
+ * Drives the daemon connection (initial fetch, event-triggered and polled
+ * refreshes, close handling) and mounts the Ink app. All impure I/O — real
+ * timers, the real terminal — lives here; `App` and below are pure renders
+ * of whatever `TopStore` currently holds, re-rendering whenever it changes.
+ */
+// fallow-ignore-next-line unused-export -- CLI routing invokes this public frontend entrypoint.
+export async function runTopUi(options: TopRunOptions): Promise<number> {
+  const { connection, now, signals } = options;
+
+  const [statusRaw, shutdownAfterMs] = await Promise.all([
+    connection.request("status.get", {}),
+    connection.request("config.get", {}).then(parseIdleShutdownAfterMs).catch(returnUndefined),
+  ]);
+
+  const store = new TopStore(parseViewModel(statusRaw, now(), shutdownAfterMs));
+
+  const refresh = (): void => {
+    connection
+      .request("status.get", {})
+      .then((raw) => store.setViewModel(parseViewModel(raw, now(), shutdownAfterMs)))
+      .catch(returnUndefined);
+  };
+
+  let debounceTimer: NodeJS.Timeout | undefined;
+  const scheduleRefresh = (): void => {
+    if (debounceTimer !== undefined) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(refresh, REFRESH_DEBOUNCE_MS);
+  };
+
+  const deviceLabel = (id: string): string | undefined =>
+    store.getSnapshot().viewModel.devices.find((device) => device.id === id)?.model;
+
+  const unsubscribePush = connection.onPush((kind, payload) => {
+    if (kind !== "event") return;
+    const summary = summarizeEvent(payload, now(), deviceLabel);
+    if (summary !== undefined)
+      store.setLastEvent({ ...summary, timestampMs: now() - summary.ageMs });
+    scheduleRefresh();
+  });
+
+  // Read-only dashboard: if subscribing fails, the 5s poll below still keeps the view live.
+  await connection.request("events.subscribe", {}).catch(returnUndefined);
+
+  const pollTimer = setInterval(refresh, POLL_INTERVAL_MS);
+  const instance = render(<App store={store} now={now} />, {
+    alternateScreen: true,
+    exitOnCtrlC: true,
+  });
+  const unsubscribeClose = connection.onClose(() => {
+    store.setCloseError(
+      new DaemonClientError("DAEMON_CONNECTION_LOST", "Daemon connection closed"),
+    );
+  });
+  // Belt-and-suspenders alongside Ink's own Ctrl+C handling: Ink can only capture
+  // Ctrl+C as *input* when stdin is a TTY in raw mode (see `App`'s `isRawModeSupported`
+  // guard). Piped/non-interactive stdin gets no such input, so an external SIGINT/SIGTERM
+  // (Ctrl+C at a controlling terminal that isn't stdin, `kill`, `timeout`, …) still needs
+  // an explicit handler here to unmount and clean up rather than dying with no cleanup at all.
+  const handleSignal = (): void => instance.unmount();
+  signals.on("SIGINT", handleSignal);
+  signals.on("SIGTERM", handleSignal);
+
+  try {
+    await instance.waitUntilExit();
+  } finally {
+    signals.off("SIGINT", handleSignal);
+    signals.off("SIGTERM", handleSignal);
+    clearInterval(pollTimer);
+    if (debounceTimer !== undefined) clearTimeout(debounceTimer);
+    unsubscribePush();
+    // Unsubscribe before our own close() below, so it can't re-fire this listener.
+    unsubscribeClose();
+    await connection.request("events.unsubscribe", {}).catch(returnUndefined);
+    await connection.close();
+  }
+  return 0;
+}
+
+function parseViewModel(
+  raw: unknown,
+  now: number,
+  shutdownAfterMs: number | undefined,
+): TopViewModel {
+  return parseStatus(raw, { now, ...(shutdownAfterMs === undefined ? {} : { shutdownAfterMs }) });
+}
+
+function returnUndefined(): undefined {
+  return undefined;
+}
+
+interface LastEventState extends EventSummary {
+  /** Wall-clock moment the event was received, so age can be recomputed fresh on every render. */
+  readonly timestampMs: number;
+}
+
+interface Snapshot {
+  readonly viewModel: TopViewModel;
+  readonly lastEvent: LastEventState | undefined;
+  readonly closeError: DaemonClientError | undefined;
+}
+
+/**
+ * Minimal external store so the Ink tree only re-renders when data actually
+ * changes. `getSnapshot()` must return the *same* object reference between
+ * updates — `useSyncExternalStore` calls it on every render to decide
+ * whether anything changed, and a freshly-allocated object each call reads
+ * as "always changed", which is an infinite render loop. So the snapshot is
+ * built once per update, not once per `getSnapshot()` call.
+ */
+class TopStore {
+  #snapshot: Snapshot;
+  readonly #listeners = new Set<() => void>();
+
+  constructor(initial: TopViewModel) {
+    this.#snapshot = { closeError: undefined, lastEvent: undefined, viewModel: initial };
+  }
+
+  readonly subscribe = (listener: () => void): (() => void) => {
+    this.#listeners.add(listener);
+    return () => this.#listeners.delete(listener);
+  };
+
+  readonly getSnapshot = (): Snapshot => this.#snapshot;
+
+  setViewModel(viewModel: TopViewModel): void {
+    this.#snapshot = { ...this.#snapshot, viewModel };
+    this.#emit();
+  }
+
+  setLastEvent(lastEvent: LastEventState): void {
+    this.#snapshot = { ...this.#snapshot, lastEvent };
+    this.#emit();
+  }
+
+  setCloseError(closeError: DaemonClientError): void {
+    this.#snapshot = { ...this.#snapshot, closeError };
+    this.#emit();
+  }
+
+  #emit(): void {
+    for (const listener of this.#listeners) listener();
+  }
+}
+
+function App({
+  store,
+  now,
+}: {
+  readonly store: TopStore;
+  readonly now: () => number;
+}): React.ReactElement {
+  const snapshot = useSyncExternalStore(store.subscribe, store.getSnapshot);
+  const { exit } = useApp();
+  const { stdout } = useStdout();
+  const { isRawModeSupported } = useStdin();
+
+  // The daemon-death path (below) can only reach `exit()` from inside the React
+  // tree — Ink's public `render()` return value silently drops any error passed
+  // to its `unmount()`, so a close error is threaded through the store instead
+  // and turned into a real, `waitUntilExit()`-rejecting exit here.
+  const { closeError } = snapshot;
+  useEffect(() => {
+    if (closeError !== undefined) exit(closeError);
+  }, [closeError, exit]);
+
+  // Guarded: enabling raw mode throws when stdin isn't a TTY (piped/non-interactive),
+  // and `q`/Esc obviously can't be typed there anyway — Ctrl+C (SIGTERM/SIGINT) still
+  // tears the process down in that case, just without this graceful key-driven exit.
+  // `isRawModeSupported` is `stdin.isTTY`, which reads `undefined` (not `false`) off a
+  // TTY, so it must be coerced — `useInput` only skips enabling raw mode on `=== false`.
+  useInput(
+    (input, key) => {
+      if (input === "q" || key.escape) exit();
+    },
+    { isActive: isRawModeSupported === true },
+  );
+
+  // A real TTY populates `stdout.columns`, and that is the authoritative value.
+  // On a pipe it is `undefined` while Ink's own layout engine still honours
+  // `COLUMNS`; falling back to it keeps our column budget and Ink's agreeing,
+  // instead of us assuming 80 and Ink wrapping the rules at something narrower.
+  const width = resolveWidth(stdout.columns, process.env.COLUMNS);
+  return (
+    <Dashboard
+      viewModel={snapshot.viewModel}
+      lastEvent={snapshot.lastEvent}
+      width={width}
+      now={now()}
+    />
+  );
+}
+
+const STATE_LABEL: Readonly<Record<RowState, string>> = {
+  busy: "busy",
+  leased: "leased",
+  shutdown: "off",
+  warm: "warm",
+};
+const STATE_BULLET: Readonly<Record<RowState, string>> = {
+  busy: "◐",
+  leased: "●",
+  shutdown: "·",
+  warm: "○",
+};
+const STATE_COLOR: Readonly<Record<RowState, string | undefined>> = {
+  busy: "yellow",
+  leased: "green",
+  shutdown: undefined,
+  warm: "cyan",
+};
+const SEGMENT_COLOR: Readonly<Record<"leased" | "warm" | "busy" | "empty", string | undefined>> = {
+  busy: "yellow",
+  empty: undefined,
+  leased: "green",
+  warm: "cyan",
+};
+
+/** `exactOptionalPropertyTypes` rejects `color={undefined}` on Ink's `Text`, so omit the key entirely instead. */
+function colorProp(color: string | undefined): { readonly color?: string } {
+  return color === undefined ? {} : { color };
+}
+
+function Dashboard({
+  viewModel,
+  lastEvent,
+  width,
+  now,
+}: {
+  readonly viewModel: TopViewModel;
+  readonly lastEvent: LastEventState | undefined;
+  readonly width: number;
+  readonly now: number;
+}): React.ReactElement {
+  const showAgent = width >= 72;
+  const showOs = width >= 60;
+  const rows = viewModel.devices.map(deviceRowText);
+  const columns: ColumnWidths = {
+    device: columnWidth(
+      rows.map((row) => row.device),
+      10,
+      24,
+    ),
+    for: columnWidth(
+      rows.map((row) => row.forText),
+      4,
+      12,
+    ),
+    os: showOs
+      ? columnWidth(
+          rows.map((row) => row.os),
+          2,
+          8,
+        )
+      : 0,
+    requester: showAgent
+      ? columnWidth(
+          rows.map((row) => row.agent),
+          5,
+          16,
+        )
+      : 0,
+    state: columnWidth(Object.values(STATE_LABEL), 4, 8) + 2,
+  };
+  const rule = "─".repeat(Math.max(20, Math.min(width - 2, 74)));
+
+  return (
+    <Box flexDirection="column" paddingLeft={2} paddingTop={1}>
+      <HeaderLine
+        health={viewModel.health}
+        deviceCount={viewModel.devices.length}
+        width={rule.length}
+      />
+      <Box height={1} />
+      <MeterLine viewModel={viewModel} width={width} />
+      <Box height={1} />
+      <Text dimColor>{rule}</Text>
+      <TableHeader columns={columns} showOs={showOs} showAgent={showAgent} />
+      {rows.map((row) => (
+        <DeviceLine
+          key={row.id}
+          row={row}
+          columns={columns}
+          showOs={showOs}
+          showAgent={showAgent}
+        />
+      ))}
+      <Text dimColor>{rule}</Text>
+      {viewModel.queueDepth > 0 ? (
+        <>
+          <Box height={1} />
+          <Text>{viewModel.queueDepth} waiting</Text>
+        </>
+      ) : null}
+      <Box height={1} />
+      <LastEventLine lastEvent={lastEvent} now={now} width={width} />
+      <Text dimColor>q quit</Text>
+    </Box>
+  );
+}
+
+/**
+ * Constrained to the rule width rather than the terminal width: a
+ * `space-between` row spanning a 200-column terminal strands the device count
+ * far off to the right, visually disconnected from the body beneath it. Both
+ * ends stay tied to the same column the rules and table occupy.
+ */
+function HeaderLine({
+  health,
+  deviceCount,
+  width,
+}: {
+  readonly width: number;
+  readonly health: TopViewModel["health"];
+  readonly deviceCount: number;
+}): React.ReactElement {
+  const healthColor = health === "running" ? "green" : health === "failed" ? "red" : "yellow";
+  return (
+    <Box justifyContent="space-between" width={width}>
+      <Text>
+        <Text bold> PITLANE </Text>
+        <Text color={healthColor}>● {health}</Text>
+      </Text>
+      <Text dimColor>{deviceCount} devices</Text>
+    </Box>
+  );
+}
+
+function MeterLine({
+  viewModel,
+  width,
+}: {
+  readonly viewModel: TopViewModel;
+  readonly width: number;
+}): React.ReactElement {
+  const { counts, capacity } = viewModel;
+  const { barWidth, showPlatforms } = meterLayout(width, capacity, METER_WIDTH);
+  const meter = buildMeter(counts, capacity.global, barWidth);
+  const overLimit = meter.overLimit || viewModel.overLimit;
+  const emptyWidth = meter.segments.find((segment) => segment.kind === "empty")?.width ?? 0;
+  const bar = overLimit ? (
+    <Text color="red">
+      {"█".repeat(barWidth - emptyWidth)}
+      {"░".repeat(emptyWidth)}
+    </Text>
+  ) : (
+    <Text>
+      {meter.segments.map((segment) => (
+        <Text
+          key={segment.kind}
+          dimColor={segment.kind === "empty"}
+          {...colorProp(SEGMENT_COLOR[segment.kind])}
+        >
+          {(segment.kind === "empty" ? "░" : "█").repeat(segment.width)}
+        </Text>
+      ))}
+    </Text>
+  );
+  // Each legend bullet carries its own state color, tying the counts back to the
+  // matching segment in the bar above; only the words stay dim.
+  const legend = (["leased", "warm", "busy"] as const).filter((kind) => counts[kind] > 0);
+
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Text dimColor>Running </Text>
+        {bar}
+        <Text>
+          {"  "}
+          {capacity.global.running}/{capacity.global.maxRunning}
+        </Text>
+        {showPlatforms ? (
+          <Text>
+            <Text dimColor>{"   ios "}</Text>
+            {capacity.ios.running}/{capacity.ios.maxRunning}
+            <Text dimColor>{"   android "}</Text>
+            {capacity.android.running}/{capacity.android.maxRunning}
+          </Text>
+        ) : null}
+      </Box>
+      {legend.length === 0 ? null : (
+        <Text>
+          {"  "}
+          {legend.map((kind, index) => (
+            <Text key={kind}>
+              {index === 0 ? "" : "   "}
+              <Text {...colorProp(SEGMENT_COLOR[kind])}>●</Text>
+              <Text dimColor>
+                {" "}
+                {counts[kind]} {kind}
+              </Text>
+            </Text>
+          ))}
+        </Text>
+      )}
+    </Box>
+  );
+}
+
+interface ColumnWidths {
+  readonly state: number;
+  readonly device: number;
+  readonly os: number;
+  readonly requester: number;
+  readonly for: number;
+}
+
+function TableHeader({
+  columns,
+  showOs,
+  showAgent,
+}: {
+  readonly columns: ColumnWidths;
+  readonly showOs: boolean;
+  readonly showAgent: boolean;
+}): React.ReactElement {
+  return (
+    <Text dimColor>
+      {" "}
+      {"STATE".padEnd(columns.state)} {"DEVICE".padEnd(columns.device)}{" "}
+      {showOs ? `${"OS".padEnd(columns.os)} ` : ""}
+      {showAgent ? `${"AGENT".padEnd(columns.requester)} ` : ""}
+      {"FOR".padStart(columns.for)}
+    </Text>
+  );
+}
+
+interface RowText {
+  readonly id: string;
+  readonly state: RowState;
+  readonly device: string;
+  readonly os: string;
+  readonly agent: string;
+  readonly forText: string;
+  readonly countdown: string;
+  readonly flagged: boolean;
+}
+
+function deviceRowText(device: DeviceRow): RowText {
+  const countdown =
+    device.shutdownInMs === undefined ? "" : `   ↓ ${formatDuration(device.shutdownInMs)}`;
+  return {
+    agent: device.agent ?? "—",
+    countdown,
+    device: device.model,
+    flagged: device.flagged,
+    forText:
+      device.state === "shutdown"
+        ? formatCoarseDuration(device.forMs)
+        : formatDuration(device.forMs),
+    id: device.id,
+    os: device.osVersion,
+    state: device.state,
+  };
+}
+
+function columnWidth(values: readonly string[], min: number, max: number): number {
+  const longest = values.reduce((width, value) => Math.max(width, value.length), 0);
+  return Math.min(Math.max(longest, min), max);
+}
+
+function truncate(value: string, width: number): string {
+  if (value.length <= width) return value.padEnd(width);
+  if (width <= 1) return value.slice(0, width);
+  return `${value.slice(0, width - 1)}…`;
+}
+
+function DeviceLine({
+  row,
+  columns,
+  showOs,
+  showAgent,
+}: {
+  readonly row: RowText;
+  readonly columns: ColumnWidths;
+  readonly showOs: boolean;
+  readonly showAgent: boolean;
+}): React.ReactElement {
+  const color = STATE_COLOR[row.state];
+  const stateText = `${STATE_BULLET[row.state]} ${STATE_LABEL[row.state]}`.padEnd(columns.state);
+  return (
+    <Text>
+      {" "}
+      <Text dimColor={color === undefined} {...colorProp(color)}>
+        {stateText}
+      </Text>{" "}
+      <Text>{truncate(row.device, columns.device)}</Text>{" "}
+      {showOs ? (
+        <>
+          <Text dimColor>{truncate(row.os, columns.os)}</Text>{" "}
+        </>
+      ) : null}
+      {showAgent ? (
+        <>
+          <Text dimColor={row.agent === "—"}>{truncate(row.agent, columns.requester)}</Text>{" "}
+        </>
+      ) : null}
+      <Text>{row.forText.padStart(columns.for)}</Text>
+      {row.countdown === "" ? null : <Text dimColor>{row.countdown}</Text>}
+      {row.flagged ? <Text color="red"> !</Text> : null}
+    </Text>
+  );
+}
+
+function LastEventLine({
+  lastEvent,
+  now,
+  width,
+}: {
+  readonly lastEvent: LastEventState | undefined;
+  readonly now: number;
+  readonly width: number;
+}): React.ReactElement {
+  if (lastEvent === undefined) return <Box height={1} />;
+  const age = formatRelativeAge(Math.max(0, now - lastEvent.timestampMs));
+  const line = `${lastEvent.event}  ${lastEvent.summary}`;
+  return (
+    <Text dimColor>
+      {truncate(line, Math.max(10, width - 2 - age.length - 1))} {age}
+    </Text>
+  );
+}

--- a/src/cli/top/view-model.test.ts
+++ b/src/cli/top/view-model.test.ts
@@ -1,0 +1,560 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildMeter,
+  formatCoarseDuration,
+  formatDuration,
+  formatRelativeAge,
+  meterLayout,
+  resolveWidth,
+  parseIdleShutdownAfterMs,
+  parseStatus,
+  summarizeEvent,
+  type Capacity,
+  type CapacityUsage,
+} from "./view-model.js";
+
+describe("parseStatus: device classification", () => {
+  it("classifies a leased device, resolving the agent from the matching lease", () => {
+    const vm = parseStatus(
+      {
+        devices: [device("dev_1", "leased", { spec: { model: "iPhone 17 Pro" } })],
+        leases: [lease("dev_1", "agent-a", { grantedAt: 900 })],
+      },
+      { now: 1_000 },
+    );
+    expect(vm.devices).toEqual([
+      expect.objectContaining({ agent: "agent-a", forMs: 100, id: "dev_1", state: "leased" }),
+    ]);
+  });
+
+  it("classifies a ready device with no lease as warm", () => {
+    const vm = parseStatus(
+      { devices: [device("dev_1", "ready", { lastLeaseEndedAt: 700 })], leases: [] },
+      { now: 1_000 },
+    );
+    expect(vm.devices).toEqual([expect.objectContaining({ forMs: 300, state: "warm" })]);
+  });
+
+  it("treats a ready device still referenced by a lease as leased (ready-but-leased edge case)", () => {
+    const vm = parseStatus(
+      {
+        devices: [device("dev_1", "ready")],
+        leases: [lease("dev_1", "agent-b", { grantedAt: 400 })],
+      },
+      { now: 1_000 },
+    );
+    expect(vm.devices).toEqual([
+      expect.objectContaining({ agent: "agent-b", forMs: 600, state: "leased" }),
+    ]);
+  });
+
+  it.each(["provisioning", "reclaiming"])("classifies %s as busy", (state) => {
+    const vm = parseStatus(
+      { devices: [device("dev_1", state, { createdAt: 500 })] },
+      { now: 1_000 },
+    );
+    expect(vm.devices).toEqual([expect.objectContaining({ forMs: 500, state: "busy" })]);
+  });
+
+  it("classifies shutdown as shutdown", () => {
+    const vm = parseStatus(
+      { devices: [device("dev_1", "shutdown", { lastLeaseEndedAt: 600 })] },
+      { now: 1_000 },
+    );
+    expect(vm.devices).toEqual([expect.objectContaining({ forMs: 400, state: "shutdown" })]);
+  });
+
+  it("never shows deleted devices", () => {
+    const vm = parseStatus({ devices: [device("dev_1", "deleted")] }, { now: 1_000 });
+    expect(vm.devices).toEqual([]);
+  });
+
+  it("falls back an unrecognized/renamed state to the quiet shutdown row instead of throwing", () => {
+    const vm = parseStatus({ devices: [device("dev_1", "quantum-superposed")] }, { now: 1_000 });
+    expect(vm.devices).toEqual([expect.objectContaining({ state: "shutdown" })]);
+  });
+
+  it("flags a device carrying a foreign-state or foreign-provenance marker", () => {
+    const vm = parseStatus(
+      {
+        devices: [
+          { ...device("dev_1", "ready"), foreignStateDetectedAt: 999 },
+          { ...device("dev_2", "ready"), foreignProvenanceDetectedAt: 999 },
+          device("dev_3", "ready"),
+        ],
+      },
+      { now: 1_000 },
+    );
+    expect(vm.devices.map((d) => [d.id, d.flagged])).toEqual([
+      ["dev_1", true],
+      ["dev_2", true],
+      ["dev_3", false],
+    ]);
+  });
+});
+
+describe("parseStatus: sort order and grouping", () => {
+  it("sorts leased, warm, busy, shutdown, alphabetical by model within each group", () => {
+    const vm = parseStatus(
+      {
+        devices: [
+          device("shutdown-b", "shutdown", { spec: { model: "Zeta" } }),
+          device("shutdown-a", "shutdown", { spec: { model: "Alpha" } }),
+          device("warm-b", "ready", { spec: { model: "Zeta" } }),
+          device("warm-a", "ready", { spec: { model: "Alpha" } }),
+          device("busy-b", "provisioning", { spec: { model: "Zeta" } }),
+          device("busy-a", "provisioning", { spec: { model: "Alpha" } }),
+          device("leased-b", "leased", { spec: { model: "Zeta" } }),
+          device("leased-a", "leased", { spec: { model: "Alpha" } }),
+        ],
+      },
+      { now: 1_000 },
+    );
+    expect(vm.devices.map((d) => d.id)).toEqual([
+      "leased-a",
+      "leased-b",
+      "warm-a",
+      "warm-b",
+      "busy-a",
+      "busy-b",
+      "shutdown-a",
+      "shutdown-b",
+    ]);
+  });
+
+  it("counts rows per group", () => {
+    const vm = parseStatus(
+      {
+        devices: [
+          device("d1", "leased"),
+          device("d2", "ready"),
+          device("d3", "provisioning"),
+          device("d4", "shutdown"),
+          device("d5", "shutdown"),
+        ],
+      },
+      { now: 1_000 },
+    );
+    expect(vm.counts).toEqual({ busy: 1, leased: 1, shutdown: 2, warm: 1 });
+  });
+});
+
+describe("parseStatus: defensive parsing", () => {
+  it("never throws on a completely empty/garbage payload", () => {
+    expect(() => parseStatus(undefined, { now: 1 })).not.toThrow();
+    expect(() => parseStatus(null, { now: 1 })).not.toThrow();
+    expect(() => parseStatus("nope", { now: 1 })).not.toThrow();
+    expect(() => parseStatus([], { now: 1 })).not.toThrow();
+    expect(() => parseStatus({}, { now: 1 })).not.toThrow();
+  });
+
+  it("defaults capacity buckets to zero when capacity is missing", () => {
+    const vm = parseStatus({ devices: [] }, { now: 1 });
+    expect(vm.capacity).toEqual({
+      android: {
+        limit: undefined,
+        maxRunning: 0,
+        overLimit: false,
+        reserved: 0,
+        running: 0,
+        used: undefined,
+        warm: 0,
+      },
+      global: {
+        limit: undefined,
+        maxRunning: 0,
+        overLimit: false,
+        reserved: 0,
+        running: 0,
+        used: undefined,
+        warm: 0,
+      },
+      ios: {
+        limit: undefined,
+        maxRunning: 0,
+        overLimit: false,
+        reserved: 0,
+        running: 0,
+        used: undefined,
+        warm: 0,
+      },
+    });
+    expect(vm.overLimit).toBe(false);
+  });
+
+  it("defaults to an empty device list when devices is missing or malformed", () => {
+    expect(parseStatus({ leases: [] }, { now: 1 }).devices).toEqual([]);
+    expect(parseStatus({ devices: "not-an-array" }, { now: 1 }).devices).toEqual([]);
+    expect(parseStatus({ devices: [null, 42, "x"] }, { now: 1 }).devices).toEqual([]);
+  });
+
+  it("falls back model/os to a placeholder when a device's spec is absent", () => {
+    const vm = parseStatus(
+      { devices: [{ createdAt: 0, id: "dev_1", state: "ready" }] },
+      { now: 1 },
+    );
+    expect(vm.devices).toEqual([
+      expect.objectContaining({ model: "?", osVersion: "?", platform: undefined }),
+    ]);
+  });
+
+  it("never throws when a lease points at a device that does not exist", () => {
+    expect(() =>
+      parseStatus({ devices: [], leases: [lease("ghost-device", "agent-x")] }, { now: 1 }),
+    ).not.toThrow();
+    const vm = parseStatus({ devices: [], leases: [lease("ghost-device", "agent-x")] }, { now: 1 });
+    expect(vm.devices).toEqual([]);
+  });
+
+  it("falls back health to starting on a missing/invalid value", () => {
+    expect(parseStatus({}, { now: 1 }).health).toBe("starting");
+    expect(parseStatus({ health: "on-fire" }, { now: 1 }).health).toBe("starting");
+    expect(parseStatus({ health: "failed" }, { now: 1 }).health).toBe("failed");
+  });
+
+  it("falls back queueDepth to 0 on a missing/invalid value", () => {
+    expect(parseStatus({}, { now: 1 }).queueDepth).toBe(0);
+    expect(parseStatus({ queueDepth: "many" }, { now: 1 }).queueDepth).toBe(0);
+    expect(parseStatus({ queueDepth: 3 }, { now: 1 }).queueDepth).toBe(3);
+  });
+});
+
+describe("shutdown countdown derivation", () => {
+  it("adds a shutdown countdown to a warm device when shutdownAfterMs is available", () => {
+    const vm = parseStatus(
+      { devices: [device("dev_1", "ready", { lastLeaseEndedAt: 900 })] },
+      { now: 1_000, shutdownAfterMs: 10_000 },
+    );
+    expect(vm.devices).toEqual([expect.objectContaining({ forMs: 100, shutdownInMs: 9_900 })]);
+  });
+
+  it("clamps the countdown to 0 rather than going negative once the deadline has passed", () => {
+    const vm = parseStatus(
+      { devices: [device("dev_1", "ready", { lastLeaseEndedAt: 0 })] },
+      { now: 1_000, shutdownAfterMs: 100 },
+    );
+    expect(vm.devices).toEqual([expect.objectContaining({ shutdownInMs: 0 })]);
+  });
+
+  it("omits the countdown when shutdownAfterMs was not available (config.get gave nothing)", () => {
+    const vm = parseStatus({ devices: [device("dev_1", "ready")] }, { now: 1_000 });
+    expect(vm.devices).toEqual([expect.objectContaining({ shutdownInMs: undefined })]);
+  });
+
+  it("never adds a countdown to a non-warm row", () => {
+    const vm = parseStatus(
+      { devices: [device("dev_1", "leased")], leases: [lease("dev_1", "agent-a")] },
+      { now: 1_000, shutdownAfterMs: 10_000 },
+    );
+    expect(vm.devices).toEqual([expect.objectContaining({ shutdownInMs: undefined })]);
+  });
+});
+
+describe("parseIdleShutdownAfterMs", () => {
+  it("reads idle.shutdownAfterMs from a config.get response", () => {
+    expect(parseIdleShutdownAfterMs({ idle: { shutdownAfterMs: 42_000 } })).toBe(42_000);
+  });
+
+  it.each([undefined, null, "nope", {}, { idle: {} }, { idle: { shutdownAfterMs: "soon" } }])(
+    "returns undefined for %p",
+    (raw) => {
+      expect(parseIdleShutdownAfterMs(raw)).toBeUndefined();
+    },
+  );
+});
+
+describe("buildMeter", () => {
+  it("splits the filled width proportionally to leased/warm/busy counts", () => {
+    const meter = buildMeter(
+      { busy: 1, leased: 2, warm: 1 },
+      { maxRunning: 4, overLimit: false, running: 4 },
+      20,
+    );
+    expect(meter.segments).toEqual([
+      { kind: "leased", width: 10 },
+      { kind: "warm", width: 5 },
+      { kind: "busy", width: 5 },
+    ]);
+    expect(meter.fraction).toBe(1);
+    expect(meter.overLimit).toBe(false);
+  });
+
+  it("segment widths always sum exactly to the requested width, despite rounding", () => {
+    const meter = buildMeter(
+      { busy: 1, leased: 1, warm: 1 },
+      { maxRunning: 6, overLimit: false, running: 4 },
+      20,
+    );
+    const sum = meter.segments.reduce((total, segment) => total + segment.width, 0);
+    expect(sum).toBe(20);
+  });
+
+  it("never divides by zero when maxRunning is 0, and does not fill the bar", () => {
+    const idle = buildMeter(
+      { busy: 0, leased: 0, warm: 0 },
+      { maxRunning: 0, overLimit: false, running: 0 },
+      20,
+    );
+    expect(idle.fraction).toBe(0);
+    expect(idle.segments).toEqual([{ kind: "empty", width: 20 }]);
+
+    const stuck = buildMeter(
+      { busy: 1, leased: 0, warm: 0 },
+      { maxRunning: 0, overLimit: false, running: 1 },
+      20,
+    );
+    expect(stuck.fraction).toBe(1);
+    expect(Number.isFinite(stuck.fraction)).toBe(true);
+  });
+
+  it("flags overLimit when running exceeds maxRunning, even if the daemon didn't say so", () => {
+    const meter = buildMeter(
+      { busy: 0, leased: 5, warm: 0 },
+      { maxRunning: 4, overLimit: false, running: 5 },
+      20,
+    );
+    expect(meter.overLimit).toBe(true);
+    expect(meter.fraction).toBe(1);
+  });
+
+  it("trusts the daemon's own overLimit flag too", () => {
+    const meter = buildMeter(
+      { busy: 0, leased: 1, warm: 0 },
+      { maxRunning: 4, overLimit: true, running: 1 },
+      20,
+    );
+    expect(meter.overLimit).toBe(true);
+  });
+
+  it("renders an all-empty bar when there is nothing running", () => {
+    const meter = buildMeter(
+      { busy: 0, leased: 0, warm: 0 },
+      { maxRunning: 4, overLimit: false, running: 0 },
+      20,
+    );
+    expect(meter.segments).toEqual([{ kind: "empty", width: 20 }]);
+  });
+});
+
+describe("duration formatting", () => {
+  it("formatDuration: precise M:SS below an hour, HhMMm at/above an hour", () => {
+    expect(formatDuration(0)).toBe("0:00");
+    expect(formatDuration(8_000)).toBe("0:08");
+    expect(formatDuration(252_000)).toBe("4:12");
+    expect(formatDuration(63_000)).toBe("1:03");
+    expect(formatDuration((2 * 3600 + 4 * 60) * 1000)).toBe("2h04m");
+    expect(formatDuration(-5_000)).toBe("0:00");
+  });
+
+  it("formatCoarseDuration: bare Mm below an hour, HhMMm at/above an hour", () => {
+    expect(formatCoarseDuration(41 * 60_000)).toBe("41m");
+    expect(formatCoarseDuration((2 * 3600 + 4 * 60) * 1000)).toBe("2h04m");
+    expect(formatCoarseDuration(0)).toBe("0m");
+    expect(formatCoarseDuration(-1_000)).toBe("0m");
+  });
+
+  it("formatRelativeAge: compact Ns/Nm/Nh/Nd", () => {
+    expect(formatRelativeAge(12_000)).toBe("12s");
+    expect(formatRelativeAge(3 * 60_000)).toBe("3m");
+    expect(formatRelativeAge(5 * 3_600_000)).toBe("5h");
+    expect(formatRelativeAge(2 * 86_400_000)).toBe("2d");
+    expect(formatRelativeAge(-1)).toBe("0s");
+  });
+});
+
+describe("summarizeEvent", () => {
+  const label = (id: string) => (id === "dev_1" ? "iPhone 17 Pro" : undefined);
+
+  it("summarizes lease.granted with the resolved device label and age", () => {
+    const summary = summarizeEvent(
+      {
+        event: "lease.granted",
+        payload: { deviceId: "dev_1", requester: "agent-e2e-7" },
+        timestamp: 988,
+      },
+      1_000,
+      label,
+    );
+    expect(summary).toEqual({
+      ageMs: 12,
+      event: "lease.granted",
+      summary: "agent-e2e-7 → iPhone 17 Pro",
+    });
+  });
+
+  it("falls back to the raw device id when the label lookup misses", () => {
+    const summary = summarizeEvent(
+      { event: "device.shutdown", payload: { deviceId: "dev_unknown" }, timestamp: 1_000 },
+      1_000,
+      label,
+    );
+    expect(summary?.summary).toBe("dev_unknown");
+  });
+
+  it("returns undefined for a malformed envelope instead of throwing", () => {
+    expect(summarizeEvent(undefined, 1_000, label)).toBeUndefined();
+    expect(summarizeEvent({}, 1_000, label)).toBeUndefined();
+    expect(summarizeEvent({ event: 42 }, 1_000, label)).toBeUndefined();
+  });
+
+  it("clamps age to 0 rather than going negative on clock skew", () => {
+    const summary = summarizeEvent(
+      { event: "daemon.started", payload: {}, timestamp: 5_000 },
+      1_000,
+      label,
+    );
+    expect(summary?.ageMs).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function device(
+  id: string,
+  state: string,
+  overrides: {
+    readonly createdAt?: number;
+    readonly lastLeaseEndedAt?: number;
+    readonly spec?: {
+      readonly model?: string;
+      readonly osVersion?: string;
+      readonly platform?: string;
+    };
+  } = {},
+): Record<string, unknown> {
+  return {
+    createdAt: overrides.createdAt ?? 0,
+    id,
+    spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios", ...overrides.spec },
+    state,
+    ...(overrides.lastLeaseEndedAt === undefined
+      ? {}
+      : { lastLeaseEndedAt: overrides.lastLeaseEndedAt }),
+  };
+}
+
+function lease(
+  deviceId: string,
+  requesterId: string,
+  overrides: { readonly grantedAt?: number } = {},
+): Record<string, unknown> {
+  return { deviceId, grantedAt: overrides.grantedAt ?? 0, id: `lse_${deviceId}`, requesterId };
+}
+
+describe("parseStatus: sort order", () => {
+  it("orders models case-insensitively so capitalization does not jump the queue", () => {
+    const now = 1_000_000;
+    const vm = parseStatus(
+      {
+        devices: [
+          {
+            id: "d1",
+            spec: { model: "Pixel 8", osVersion: "35", platform: "android" },
+            state: "leased",
+            createdAt: 0,
+          },
+          {
+            id: "d2",
+            spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
+            state: "leased",
+            createdAt: 0,
+          },
+        ],
+        leases: [],
+      },
+      { now },
+    );
+
+    expect(vm.devices.map((device) => device.model)).toEqual(["iPhone 17 Pro", "Pixel 8"]);
+  });
+});
+
+describe("meterLayout", () => {
+  const capacity = (
+    global: [number, number],
+    ios: [number, number],
+    android: [number, number],
+  ): Capacity => {
+    const usage = ([running, maxRunning]: [number, number]): CapacityUsage => ({
+      limit: undefined,
+      maxRunning,
+      overLimit: false,
+      reserved: 0,
+      running,
+      used: undefined,
+      warm: 0,
+    });
+    return { android: usage(android), global: usage(global), ios: usage(ios) };
+  };
+
+  const renderedWidth = (width: number, value: Capacity): number => {
+    const { barWidth, showPlatforms } = meterLayout(width, value, 20);
+    const tail = showPlatforms
+      ? `   ios ${value.ios.running}/${value.ios.maxRunning}` +
+        `   android ${value.android.running}/${value.android.maxRunning}`
+      : "";
+    const core =
+      2 + "Running ".length + 2 + `${value.global.running}/${value.global.maxRunning}`.length;
+    return core + barWidth + tail.length;
+  };
+
+  it.each([40, 50, 60, 66, 72, 80, 120])(
+    "never exceeds the terminal width at %d columns",
+    (width) => {
+      expect(renderedWidth(width, capacity([4, 6], [3, 4], [1, 2]))).toBeLessThanOrEqual(width);
+    },
+  );
+
+  it.each([40, 60, 66, 72, 80, 120])(
+    "never exceeds the terminal width at %d columns with two-digit capacities",
+    (width) => {
+      expect(renderedWidth(width, capacity([12, 16], [10, 12], [2, 4]))).toBeLessThanOrEqual(width);
+    },
+  );
+
+  it("drops the per-platform tail before shrinking the bar", () => {
+    const narrow = meterLayout(50, capacity([4, 6], [3, 4], [1, 2]), 20);
+
+    expect(narrow.showPlatforms).toBe(false);
+    expect(narrow.barWidth).toBe(20);
+  });
+
+  it("keeps the per-platform tail when there is room for it", () => {
+    expect(meterLayout(80, capacity([4, 6], [3, 4], [1, 2]), 20).showPlatforms).toBe(true);
+  });
+
+  it("shrinks the bar rather than wrapping once the tail is already gone", () => {
+    expect(meterLayout(30, capacity([4, 6], [3, 4], [1, 2]), 20).barWidth).toBe(15);
+  });
+
+  it("floors the bar at 6 columns instead of going negative", () => {
+    expect(meterLayout(5, capacity([4, 6], [3, 4], [1, 2]), 20).barWidth).toBe(6);
+  });
+
+  it("accounts for wider capacity digits when deciding to show platforms", () => {
+    const single = meterLayout(60, capacity([4, 6], [3, 4], [1, 2]), 20);
+    const double = meterLayout(60, capacity([12, 16], [10, 12], [2, 4]), 20);
+
+    expect(single.showPlatforms).toBe(true);
+    expect(double.showPlatforms).toBe(false);
+  });
+});
+
+describe("resolveWidth", () => {
+  it("prefers a real TTY column count", () => {
+    expect(resolveWidth(120, "60")).toBe(120);
+  });
+
+  it("falls back to COLUMNS on a pipe, matching what Ink lays out against", () => {
+    expect(resolveWidth(undefined, "66")).toBe(66);
+  });
+
+  it("falls back to 80 when neither is usable", () => {
+    expect(resolveWidth(undefined, undefined)).toBe(80);
+    expect(resolveWidth(0, "not-a-number")).toBe(80);
+    expect(resolveWidth(undefined, "-5")).toBe(80);
+  });
+});

--- a/src/cli/top/view-model.ts
+++ b/src/cli/top/view-model.ts
@@ -1,0 +1,553 @@
+/**
+ * Pure view-model for `pitlane top`: turns the raw, untrusted `status.get` /
+ * `config.get` daemon responses into a typed, render-ready shape, plus all
+ * the small derivations (classification, sorting, meter math, duration
+ * formatting, event summaries) the Ink layer needs.
+ *
+ * Nothing here imports Ink or React, and nothing here throws on malformed
+ * input — nothing is trusted at this boundary, so every read is defensive.
+ * This is deliberate: it is the only part of `pitlane top` worth unit
+ * testing, and it stays testable by staying pure.
+ */
+
+export type Platform = "ios" | "android";
+export type RowState = "leased" | "warm" | "busy" | "shutdown";
+export type Health = "starting" | "running" | "failed";
+
+export interface DeviceRow {
+  readonly id: string;
+  readonly state: RowState;
+  readonly platform: Platform | undefined;
+  readonly model: string;
+  readonly osVersion: string;
+  readonly agent: string | undefined;
+  readonly forMs: number;
+  /** Only ever set for `warm` rows, and only when a shutdown-after config was supplied. */
+  readonly shutdownInMs: number | undefined;
+  /** True when the device carries a foreign-state or foreign-provenance drift marker. */
+  readonly flagged: boolean;
+}
+
+export interface CapacityUsage {
+  readonly running: number;
+  readonly maxRunning: number;
+  readonly reserved: number;
+  readonly overLimit: boolean;
+  readonly warm: number;
+  readonly used: number | undefined;
+  readonly limit: number | undefined;
+}
+
+export interface Capacity {
+  readonly global: CapacityUsage;
+  readonly ios: CapacityUsage;
+  readonly android: CapacityUsage;
+}
+
+export interface RowCounts {
+  readonly leased: number;
+  readonly warm: number;
+  readonly busy: number;
+  readonly shutdown: number;
+}
+
+export interface TopViewModel {
+  readonly health: Health;
+  readonly queueDepth: number;
+  readonly devices: readonly DeviceRow[];
+  readonly capacity: Capacity;
+  readonly counts: RowCounts;
+  /** True when any capacity bucket (global/ios/android) is over its limit. */
+  readonly overLimit: boolean;
+}
+
+export interface ParseStatusOptions {
+  readonly now: number;
+  /** `config.idle.shutdownAfterMs`, fetched once at startup; omit if unavailable. */
+  readonly shutdownAfterMs?: number;
+}
+
+const ROW_ORDER: Readonly<Record<RowState, number>> = { leased: 0, warm: 1, busy: 2, shutdown: 3 };
+
+export function parseStatus(raw: unknown, options: ParseStatusOptions): TopViewModel {
+  const root = isRecord(raw) ? raw : {};
+  const now = options.now;
+
+  const leases = (Array.isArray(root.leases) ? root.leases : [])
+    .map(parseLease)
+    .filter((lease): lease is ParsedLease => lease !== undefined);
+  const leaseByDeviceId = new Map(leases.map((lease) => [lease.deviceId, lease]));
+
+  const rawDevices = Array.isArray(root.devices) ? root.devices : [];
+  const devices: DeviceRow[] = [];
+  for (const entry of rawDevices) {
+    const device = parseDevice(entry);
+    if (device === undefined || device.state === "deleted") continue;
+    devices.push(
+      classifyDevice(device, leaseByDeviceId.get(device.id), now, options.shutdownAfterMs),
+    );
+  }
+  devices.sort(compareRows);
+
+  const counts: { leased: number; warm: number; busy: number; shutdown: number } = {
+    busy: 0,
+    leased: 0,
+    shutdown: 0,
+    warm: 0,
+  };
+  for (const device of devices) counts[device.state] += 1;
+
+  const capacityRoot = isRecord(root.capacity) ? root.capacity : {};
+  const capacity: Capacity = {
+    android: parseCapacityUsage(capacityRoot.android),
+    global: parseCapacityUsage(capacityRoot.global),
+    ios: parseCapacityUsage(capacityRoot.ios),
+  };
+
+  return {
+    capacity,
+    counts,
+    devices,
+    health: parseHealth(root.health),
+    overLimit: capacity.global.overLimit || capacity.ios.overLimit || capacity.android.overLimit,
+    queueDepth:
+      typeof root.queueDepth === "number" && Number.isFinite(root.queueDepth) ? root.queueDepth : 0,
+  };
+}
+
+/** Parses `config.get`'s `idle.shutdownAfterMs`; `undefined` on any missing/invalid shape. */
+export function parseIdleShutdownAfterMs(raw: unknown): number | undefined {
+  if (!isRecord(raw) || !isRecord(raw.idle)) return undefined;
+  return typeof raw.idle.shutdownAfterMs === "number" ? raw.idle.shutdownAfterMs : undefined;
+}
+
+interface ParsedDevice {
+  readonly id: string;
+  readonly state: string;
+  readonly platform: Platform | undefined;
+  readonly model: string;
+  readonly osVersion: string;
+  readonly createdAt: number;
+  readonly lastLeaseEndedAt: number | undefined;
+  readonly flagged: boolean;
+}
+
+/** `undefined` for anything that is not a non-empty string; the caller supplies the placeholder. */
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value !== "" ? value : undefined;
+}
+
+function optionalNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function parsePlatform(value: unknown): Platform | undefined {
+  return value === "ios" || value === "android" ? value : undefined;
+}
+
+function parseDevice(raw: unknown): ParsedDevice | undefined {
+  if (!isRecord(raw)) return undefined;
+  const id = nonEmptyString(raw.id);
+  if (id === undefined) return undefined;
+  const spec = isRecord(raw.spec) ? raw.spec : {};
+  return {
+    createdAt: optionalNumber(raw.createdAt) ?? 0,
+    flagged:
+      raw.foreignStateDetectedAt !== undefined || raw.foreignProvenanceDetectedAt !== undefined,
+    id,
+    lastLeaseEndedAt: optionalNumber(raw.lastLeaseEndedAt),
+    model: nonEmptyString(spec.model) ?? "?",
+    osVersion: nonEmptyString(spec.osVersion) ?? "?",
+    platform: parsePlatform(spec.platform),
+    state: nonEmptyString(raw.state) ?? "shutdown",
+  };
+}
+
+interface ParsedLease {
+  readonly deviceId: string;
+  readonly requesterId: string;
+  readonly grantedAt: number;
+}
+
+function parseLease(raw: unknown): ParsedLease | undefined {
+  if (!isRecord(raw) || typeof raw.deviceId !== "string" || raw.deviceId === "") return undefined;
+  return {
+    deviceId: raw.deviceId,
+    grantedAt: typeof raw.grantedAt === "number" ? raw.grantedAt : 0,
+    requesterId: typeof raw.requesterId === "string" ? raw.requesterId : "",
+  };
+}
+
+/**
+ * Classification priority: an explicit `leased` state, OR any lease record
+ * pointing at this device (the "ready but leased" edge case — a device the
+ * daemon reports as `ready` while a lease still references it) both count
+ * as `leased`. Then `provisioning`/`reclaiming` are `busy` (there is no
+ * separate "booting" state). Then `ready` with no lease is `warm`. Anything
+ * else — `shutdown`, or an unrecognized/renamed state — renders as the
+ * quiet, dim `shutdown` row rather than crashing or guessing.
+ */
+function classifyState(device: ParsedDevice, lease: ParsedLease | undefined): RowState {
+  if (device.state === "leased" || lease !== undefined) return "leased";
+  if (device.state === "provisioning" || device.state === "reclaiming") return "busy";
+  return device.state === "ready" ? "warm" : "shutdown";
+}
+
+/** The timestamp each row's "for" column counts from, which differs per classification. */
+function rowSince(state: RowState, device: ParsedDevice, lease: ParsedLease | undefined): number {
+  if (state === "leased") return lease?.grantedAt ?? device.createdAt;
+  if (state === "busy") return device.createdAt;
+  return device.lastLeaseEndedAt ?? device.createdAt;
+}
+
+function classifyDevice(
+  device: ParsedDevice,
+  lease: ParsedLease | undefined,
+  now: number,
+  shutdownAfterMs: number | undefined,
+): DeviceRow {
+  const state = classifyState(device, lease);
+  const forMs = nonNegative(now - rowSince(state, device, lease));
+  const warmCountdown = state === "warm" && shutdownAfterMs !== undefined;
+  return {
+    agent: state === "leased" ? lease?.requesterId : undefined,
+    flagged: device.flagged,
+    forMs,
+    id: device.id,
+    model: device.model,
+    osVersion: device.osVersion,
+    platform: device.platform,
+    shutdownInMs: warmCountdown ? Math.max(0, shutdownAfterMs - forMs) : undefined,
+    state,
+  };
+}
+
+/**
+ * Groups by state, then orders by model *case-insensitively*. A raw `<`
+ * comparison sorts by code point, which puts every capitalized model ahead of
+ * every lowercase-initial one — `Pixel 8` before `iPhone 17 Pro`, since `P`
+ * (80) precedes `i` (105). That reads as broken to anyone scanning the list,
+ * so case is folded first and the raw model breaks exact ties to keep the
+ * order total and stable.
+ */
+function compareRows(a: DeviceRow, b: DeviceRow): number {
+  const order = ROW_ORDER[a.state] - ROW_ORDER[b.state];
+  if (order !== 0) return order;
+  const folded = a.model.toLowerCase().localeCompare(b.model.toLowerCase());
+  if (folded !== 0) return folded;
+  if (a.model < b.model) return -1;
+  if (a.model > b.model) return 1;
+  return 0;
+}
+
+function parseCapacityUsage(raw: unknown): CapacityUsage {
+  const record = isRecord(raw) ? raw : {};
+  return {
+    limit: typeof record.limit === "number" ? record.limit : undefined,
+    maxRunning: numberOr(record.maxRunning, 0),
+    overLimit: record.overLimit === true,
+    reserved: numberOr(record.reserved, 0),
+    running: numberOr(record.running, 0),
+    used: typeof record.used === "number" ? record.used : undefined,
+    warm: numberOr(record.warm, 0),
+  };
+}
+
+function parseHealth(value: unknown): Health {
+  return value === "starting" || value === "running" || value === "failed" ? value : "starting";
+}
+
+function numberOr(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function nonNegative(value: number): number {
+  return value > 0 ? value : 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// ---------------------------------------------------------------------------
+// Meter
+// ---------------------------------------------------------------------------
+
+export type MeterSegmentKind = "leased" | "warm" | "busy" | "empty";
+
+export interface MeterSegment {
+  readonly kind: MeterSegmentKind;
+  readonly width: number;
+}
+
+export interface Meter {
+  readonly width: number;
+  readonly segments: readonly MeterSegment[];
+  /** `running / maxRunning`, clamped to `[0, 1]`; `maxRunning <= 0` reads as 0 (or 1 if `running > 0`). */
+  readonly fraction: number;
+  readonly overLimit: boolean;
+}
+
+const COLORED_KINDS = ["leased", "warm", "busy"] as const;
+
+/**
+ * Renders the block-meter as a list of colored segments that sum exactly to
+ * `width`. The filled portion (`fraction` of `width`) is split between
+ * leased/warm/busy proportionally to `counts`, using largest-remainder
+ * allocation so rounding never leaves the segments short or over `width`.
+ * `maxRunning === 0` never divides by zero; `running > maxRunning` (over
+ * capacity) is reported via `overLimit` regardless of what the daemon itself
+ * reported, in addition to trusting `capacity.overLimit`.
+ */
+/** `running / maxRunning`, clamped; `maxRunning <= 0` reads as full when anything runs, else empty. */
+function meterFraction(running: number, maxRunning: number): number {
+  if (maxRunning > 0) return Math.min(running / maxRunning, 1);
+  return running > 0 ? 1 : 0;
+}
+
+/**
+ * Largest-remainder allocation of `filledWidth` columns across the colored
+ * kinds, proportional to `counts`. Floors first, then hands the leftover
+ * columns to the largest fractional parts, so the widths always sum to
+ * exactly `filledWidth` instead of drifting with rounding.
+ */
+function allocateSegmentWidths(
+  counts: { readonly leased: number; readonly warm: number; readonly busy: number },
+  filledWidth: number,
+): Map<MeterSegmentKind, number> {
+  const widths = new Map<MeterSegmentKind, number>();
+  const total = counts.leased + counts.warm + counts.busy;
+  if (total <= 0 || filledWidth <= 0) return widths;
+
+  const exact = COLORED_KINDS.map((kind) => (counts[kind] / total) * filledWidth);
+  const floors = exact.map(Math.floor);
+  COLORED_KINDS.forEach((kind, index) => widths.set(kind, floors[index] ?? 0));
+
+  const byRemainder = COLORED_KINDS.map((kind, index) => ({
+    frac: (exact[index] ?? 0) - (floors[index] ?? 0),
+    kind,
+  })).sort((a, b) => b.frac - a.frac);
+  let remainder = filledWidth - floors.reduce((sum, value) => sum + value, 0);
+  for (const { kind } of byRemainder) {
+    if (remainder <= 0) break;
+    widths.set(kind, (widths.get(kind) ?? 0) + 1);
+    remainder -= 1;
+  }
+  return widths;
+}
+
+export function buildMeter(
+  counts: { readonly leased: number; readonly warm: number; readonly busy: number },
+  capacity: { readonly running: number; readonly maxRunning: number; readonly overLimit: boolean },
+  width = 20,
+): Meter {
+  const fraction = meterFraction(capacity.running, capacity.maxRunning);
+  const filledWidth = Math.min(width, Math.max(0, Math.round(fraction * width)));
+  const widths = allocateSegmentWidths(counts, filledWidth);
+
+  const segments: MeterSegment[] = [];
+  let filledSum = 0;
+  for (const kind of COLORED_KINDS) {
+    const segmentWidth = widths.get(kind) ?? 0;
+    if (segmentWidth > 0) {
+      segments.push({ kind, width: segmentWidth });
+      filledSum += segmentWidth;
+    }
+  }
+  const emptyWidth = width - filledSum;
+  if (emptyWidth > 0) segments.push({ kind: "empty", width: emptyWidth });
+
+  return {
+    fraction,
+    overLimit: capacity.overLimit || capacity.running > capacity.maxRunning,
+    segments,
+    width,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Duration formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Three formatting schemes, each used where its precision matters:
+ *
+ * - {@link formatDuration} — precise `M:SS` below an hour, `HhMMm` at/above
+ *   an hour. Used for the "for" column on rows the operator watches closely
+ *   (leased/warm/busy) and for the warm shutdown countdown, where seconds
+ *   are the point.
+ * - {@link formatCoarseDuration} — bare `Mm` below an hour, `HhMMm` at/above
+ *   an hour. Used where only rough idle time matters (the shutdown row's
+ *   "for").
+ * - {@link formatRelativeAge} — compact `Ns`/`Nm`/`Nh`/`Nd`. Used for "how
+ *   long ago" on the last-event line.
+ *
+ * All three clamp negative input to zero rather than throwing or printing a
+ * negative duration, since clock skew between `now` and a server timestamp
+ * is expected, not exceptional.
+ */
+export function formatDuration(ms: number): string {
+  const totalSeconds = Math.floor(nonNegative(ms) / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  if (hours > 0) return `${hours}h${pad(minutes)}m`;
+  return `${minutes}:${pad(seconds)}`;
+}
+
+export function formatCoarseDuration(ms: number): string {
+  const totalMinutes = Math.floor(nonNegative(ms) / 60_000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours > 0) return `${hours}h${pad(minutes)}m`;
+  return `${minutes}m`;
+}
+
+export function formatRelativeAge(ms: number): string {
+  const totalSeconds = Math.floor(nonNegative(ms) / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  if (totalMinutes < 60) return `${totalMinutes}m`;
+  const totalHours = Math.floor(totalMinutes / 60);
+  if (totalHours < 24) return `${totalHours}h`;
+  return `${Math.floor(totalHours / 24)}d`;
+}
+
+function pad(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+// ---------------------------------------------------------------------------
+// Event summaries
+// ---------------------------------------------------------------------------
+
+export interface EventSummary {
+  readonly event: string;
+  readonly summary: string;
+  readonly ageMs: number;
+}
+
+/**
+ * Summarizes one pushed event envelope (`{ seq, timestamp, event, payload,
+ * module }`) into the single dim line the dashboard footer shows. `label`
+ * resolves a device id to a display label (its model, typically) — callers
+ * pass a lookup built from the current view model so events about a device
+ * that has since been deleted still degrade to showing its raw id.
+ */
+export function summarizeEvent(
+  raw: unknown,
+  now: number,
+  label: (deviceId: string) => string | undefined,
+): EventSummary | undefined {
+  if (!isRecord(raw) || typeof raw.event !== "string") return undefined;
+  const event = raw.event;
+  const payload = isRecord(raw.payload) ? raw.payload : {};
+  const timestamp = typeof raw.timestamp === "number" ? raw.timestamp : now;
+  return {
+    ageMs: nonNegative(now - timestamp),
+    event,
+    summary: describeEvent(event, payload, label),
+  };
+}
+
+function deviceText(
+  payload: Record<string, unknown>,
+  label: (id: string) => string | undefined,
+): string {
+  const deviceId = typeof payload.deviceId === "string" ? payload.deviceId : undefined;
+  if (deviceId === undefined) return "";
+  return label(deviceId) ?? deviceId;
+}
+
+// fallow-ignore-next-line complexity -- one flat lookup table of known event names to a short human summary.
+function describeEvent(
+  event: string,
+  payload: Record<string, unknown>,
+  label: (id: string) => string | undefined,
+): string {
+  const device = deviceText(payload, label);
+  const requester = typeof payload.requester === "string" ? payload.requester : undefined;
+  switch (event) {
+    case "lease.granted":
+      return requester === undefined ? `→ ${device}` : `${requester} → ${device}`;
+    case "lease.released":
+      return `${device} (${String(payload.reason ?? "released")})`;
+    case "lease.expired":
+      return device;
+    case "lease.renewed":
+      return device === "" ? "lease renewed" : device;
+    case "lease.queued":
+      return `position ${String(payload.queuePosition ?? "?")}`;
+    case "lease.rejected":
+      return String(payload.reason ?? "rejected");
+    case "device.provisioned":
+    case "device.ready":
+    case "device.reclaimed":
+    case "device.shutdown":
+    case "device.deleted":
+      return device;
+    case "device.purge-failed":
+      return `${device} purge failed`;
+    case "device.foreign-state-detected":
+    case "device.foreign-provenance-detected":
+      return `${device} drift detected`;
+    case "cleanup.executed":
+      return `${String(payload.ruleName ?? "rule")} → ${String(payload.target ?? "")}`;
+    case "doctor.reconciled":
+      return "reconcile complete";
+    case "daemon.started":
+      return "daemon started";
+    case "daemon.stopping":
+      return "daemon stopping";
+    case "disk.pressure-detected":
+      return "disk pressure";
+    case "runtime.deleted":
+      return String(payload.runtimeId ?? "");
+    default:
+      return device;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Meter line layout
+// ---------------------------------------------------------------------------
+
+export interface MeterLayout {
+  readonly barWidth: number;
+  readonly showPlatforms: boolean;
+}
+
+/**
+ * Width budget for the meter line, so it can never wrap — a wrapped meter
+ * destroys the alignment of every row beneath it. `Running ` + bar + `  n/m`
+ * is the irreducible core; the per-platform `   ios n/m   android n/m` tail
+ * is dropped first, and only then does the bar itself shrink (to a floor of
+ * 6, below which a bar conveys nothing).
+ *
+ * The table's own breakpoints (72 for AGENT, 60 for OS) are deliberately not
+ * reused here: this line's natural width is ~67 columns with single-digit
+ * capacities and grows with the digits, so it has to give way on its own
+ * measured budget rather than a shared constant.
+ */
+export function meterLayout(width: number, capacity: Capacity, maxBarWidth: number): MeterLayout {
+  const platformTail =
+    `   ios ${capacity.ios.running}/${capacity.ios.maxRunning}` +
+    `   android ${capacity.android.running}/${capacity.android.maxRunning}`;
+  const core =
+    2 + "Running ".length + 2 + `${capacity.global.running}/${capacity.global.maxRunning}`.length;
+  const showPlatforms = width >= core + maxBarWidth + platformTail.length;
+  const available = width - core - (showPlatforms ? platformTail.length : 0);
+  return { barWidth: Math.max(6, Math.min(maxBarWidth, available)), showPlatforms };
+}
+
+/**
+ * Resolves the column budget the dashboard lays out against. A TTY's
+ * `stdout.columns` wins; otherwise `COLUMNS` (which Ink's own layout engine
+ * honours even on a pipe) keeps our budget and Ink's in agreement; otherwise
+ * the conventional 80.
+ */
+export function resolveWidth(columns: number | undefined, envColumns: string | undefined): number {
+  if (typeof columns === "number" && columns > 0) return columns;
+  const parsed = Number(envColumns);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 80;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,9 +7,10 @@
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
+    "jsx": "react-jsx",
     "outDir": "dist",
     "rootDir": "src",
     "types": ["node"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }


### PR DESCRIPTION
A read-only, full-screen [Ink](https://github.com/vadimdemedes/ink) dashboard over daemon state, added as `pitlane top`.

This started as a question about a macOS menu bar app. The terminal version landed first on purpose: it works over SSH and on Linux (where Android emulators run), needs no Swift toolchain, signing, notarization or distribution channel, and — most importantly — reuses the existing TypeScript daemon client instead of becoming a second implementation of protocol v2. It also settles the information hierarchy cheaply before any of it gets ported to a native popover.

Architecturally it's a **fourth thin frontend** alongside the CLI, MCP server and daemon client, which is what `docs/ARCHITECTURE.md` already anticipates ("the core never knows which frontend made a request"). No core changes.

## What it looks like

```
   PITLANE ● running                                               5 devices

  Running █████████████░░░░░░░  4/6   ios 3/4   android 1/2
    ● 2 leased   ● 1 warm   ● 1 busy

  ──────────────────────────────────────────────────────────────────────────
   STATE    DEVICE            OS   AGENT         FOR
   ● leased iPhone 17 Pro     26.5 agent-e2e-7  4:12
   ● leased Pixel 8           35   agent-perf-2 1:03
   ○ warm   iPhone 16         26.5 —            2:31   ↓ 7:28
   ◐ busy   iPhone 17 Pro Max 26.5 —            0:08
   · off    Pixel 7           34   —             41m !
  ──────────────────────────────────────────────────────────────────────────

  2 waiting

  lease.granted  agent-e2e-7 → iPhone 17 Pro                              12s
  q quit
```

Following k9s/lazygit/btop conventions: color carries semantics only (green leased, cyan warm, yellow busy, dim shutdown, red for drift/over-limit), dim chrome, thin rules instead of boxes, aligned columns with right-aligned numbers, and no full-screen border. The `↓ 7:28` on warm rows is the countdown to idle shutdown, derived from `lastLeaseEndedAt` + `config.idle.shutdownAfterMs`. The trailing red `!` marks a device carrying a foreign-state or foreign-provenance drift marker.

## Deliberate scope

- **Read-only.** No release/cleanup/doctor/nuke surface, so the dashboard has no destructive path at all and nothing to reconcile against `docs/agent-rules/safety.md`.
- **Never auto-starts the daemon.** A dashboard silently booting simulators is wrong. It connects over the existing-connection path and, if the daemon isn't running, fails exactly like every other command — one structured stderr line, non-zero exit, without loading Ink.
- **Event-driven, not poll-heavy.** Refreshes on pushed events (debounced ~150ms) with a 5s safety-net poll. Refetches `status.get` rather than applying event deltas to local state, so the view is always authoritative.
- **The queue line only renders when `queueDepth > 0`**, and the last-event line is capped at one line — both to keep the view uncrowded.

**Latency/throughput stat tiles were intentionally left out.** Warm-pool hit rate and request→grant p50/p95 are the numbers that would most justify this view, but they aren't derivable today: `lease.requested` carries `requestSpec`/`requester`/`waitPolicy` and no request id, while only `lease.queued` has `requestId`, so a request cannot be correlated to its grant from the event stream. Adding a stable `requestId` to `lease.requested`/`lease.granted`/`lease.rejected` (with `docs/EVENTS.md` updated in the same change) would unlock them — worth doing separately, not inside a UI change.

## Structure

All parsing and derivation lives in `src/cli/top/view-model.ts` — pure, no Ink/React imports, and treats every field of `status.get` as untrusted so a missing or renamed field degrades instead of crashing. `src/cli/top/ui.tsx` is the thin rendering layer on top. Ink is lazily imported via `loadTopUi`, mirroring the existing `loadMcpStdio` pattern, so every other command keeps its current startup cost.

## Testing

`pnpm run check` is green: typecheck, lint, format, **563 tests passing** (53 files). ~60 of those are new, covering classification (including the "ready but leased" edge case), sort order, meter segment math (over-limit, `maxRunning === 0`), the three duration formatters, defensive parsing of malformed payloads, the shutdown countdown, and the width-budget layout. Plus CLI-boundary tests proving `top` dispatches to an injected fake and that `--help` never connects.

Verified by rendering real frames at 110/64/80 columns and asserting **zero lines exceed the terminal width** at any of them.

## Notes for review

- Three bugs surfaced during implementation and are fixed here: `useSyncExternalStore` requires a stable snapshot reference (a fresh object per call is an infinite render loop); Ink 7's public `render()` wrapper silently drops the argument to `unmount(error)`, so the daemon-death path routes through `useApp().exit(error)` instead; and `isRawModeSupported` reads `undefined` rather than `false` off a non-TTY, which crashed on piped stdin.
- Two layout defects were caught by rendering rather than by tests, and fixed: the meter line had a fixed ~67-column minimum that wrapped on narrow terminals (it now drops the per-platform tail before shrinking the bar), and device sort was case-sensitive, putting `Pixel 8` ahead of `iPhone 17 Pro` because `P` (80) precedes `i` (105).
- `tsconfig.json` gains `"jsx": "react-jsx"` and `src/**/*.tsx`. Both `oxlint` and `oxfmt` handle `.tsx` cleanly (verified before committing to the JSX path).
- **Open question worth your call:** `ink` and `react` are added as regular `dependencies`, which takes this package from 2 runtime deps to a noticeably larger tree. They're lazily imported so there's no startup cost for other commands, but the install footprint is real. Happy to move them to `optionalDependencies` with a graceful "run `pnpm add ink react` to use `pitlane top`" message if you'd rather protect the lean dependency tree.
- **Not verified:** I could not view the TUI in a real interactive terminal in this environment. Layout, alignment and color were checked by capturing and de-escaping rendered frames, but true TTY behavior — alternate-screen entry/exit, live resize, `q`/Esc keypresses — is unconfirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQ6y4AG2wQWdy7kBZmy8Fw

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQ6y4AG2wQWdy7kBZmy8Fw)_