### PR TITLE
fix(driver): price reclaim by the strategy it actually runs

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -120,9 +120,16 @@ without speculative work stages; reclaiming work is reported separately:
 ```json
 {"event":"queued","queue_position":1}
 {"event":"provisioning","eta_seconds":90}
-{"event":"booting","eta_seconds":30}
-{"event":"reclaiming","eta_seconds":15}
+{"event":"booting","eta_seconds":60}
+{"event":"reclaiming","eta_seconds":34}
 ```
+
+`reclaiming` follows `queued` when the device the request is waiting on is
+being purged for its previous holder: the position alone would not say that
+the wait is an iOS erase rather than a moment. Every `eta_seconds` comes from
+the driver's own estimate for the work it selected, which for a reclaim means
+the strategy that clean level uses -- an erase runs tens of seconds, a
+snapshot restore a few.
 
 Once granted, held mode also relays the health monitor's findings about the
 leased device for as long as the connection holds it, on the same stderr

--- a/e2e/contention.test.ts
+++ b/e2e/contention.test.ts
@@ -69,7 +69,51 @@ describe("contention & queueing", () => {
     waiterE.kill("SIGTERM");
     await waiterE.waitForExit(15_000);
   });
+
+  it("tells a waiter queued behind a reclaim how long that reclaim runs", async () => {
+    const env = await withDaemon({
+      configOverrides: { limits: { maxRunning: 1, ios: { maxDevices: 1, maxRunning: 1 } } },
+    });
+    await env.driverScript.set({
+      ios: {
+        knownModels: ["iPhone 16"],
+        availableOsVersions: ["18.4"],
+        estimateMs: { reclaim: 34_000 },
+        latencyMs: { reclaim: 4_000 },
+      },
+    });
+
+    const holder = await env.cli([...LEASE_ARGS, "--agent-id", "agent-holder", "--detach"]);
+    expect(holder.code).toBe(0);
+    const holderGrant = holder.json as { lease: string };
+
+    // Release hands the caller back before the purge (#58), so the device is `reclaiming` with
+    // its full latency still ahead when the next requester arrives -- the case the stage exists
+    // for, and the one nothing exercised before this covered the whole path out to the CLI.
+    const release = await env.cli(["release", holderGrant.lease]);
+    expect(release.code).toBe(0);
+
+    const waiter = env.cliBackground([...LEASE_ARGS, "--agent-id", "agent-waiter"]);
+    await waitFor(() => waiter.progressEvents().some(isReclaimingWithEta(34)), {
+      label: "agent-waiter told the reclaim's ETA",
+    });
+    expect(waiter.progressEvents().some((event) => isQueuedAt(event, 1))).toBe(true);
+
+    const granted = JSON.parse(await waiter.firstStdoutLine(15_000)) as { device: string };
+    expect(granted.device).toBe("iPhone 16");
+
+    waiter.kill("SIGTERM");
+    await waiter.waitForExit(15_000);
+  });
 });
+
+function isReclaimingWithEta(seconds: number): (event: unknown) => boolean {
+  return (event) =>
+    typeof event === "object" &&
+    event !== null &&
+    (event as Record<string, unknown>).event === "reclaiming" &&
+    (event as Record<string, unknown>).eta_seconds === seconds;
+}
 
 function isQueuedAt(event: unknown, position: number): boolean {
   return (

--- a/e2e/fake-driver/fake-driver.ts
+++ b/e2e/fake-driver/fake-driver.ts
@@ -10,6 +10,7 @@ import {
   type Driver,
   type DriverCatalogEntry,
   type DriverDevice,
+  type DriverEstimate,
   type DriverReality,
   type ObservedMark,
   type ObservedRunState,
@@ -187,10 +188,10 @@ export class OutOfProcessFakeDriver implements Driver {
     };
   }
 
-  estimate(operation: "provision" | "boot" | "reclaim", _spec: DeviceSpec): number {
+  estimate(estimate: DriverEstimate, _spec: DeviceSpec): number {
     // estimate() is synchronous in the Driver interface, so it reads the script
     // synchronously best-effort; a stale/missing read just falls back to 0.
-    return this.#lastKnownEstimateMs?.[operation] ?? 0;
+    return this.#lastKnownEstimateMs?.[estimate.operation] ?? 0;
   }
 
   async #beforeCall(

--- a/src/core/acquisition-planner.ts
+++ b/src/core/acquisition-planner.ts
@@ -1,6 +1,12 @@
 import type { CapacityReservation, CapacityCoordinator } from "./capacity-coordinator.js";
 import type { DeviceOperationClaim, DeviceOperationClaims } from "./device-operation-claims.js";
-import type { DeviceRecord, DeviceSpec, LeaseRecord, Platform } from "./domain.js";
+import {
+  type DeviceRecord,
+  type DeviceSpec,
+  type LeaseRecord,
+  type Platform,
+  sameSpec,
+} from "./domain.js";
 import { selectManagedVictim, selectWarmVictim, type WarmVictimScope } from "./warm-pool.js";
 
 export interface AcquisitionPlannerSnapshot {
@@ -153,12 +159,4 @@ function capacityDevices(snapshot: AcquisitionPlannerSnapshot) {
     platform: device.spec.platform,
     state: device.state,
   }));
-}
-
-function sameSpec(left: DeviceSpec, right: DeviceSpec): boolean {
-  return (
-    left.platform === right.platform &&
-    left.model === right.model &&
-    left.osVersion === right.osVersion
-  );
 }

--- a/src/core/device-provisioner.ts
+++ b/src/core/device-provisioner.ts
@@ -43,7 +43,10 @@ export class DeviceProvisioner {
     const startedAt = this.options.clock.now();
     let driverDevice: DriverDevice;
     try {
-      options.onProgress?.({ stage: "provisioning", etaMs: driver.estimate("provision", spec) });
+      options.onProgress?.({
+        stage: "provisioning",
+        etaMs: driver.estimate({ operation: "provision" }, spec),
+      });
       driverDevice = await driver.provision(spec);
     } catch (error: unknown) {
       options.reservation.release();
@@ -66,7 +69,10 @@ export class DeviceProvisioner {
     }
 
     try {
-      options.onProgress?.({ stage: "booting", etaMs: driver.estimate("boot", spec) });
+      options.onProgress?.({
+        stage: "booting",
+        etaMs: driver.estimate({ operation: "boot" }, spec),
+      });
       const ready = await this.options.lifecycle.readyProvisionedForLease(device);
       if (ready === undefined)
         throw new Error(`Registered device could not be made ready: ${device.id}`);

--- a/src/core/doctor.test.ts
+++ b/src/core/doctor.test.ts
@@ -846,6 +846,58 @@ describe("Doctor", () => {
       );
     });
 
+    it("holds a reclaiming device to the slower clean level's estimate", async () => {
+      const clock = new FakeClock(10_000);
+      const eventBus = new EventBus(clock);
+      const registry = await Registry.load({
+        clock,
+        eventBus,
+        filesystem: new MemoryFilesystem(),
+        idGenerator: sequence(),
+        statePath: "/state.json",
+      });
+      // A record in `reclaiming` does not say which clean level started it, so the threshold
+      // has to clear the slower of the two: pricing it at `standard` would call a healthy
+      // `full` reclaim a stall.
+      const driver = new FakeDriver({
+        clock,
+        estimateMs: { reclaim: 2_000 },
+        fullCleanReclaimEstimateMs: 20_000,
+        platform: "ios",
+      });
+      const device = await readyDevice(registry, "simlock-slow-clean", "ios");
+      const lease = await registry.createLease({
+        deviceId: device.id,
+        mode: "held",
+        requesterId: "agent",
+        ttlDeadline: 999_999,
+      });
+      await registry.beginRelease(lease.id);
+      const doctor = new Doctor({
+        clock,
+        config: config(),
+        drivers: [driver],
+        eventBus,
+        registry,
+      });
+
+      // Past the `standard` threshold (2_000 * 3) but inside the `full` one (20_000 * 3).
+      clock.advance(6_001);
+      const early = await doctor.reconcile();
+      expect(early.findings.filter((finding) => finding.kind === "stalled-transition")).toEqual([]);
+
+      clock.advance(60_000);
+      const late = await doctor.reconcile();
+      expect(late.findings).toContainEqual(
+        expect.objectContaining({
+          deviceId: device.id,
+          kind: "stalled-transition",
+          state: "reclaiming",
+          thresholdMs: 60_000,
+        }),
+      );
+    });
+
     it("emits device.stalled-transition-detected for a stalled device", async () => {
       const clock = new FakeClock(10_000);
       const eventBus = new EventBus(clock);

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -3,6 +3,7 @@ import type { Clock } from "../ports/index.js";
 import type { Config } from "./config.js";
 import {
   type DeviceRecord,
+  type DeviceSpec,
   type DeviceState,
   type Platform,
   transitionEnteredAt,
@@ -327,6 +328,21 @@ function registryDriftFindings(
 }
 
 /**
+ * The reclaim estimate for the slowest strategy the driver would pick, whatever the clean
+ * level. A `reclaiming` record does not say which level started it -- every production path
+ * asks for `standard`, but that is the caller's choice, not an invariant this finding can
+ * depend on -- and the two errors are not symmetric: an estimate that is too tight turns a
+ * healthy reclaim into a false stall finding, while one that is too loose only delays a real
+ * one. So this takes the slower branch rather than assuming.
+ */
+function slowestReclaimEstimateMs(driver: Driver, spec: DeviceSpec): number {
+  return Math.max(
+    driver.estimate({ clean: "standard", operation: "reclaim" }, spec),
+    driver.estimate({ clean: "full", operation: "reclaim" }, spec),
+  );
+}
+
+/**
  * A `provisioning` / `reclaiming` device is normally in-flight work Simlock itself is
  * driving (see `expectedRunState`), not drift -- but only up to a point. Past a
  * driver-derived threshold it stops being "still working" and becomes a stall: the
@@ -348,11 +364,12 @@ function registryDriftFindings(
  * runs. This is the same live-versus-orphaned test `StartupConverger
  * #recoverInterruptedReclaims` already makes, and it is load-bearing rather than
  * belt-and-braces -- every release now backgrounds its reclaim, holding the device in
- * `reclaiming` for a full erase, measured at ~34s against a threshold that floors at
- * 60s for both drivers, and several such erases run at once and contend for the same
- * disk. Tuning the threshold against that would be guessing at disk speed; the claim
- * answers it exactly. A reclaim orphaned by a crash has no claim in the new process,
- * so the case this finding exists to catch is untouched.
+ * `reclaiming` for a full erase, measured at ~34s, and several such erases run at once
+ * and contend for the same disk. The estimate the threshold is built from now reflects
+ * that erase rather than the 1s it used to claim (#56), but tuning a threshold against
+ * contended disk speed would still be guessing; the claim answers it exactly. A reclaim
+ * orphaned by a crash has no claim in the new process, so the case this finding exists to
+ * catch is untouched.
  */
 function stalledTransitionFinding(
   device: DeviceRecord,
@@ -375,8 +392,9 @@ function stalledTransitionFinding(
 
   const estimateMs =
     device.state === "provisioning"
-      ? driver.estimate("provision", device.spec) + driver.estimate("boot", device.spec)
-      : driver.estimate("reclaim", device.spec);
+      ? driver.estimate({ operation: "provision" }, device.spec) +
+        driver.estimate({ operation: "boot" }, device.spec)
+      : slowestReclaimEstimateMs(driver, device.spec);
   const thresholdMs = Math.max(estimateMs * config.thresholdMultiplier, config.minimumThresholdMs);
   const ageMs = now - enteredAt;
   if (ageMs <= thresholdMs) {

--- a/src/core/domain.ts
+++ b/src/core/domain.ts
@@ -6,6 +6,15 @@ export interface DeviceSpec {
   readonly osVersion: string;
 }
 
+/** Spec identity as every selection path means it: same platform, model, and OS version. */
+export function sameSpec(left: DeviceSpec, right: DeviceSpec): boolean {
+  return (
+    left.platform === right.platform &&
+    left.model === right.model &&
+    left.osVersion === right.osVersion
+  );
+}
+
 export type DeviceState =
   | "provisioning"
   | "ready"

--- a/src/core/driver.ts
+++ b/src/core/driver.ts
@@ -72,6 +72,19 @@ export interface ReclaimResult {
 export type ReclaimStrategy = ReclaimResult["strategy"];
 
 /**
+ * What `estimate` is being asked to price. `reclaim` carries the clean level because it is
+ * the input `reclaimStrategy` already selects on, and the strategies it picks between differ
+ * by an order of magnitude -- an iOS `erase` runs tens of seconds while an Android `snapshot`
+ * restore runs in a few. A single blended reclaim number cannot be right for both, and the
+ * callers that consume it (a requester's ETA, `Doctor`'s stalled-transition threshold) are
+ * both misled by one that is wrong in the optimistic direction.
+ */
+export type DriverEstimate =
+  | { readonly operation: "provision" }
+  | { readonly operation: "boot" }
+  | { readonly operation: "reclaim"; readonly clean: "standard" | "full" };
+
+/**
  * What a driver can resolve right now, read from the platform SDK without
  * side effects: resolvable device models plus installed runtimes / system
  * images, and which installed runtime `resolveSpec` would pick by default
@@ -107,7 +120,7 @@ export interface Driver {
   listManaged(): Promise<DriverReality>;
   /** Read-only: must never trigger a runtime / system-image download. */
   listCatalog(): Promise<DriverCatalogEntry>;
-  estimate(operation: "provision" | "boot" | "reclaim", spec: DeviceSpec): number;
+  estimate(estimate: DriverEstimate, spec: DeviceSpec): number;
 }
 
 export class RuntimeMissingError extends Error {

--- a/src/core/fake-driver.test.ts
+++ b/src/core/fake-driver.test.ts
@@ -58,9 +58,9 @@ describe("FakeDriver", () => {
     });
     const spec = { model: "iPhone 16", osVersion: "26.5", platform: "ios" } as const;
 
-    expect(driver.estimate("provision", spec)).toBe(10);
-    expect(driver.estimate("boot", spec)).toBe(20);
-    expect(driver.estimate("reclaim", spec)).toBe(30);
+    expect(driver.estimate({ operation: "provision" }, spec)).toBe(10);
+    expect(driver.estimate({ operation: "boot" }, spec)).toBe(20);
+    expect(driver.estimate({ clean: "standard", operation: "reclaim" }, spec)).toBe(30);
   });
 
   it("implements the platform-agnostic Driver contract", () => {

--- a/src/core/fake-driver.ts
+++ b/src/core/fake-driver.ts
@@ -5,6 +5,7 @@ import {
   type Driver,
   type DriverCatalogEntry,
   type DriverDevice,
+  type DriverEstimate,
   type DriverReality,
   type ObservedRunState,
   RuntimeMissingError,
@@ -32,6 +33,12 @@ export interface FakeDriverOptions {
   readonly availableOsVersions?: readonly string[];
   readonly clock: Clock;
   readonly estimateMs?: Partial<Record<DriverEstimateOperation, number>>;
+  /**
+   * Reclaim estimate for a `full` clean, when a test needs the two clean levels priced apart
+   * the way a real driver prices them (an Android `snapshot` against a `wipe`). Falls back to
+   * `estimateMs.reclaim`, so a test that does not care about the split says nothing.
+   */
+  readonly fullCleanReclaimEstimateMs?: number;
   readonly knownModels?: readonly string[];
   readonly latencyMs?: Partial<Record<FakeDriverOperation, number>>;
   readonly platform: Platform;
@@ -53,6 +60,7 @@ export class FakeDriver implements Driver {
   readonly #calls: FakeDriverCall[] = [];
   readonly #clock: Clock;
   readonly #estimateMs: FakeDriverOptions["estimateMs"];
+  readonly #fullCleanReclaimEstimateMs: number | undefined;
   readonly #failures = new Map<string, Error>();
   #hangMakeReady = false;
   readonly #knownModels: Set<string> | undefined;
@@ -70,6 +78,7 @@ export class FakeDriver implements Driver {
     this.#availableOsVersions = new Set(options.availableOsVersions ?? ["latest"]);
     this.#clock = options.clock;
     this.#estimateMs = options.estimateMs;
+    this.#fullCleanReclaimEstimateMs = options.fullCleanReclaimEstimateMs;
     this.#knownModels =
       options.knownModels === undefined ? undefined : new Set(options.knownModels);
     this.#latencyMs = options.latencyMs;
@@ -198,8 +207,11 @@ export class FakeDriver implements Driver {
     };
   }
 
-  estimate(operation: DriverEstimateOperation, _spec: DeviceSpec): number {
-    return this.#estimateMs?.[operation] ?? 0;
+  estimate(estimate: DriverEstimate, _spec: DeviceSpec): number {
+    if (estimate.operation === "reclaim" && estimate.clean === "full") {
+      return this.#fullCleanReclaimEstimateMs ?? this.#estimateMs?.reclaim ?? 0;
+    }
+    return this.#estimateMs?.[estimate.operation] ?? 0;
   }
 
   failOn(operation: FakeDriverOperation, callNumber: number, error: Error): void {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -23,6 +23,7 @@ export {
   type DriverCatalogEntry,
   DriverCrashError,
   type DriverDevice,
+  type DriverEstimate,
   type DriverReality,
   type ObservedDevice,
   type ObservedRunState,

--- a/src/core/lease-acquisition-coordinator.ts
+++ b/src/core/lease-acquisition-coordinator.ts
@@ -6,7 +6,7 @@ import {
   type DeviceOperationClaims,
 } from "./device-operation-claims.js";
 import { type DeviceProvisioner } from "./device-provisioner.js";
-import type { DeviceRecord, DeviceSpec, LeaseRecord } from "./domain.js";
+import { type DeviceRecord, type DeviceSpec, type LeaseRecord, sameSpec } from "./domain.js";
 import { BootTimeoutError, type DeviceRequest, type Driver } from "./driver.js";
 import { type DriverCatalog } from "./driver-catalog.js";
 import { type LeaseLifecycle } from "./lease-lifecycle.js";
@@ -318,6 +318,10 @@ export class LeaseAcquisitionCoordinator implements AcquisitionMaintenance {
     const plan = this.#nextPlan(waiter);
     if (plan === undefined) return undefined;
     if (plan.kind === "grant-ready") {
+      waiter.timing = grantReadyTiming(
+        this.options.drivers.get(plan.device.spec.platform),
+        plan.device.spec,
+      );
       await this.#grant(waiter, plan.device.id);
       return undefined;
     }
@@ -424,7 +428,7 @@ export class LeaseAcquisitionCoordinator implements AcquisitionMaintenance {
     try {
       this.options.queue.notifyProgress(waiter, {
         stage: "booting",
-        etaMs: driver.estimate("boot", device.spec),
+        etaMs: driver.estimate({ operation: "boot" }, device.spec),
       });
       const ready = await this.options.lifecycle.bootForLease(device, claim);
       if (ready === undefined) throw new Error(`Boot target is no longer safe: ${device.id}`);
@@ -452,8 +456,33 @@ export class LeaseAcquisitionCoordinator implements AcquisitionMaintenance {
   }
 
   #defer(waiter: AcquisitionWaiter): void {
-    if (waiter.options.noWait) this.#reject(waiter, new NoCapacityError(), "no-wait");
-    else this.#enqueue(waiter);
+    if (waiter.options.noWait) {
+      this.#reject(waiter, new NoCapacityError(), "no-wait");
+      return;
+    }
+    this.#enqueue(waiter);
+    this.#notifyReclaimWait(waiter);
+  }
+
+  /**
+   * A queued waiter whose spec matches a device already being reclaimed is waiting on that
+   * reclaim, not on nothing in particular: an iOS erase holds the only matching device for
+   * tens of seconds, and reporting only `queued` leaves the requester with a position and no
+   * sense of how long. Purely informational -- the plan is untouched, and the device is
+   * granted through the normal `ready` path when its reclaim commits. Nothing is reported
+   * when no matching device is reclaiming, so this never invents a stage out of an idle wait.
+   */
+  #notifyReclaimWait(waiter: AcquisitionWaiter): void {
+    const spec = waiter.spec;
+    if (spec === undefined) return;
+    const reclaiming = this.options.registry.snapshot.devices.some(
+      (device) => device.state === "reclaiming" && sameSpec(device.spec, spec),
+    );
+    if (!reclaiming) return;
+    this.options.queue.notifyProgress(waiter, {
+      etaMs: releaseReclaimEstimateMs(this.options.drivers.get(spec.platform), spec),
+      stage: "reclaiming",
+    });
   }
 
   async #grantHandoff(
@@ -533,24 +562,44 @@ function asError(error: unknown): Error {
 }
 
 function estimatedTiming(driver: Driver, spec: DeviceSpec): LeaseTiming {
-  const estimatedProvisionMs = driver.estimate("provision", spec);
-  const estimatedBootMs = driver.estimate("boot", spec);
+  const estimatedProvisionMs = driver.estimate({ operation: "provision" }, spec);
+  const estimatedBootMs = driver.estimate({ operation: "boot" }, spec);
   return {
     estimatedBootMs,
     estimatedProvisionMs,
-    estimatedReclaimMs: 0,
+    estimatedReclaimMs: releaseReclaimEstimateMs(driver, spec),
     estimatedReadyMs: estimatedProvisionMs + estimatedBootMs,
   };
 }
 
 function estimatedBootTiming(driver: Driver, spec: DeviceSpec): LeaseTiming {
-  const estimatedBootMs = driver.estimate("boot", spec);
+  const estimatedBootMs = driver.estimate({ operation: "boot" }, spec);
   return {
     estimatedBootMs,
     estimatedProvisionMs: 0,
-    estimatedReclaimMs: 0,
+    estimatedReclaimMs: releaseReclaimEstimateMs(driver, spec),
     estimatedReadyMs: estimatedBootMs,
   };
+}
+
+/** A device that is already ready costs nothing to hand over; only its reclaim lies ahead. */
+function grantReadyTiming(driver: Driver, spec: DeviceSpec): LeaseTiming {
+  return {
+    estimatedBootMs: 0,
+    estimatedProvisionMs: 0,
+    estimatedReclaimMs: releaseReclaimEstimateMs(driver, spec),
+    estimatedReadyMs: 0,
+  };
+}
+
+/**
+ * What this device's reclaim will cost once the lease is released -- the one part of a
+ * grant's timing that describes work still ahead of the holder rather than work already
+ * done. `standard` because that is what every release path asks for (`WarmPoolCoordinator
+ * #reclaim`, `QuarantineCoordinator`); a holder cannot request a different clean level.
+ */
+function releaseReclaimEstimateMs(driver: Driver, spec: DeviceSpec): number {
+  return driver.estimate({ clean: "standard", operation: "reclaim" }, spec);
 }
 
 function operationPlan(plan: AcquisitionPlan): OperationPlan | undefined {

--- a/src/core/lease-engine.test.ts
+++ b/src/core/lease-engine.test.ts
@@ -8,6 +8,7 @@ import {
   DriverCrashError,
   FakeDriver,
   LeaseEngine,
+  type LeaseProgress,
   NoCapacityError,
   QueueTimeoutError,
   Registry,
@@ -141,6 +142,61 @@ describe("LeaseEngine", () => {
     await expect(second).resolves.toMatchObject({ device: { id: first.device.id } });
     expect(driver.calls.filter((call) => call.operation === "provision")).toHaveLength(1);
     expect(driver.calls.filter((call) => call.operation === "makeReady")).toHaveLength(2);
+  });
+
+  it("tells a waiter queued behind a reclaim how long that reclaim runs", async () => {
+    const clock = new FakeClock(1_000);
+    const driver = new FakeDriver({
+      availableOsVersions: ["26.5"],
+      clock,
+      estimateMs: { reclaim: 34_000 },
+      latencyMs: { reclaim: 20 },
+      platform: "ios",
+      reclaimResult: "shutdown",
+    });
+    const harness = await createHarness({ driver });
+    const first = await harness.engine.request(request, { mode: "held", requesterId: "first" });
+
+    await harness.engine.release(first.lease.id, "explicit");
+    const progress: LeaseProgress[] = [];
+    const second = harness.engine.request(request, {
+      mode: "held",
+      onProgress: (update) => progress.push(update),
+      requesterId: "second",
+    });
+    await flush();
+
+    // A queue position on its own says nothing about the wait; the erase the waiter is
+    // actually behind is what makes it tens of seconds rather than immediate (#56).
+    expect(progress).toEqual([
+      { queuePosition: 1, stage: "queued" },
+      { etaMs: 34_000, stage: "reclaiming" },
+    ]);
+    clock.advance(20);
+    await harness.engine.settle();
+    await expect(second).resolves.toMatchObject({ device: { id: first.device.id } });
+  });
+
+  it("does not report a reclaim stage to a waiter queued behind something else", async () => {
+    const clock = new FakeClock(1_000);
+    const driver = new FakeDriver({
+      availableOsVersions: ["26.5"],
+      clock,
+      estimateMs: { reclaim: 34_000 },
+      platform: "ios",
+    });
+    const harness = await createHarness({ driver });
+    await harness.engine.request(request, { mode: "held", requesterId: "holder" });
+    const progress: LeaseProgress[] = [];
+    void harness.engine.request(request, {
+      mode: "held",
+      onProgress: (update) => progress.push(update),
+      requesterId: "queued",
+    });
+    await flush();
+
+    // The only matching device is leased, not reclaiming: nothing to quote.
+    expect(progress).toEqual([{ queuePosition: 1, stage: "queued" }]);
   });
 
   it("purges then shuts down on release when the system is over its running limit", async () => {
@@ -567,7 +623,7 @@ describe("LeaseEngine", () => {
     const driver = new FakeDriver({
       availableOsVersions: ["26.5"],
       clock,
-      estimateMs: { boot: 20, provision: 10 },
+      estimateMs: { boot: 20, provision: 10, reclaim: 34 },
       platform: "ios",
     });
     const harness = await createHarness({ driver });
@@ -579,15 +635,43 @@ describe("LeaseEngine", () => {
       requesterId: "agent-1",
     });
 
+    // `estimatedReclaimMs` is the one figure describing work still ahead of the holder --
+    // what releasing this device will cost -- rather than work already done to grant it.
     expect(grant).toMatchObject({
       device: { spec: request, state: "leased" },
-      timing: { estimatedBootMs: 20, estimatedProvisionMs: 10, estimatedReadyMs: 30 },
+      timing: {
+        estimatedBootMs: 20,
+        estimatedProvisionMs: 10,
+        estimatedReadyMs: 30,
+        estimatedReclaimMs: 34,
+      },
     });
     expect(driver.calls.map((call) => call.operation)).toEqual([
       "resolveSpec",
       "provision",
       "makeReady",
     ]);
+  });
+
+  it("prices the eventual reclaim even when a warm device is granted with no work at all", async () => {
+    const clock = new FakeClock(1_000);
+    const driver = new FakeDriver({
+      availableOsVersions: ["26.5"],
+      clock,
+      estimateMs: { boot: 20, provision: 10, reclaim: 34 },
+      platform: "ios",
+    });
+    const harness = await createHarness({ driver });
+    await seedReady(harness);
+
+    const grant = await harness.engine.request(request, { mode: "held", requesterId: "agent-1" });
+
+    expect(grant.timing).toEqual({
+      estimatedBootMs: 0,
+      estimatedProvisionMs: 0,
+      estimatedReadyMs: 0,
+      estimatedReclaimMs: 34,
+    });
   });
 
   it("reports only the selected work as it begins", async () => {

--- a/src/core/warm-pool-coordinator.ts
+++ b/src/core/warm-pool-coordinator.ts
@@ -1,12 +1,13 @@
 import type { EventBus } from "../bus/index.js";
 import type { Clock } from "../ports/index.js";
 import type { CapacityDecision, CapacityDevice, RunningCapacity } from "./capacity.js";
-import type {
-  DeviceRecord,
-  DeviceSpec,
-  DeviceTransitionUpdate,
-  LeaseRecord,
-  Platform,
+import {
+  type DeviceRecord,
+  type DeviceSpec,
+  type DeviceTransitionUpdate,
+  type LeaseRecord,
+  type Platform,
+  sameSpec,
 } from "./domain.js";
 import type { Driver, DriverDevice } from "./driver.js";
 import type { QuarantinePurgeFailure } from "./quarantine-coordinator.js";
@@ -208,14 +209,6 @@ export class WarmPoolCoordinator {
 
 function capacityDevices(devices: readonly DeviceRecord[]): readonly CapacityDevice[] {
   return devices.map((device) => ({ platform: device.spec.platform, state: device.state }));
-}
-
-function sameSpec(left: DeviceSpec, right: DeviceSpec): boolean {
-  return (
-    left.platform === right.platform &&
-    left.model === right.model &&
-    left.osVersion === right.osVersion
-  );
 }
 
 function stableError(error: unknown): string {

--- a/src/drivers/android/index.test.ts
+++ b/src/drivers/android/index.test.ts
@@ -465,9 +465,21 @@ describe("AndroidDriver", () => {
     );
     const spec = { model: "Pixel 8", osVersion: "34", platform: "android" } as const;
 
-    expect(driver.estimate("provision", spec)).toBe(1_000);
-    expect(driver.estimate("boot", spec)).toBe(31_000);
-    expect(driver.estimate("reclaim", spec)).toBe(2_000);
+    expect(driver.estimate({ operation: "provision" }, spec)).toBe(1_000);
+    expect(driver.estimate({ operation: "boot" }, spec)).toBe(31_000);
+  });
+
+  it("prices reclaim by the strategy the clean level selects", async () => {
+    const driver: Driver = await createDriver(
+      await androidFilesystem(),
+      new ScriptedProcessRunner([]),
+    );
+    const spec = { model: "Pixel 8", osVersion: "34", platform: "android" } as const;
+
+    // A `wipe` reclaim only shuts the emulator down -- the wipe itself is deferred to the
+    // next `makeReady` -- so it is the cheaper of the two here, not the dearer.
+    expect(driver.estimate({ clean: "standard", operation: "reclaim" }, spec)).toBe(6_000);
+    expect(driver.estimate({ clean: "full", operation: "reclaim" }, spec)).toBe(3_000);
   });
 
   it("lists resolvable models and installed API levels, defaulting to the newest", async () => {

--- a/src/drivers/android/index.test.ts
+++ b/src/drivers/android/index.test.ts
@@ -476,10 +476,11 @@ describe("AndroidDriver", () => {
     );
     const spec = { model: "Pixel 8", osVersion: "34", platform: "android" } as const;
 
-    // A `wipe` reclaim only shuts the emulator down -- the wipe itself is deferred to the
-    // next `makeReady` -- so it is the cheaper of the two here, not the dearer.
+    // Both measured on an M3 Pro / Pixel 8 / API 35. The gap is real: a `wipe` reclaim defers
+    // the wipe to the next `makeReady`, but the warm-pool disposition runs that boot before the
+    // device leaves `reclaiming`, so the window is a cold wipe boot rather than a shutdown.
     expect(driver.estimate({ clean: "standard", operation: "reclaim" }, spec)).toBe(6_000);
-    expect(driver.estimate({ clean: "full", operation: "reclaim" }, spec)).toBe(3_000);
+    expect(driver.estimate({ clean: "full", operation: "reclaim" }, spec)).toBe(32_000);
   });
 
   it("lists resolvable models and installed API levels, defaulting to the newest", async () => {

--- a/src/drivers/android/index.ts
+++ b/src/drivers/android/index.ts
@@ -36,14 +36,22 @@ const SDK_DOWNLOAD_TIMEOUT_MS = 20 * 60_000;
 const SIGKILL_REAP_TIMEOUT_MS = 5_000;
 const SNAPSHOT_BOOT_ESTIMATE_MS = 4_000;
 const PROVISION_ESTIMATE_MS = 1_000;
-// A `snapshot` reclaim is a snapshot load followed by the same readiness wait a snapshot boot
-// pays, so it costs about what SNAPSHOT_BOOT_ESTIMATE_MS covers plus the load itself.
+// Measured on an M3 Pro against Pixel 8 / API 35: 2.4-5.1s over nine steady-state reclaims
+// (median 4.6s), and 3.7-5.7s with three running at once. A `snapshot` reclaim loads the clean
+// baseline and commits the device straight back to `ready`, so the driver call is the whole
+// window the device spends `reclaiming`. Held just above the observed maximum.
 const SNAPSHOT_RECLAIM_ESTIMATE_MS = 6_000;
-// A `wipe` reclaim is cheaper than it sounds, and cheaper than a `full` clean suggests: this
-// path only shuts the emulator down and sets `needsWipe`, deferring the wipe itself to the
-// next `makeReady`, where it is paid as a cold boot. So what `reclaim` costs here is bounded
-// by the shutdown, not by the erase -- the opposite of iOS, whose `erase` is synchronous.
-const WIPE_RECLAIM_ESTIMATE_MS = 3_000;
+// Measured at 22.8-42.8s on the same hardware (median 31.7s) -- an order of magnitude above the
+// 3s this first guessed, for a reason worth stating precisely. `reclaim` itself really does
+// only shut the emulator down and defer the wipe to the next `makeReady`; what it does not do
+// is end the device's time in `reclaiming`. `WarmPoolCoordinator#disposition` re-readies a
+// device the pool wants to keep warm before committing the transition, so the wipe boot and the
+// baseline re-capture land inside the same window -- and that window, not the driver call, is
+// what both consumers of this number measure: a waiting requester's ETA, and the state age
+// `Doctor` compares against. A device the pool does not keep warm settles in seconds instead.
+// The slow branch is the one to quote: pricing the fast one would make every kept-warm reclaim
+// look stalled, while over-quoting only delays a finding.
+const WIPE_RECLAIM_ESTIMATE_MS = 32_000;
 const CLEAN_BASELINE = "simlock_clean_baseline";
 const DURABLE_MARK_KEY = "simlock.mark";
 const ERASABLE_MARK_PATH = "/data/local/tmp/simlock-mark.json";
@@ -490,6 +498,10 @@ export class AndroidDriver implements Driver {
       case "boot":
         return COLD_BOOT_ESTIMATE_MS;
       case "reclaim":
+        // `standard` is priced as the snapshot restore it selects. It can still fall back to
+        // the wipe branch when the baseline no longer matches the AVD config, which runs some
+        // five times longer; that is the exception rather than the case to quote, and `Doctor`
+        // covers it by taking the slower clean level instead of this averaging the two.
         return this.reclaimStrategy({ clean: estimate.clean }) === "wipe"
           ? WIPE_RECLAIM_ESTIMATE_MS
           : SNAPSHOT_RECLAIM_ESTIMATE_MS;

--- a/src/drivers/android/index.ts
+++ b/src/drivers/android/index.ts
@@ -6,6 +6,7 @@ import {
   type DriverCatalogEntry,
   type DriverDevice,
   DriverCrashError,
+  type DriverEstimate,
   type DriverReality,
   type ObservedDevice,
   type ObservedMark,
@@ -34,6 +35,15 @@ const SDK_DOWNLOAD_TIMEOUT_MS = 20 * 60_000;
 // from ever turning a "we already killed it" cleanup into an unbounded await.
 const SIGKILL_REAP_TIMEOUT_MS = 5_000;
 const SNAPSHOT_BOOT_ESTIMATE_MS = 4_000;
+const PROVISION_ESTIMATE_MS = 1_000;
+// A `snapshot` reclaim is a snapshot load followed by the same readiness wait a snapshot boot
+// pays, so it costs about what SNAPSHOT_BOOT_ESTIMATE_MS covers plus the load itself.
+const SNAPSHOT_RECLAIM_ESTIMATE_MS = 6_000;
+// A `wipe` reclaim is cheaper than it sounds, and cheaper than a `full` clean suggests: this
+// path only shuts the emulator down and sets `needsWipe`, deferring the wipe itself to the
+// next `makeReady`, where it is paid as a cold boot. So what `reclaim` costs here is bounded
+// by the shutdown, not by the erase -- the opposite of iOS, whose `erase` is synchronous.
+const WIPE_RECLAIM_ESTIMATE_MS = 3_000;
 const CLEAN_BASELINE = "simlock_clean_baseline";
 const DURABLE_MARK_KEY = "simlock.mark";
 const ERASABLE_MARK_PATH = "/data/local/tmp/simlock-mark.json";
@@ -473,14 +483,16 @@ export class AndroidDriver implements Driver {
     };
   }
 
-  estimate(operation: "provision" | "boot" | "reclaim", _spec: DeviceSpec): number {
-    switch (operation) {
+  estimate(estimate: DriverEstimate, _spec: DeviceSpec): number {
+    switch (estimate.operation) {
       case "provision":
-        return 1_000;
+        return PROVISION_ESTIMATE_MS;
       case "boot":
         return COLD_BOOT_ESTIMATE_MS;
       case "reclaim":
-        return 2_000;
+        return this.reclaimStrategy({ clean: estimate.clean }) === "wipe"
+          ? WIPE_RECLAIM_ESTIMATE_MS
+          : SNAPSHOT_RECLAIM_ESTIMATE_MS;
     }
   }
 

--- a/src/drivers/ios/index.test.ts
+++ b/src/drivers/ios/index.test.ts
@@ -374,9 +374,19 @@ describe("IosSimctlDriver", () => {
       ["simctl", "shutdown", driverData.udid],
       ["simctl", "delete", driverData.udid],
     ]);
-    expect(driver.estimate("provision", spec)).toBe(500);
-    expect(driver.estimate("boot", spec)).toBe(30_000);
-    expect(driver.estimate("reclaim", spec)).toBe(1_000);
+    expect(driver.estimate({ operation: "provision" }, spec)).toBe(500);
+    expect(driver.estimate({ operation: "boot" }, spec)).toBe(60_000);
+  });
+
+  it("prices reclaim as the erase it always runs, at either clean level", () => {
+    const driver = createDriver(new ScriptedProcessRunner([]));
+
+    // `reclaimStrategy` answers `erase` for both levels, so both must be priced as one --
+    // and as tens of seconds, not the ~1s the estimate used to claim (#56).
+    expect(driver.reclaimStrategy({ clean: "standard" })).toBe("erase");
+    expect(driver.reclaimStrategy({ clean: "full" })).toBe("erase");
+    expect(driver.estimate({ clean: "standard", operation: "reclaim" }, spec)).toBe(34_000);
+    expect(driver.estimate({ clean: "full", operation: "reclaim" }, spec)).toBe(34_000);
   });
 
   it("lists resolvable models and installed runtimes, defaulting to the newest", async () => {

--- a/src/drivers/ios/index.ts
+++ b/src/drivers/ios/index.ts
@@ -5,6 +5,7 @@ import {
   type DriverCatalogEntry,
   type DriverDevice,
   DriverCrashError,
+  type DriverEstimate,
   type DriverReality,
   type ObservedDevice,
   type ObservedRunState,
@@ -23,6 +24,17 @@ import type {
 
 const COMMAND_TIMEOUT_MS = 30_000;
 const BOOTSTATUS_TIMEOUT_MS = 120_000;
+const PROVISION_ESTIMATE_MS = 500;
+// A cold `simctl boot` to `bootstatus` measures roughly 30s on a fast, idle machine and up to
+// a minute on a loaded or slower one. The upper end is the estimate, deliberately: this number
+// is what a waiting requester is quoted, and quoting 30s to someone who then waits 60s is the
+// failure mode #56 is about. The cost is that `Doctor`'s `provisioning` stall threshold widens
+// with it -- see the note there on why that is the cheaper of the two errors.
+const COLD_BOOT_ESTIMATE_MS = 60_000;
+// Measured, not guessed: a single `simctl erase` took ~34s in #43's investigation. Unlike
+// Android, iOS has no deferred-wipe path -- `erase` is synchronous and every reclaim pays it,
+// at either clean level, so this is the only reclaim number the driver has.
+const ERASE_ESTIMATE_MS = 34_000;
 const MARK_FILE_NAME = "simlock-mark.json";
 
 interface IosDriverData {
@@ -236,14 +248,16 @@ export class IosSimctlDriver implements Driver {
     };
   }
 
-  estimate(operation: "provision" | "boot" | "reclaim", _spec: DeviceSpec): number {
-    switch (operation) {
+  estimate(estimate: DriverEstimate, _spec: DeviceSpec): number {
+    switch (estimate.operation) {
       case "provision":
-        return 500;
+        return PROVISION_ESTIMATE_MS;
       case "boot":
-        return 30_000;
+        return COLD_BOOT_ESTIMATE_MS;
       case "reclaim":
-        return 1_000;
+        // `reclaimStrategy` returns `erase` for both clean levels, so there is nothing to
+        // branch on here -- the clean level only matters to a driver that has a fast path.
+        return ERASE_ESTIMATE_MS;
     }
   }
 


### PR DESCRIPTION
Closes #56.

## What was wrong

`estimate("reclaim", spec)` returned **1s** for iOS and **2s** for Android against a measured **~34s** simulator erase. Both consumers were misled in the optimistic direction — a waiting requester's ETA, and the stalled-transition threshold, which at 1s could never clear its own 60s floor, so the "derived from the driver's own estimates" property #37/#55 asked for was not in effect for reclaim.

Two of the three acceptance criteria turned out to describe consumers that were **never wired up**, so fixing the number alone would not have shown anywhere:

- `estimatedReclaimMs` was hardcoded to `0` in both timing helpers — `estimated_reclaim_ms` has always been a literal zero in the grant payload.
- The `reclaiming` progress stage is documented in `docs/CLI.md` and typed in the contract, but nothing in production emitted it. Only a test ever pushed one.

## The change

`estimate` now takes a `DriverEstimate` rather than a bare operation name, so `reclaim` carries the clean level `reclaimStrategy` already selects on. **All figures below are measured**, not derived — see the measurement section.

| driver | clean | strategy | estimate | measured |
|---|---|---|---|---|
| iOS | standard / full | `erase` | 34s | ~34s (#43) |
| Android | standard | `snapshot` | 6s | 2.4–5.1s, median 4.6s (n=9) |
| Android | full | `wipe` | 32s | 22.8–42.8s, median 31.7s (n=5) |

Wiring the two dead consumers:

- **`estimatedReclaimMs`** carries what releasing the device will cost — the one figure in a grant's timing that describes work still ahead of the holder rather than work already done. Set for provision, boot-shutdown, and (new) warm grants, which previously reported all zeros.
- **The `reclaiming` stage** is emitted when a waiter is queued and a spec-matching device is currently being reclaimed. Purely informational: the plan is untouched and the device is granted through the normal `ready` path when its reclaim commits.

`Doctor` takes the slower of the two clean levels. A `reclaiming` record does not say which one started it, and the errors are not symmetric — too tight invents a false stall, too loose only delays a real finding. With the measured numbers this now matters in practice: Android's `reclaiming` threshold is 32s × 3 = 96s and clears the 60s floor, where the earlier guesses left it landing on the floor exactly as before this work. iOS clears it at 102s.

`sameSpec` moved to `domain.ts`; it was already duplicated in the planner and the warm-pool coordinator, and this needed a third copy.

## Measurement

Run on an M3 Pro / 38 GB, AC power, Android emulator 36.5.11.0, Pixel 8 / API 35 (`android-35/default/arm64-v8a`), instrumented through simlock's own `device.reclaimed` / `device.ready` events rather than by timing SDK calls externally.

**A wipe reclaim is ~10× what this PR first guessed, and the guess was wrong about what the number measures.** `reclaim` itself does only shut the emulator down and defer the wipe to the next `makeReady` — that part of the original comment was accurate. What it missed is that the device does not leave `reclaiming` there: `WarmPoolCoordinator#disposition` re-readies a device the pool wants to keep warm before committing the transition, so the wipe boot and the baseline re-capture fall inside the same window. That window — not the driver call — is what both consumers of this estimate observe: the age `Doctor` compares against, and how long a waiting requester actually waits. The estimate now models the window.

It is bimodal: a device the pool does *not* keep warm settles in seconds. The slow branch is the one quoted, because under-quoting makes every kept-warm reclaim look stalled while over-quoting only delays a finding.

Other numbers from the same run, unchanged as a result:

- Cold boot 22.5–29.5s (n=3) against a 31s estimate — a safe upper bound on this hardware.
- Provision 0.9–1.5s (n=3) against 1s.
- Three concurrent snapshot reclaims: 3.7s, 4.5s, 5.7s — contention is mild at this pool size.
- No `device.purge-failed` or `device.quarantined` events, no failed boots.

`SNAPSHOT_BOOT_ESTIMATE_MS` (4s) remains unvalidated — a snapshot *boot* needs the device shut down first, and `daemon stop` deliberately leaves emulators running (the warm pool survives a daemon restart; `idle.shutdownAfterMs` is what shuts them). It only feeds a diagnostic log threshold, so it is not load-bearing here.

## iOS cold boot: 30s → 60s

Separate from #56, and a judgement call worth flagging. A cold `simctl boot` to `bootstatus` measures 30–60s depending on the machine, and the quoted ETA should not be the best case. The cost is that `Doctor`'s `provisioning` stall threshold widens with it — `(0.5 + 60) × 3 ≈ 181s`, up from ~91s — so a genuinely hung boot goes unreported for roughly twice as long. That is the cheaper of the two errors, but it is a real trade-off rather than free safety; happy to revert this half if you'd rather keep the tighter threshold and quote the median instead.

## Tests

- iOS: reclaim priced as an erase at both clean levels.
- Android: strategy split, at the measured values.
- `Doctor`: a `full`-level reclaim past the `standard` threshold is not a stall; past the `full` one it is.
- `LeaseEngine`: a waiter queued behind a reclaim gets `queued` then `reclaiming` with the driver's ETA; a waiter queued behind a *leased* device gets only `queued`.
- `LeaseEngine`: grant timing carries `estimatedReclaimMs`, including for a warm grant that does no work.
- **e2e**: the `reclaiming` stage all the way out to the CLI's stderr — coordinator, daemon push, and rendered `eta_seconds`. This was the one new user-facing output with no coverage past the coordinator, and an attempt to observe it on real hardware missed the branch (three AVDs in the pool meant the second request booted a spare instead of queueing). Verified to fail when the notification is removed.

`pnpm check` green (typecheck, typecheck:e2e, lint, format:check, 642 unit, 33 e2e). `fallow` reports no new findings on the changed files.