### PR TITLE
chore(ci): harden CI supply chain and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+
+updates:
+  # Actions are pinned to commit SHAs, which never move on their own — without
+  # this they silently go stale, including past security advisories. Dependabot
+  # rewrites both the pin and the `# vX.Y.Z` comment next to it.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore(ci)
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: read
+# Deny by default; every job opts in to exactly what it needs.
+permissions: {}
 
 env:
   COREPACK_ENABLE_PROJECT_SPEC: "0"
@@ -19,16 +19,20 @@ jobs:
   quality:
     name: Quality
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
       - name: Enable Corepack
         run: |
           corepack enable
-          corepack prepare pnpm@11.9.0 --activate
+          corepack prepare pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b --activate
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Quality checks
@@ -37,16 +41,20 @@ jobs:
   fallow:
     name: Fallow
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
       - name: Enable Corepack
         run: |
           corepack enable
-          corepack prepare pnpm@11.9.0 --activate
+          corepack prepare pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b --activate
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Fallow analysis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Enable Corepack
         run: |
           corepack enable
-          corepack prepare pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b --activate
+          corepack prepare pnpm@11.22.0+sha512.1ff870c4c6133dfd88fb2afc46dd13d47f09c9794b438c6fdb47ca98caf3bc16381ee0be93a091b8e3824cf01f889f46d7d9e20910fb0be1ab0fb5baa80dd621 --activate
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Quality checks
@@ -54,7 +54,7 @@ jobs:
       - name: Enable Corepack
         run: |
           corepack enable
-          corepack prepare pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b --activate
+          corepack prepare pnpm@11.22.0+sha512.1ff870c4c6133dfd88fb2afc46dd13d47f09c9794b438c6fdb47ca98caf3bc16381ee0be93a091b8e3824cf01f889f46d7d9e20910fb0be1ab0fb5baa80dd621 --activate
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Fallow analysis

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": "^11.9.0",
+      "version": "11.22.0",
       "onFail": "download"
     }
   },


### PR DESCRIPTION
Security review of the GitHub Actions setup, plus the fixes it turned up.

## What was already right

- Both actions pinned to full commit SHAs. Resolved the tags upstream to confirm the SHAs aren't spoofed: `11bd7190…` is genuinely `actions/checkout` v4.2.2, `49933ea5…` is genuinely `actions/setup-node` v4.4.0. Runner pinned to `ubuntu-24.04`.
- No cache poisoning surface at all — no `actions/cache`, no `cache:` on setup-node, no artifacts. Nothing for a PR branch to poison.
- `--ignore-scripts` on install, so a malicious `postinstall` in a transitive dep can't run. Lockfile is `--frozen-lockfile`, all resolutions from the registry with integrity hashes, no git/tarball deps.
- `pull_request`, not `pull_request_target`. No secrets referenced, no `${{ github.event.* }}` interpolated into a `run:` block, timeouts on both jobs.

## Changes

**Integrity-pin the pnpm bootstrap.** `corepack prepare pnpm@11.9.0` resolved the version off the registry with no hash to check it against, and `COREPACK_ENABLE_PROJECT_SPEC: "0"` disables reading the project spec, so nothing verified the tarball. That binary then runs as the package manager for the rest of the job, before the lockfile's integrity pinning applies. Now uses a `+sha512.<hex>` spec — verified both directions locally: correct hash activates, tampered hash hard-fails.

**Least privilege.** Workflow-level `permissions: {}` with each job declaring `contents: read`. Same effective grant, but a job added later starts at zero instead of silently inheriting read.

**`persist-credentials: false` on checkout.** `pnpm check` runs the PR's own test suite, which could otherwise read the job token out of `.git/config`. Low impact while the token is read-only and the repo is private; free to fix.

**Dependabot.** Actions pinned to SHAs never move on their own, including past security advisories. Weekly grouped `github-actions` updates; Dependabot rewrites both the pin and its `# vX.Y.Z` comment.

**pnpm version alignment.** CI bootstrapped 11.9.0 while the lockfile resolves and integrity-pins 11.22.0. `devEngines.packageManager` now declares 11.22.0 exactly and CI bootstraps that same version. Declared via `devEngines` rather than a `packageManager` field because pnpm ignores `packageManager` and warns on every command when both are present; integrity still comes from the lockfile's `packageManagerDependencies` entries plus the hash-pinned bootstrap. Side benefit: 11.22.0 runs a lockfile supply-chain policy check that 11.9.0 didn't.

The lockfile is unchanged. Its `specifier: ^11.9.0` line is now stale, but pnpm won't rewrite it (the resolved version didn't move) and `--frozen-lockfile` accepts it, so it wasn't hand-edited.

## Verification

Replayed the CI steps from a clean `node_modules` with the new bootstrap, then ran everything `pnpm check` runs — typecheck, typecheck:e2e, lint, format:check, 628 unit tests, 32 e2e tests — plus `pnpm fallow --ci` (exit 0). All green under pnpm 11.22.0.

## Not included

`package-ecosystem: npm` for Dependabot — version updates across 10 devDeps would open considerably more PRs, which is a noise tradeoff worth deciding separately. Dependabot security alerts for npm work independently of this file.

Two things worth checking in repo settings, which aren't visible from the workflow files: that Actions is restricted to verified creators or a specific allowlist rather than "allow all", and that the default `GITHUB_TOKEN` permission is read-only org-wide.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EG3gzW8xhdKvzBkb9CiYsw)_