### PR TITLE
feat(lease): return from release before the device purge finishes

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -96,11 +96,11 @@ At startup, `StartupConverger` first releases every persisted `held` lease
 (reason `orphaned`) through the normal release path — a held lease's liveness
 is its daemon connection, so it cannot have a live holder across a restart,
 and this runs before timers are restored so an orphaned lease's timer is
-never re-armed. This release step is registry-only: the device commits
-straight to `reclaiming` and the lease record is gone, but the driver-side
-reclaim itself (an erase can run tens of seconds) is kicked off in the
-background instead of awaited inline (#43), one per device rather than
-queued, so N orphaned leases no longer cost N serial erases on this path. It
+never re-armed. Like every release (see "Release hands the purge off" below),
+this step is registry-only: the device commits straight to `reclaiming` and
+the lease record is gone, while the driver-side reclaim is kicked off in the
+background, one per device rather than queued, so N orphaned leases no longer
+cost N serial erases on this path. It
 then restores persisted TTL timers for the remaining (`detached`) leases,
 whose liveness is the TTL rather than a connection, and re-arms retry timers
 for devices still `quarantined` (see below) from their persisted next-retry
@@ -243,6 +243,49 @@ Conclusions baked into the drivers:
 - One lease per agent in v1; no atomic multi-device acquisition (documented
   deadlock risk if two devices are taken sequentially).
 
+### Release hands the purge off
+
+A release is two halves with very different costs. The first is a registry
+commit inside the serialized decision section: the lease record is gone,
+`lease.released` is emitted, and the device is `reclaiming`. The second is the
+driver-side purge — an iOS `simctl erase` runs tens of seconds, an Android
+snapshot restore comparably — and it carries no information the releasing
+caller can act on. So `LeaseReleaseCoordinator` commits the first half, hands
+the second to `WarmPoolCoordinator` without awaiting it, and returns. An agent
+releasing over MCP or the CLI gets its turn back immediately instead of
+blocking on a device it has already given up; startup's orphan sweep gets the
+same treatment (see "Running capacity"), which is where the pattern started.
+
+The device is not lost track of while that runs. It is `reclaiming`, so it
+still counts as running capacity and is invisible to every grant path
+(`AcquisitionPlanner` selects by exact state), and the reclaim holds a
+`reclaim` operation claim for its whole duration — which is how
+`StartupConverger#recoverInterruptedReclaims` and `pitlane doctor`'s
+stalled-transition finding both tell a live purge from an abandoned one. A
+waiter queued for exactly that device is granted the moment the purge settles:
+the coordinator re-notifies acquisition *after* releasing the claim, because
+the warm pool's own notification fires while the device is still claimed and
+therefore still unselectable.
+
+Three things still wait for the purge, deliberately:
+
+- **An operator reset.** `NukeService` only acts on `ready`/`shutdown`
+  records, so a device left mid-reclaim would be skipped by the very reset
+  meant to take it down. `beginMaintenance` drains in-flight background
+  reclaims, and the maintenance-authorized release awaits its own inline.
+- **A graceful `pitlane daemon stop`.** It drains the in-flight reclaims
+  (before disposing timers, so a purge that settles into quarantine still gets
+  its retry cancelled), leaving the pool in the same settled shape an inline
+  reclaim used to.
+- **The next start, if the daemon died instead.** Interrupted reclaims are
+  recovered from the registry as before.
+
+The trade the backgrounding makes is where a purge failure surfaces: the
+caller is gone, so it cannot be rejected to. It does not go missing — a driver
+purge failure is already `QuarantineCoordinator`'s job and stays visible as
+`device.purge-failed` plus a `quarantined` device — and anything unexpected
+beyond that is logged by the coordinator rather than left unhandled.
+
 ### Lease subsystem boundaries and wiring
 
 The lease subsystem is assembled from focused modules. `LeaseEngine` is the
@@ -256,7 +299,8 @@ capacity coordinator into these direct transactional call chains:
   work and registry transitions.
 - `LeaseLifecycle` owns grant, renewal, release commits, and expiry scheduling.
   A release passes its committed result directly to `WarmPoolCoordinator`,
-  which performs reclaim and warm-pool disposition.
+  which performs reclaim and warm-pool disposition — without the releasing
+  caller waiting on it (see "Release hands the purge off").
 - `CapacityCoordinator` owns provisioning and running reservations while pure
   capacity functions calculate limits. `DeviceOperationClaims` excludes
   overlapping boot, eviction, cleanup, and nuke operations per device.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -181,6 +181,23 @@ Explicitly release a lease (primarily for detached mode or operator
 intervention). `--all` force-releases every lease — confirmation required
 unless `--yes`.
 
+Release returns as soon as the lease is gone, not when the device is clean.
+Giving up the lease is a registry commit; wiping the device behind it is a
+driver operation that can run tens of seconds (an iOS `simctl erase`), and it
+proceeds in the background once the command has already exited. The same holds
+for a held lease released by its holder exiting, and for `release_simulator`
+over MCP — an agent gets its turn back immediately instead of waiting on a
+device it has already given up.
+
+What that means for the next command: the device is `reclaiming` for a moment
+after `release` returns, so it still counts as running capacity and is not
+grantable yet. A `lease` request that wants it simply queues and is granted the
+instant the purge finishes; nothing is lost, but `status` right after a release
+will show `reclaiming` rather than `ready`. `pitlane daemon stop` waits for
+in-flight purges before exiting, so a graceful shutdown still leaves the pool
+settled; a daemon killed mid-purge leaves its devices `reclaiming` for the next
+startup to recover.
+
 ## `pitlane mcp`
 
 Start Pitlane's local stdio MCP server. It accepts no flags. Standard output

--- a/e2e/lease-lifecycle.test.ts
+++ b/e2e/lease-lifecycle.test.ts
@@ -99,6 +99,11 @@ describe("lease lifecycle across both frontends", () => {
         ]),
       );
 
+      // A slow purge is the realistic case (an iOS erase runs tens of seconds), and
+      // the agent must not be made to sit through it: release_simulator returns on
+      // the registry commit and the wipe finishes behind it.
+      await env.driverScript.merge({ ios: { latencyMs: { reclaim: 5_000 } } });
+
       const releaseResult = await mcp.client.callTool({
         name: "release_simulator",
         arguments: { lease_id: leased.lease_id },
@@ -108,10 +113,16 @@ describe("lease lifecycle across both frontends", () => {
         released: true,
       });
 
-      await waitForDeviceState(env, leased.device_id, "ready");
-
+      // Already answered, while the erase it handed off is still running: the lease is
+      // gone from the CLI's view and the device is `reclaiming`, not yet `ready`.
       const cliLeasesAfter = await env.cli(["list", "--leases"]);
       expect(cliLeasesAfter.json).toEqual([]);
+      const midPurge = await env.cli(["list", "--devices"]);
+      expect(midPurge.json).toEqual([
+        expect.objectContaining({ driverDeviceId: leased.device_id, state: "reclaiming" }),
+      ]);
+
+      await waitForDeviceState(env, leased.device_id, "ready");
     } finally {
       await mcp.close();
     }

--- a/src/core/device-operation-claims.ts
+++ b/src/core/device-operation-claims.ts
@@ -1,10 +1,12 @@
 /**
  * Operations that must not overlap for a single device: booting, eviction,
  * cleanup, nuke, the lease-scoped crash `recovery` reboot, and a backgrounded
- * (orphaned-lease) `reclaim` -- the last marks the device as a live, in-process
- * operation so `StartupConverger#recoverInterruptedReclaims` (which only recovers
- * *unclaimed* `reclaiming` devices) never mistakes it for one left over from a
- * previous crash. See `LeaseReleaseCoordinator#reclaimInBackground`.
+ * `reclaim` -- the last marks the device as a live, in-process operation so
+ * `StartupConverger#recoverInterruptedReclaims` (which only recovers *unclaimed*
+ * `reclaiming` devices) never mistakes it for one left over from a previous crash,
+ * and so `pitlane doctor` never reads a long-but-healthy erase as a stalled
+ * transition. Every release takes one, since none of them wait for the purge.
+ * See `LeaseReleaseCoordinator#reclaimInBackground`.
  */
 export type DeviceOperation = "boot" | "eviction" | "cleanup" | "nuke" | "recovery" | "reclaim";
 

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -347,7 +347,7 @@ function registryDriftFindings(
  * live operation can never be read as a stall no matter how long it legitimately
  * runs. This is the same live-versus-orphaned test `StartupConverger
  * #recoverInterruptedReclaims` already makes, and it is load-bearing rather than
- * belt-and-braces -- a backgrounded orphaned-lease reclaim (#43) holds its device in
+ * belt-and-braces -- every release now backgrounds its reclaim, holding the device in
  * `reclaiming` for a full erase, measured at ~34s against a threshold that floors at
  * 60s for both drivers, and several such erases run at once and contend for the same
  * disk. Tuning the threshold against that would be guessing at disk speed; the claim

--- a/src/core/lease-engine.test.ts
+++ b/src/core/lease-engine.test.ts
@@ -115,7 +115,7 @@ async function flush(): Promise<void> {
 }
 
 describe("LeaseEngine", () => {
-  it("keeps a released device reclaiming until purge completes, then re-leases it without another boot", async () => {
+  it("hands the caller back before the purge, keeps the device reclaiming, then re-leases it without another boot", async () => {
     const clock = new FakeClock(1_000);
     const driver = new FakeDriver({
       availableOsVersions: ["26.5"],
@@ -131,10 +131,13 @@ describe("LeaseEngine", () => {
     const second = harness.engine.request(request, { mode: "held", requesterId: "second" });
     await flush();
 
+    // The releasing caller (an agent's MCP/CLI release) is already free to move on
+    // while the erase still has its full 20ms of driver latency ahead of it.
+    await expect(release).resolves.toBeUndefined();
     expect(harness.registry.snapshot.devices).toMatchObject([{ state: "reclaiming" }]);
     expect(harness.engine.queueDepth).toBe(1);
     clock.advance(20);
-    await release;
+    await harness.engine.settle();
     await expect(second).resolves.toMatchObject({ device: { id: first.device.id } });
     expect(driver.calls.filter((call) => call.operation === "provision")).toHaveLength(1);
     expect(driver.calls.filter((call) => call.operation === "makeReady")).toHaveLength(2);
@@ -152,6 +155,9 @@ describe("LeaseEngine", () => {
     const excess = await seedReady(harness);
 
     await harness.engine.release(first.lease.id, "explicit");
+    // Release commits registry-only and hands the purge off; settle() is the test's
+    // stand-in for the graceful-shutdown drain that waits on it in production.
+    await harness.engine.settle();
 
     expect(harness.driver.calls.map((call) => call.operation)).toContain("reclaim");
     expect(
@@ -282,6 +288,7 @@ describe("LeaseEngine", () => {
     const first = await harness.engine.request(request, { mode: "held", requesterId: "first" });
 
     await harness.engine.release(first.lease.id, "explicit");
+    await harness.engine.settle();
 
     expect(harness.registry.snapshot.devices[0]?.state).toBe("quarantined");
     expect(
@@ -322,6 +329,7 @@ describe("LeaseEngine", () => {
     const first = await harness.engine.request(request, { mode: "held", requesterId: "first" });
 
     await harness.engine.release(first.lease.id, "explicit");
+    await harness.engine.settle();
 
     expect(harness.registry.snapshot.devices[0]?.state).toBe("shutdown");
   });
@@ -600,6 +608,7 @@ describe("LeaseEngine", () => {
     });
     expect(provisioned).toEqual(["provisioning", "booting"]);
     await harness.engine.release(provisionedGrant.lease.id, "explicit");
+    await harness.engine.settle();
 
     const shutdown = harness.registry.snapshot.devices[0];
     if (shutdown === undefined) throw new Error("Expected provisioned device");
@@ -818,6 +827,7 @@ describe("LeaseEngine", () => {
       name: "RequesterAlreadyLeasedError",
     });
     await harness.engine.release(first.lease.id, "explicit");
+    await harness.engine.settle();
     expect(harness.clock.pendingTimerCount).toBe(0);
     await expect(
       harness.engine.request(request, { mode: "held", requesterId: "agent-1" }),

--- a/src/core/lease-engine.ts
+++ b/src/core/lease-engine.ts
@@ -1,5 +1,5 @@
 import type { EventBus } from "../bus/index.js";
-import type { Clock, IdGenerator, SystemStats } from "../ports/index.js";
+import type { Clock, IdGenerator, Logger, SystemStats } from "../ports/index.js";
 import type { RunningCapacity } from "./capacity.js";
 import { AcquisitionPlanner } from "./acquisition-planner.js";
 import { CapacityCoordinator } from "./capacity-coordinator.js";
@@ -37,6 +37,12 @@ export interface LeaseEngineOptions {
   readonly drivers: readonly Driver[];
   readonly eventBus: EventBus;
   readonly idGenerator: IdGenerator;
+  /**
+   * Where work the engine finishes off its callers' paths reports its failures.
+   * A backgrounded reclaim has no caller left to reject to, so without this its
+   * only trace is the device's own registry state.
+   */
+  readonly logger?: Logger;
   readonly registry: Registry;
   readonly systemStats: SystemStats;
 }
@@ -164,6 +170,8 @@ export class LeaseEngine {
       claims: this.#claims,
       decisions: this.#decisions,
       lifecycle: this.#leases,
+      ...(options.logger === undefined ? {} : { logger: options.logger }),
+      notifyAvailability: () => this.#acquisition.kick(),
       registry: options.registry,
       warmPool: this.#warmPool,
     });
@@ -240,6 +248,16 @@ export class LeaseEngine {
   /** Operator-only reset; targets device records from this registry exclusively. */
   async nuke(deleteDevices: boolean): Promise<{ readonly releasedLeaseIds: readonly string[] }> {
     return this.#nuke.nuke(deleteDevices);
+  }
+
+  /**
+   * Awaits the reclaims release left running in the background, so a graceful
+   * shutdown hands back the same settled pool an inline reclaim used to. Runs
+   * before `dispose`: a reclaim that settles into a purge failure arms a
+   * quarantine retry timer, and cancelling those first would strand it armed.
+   */
+  async settle(): Promise<void> {
+    await this.#releaseCoordinator.settleBackgroundReclaims();
   }
 
   /** Cancels the quarantine coordinator's armed retry timers on daemon shutdown. */

--- a/src/core/lease-release-coordinator.test.ts
+++ b/src/core/lease-release-coordinator.test.ts
@@ -44,14 +44,32 @@ async function createHarness() {
     },
   };
   const claims = new DeviceOperationClaims();
+  const availability: { count: number; onNotify: (() => void) | undefined } = {
+    count: 0,
+    onNotify: undefined,
+  };
   const coordinator = new LeaseReleaseCoordinator({
     claims,
     decisions: new SerializedDecision(),
     lifecycle,
+    notifyAvailability: () => {
+      availability.count += 1;
+      availability.onNotify?.();
+    },
     registry,
     warmPool,
   });
-  return { claims, clock, coordinator, eventBus, lifecycle, reclaims, registry, warmPool };
+  return {
+    availability,
+    claims,
+    clock,
+    coordinator,
+    eventBus,
+    lifecycle,
+    reclaims,
+    registry,
+    warmPool,
+  };
 }
 
 async function grant(
@@ -92,6 +110,7 @@ describe("LeaseReleaseCoordinator", () => {
 
     if (reason === "expired") await harness.coordinator.expire(granted.lease.id);
     else await harness.coordinator.release(granted.lease.id, reason);
+    await harness.coordinator.settleBackgroundReclaims();
 
     expect(leasesAtFact).toBe(0);
     expect(harness.reclaims).toMatchObject([{ lease: { id: granted.lease.id } }]);
@@ -111,6 +130,7 @@ describe("LeaseReleaseCoordinator", () => {
       first.lease.id,
       second.lease.id,
     ]);
+    await harness.coordinator.settleBackgroundReclaims();
     expect(harness.reclaims.map((released) => released.lease.id)).toEqual(
       expect.arrayContaining([first.lease.id, second.lease.id]),
     );
@@ -163,21 +183,30 @@ describe("LeaseReleaseCoordinator", () => {
     expect(harness.reclaims).toEqual([]);
   });
 
-  it("propagates warm-pool failure only after beginRelease has committed", async () => {
+  // The reclaim runs after the release has committed and after its caller is gone, so
+  // its failure has nowhere to propagate to -- it is logged (see the background-failure
+  // test below) rather than surfaced. What must still hold is that the registry-only
+  // half committed first: the lease is gone and the device is `reclaiming`, which is
+  // the state `QuarantineCoordinator` and startup recovery both expect to find.
+  it("commits beginRelease before a warm-pool failure, and keeps the device reclaiming", async () => {
     const harness = await createHarness();
     const granted = await grant(harness);
+    let leasesAtReclaim = -1;
     harness.warmPool.reclaim = async () => {
-      expect(harness.registry.snapshot.leases).toEqual([]);
+      leasesAtReclaim = harness.registry.snapshot.leases.length;
       throw new Error("reclaim failed");
     };
 
-    await expect(harness.coordinator.release(granted.lease.id, "explicit")).rejects.toThrow(
-      "reclaim failed",
-    );
+    await expect(
+      harness.coordinator.release(granted.lease.id, "explicit"),
+    ).resolves.toBeUndefined();
+    await harness.coordinator.settleBackgroundReclaims();
+
+    expect(leasesAtReclaim).toBe(0);
     expect(harness.registry.snapshot.devices).toMatchObject([{ state: "reclaiming" }]);
   });
 
-  it("drains an active reclaim and holds new releases until maintenance reopens", async () => {
+  it("drains a backgrounded reclaim and holds new releases until maintenance reopens", async () => {
     const harness = await createHarness();
     const first = await grant(harness);
     const second = await grant(harness);
@@ -195,22 +224,67 @@ describe("LeaseReleaseCoordinator", () => {
       await blocked;
     };
 
-    const activeRelease = harness.coordinator.release(first.lease.id, "explicit");
+    // The release itself is already done -- its reclaim is still stuck on `blocked`.
+    await harness.coordinator.release(first.lease.id, "explicit");
     await started;
-    const maintenance = harness.coordinator.beginMaintenance();
+
+    let maintenanceOpen = false;
+    const maintenance = harness.coordinator.beginMaintenance().then(() => {
+      maintenanceOpen = true;
+    });
     const queuedRelease = harness.coordinator.release(second.lease.id, "explicit");
 
-    await Promise.resolve();
+    await flush();
+    // Maintenance stays shut on the backgrounded reclaim, not just on the release that
+    // started it: an operator reset only ever acts on `ready`/`shutdown` records
+    // (NukeService#canOperate), so a device left mid-reclaim would be skipped by the
+    // very reset that was supposed to take it down.
+    expect(maintenanceOpen).toBe(false);
     expect(harness.registry.snapshot.leases).toMatchObject([{ id: second.lease.id }]);
 
     unblockReclaim();
-    await activeRelease;
     await maintenance;
+    expect(maintenanceOpen).toBe(true);
     expect(harness.registry.snapshot.leases).toMatchObject([{ id: second.lease.id }]);
 
     await harness.coordinator.endMaintenance();
     await queuedRelease;
     expect(harness.registry.snapshot.leases).toEqual([]);
+  });
+
+  it("awaits the reclaim inline for a maintenance-authorized release", async () => {
+    const harness = await createHarness();
+    const granted = await grant(harness);
+    let unblockReclaim!: () => void;
+    let reclaimStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      reclaimStarted = resolve;
+    });
+    const blocked = new Promise<void>((resolve) => {
+      unblockReclaim = resolve;
+    });
+    harness.warmPool.reclaim = async (released) => {
+      harness.reclaims.push(released);
+      reclaimStarted();
+      await blocked;
+    };
+
+    await harness.coordinator.beginMaintenance();
+    let releaseSettled = false;
+    const releasing = harness.coordinator.releaseAllDuringMaintenance("killed").then((ids) => {
+      releaseSettled = true;
+      return ids;
+    });
+
+    await started;
+    await flush();
+    // Unlike every client-reachable release, this one does not hand the reclaim off:
+    // the reset walks the device list the moment it resolves.
+    expect(releaseSettled).toBe(false);
+
+    unblockReclaim();
+    await expect(releasing).resolves.toEqual([granted.lease.id]);
+    await harness.coordinator.endMaintenance();
   });
 
   it("retries an expiry after maintenance reopens", async () => {
@@ -237,10 +311,49 @@ describe("LeaseReleaseCoordinator", () => {
     await expect(Promise.all([first, second])).rejects.toBeInstanceOf(UnknownLeaseError);
   });
 
-  describe("orphaned release (#43: backgrounded reclaim)", () => {
-    it("commits the registry-only release and resolves without waiting for the reclaim", async () => {
+  describe("backgrounded reclaim", () => {
+    it.each(["explicit", "closed", "device-lost", "orphaned"] as const)(
+      "commits the registry-only %s release and resolves without waiting for the reclaim",
+      async (reason) => {
+        const harness = await createHarness();
+        const granted = await grant(harness);
+        let unblockReclaim!: () => void;
+        const blocked = new Promise<void>((resolve) => {
+          unblockReclaim = resolve;
+        });
+        harness.warmPool.reclaim = async (released) => {
+          harness.reclaims.push(released);
+          await blocked;
+        };
+
+        // The registry-only half (device -> reclaiming, lease gone, `lease.released`
+        // emitted) is the whole of what the releasing caller needs -- an agent's MCP
+        // or CLI release, a closing connection, or startup's orphan sweep. The
+        // driver-side reclaim is still stuck on `blocked` and none of them may wait
+        // for it, or nothing was gained over the old inline-await shape.
+        if (reason === "device-lost") await harness.coordinator.releaseDeviceLost(granted.lease.id);
+        else await harness.coordinator.release(granted.lease.id, reason);
+
+        expect(harness.registry.snapshot.leases).toEqual([]);
+        expect(harness.registry.snapshot.devices).toMatchObject([{ state: "reclaiming" }]);
+        expect(
+          harness.eventBus
+            .replay()
+            .some(
+              (envelope) =>
+                envelope.event === "lease.released" && envelope.payload.reason === reason,
+            ),
+        ).toBe(true);
+
+        unblockReclaim();
+        await flush();
+        expect(harness.reclaims).toMatchObject([{ lease: { id: granted.lease.id } }]);
+      },
+    );
+
+    it("resolves an expiry without waiting for the reclaim either", async () => {
       const harness = await createHarness();
-      const granted = await grant(harness);
+      const granted = await grant(harness, "detached");
       let unblockReclaim!: () => void;
       const blocked = new Promise<void>((resolve) => {
         unblockReclaim = resolve;
@@ -250,26 +363,64 @@ describe("LeaseReleaseCoordinator", () => {
         await blocked;
       };
 
-      // The registry-only half (device -> reclaiming, lease gone, `lease.released`
-      // emitted) is exactly what StartupConverger's orphaned-lease release needs to
-      // be fast; the driver-side reclaim is still stuck on `blocked` and this must
-      // not wait for it, or nothing was gained over the old inline-await shape.
-      await harness.coordinator.release(granted.lease.id, "orphaned");
+      await harness.coordinator.expire(granted.lease.id);
 
       expect(harness.registry.snapshot.leases).toEqual([]);
       expect(harness.registry.snapshot.devices).toMatchObject([{ state: "reclaiming" }]);
-      expect(
-        harness.eventBus
-          .replay()
-          .some(
-            (envelope) =>
-              envelope.event === "lease.released" && envelope.payload.reason === "orphaned",
-          ),
-      ).toBe(true);
 
       unblockReclaim();
       await flush();
       expect(harness.reclaims).toMatchObject([{ lease: { id: granted.lease.id } }]);
+    });
+
+    it("settleBackgroundReclaims waits for every reclaim still in flight", async () => {
+      const harness = await createHarness();
+      const first = await grant(harness);
+      const second = await grant(harness);
+      let unblockReclaim!: () => void;
+      const blocked = new Promise<void>((resolve) => {
+        unblockReclaim = resolve;
+      });
+      harness.warmPool.reclaim = async (released) => {
+        await blocked;
+        harness.reclaims.push(released);
+      };
+
+      await harness.coordinator.release(first.lease.id, "explicit");
+      await harness.coordinator.release(second.lease.id, "explicit");
+
+      let settled = false;
+      const settling = harness.coordinator.settleBackgroundReclaims().then(() => {
+        settled = true;
+      });
+      await flush();
+      expect(settled).toBe(false);
+
+      unblockReclaim();
+      await settling;
+      // This is what keeps a graceful `daemon stop` finishing on a settled pool
+      // rather than leaving devices `reclaiming` for the next startup to recover.
+      expect(harness.reclaims.map((released) => released.lease.id)).toEqual(
+        expect.arrayContaining([first.lease.id, second.lease.id]),
+      );
+    });
+
+    it("notifies availability only once the reclaim's own claim is gone", async () => {
+      const harness = await createHarness();
+      const granted = await grant(harness);
+      const claimedAtNotice: boolean[] = [];
+      harness.availability.onNotify = () => {
+        claimedAtNotice.push(harness.claims.isClaimed(granted.device.id));
+      };
+
+      await harness.coordinator.release(granted.lease.id, "explicit");
+      await harness.coordinator.settleBackgroundReclaims();
+
+      // WarmPoolCoordinator fires its own availability kick while this claim is still
+      // held, and AcquisitionPlanner skips claimed devices -- so without a notice on
+      // this side of the claim release, a waiter queued for exactly this device sleeps
+      // through the only signal it was going to get.
+      expect(claimedAtNotice).toContain(false);
     });
 
     it("claims the device for the background reclaim's duration, then releases the claim", async () => {
@@ -283,11 +434,12 @@ describe("LeaseReleaseCoordinator", () => {
         await blocked;
       };
 
-      await harness.coordinator.release(granted.lease.id, "orphaned");
+      await harness.coordinator.release(granted.lease.id, "explicit");
 
       // Claimed while the reclaim is in flight -- this is what keeps
       // StartupConverger#recoverInterruptedReclaims from treating a reclaim this
-      // process just started as one orphaned by a *previous* crash.
+      // process just started as one orphaned by a *previous* crash, and what keeps
+      // `pitlane doctor` from reading a long-but-healthy erase as a stalled transition.
       expect(harness.claims.isClaimed(granted.device.id)).toBe(true);
       expect(harness.claims.operationFor(granted.device.id)).toBe("reclaim");
 
@@ -306,6 +458,7 @@ describe("LeaseReleaseCoordinator", () => {
         decisions: new SerializedDecision(),
         lifecycle: harness.lifecycle,
         logger,
+        notifyAvailability: () => undefined,
         registry: harness.registry,
         warmPool: { reclaim: async () => Promise.reject(new Error("reclaim failed")) },
       });
@@ -313,7 +466,7 @@ describe("LeaseReleaseCoordinator", () => {
       // Vitest fails a test on an unhandled rejection, so simply not throwing here
       // already proves the background failure was caught, not just re-thrown late.
       await expect(
-        failingCoordinator.release(granted.lease.id, "orphaned"),
+        failingCoordinator.release(granted.lease.id, "explicit"),
       ).resolves.toBeUndefined();
       await flush();
 

--- a/src/core/lease-release-coordinator.ts
+++ b/src/core/lease-release-coordinator.ts
@@ -36,18 +36,36 @@ export interface LeaseReleaseRegistry {
 }
 
 export interface LeaseReleaseCoordinatorOptions {
-  /** Claims the reclaiming device for the duration of a backgrounded (orphaned) reclaim. */
+  /** Claims the reclaiming device for the duration of a backgrounded reclaim. */
   readonly claims: Pick<DeviceOperationClaims, "tryClaim">;
   readonly decisions: Pick<SerializedDecision, "run">;
   readonly lifecycle: LeaseReleaseLifecycle;
   readonly logger?: Logger;
+  /**
+   * Re-kicks acquisition once a backgrounded reclaim has fully settled *and* given
+   * up its claim. Load-bearing rather than belt-and-braces: see `#reclaimInBackground`.
+   */
+  readonly notifyAvailability: () => void;
   readonly registry: LeaseReleaseRegistry;
   readonly warmPool: Pick<WarmPoolCoordinator, "reclaim">;
 }
 
 /**
+ * How a release sequences its driver-side reclaim against its own caller.
+ *
+ * `background` is the default for every release a client or a timer can reach:
+ * the registry-only half (lease gone, device `reclaiming`) is what the caller
+ * actually needs, and the purge behind it is the slow part. `await` exists for
+ * the one caller that needs the device settled before it continues -- the
+ * maintenance-authorized release an operator reset runs (see
+ * `releaseAllDuringMaintenance`).
+ */
+type ReclaimMode = "await" | "background";
+
+/**
  * Coordinates lease-side commands. Lease commits happen in the serialized
- * decision section; reclaiming is intentionally outside it.
+ * decision section; reclaiming is intentionally outside it, and -- except under
+ * maintenance -- outside the caller's await as well (see `ReclaimMode`).
  *
  * releaseAll preserves the engine's snapshot-and-parallel behavior. Concurrent
  * calls are not idempotent: overlapping snapshots can yield UnknownLeaseError.
@@ -57,10 +75,13 @@ export class LeaseReleaseCoordinator
 {
   readonly #activeWorkflows = new Set<Promise<void>>();
   /**
-   * Reclaims started by `#release`'s `orphaned` branch, tracked only so tests can
-   * observe them settling; nothing in this class awaits the set itself. A daemon
-   * that exits while one is in flight relies on `StartupConverger#recoverInterruptedReclaims`
-   * to finish it on the next start (see the `orphaned` branch of `#release`).
+   * Every reclaim `#release` handed off instead of awaiting. Ordinary release
+   * callers never wait on this set -- that is the point of it -- but two callers
+   * that cannot proceed against a half-reclaimed device do: `beginMaintenance`
+   * (an operator reset must see settled devices) and `settleBackgroundReclaims`
+   * (graceful daemon shutdown). A daemon that dies without that drain leaves its
+   * in-flight reclaims for `StartupConverger#recoverInterruptedReclaims` to
+   * finish on the next start.
    */
   readonly #backgroundReclaims = new Set<Promise<void>>();
   readonly #logger: Logger;
@@ -72,11 +93,11 @@ export class LeaseReleaseCoordinator
   }
 
   async release(leaseId: string, reason: LeaseReleaseReason): Promise<void> {
-    await this.#runNormal(() => this.#release(leaseId, reason));
+    await this.#runNormal(() => this.#release(leaseId, reason, { reclaim: "background" }));
   }
 
   async releaseAll(reason: "explicit" | "killed"): Promise<readonly string[]> {
-    return this.#runNormal(() => this.#releaseAll(reason));
+    return this.#runNormal(() => this.#releaseAll(reason, "background"));
   }
 
   /**
@@ -86,11 +107,29 @@ export class LeaseReleaseCoordinator
    * warm-pool reclaim as every other one.
    */
   async releaseDeviceLost(leaseId: string): Promise<void> {
-    await this.#runNormal(() => this.#release(leaseId, "device-lost"));
+    await this.#runNormal(() => this.#release(leaseId, "device-lost", { reclaim: "background" }));
   }
 
   async expire(leaseId: string, expectedDeadline?: number): Promise<void> {
-    await this.#runNormal(() => this.#release(leaseId, "expired", expectedDeadline));
+    await this.#runNormal(() =>
+      this.#release(leaseId, "expired", {
+        ...(expectedDeadline === undefined ? {} : { expectedDeadline }),
+        reclaim: "background",
+      }),
+    );
+  }
+
+  /**
+   * Awaits every reclaim currently running in the background. Nothing on a
+   * client's path calls this -- a graceful daemon shutdown does, so a `pitlane
+   * daemon stop` still leaves the pool in the same settled shape an inline
+   * reclaim used to. An ungraceful death instead leaves those devices
+   * `reclaiming` for `StartupConverger#recoverInterruptedReclaims`.
+   */
+  async settleBackgroundReclaims(): Promise<void> {
+    while (this.#backgroundReclaims.size > 0) {
+      await Promise.allSettled(this.#backgroundReclaims);
+    }
   }
 
   async renew(leaseId: string, ttlMs?: number): Promise<LeaseRecord> {
@@ -110,8 +149,12 @@ export class LeaseReleaseCoordinator
     await this.options.decisions.run(() => {
       this.#maintenanceDepth += 1;
     });
-    while (this.#activeWorkflows.size > 0) {
-      await Promise.allSettled(this.#activeWorkflows);
+    // Backgrounded reclaims are drained alongside the workflows that started them:
+    // a device still `reclaiming` is neither `ready` nor `shutdown`, so an operator
+    // reset would silently skip it (`NukeService#canOperate`) and leave a device
+    // running that the reset was supposed to take down.
+    while (this.#activeWorkflows.size > 0 || this.#backgroundReclaims.size > 0) {
+      await Promise.allSettled([...this.#activeWorkflows, ...this.#backgroundReclaims]);
     }
   }
 
@@ -122,7 +165,10 @@ export class LeaseReleaseCoordinator
         throw new Error("Maintenance-authorized release requires active maintenance");
       }
     });
-    return this.#releaseAll(reason);
+    // Awaited rather than backgrounded: the reset walks the device list straight
+    // afterwards and only acts on `ready`/`shutdown` records, so a reclaim still in
+    // flight would take its device out of that walk entirely.
+    return this.#releaseAll(reason, "await");
   }
 
   // fallow-ignore-next-line unused-class-member -- called through LeaseMaintenance by NukeService.
@@ -137,8 +183,9 @@ export class LeaseReleaseCoordinator
   async #release(
     leaseId: string,
     reason: LeaseReleaseReason | "expired",
-    expectedDeadline?: number,
+    options: { readonly expectedDeadline?: number; readonly reclaim: ReclaimMode },
   ): Promise<void> {
+    const { expectedDeadline } = options;
     const released = await this.options.decisions.run(() => {
       if (expectedDeadline !== undefined) {
         const current = this.options.registry.snapshot.leases.find((lease) => lease.id === leaseId);
@@ -147,17 +194,23 @@ export class LeaseReleaseCoordinator
       return this.options.lifecycle.beginRelease(leaseId, reason);
     });
     if (released === undefined) return;
-    if (reason === "orphaned") {
-      // Startup convergence (StartupConverger#releaseOrphanedHeldLeases) only awaits
-      // the registry-only release committed above -- the device is already
-      // `reclaiming` and therefore already ungrantable (AcquisitionPlanner only ever
-      // selects `ready`). The slow part, the driver-side reclaim (an erase can run
-      // tens of seconds), proceeds in the background instead of blocking convergence,
-      // so N orphaned leases no longer cost N serial erases on the startup critical
-      // path (#43). Kicked off here rather than queued, so every orphaned device's
-      // reclaim starts immediately (not one-after-another): queuing would let a
-      // healthy reclaim sit idle in `reclaiming` waiting its turn, which is exactly
-      // the state age a stalled-transition detector would misread as a stall.
+    if (options.reclaim === "background") {
+      // The registry-only half committed above is the whole of what a releasing
+      // caller needs: the lease record is gone, `lease.released` has been emitted,
+      // and the device is `reclaiming` and therefore already ungrantable
+      // (AcquisitionPlanner only ever selects `ready`). The slow part -- the
+      // driver-side purge, where an iOS erase runs tens of seconds -- carries no
+      // information the caller can act on, so it proceeds in the background and the
+      // caller gets its turn back immediately. That matters most for an agent
+      // releasing through MCP or the CLI, which would otherwise sit on a tool call
+      // waiting for a device it has already given up, and for startup convergence
+      // (StartupConverger#releaseOrphanedHeldLeases), where N orphaned leases used
+      // to cost N serial erases on the critical path (#43).
+      //
+      // Kicked off here rather than queued, so every device's reclaim starts
+      // immediately (not one-after-another): queuing would let a healthy reclaim sit
+      // idle in `reclaiming` waiting its turn, which is exactly the state age a
+      // stalled-transition detector would misread as a stall.
       this.#reclaimInBackground(released);
       return;
     }
@@ -165,14 +218,21 @@ export class LeaseReleaseCoordinator
   }
 
   /**
-   * Claims the device before starting its reclaim so `StartupConverger
-   * #recoverInterruptedReclaims`, which runs immediately afterward in the same
-   * startup pass, does not mistake a reclaim this process just started for one
-   * orphaned by a *previous* crash (that check excludes claimed devices
-   * precisely so a live, in-process operation is never treated as interrupted).
+   * Claims the device for the reclaim's duration. Two readers depend on that claim
+   * to tell a live in-process reclaim apart from an abandoned one: `StartupConverger
+   * #recoverInterruptedReclaims`, which must not mistake a reclaim this process just
+   * started for one orphaned by a *previous* crash, and `pitlane doctor`'s
+   * stalled-transition finding, which must not read a legitimately long erase as a
+   * driver call that never returned. Both exclude claimed devices for exactly this
+   * reason; a reclaim orphaned by a crash carries no claim in the new process, so
+   * neither check loses the case it exists for.
+   *
    * The claim is released, and the failure logged rather than thrown, once the
-   * reclaim settles -- nothing is awaiting this promise, so a rejection here
-   * would otherwise be unhandled.
+   * reclaim settles -- no caller is awaiting this promise, so a rejection here would
+   * otherwise be unhandled. A purge that fails at the driver is not that case: it is
+   * handled inside `WarmPoolCoordinator#reclaim`, which quarantines the device
+   * instead of rejecting, and stays visible in `pitlane status` and
+   * `device.purge-failed`.
    */
   #reclaimInBackground(released: ReleasedLease): void {
     const claim = this.options.claims.tryClaim(released.device.id, "reclaim");
@@ -185,14 +245,25 @@ export class LeaseReleaseCoordinator
           leaseId: released.lease.id,
         });
       })
-      .finally(() => claim?.release());
+      .finally(() => {
+        claim?.release();
+        // `WarmPoolCoordinator#reclaim` fires its own availability notification while
+        // this claim is still held, and a claimed device is invisible to
+        // `AcquisitionPlanner` -- so a waiter queued for exactly this device would
+        // sleep through it and sit there until some unrelated event kicked the queue.
+        // Notifying again here, after the claim is gone, is what closes that window.
+        this.options.notifyAvailability();
+      });
     this.#backgroundReclaims.add(reclaim);
     void reclaim.finally(() => this.#backgroundReclaims.delete(reclaim));
   }
 
-  async #releaseAll(reason: "explicit" | "killed"): Promise<readonly string[]> {
+  async #releaseAll(
+    reason: "explicit" | "killed",
+    reclaim: ReclaimMode,
+  ): Promise<readonly string[]> {
     const leaseIds = this.options.registry.snapshot.leases.map((lease) => lease.id);
-    await Promise.all(leaseIds.map(async (leaseId) => this.#release(leaseId, reason)));
+    await Promise.all(leaseIds.map(async (leaseId) => this.#release(leaseId, reason, { reclaim })));
     return leaseIds;
   }
 

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -95,6 +95,7 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
     drivers,
     eventBus,
     idGenerator,
+    logger,
     registry,
     systemStats,
   });
@@ -108,8 +109,9 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
     diskPath: dataDirectory,
   });
   const doctor = new Doctor({
-    // Without this, a backgrounded orphaned-lease reclaim (#43) -- which holds its
-    // device in `reclaiming` for a full erase -- reads as a stalled transition.
+    // Without this, a backgrounded reclaim -- which holds its device in `reclaiming`
+    // for a full erase, and is now how every release purges -- reads as a stalled
+    // transition.
     claims: leaseEngine.claimReader,
     clock,
     config,
@@ -158,6 +160,7 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
     converge: async () => {
       await Promise.all([doctor.reconcile(), leaseEngine.convergeRunningCapacity()]);
     },
+    settle: async () => leaseEngine.settle(),
     dispose: () => leaseEngine.dispose(),
   });
   await daemon.start();

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -973,6 +973,43 @@ describe("DaemonServer lease heartbeat", () => {
         .toBe(true);
     });
 
+    it("drains the backgrounded reclaims before disposing, on a graceful stop", async () => {
+      const order: string[] = [];
+      let finishSettle!: () => void;
+      const settling = new Promise<void>((resolve) => {
+        finishSettle = resolve;
+      });
+      const harness = await createHarness({
+        dispose: () => order.push("dispose"),
+        settle: async () => {
+          order.push("settle-start");
+          await settling;
+          order.push("settle-end");
+        },
+      });
+      const holder = await createClient(harness.socketPath);
+      await hello(holder);
+      await holder.request("lease.request", {
+        mode: "held",
+        requesterId: "holder",
+        request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      });
+
+      const stopping = harness.daemon.stop("test-drain");
+      await expect.poll(() => order).toEqual(["settle-start"]);
+
+      // The held lease is already gone -- that half of the release is synchronous --
+      // but the purge it handed off is not, and `stop` waits for it so the pool is
+      // left settled rather than `reclaiming` for the next startup to recover.
+      expect(harness.registry.snapshot.leases).toHaveLength(0);
+
+      finishSettle();
+      await stopping;
+      // Disposal last: a reclaim that settles into a purge failure arms a quarantine
+      // retry timer, and cancelling before the drain would strand it armed.
+      expect(order).toEqual(["settle-start", "settle-end", "dispose"]);
+    });
+
     it("logs a clean shutdown", async () => {
       const { logger: log, sink } = logger();
       const harness = await createHarness({ logger: log });
@@ -1046,8 +1083,10 @@ async function createHarness(
     readonly start?: boolean;
     readonly clock?: FakeClock;
     readonly converge?: () => Promise<void>;
+    readonly dispose?: () => void;
     readonly driver?: FakeDriver;
     readonly logger?: Logger;
+    readonly settle?: () => Promise<void>;
     readonly stateFilesystem?: MemoryFilesystem;
   } = {},
 ) {
@@ -1117,6 +1156,8 @@ async function createHarness(
     queue: engine,
     reaper,
     registry,
+    settle: options.settle ?? (async () => engine.settle()),
+    ...(options.dispose === undefined ? {} : { dispose: options.dispose }),
     version: "test",
   });
   runningDaemons.push(daemon);

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -75,6 +75,13 @@ export interface DaemonServerOptions {
    * A rejection here stops the daemon rather than leaving it half-open — see `start()`.
    */
   readonly converge?: () => Promise<void>;
+  /**
+   * Awaits lease work the subsystem is finishing off its callers' paths — today the
+   * backgrounded device reclaims a release hands off (see `LeaseReleaseCoordinator`).
+   * A graceful stop drains it so the pool is left settled; an ungraceful death leaves
+   * it for startup recovery. Runs after held leases are released and before `dispose`.
+   */
+  readonly settle?: () => Promise<void>;
   /** Cancels any timers the lease subsystem armed (e.g. quarantine retries) on shutdown. */
   readonly dispose?: () => void;
 }
@@ -249,8 +256,13 @@ export class DaemonServer {
     for (const unsubscribe of this.#unsubscribeLeaseLost.splice(0)) unsubscribe();
     this.options.reaper.dispose();
     this.options.healthMonitor?.dispose();
-    this.options.dispose?.();
     await Promise.all([...this.#connections].map((connection) => this.#releaseHeld(connection)));
+    // Those releases only commit the registry half and hand the purge off; draining it
+    // here keeps `daemon stop` finishing on a settled pool, as it did when the reclaim
+    // was inline. Disposal follows rather than precedes it, so a retry timer armed by a
+    // reclaim that settles into quarantine is still cancelled.
+    await this.options.settle?.();
+    this.options.dispose?.();
     for (const connection of this.#connections) {
       await connection.socket.close();
     }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -143,7 +143,7 @@ export function createMcpServer(session: McpSession): McpServer {
     {
       title: "Release simulator",
       description:
-        "Release the simulator lease owned by this MCP session. A session can release only its own held lease.",
+        "Release the simulator lease owned by this MCP session. A session can release only its own held lease. Returns as soon as the lease is given up: wiping the device runs in the background afterwards, so there is nothing to wait for and you can move straight on to other work. The device is not leasable again until that wipe finishes.",
       inputSchema: releaseSimulatorInputSchema,
       outputSchema: releaseSimulatorOutputSchema,
     },


### PR DESCRIPTION
Releasing a lease was two very different pieces of work behind one `await`: a registry commit (lease record gone, `lease.released` emitted, device `reclaiming`) and the driver-side purge behind it, where an iOS `simctl erase` runs tens of seconds. Callers waited for both, so an agent releasing over MCP or the CLI sat on a tool call for a device it had already given up.

`LeaseReleaseCoordinator` now commits the first half and hands the second to `WarmPoolCoordinator` without awaiting it, for every release a client or a timer can reach — explicit, connection close, expiry, device-lost, and the orphan sweep that already worked this way (#57). The device stays accounted for while the purge runs: `reclaiming` keeps it out of every grant path and in the running-capacity total, and the reclaim holds a `reclaim` operation claim, which is what lets startup recovery and `pitlane doctor` tell a live purge from an abandoned one.

## What still waits, deliberately

- **An operator reset.** `NukeService` only acts on `ready`/`shutdown` records, so a device left mid-reclaim would be skipped by the reset meant to take it down. `beginMaintenance` drains in-flight background reclaims, and the maintenance-authorized release awaits its own inline.
- **A graceful `daemon stop`**, through a new `settle` hook — ordered before `dispose`, so a purge that settles into quarantine still gets its retry timer cancelled.
- **The next start, if the daemon died instead.** Interrupted reclaims are recovered from the registry as before.

## Two things this surfaced

- **A queued waiter could sleep through its own device.** `WarmPoolCoordinator` fires its availability notification while the reclaim claim is still held, and `AcquisitionPlanner` selects by exact state *and* skips claimed devices — so the waiter queued for exactly that device missed the only signal it was going to get. Rare before (startup only), routine once every release backgrounds. The coordinator now re-notifies after releasing the claim; a `lease-engine` test deadlocked on this before the fix.
- **Purge failures had nowhere to go.** No caller is left to reject to. A driver purge failure was already `QuarantineCoordinator`'s job and stays visible as `device.purge-failed` plus a `quarantined` device, but anything beyond that was hitting a `NoopLogger` — `LeaseEngine` now passes its logger down.

## Verification

`pnpm check` green (typecheck, e2e typecheck, lint, format, 636 unit tests, 32 e2e). `pnpm fallow --ci` clean on the changed files.

The e2e flow in `lease-lifecycle.test.ts` sets a 5s reclaim latency and asserts `release_simulator` returns while the device still reads `reclaiming`. That assertion was confirmed to fail on the old synchronous path, rather than being assumed to pass for the right reason.

## Docs

`release_simulator`'s tool description now tells the agent the wipe continues in the background and that the device is not leasable until it finishes. `docs/CLI.md` covers what that means for the next command; `docs/ARCHITECTURE.md` gains a "Release hands the purge off" section under Leases.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qo7FCuz9WVGms7Qw9tNckX)_