### PR TITLE
feat(core): owned device root validation and its ports (1/5)

### DIFF
--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -50,7 +50,7 @@ in short: `subject.past-tense-fact`, emitted post-commit, facts not commands.
 | `disk.pressure-detected` | free bytes, threshold | free disk crossed under the configured threshold (edge-triggered: once per crossing, not once per tick while it persists) | CleanupReaper | implemented |
 | `cleanup.executed` | rule name, action, target, reason | cleanup executor committed a proposed action | CleanupExecutor | implemented |
 | `doctor.reconciled` | drift findings | daemon reconciliation completed | Doctor | implemented |
-| `driver.root-rejected` | platform, root path, reason (missing-marker/invalid-marker/wrong-instance/symlink/wrong-owner/wrong-permissions/non-empty-unowned-root) | a driver's device root failed ownership validation at startup, so that platform's driver did not start | DaemonServer | planned |
+| `driver.root-rejected` | platform, root path, reason (not-absolute/missing-marker/invalid-marker/wrong-instance/symlink/wrong-owner/wrong-permissions/non-empty-unowned-root/unreadable) | a driver's device root failed ownership validation at startup, so that platform's driver did not start | DaemonServer | planned |
 | `driver.adb-server-rejected` | port, reason | Simlock's configured adb server port was occupied by a server it does not own, so the Android driver did not start | DaemonServer | planned |
 
 ## Conventions recap

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -1036,6 +1036,7 @@ function sequence() {
 function testConfig(): Config {
   return {
     diskPressure: { freeBytesThreshold: 10 * gibibyte },
+    drivers: {},
     eventBuffer: { capacity: 100 },
     health: {
       enabled: true,

--- a/src/core/acquisition-planner.test.ts
+++ b/src/core/acquisition-planner.test.ts
@@ -11,6 +11,7 @@ const gibibyte = 1024 ** 3;
 const spec = { model: "iPhone 16", osVersion: "26.5", platform: "ios" } as const;
 const config: Config = {
   diskPressure: { freeBytesThreshold: 10 * gibibyte },
+  drivers: {},
   eventBuffer: { capacity: 100 },
   health: {
     enabled: true,

--- a/src/core/cleanup/idle-destroy.test.ts
+++ b/src/core/cleanup/idle-destroy.test.ts
@@ -7,6 +7,7 @@ const gibibyte = 1024 ** 3;
 
 const config: Config = {
   diskPressure: { freeBytesThreshold: 0 },
+  drivers: {},
   eventBuffer: { capacity: 1 },
   health: {
     enabled: true,

--- a/src/core/cleanup/idle-shutdown.test.ts
+++ b/src/core/cleanup/idle-shutdown.test.ts
@@ -5,6 +5,7 @@ import { idleShutdownRule } from "./idle-shutdown.js";
 
 const config: Config = {
   diskPressure: { freeBytesThreshold: 0 },
+  drivers: {},
   eventBuffer: { capacity: 1 },
   health: {
     enabled: true,

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -10,6 +10,19 @@ function resourceOptions(config: Config): ResourceStrategyOptions {
   return config.capacity.config;
 }
 
+/**
+ * The walk `simlock config get <key>` performs over the daemon's config, reproduced here
+ * so a driver block is proven reachable by dotted key and not just present in the object.
+ */
+function dottedValue(config: Config, key: string): unknown {
+  let current: unknown = config;
+  for (const segment of key.split(".")) {
+    if (typeof current !== "object" || current === null) return undefined;
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
 const configPath = "/home/agent/.simlock/config.json";
 const gibibyte = 1024 ** 3;
 
@@ -377,6 +390,92 @@ describe("loadConfig", () => {
     [{ stalledTransition: { thresholdMultiplier: 0.5 } }, "stalledTransition.thresholdMultiplier"],
     [{ stalledTransition: { minimumThresholdMs: -1 } }, "stalledTransition.minimumThresholdMs"],
   ])("rejects invalid stalledTransition values in every field", async (contents, path) => {
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp("/home/agent/.simlock");
+    await filesystem.writeFileAtomic(configPath, JSON.stringify(contents));
+
+    await expect(
+      loadConfig({ configPath, filesystem, systemStats: createStats() }),
+    ).rejects.toThrow(path);
+  });
+
+  it("defaults to no driver settings at all", async () => {
+    const config = await loadConfig({
+      configPath,
+      filesystem: new MemoryFilesystem(),
+      systemStats: createStats(),
+    });
+
+    expect(config.drivers).toEqual({});
+  });
+
+  it("keeps driver settings verbatim, including keys it has never heard of", async () => {
+    const filesystem = new MemoryFilesystem();
+    const warn = vi.fn();
+    await filesystem.mkdirp("/home/agent/.simlock");
+    await filesystem.writeFileAtomic(
+      configPath,
+      JSON.stringify({
+        drivers: {
+          ios: { deviceRoot: "/Volumes/scratch/simlock-ios" },
+          android: { adbServerPort: 5038, headless: true, somethingOnlyTheDriverKnows: "yes" },
+        },
+      }),
+    );
+
+    const config = await loadConfig({ configPath, filesystem, systemStats: createStats(), warn });
+
+    expect(config.drivers).toEqual({
+      ios: { deviceRoot: "/Volumes/scratch/simlock-ios" },
+      android: { adbServerPort: 5038, headless: true, somethingOnlyTheDriverKnows: "yes" },
+    });
+    // Warning about an unrecognised key here would mean the core knows which keys a
+    // driver has, which is the whole thing this block is not allowed to know.
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("reads a driver setting at the dotted path `simlock config get` walks", async () => {
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp("/home/agent/.simlock");
+    await filesystem.writeFileAtomic(
+      configPath,
+      JSON.stringify({ drivers: { ios: { deviceRoot: "/Volumes/scratch/simlock-ios" } } }),
+    );
+
+    const config = await loadConfig({ configPath, filesystem, systemStats: createStats() });
+
+    expect(dottedValue(config, "drivers.ios.deviceRoot")).toBe("/Volumes/scratch/simlock-ios");
+  });
+
+  it("merges driver settings across layers key by key", async () => {
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp("/home/agent/.simlock");
+    await filesystem.writeFileAtomic(
+      configPath,
+      JSON.stringify({
+        drivers: { ios: { deviceRoot: "/from-file" }, android: { headless: true } },
+      }),
+    );
+
+    const config = await loadConfig({
+      configPath,
+      filesystem,
+      systemStats: createStats(),
+      overrides: { drivers: { ios: { deviceRoot: "/from-override" } } },
+    });
+
+    expect(config.drivers).toEqual({
+      ios: { deviceRoot: "/from-override" },
+      android: { headless: true },
+    });
+  });
+
+  it.each([
+    [{ drivers: "everything" }, "drivers"],
+    [{ drivers: { ios: "/Volumes/scratch" } }, "drivers.ios"],
+    [{ drivers: { ios: { deviceRoot: { path: "/Volumes/scratch" } } } }, "drivers.ios.deviceRoot"],
+    [{ drivers: { ios: { deviceRoot: ["/Volumes/scratch"] } } }, "drivers.ios.deviceRoot"],
+  ])("rejects driver settings that are not plain scalars", async (contents, path) => {
     const filesystem = new MemoryFilesystem();
     await filesystem.mkdirp("/home/agent/.simlock");
     await filesystem.writeFileAtomic(configPath, JSON.stringify(contents));

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -30,6 +30,13 @@ const DEFAULT_CONFIG_PATH = "~/.simlock/config.json";
 
 export interface Config {
   readonly capacity: CapacityConfig;
+  /**
+   * Per-driver settings, opaque to the core: stored, merged, and handed to the driver
+   * that owns the key without a single key being interpreted here. What
+   * `drivers.ios.deviceRoot` means is the iOS driver's business, and knowing it here
+   * would be exactly the leak architecture rule 2 forbids.
+   */
+  readonly drivers: Readonly<Record<string, Readonly<Record<string, string | number | boolean>>>>;
   readonly idle: {
     readonly shutdownAfterMs: number;
     readonly deleteAfterMs: number;
@@ -220,6 +227,7 @@ function defaultConfig(systemStats: SystemStats, strategy: CapacityStrategyName)
       strategy,
       config: defaultCapacityOptions(strategy, systemStats),
     } as CapacityConfig,
+    drivers: {},
     idle: {
       shutdownAfterMs: 10 * 60_000,
       deleteAfterMs: 60 * 60_000,
@@ -310,6 +318,7 @@ function configValidators(strategy: CapacityStrategyName): Record<string, Valida
     // Legacy spelling of the resource options; still type-checked here so a typo
     // inside them is still reported rather than silently dropped.
     ...resourceOptionValidators,
+    drivers: driversValidator,
     idle: objectValidator({ shutdownAfterMs: nonNegativeNumber, deleteAfterMs: nonNegativeNumber }),
     warmPool: objectValidator({
       quarantine: objectValidator({
@@ -340,6 +349,39 @@ function configValidators(strategy: CapacityStrategyName): Record<string, Valida
       minimumThresholdMs: nonNegativeNumber,
     }),
   };
+}
+
+/**
+ * Checks the shape of `drivers` and nothing else. Every leaf is type-checked, because a
+ * config file is hand-edited and a nested object or array there is a mistake worth
+ * naming -- but an unrecognised key inside a driver block is deliberately *not* a
+ * warning. The core does not know which keys a driver has, and warning about the ones it
+ * has not heard of would be the same leak as interpreting them.
+ */
+const driversValidator: Validator = (value, path) => {
+  const drivers = requireObject(value, path);
+
+  return Object.fromEntries(
+    Object.entries(drivers).map(([name, block]) => [
+      name,
+      driverSettings(block, `${path}.${name}`),
+    ]),
+  );
+};
+
+function driverSettings(value: unknown, path: string): Record<string, string | number | boolean> {
+  const settings = requireObject(value, path);
+  const result: Record<string, string | number | boolean> = {};
+
+  for (const [key, leaf] of Object.entries(settings)) {
+    if (typeof leaf !== "string" && typeof leaf !== "number" && typeof leaf !== "boolean") {
+      throw invalidValue(`${path}.${key}`, "a string, number, or boolean");
+    }
+
+    result[key] = leaf;
+  }
+
+  return result;
 }
 
 function mergeConfig<Base extends object>(base: Base, overrides: object): Base {

--- a/src/core/device-root.test.ts
+++ b/src/core/device-root.test.ts
@@ -1,0 +1,284 @@
+import { mkdtemp, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { type Filesystem, MemoryFilesystem, NodeFilesystem } from "../ports/index.js";
+import type { Platform } from "./domain.js";
+import { ensureOwnedRoot, OWNED_ROOT_MARKER_FILE, OwnedRootError } from "./index.js";
+
+const instanceId = "instance-a";
+const root = "/home/agent/.simlock/devices/ios";
+const markerPath = `${root}/${OWNED_ROOT_MARKER_FILE}`;
+const uid = 501;
+
+interface Overrides {
+  readonly instanceId?: string;
+  readonly path?: string;
+  readonly platform?: Platform;
+}
+
+function createFilesystem(): MemoryFilesystem {
+  return new MemoryFilesystem(undefined, uid);
+}
+
+async function ensure(filesystem: Filesystem, overrides: Overrides = {}): Promise<string> {
+  return ensureOwnedRoot({
+    filesystem,
+    instanceId: overrides.instanceId ?? instanceId,
+    path: overrides.path ?? root,
+    platform: overrides.platform ?? "ios",
+    uid,
+  });
+}
+
+/** The reason the root was refused, failing the test when it was accepted instead. */
+async function refusal(filesystem: Filesystem, overrides: Overrides = {}): Promise<string> {
+  try {
+    await ensure(filesystem, overrides);
+  } catch (error: unknown) {
+    expect(error).toBeInstanceOf(OwnedRootError);
+    return (error as OwnedRootError).reason;
+  }
+
+  throw new Error("expected the root to be refused");
+}
+
+function marker(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    schemaVersion: 1,
+    owner: "simlock",
+    instanceId,
+    platform: "ios",
+    ...overrides,
+  });
+}
+
+/** An existing root nobody validated: created behind Simlock's back, like a user's `mkdir -p`. */
+async function seedRoot(filesystem: MemoryFilesystem, markerContents?: string): Promise<void> {
+  await filesystem.mkdirp(root);
+  if (markerContents !== undefined) {
+    await filesystem.writeFileAtomic(markerPath, markerContents);
+  }
+}
+
+describe("ensureOwnedRoot", () => {
+  it("creates a missing root, its parents, and its ownership marker", async () => {
+    const filesystem = createFilesystem();
+
+    await expect(ensure(filesystem)).resolves.toBe(root);
+    await expect(filesystem.lstat(root)).resolves.toMatchObject({
+      kind: "directory",
+      mode: 0o700,
+      uid,
+    });
+    await expect(filesystem.readFile(markerPath).then(JSON.parse)).resolves.toEqual({
+      schemaVersion: 1,
+      owner: "simlock",
+      instanceId,
+      platform: "ios",
+    });
+  });
+
+  it("gives a new root owner-only permissions even when the umask stripped them", async () => {
+    const filesystem = new UmaskedFilesystem(undefined, uid);
+
+    await ensure(filesystem);
+
+    await expect(filesystem.lstat(root)).resolves.toMatchObject({ mode: 0o700 });
+  });
+
+  it("returns the resolved path for a root written with relative segments", async () => {
+    const filesystem = createFilesystem();
+
+    await expect(
+      ensure(filesystem, { path: "/home/agent/.simlock/devices/android/../ios" }),
+    ).resolves.toBe(root);
+  });
+
+  it("reuses a root it already owns without rewriting its marker", async () => {
+    const filesystem = createFilesystem();
+    await ensure(filesystem);
+    const original = await filesystem.readFile(markerPath);
+
+    await expect(ensure(filesystem)).resolves.toBe(root);
+    await expect(filesystem.readFile(markerPath)).resolves.toBe(original);
+  });
+
+  it("validates, rather than creates, a root another process created first", async () => {
+    const filesystem = new RacingFilesystem(root, uid);
+    await seedRoot(filesystem, marker());
+    const original = await filesystem.readFile(markerPath);
+
+    await expect(ensure(filesystem)).resolves.toBe(root);
+    await expect(filesystem.readFile(markerPath)).resolves.toBe(original);
+  });
+
+  it("refuses an empty root nobody marked", async () => {
+    const filesystem = createFilesystem();
+    await seedRoot(filesystem);
+
+    await expect(refusal(filesystem)).resolves.toBe("missing-marker");
+  });
+
+  it("refuses an unmarked root that already holds something", async () => {
+    const filesystem = createFilesystem();
+    await seedRoot(filesystem);
+    await filesystem.writeFileAtomic(`${root}/someone-elses-work.txt`, "");
+
+    await expect(refusal(filesystem)).resolves.toBe("non-empty-unowned-root");
+  });
+
+  it("refuses a path occupied by something that is not a directory", async () => {
+    const filesystem = createFilesystem();
+    await filesystem.mkdirp("/home/agent/.simlock/devices");
+    await filesystem.writeFileAtomic(root, "not a directory");
+
+    await expect(refusal(filesystem)).resolves.toBe("non-empty-unowned-root");
+  });
+
+  it("refuses a symlinked root", async () => {
+    const filesystem = createFilesystem();
+    await filesystem.mkdirp("/somewhere/else");
+    filesystem.defineSymlink(root, "/somewhere/else");
+
+    await expect(refusal(filesystem)).resolves.toBe("symlink");
+  });
+
+  it("refuses a symlinked marker", async () => {
+    const filesystem = createFilesystem();
+    await ensure(filesystem);
+    await filesystem.writeFileAtomic("/home/agent/elsewhere.json", marker());
+    filesystem.defineSymlink(markerPath, "/home/agent/elsewhere.json");
+
+    await expect(refusal(filesystem)).resolves.toBe("symlink");
+  });
+
+  it("refuses a root owned by another user", async () => {
+    const filesystem = createFilesystem();
+    await ensure(filesystem);
+    filesystem.defineAttributes(root, { uid: uid + 1 });
+
+    await expect(refusal(filesystem)).resolves.toBe("wrong-owner");
+  });
+
+  it("accepts a root owned by anyone when the platform has no uids", async () => {
+    const filesystem = createFilesystem();
+    await ensure(filesystem);
+    filesystem.defineAttributes(root, { uid: uid + 1 });
+
+    await expect(
+      ensureOwnedRoot({ filesystem, instanceId, path: root, platform: "ios" }),
+    ).resolves.toBe(root);
+  });
+
+  it.each([0o750, 0o770, 0o701])("refuses a root reachable beyond its owner (%s)", async (mode) => {
+    const filesystem = createFilesystem();
+    await ensure(filesystem);
+    filesystem.defineAttributes(root, { mode });
+
+    await expect(refusal(filesystem)).resolves.toBe("wrong-permissions");
+  });
+
+  it.each([
+    ["is not valid JSON", "{ definitely not json"],
+    ["names an unknown schema version", marker({ schemaVersion: 2 })],
+    ["names another owner", marker({ owner: "somebody-else" })],
+    ["names another platform", marker({ platform: "android" })],
+    ["carries no instance id", marker({ instanceId: undefined })],
+    ["is not an object", JSON.stringify("simlock")],
+  ])("refuses a root whose marker %s", async (_case, contents) => {
+    const filesystem = createFilesystem();
+    await seedRoot(filesystem, contents);
+
+    await expect(refusal(filesystem)).resolves.toBe("invalid-marker");
+  });
+
+  it("refuses a root whose marker cannot be read", async () => {
+    const filesystem = createFilesystem();
+    await seedRoot(filesystem);
+    await filesystem.mkdirp(markerPath);
+
+    await expect(refusal(filesystem)).resolves.toBe("invalid-marker");
+  });
+
+  it("refuses a root whose marker names another instance", async () => {
+    const filesystem = createFilesystem();
+    await seedRoot(filesystem, marker({ instanceId: "instance-b" }));
+
+    await expect(refusal(filesystem)).resolves.toBe("wrong-instance");
+  });
+
+  it("reports the root and platform it refused", async () => {
+    const filesystem = createFilesystem();
+    await seedRoot(filesystem);
+
+    await expect(ensure(filesystem)).rejects.toMatchObject({
+      reason: "missing-marker",
+      path: root,
+      platform: "ios",
+    });
+  });
+});
+
+describe("ensureOwnedRoot on a real filesystem", () => {
+  let home: string | undefined;
+
+  afterEach(async () => {
+    if (home !== undefined) {
+      await rm(home, { force: true, recursive: true });
+      home = undefined;
+    }
+  });
+
+  it("accepts a root reached through a symlinked ancestor", async () => {
+    // The ordinary case this must not fail on: `/tmp` is itself a symlink on macOS, and
+    // every temporary home lives under it. Only the root and its marker are checked
+    // without following links -- comparing realpath against the configured path would
+    // refuse a perfectly healthy machine.
+    const filesystem = new NodeFilesystem();
+    home = await mkdtemp(join(tmpdir(), "simlock-device-root-"));
+    await filesystem.mkdirp(join(home, "real"));
+    await symlink(join(home, "real"), join(home, "link"));
+    const path = join(home, "link", "ios");
+
+    const created = await ensureOwnedRoot({ filesystem, instanceId, path, platform: "ios" });
+    const revalidated = await ensureOwnedRoot({ filesystem, instanceId, path, platform: "ios" });
+
+    expect(created).toBe(path);
+    expect(revalidated).toBe(path);
+    expect(await filesystem.realpath(path)).not.toBe(path);
+  });
+});
+
+/** `mkdir` under a restrictive umask: the mode is a request the umask subtracts from. */
+class UmaskedFilesystem extends MemoryFilesystem {
+  async mkdir(path: string, options: { readonly mode?: number } = {}): Promise<void> {
+    await super.mkdir(path, { mode: (options.mode ?? 0o777) & ~0o277 });
+  }
+}
+
+/**
+ * Reports the root as absent exactly once, so the first `mkdir` loses a race it could not
+ * have seen coming -- the window every check-then-create has.
+ */
+class RacingFilesystem extends MemoryFilesystem {
+  #absentOnce: string | undefined;
+
+  constructor(absentOnce: string, owner: number) {
+    super(undefined, owner);
+    this.#absentOnce = absentOnce;
+  }
+
+  async lstat(path: string): ReturnType<MemoryFilesystem["lstat"]> {
+    if (path === this.#absentOnce) {
+      this.#absentOnce = undefined;
+      const error: NodeJS.ErrnoException = new Error(`No such file or directory: ${path}`);
+      error.code = "ENOENT";
+      throw error;
+    }
+
+    return super.lstat(path);
+  }
+}

--- a/src/core/device-root.test.ts
+++ b/src/core/device-root.test.ts
@@ -4,14 +4,21 @@ import { join } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { type Filesystem, MemoryFilesystem, NodeFilesystem } from "../ports/index.js";
+import {
+  CryptoIdGenerator,
+  type Filesystem,
+  MemoryFilesystem,
+  NodeFilesystem,
+} from "../ports/index.js";
 import type { Platform } from "./domain.js";
 import { ensureOwnedRoot, OWNED_ROOT_MARKER_FILE, OwnedRootError } from "./index.js";
 
 const instanceId = "instance-a";
-const root = "/home/agent/.simlock/devices/ios";
+const parent = "/home/agent/.simlock/devices";
+const root = `${parent}/ios`;
 const markerPath = `${root}/${OWNED_ROOT_MARKER_FILE}`;
 const uid = 501;
+const idGenerator = new CryptoIdGenerator();
 
 interface Overrides {
   readonly instanceId?: string;
@@ -26,6 +33,7 @@ function createFilesystem(): MemoryFilesystem {
 async function ensure(filesystem: Filesystem, overrides: Overrides = {}): Promise<string> {
   return ensureOwnedRoot({
     filesystem,
+    idGenerator,
     instanceId: overrides.instanceId ?? instanceId,
     path: overrides.path ?? root,
     platform: overrides.platform ?? "ios",
@@ -79,6 +87,33 @@ describe("ensureOwnedRoot", () => {
       instanceId,
       platform: "ios",
     });
+    // The root is assembled beside itself and published with one rename, so the only
+    // thing that may be left in the parent afterwards is the root.
+    await expect(filesystem.readdir(parent)).resolves.toEqual(["ios"]);
+  });
+
+  it("publishes a root and its marker in the same instant", async () => {
+    // A root that becomes visible before its marker does is refused for ever after by
+    // every later start, and a crash between the two steps makes that permanent.
+    const filesystem = new ObservingFilesystem(root, uid);
+
+    await ensure(filesystem);
+
+    expect(filesystem.rootContentsWhenItAppeared).toEqual([OWNED_ROOT_MARKER_FILE]);
+  });
+
+  it("leaves nothing at the root when it cannot finish creating one", async () => {
+    const filesystem = new FullDiskFilesystem(uid);
+
+    await expect(refusal(filesystem)).resolves.toBe("unreadable");
+    await expect(filesystem.exists(root)).resolves.toBe(false);
+    await expect(filesystem.readdir(parent)).resolves.toEqual([]);
+  });
+
+  it("refuses a root that was swapped between being created and being used", async () => {
+    const filesystem = new SwappedRootFilesystem(uid);
+
+    await expect(refusal(filesystem)).resolves.toBe("wrong-permissions");
   });
 
   it("gives a new root owner-only permissions even when the umask stripped them", async () => {
@@ -99,8 +134,10 @@ describe("ensureOwnedRoot", () => {
 
   it("reuses a root it already owns without rewriting its marker", async () => {
     const filesystem = createFilesystem();
-    await ensure(filesystem);
-    const original = await filesystem.readFile(markerPath);
+    // Bytes Simlock would never write itself: a marker in its own form could be rewritten
+    // byte for byte, since serialisation is deterministic, and this would notice nothing.
+    const original = `${JSON.stringify({ platform: "ios", instanceId, owner: "simlock", schemaVersion: 1, writtenBy: "0.1.0" })}\n`;
+    await seedRoot(filesystem, original);
 
     await expect(ensure(filesystem)).resolves.toBe(root);
     await expect(filesystem.readFile(markerPath)).resolves.toBe(original);
@@ -113,6 +150,49 @@ describe("ensureOwnedRoot", () => {
 
     await expect(ensure(filesystem)).resolves.toBe(root);
     await expect(filesystem.readFile(markerPath)).resolves.toBe(original);
+    await expect(filesystem.readdir(parent)).resolves.toEqual(["ios"]);
+  });
+
+  it.each([
+    ["a relative one", "devices/ios"],
+    ["one written against the home directory", "~/devices/ios"],
+    ["an empty one", ""],
+  ])(
+    "refuses %s rather than resolving it against whatever directory the daemon started in",
+    async (_case, path) => {
+      const filesystem = createFilesystem();
+
+      await expect(refusal(filesystem, { path })).resolves.toBe("not-absolute");
+    },
+  );
+
+  it("names the path it was given when refusing one that is not absolute", async () => {
+    const filesystem = createFilesystem();
+
+    await expect(ensure(filesystem, { path: "devices/ios" })).rejects.toMatchObject({
+      reason: "not-absolute",
+      path: "devices/ios",
+    });
+  });
+
+  it.each([
+    ["the root cannot be read", root],
+    ["its marker cannot be read", markerPath],
+  ])("refuses a root as unreadable when %s", async (_case, failingPath) => {
+    const filesystem = createFilesystem();
+    await seedRoot(filesystem);
+    filesystem.defineFailure(failingPath, "EACCES");
+
+    await expect(refusal(filesystem)).resolves.toBe("unreadable");
+  });
+
+  it("refuses a root whose parent cannot be created rather than failing the daemon", async () => {
+    // A `deviceRoot` of `<home>/notes.txt/ios` is a typo, not a reason to stop every
+    // driver: CP2 skips one platform on an OwnedRootError and dies on anything else.
+    const filesystem = createFilesystem();
+    filesystem.defineFailure(parent, "ENOTDIR");
+
+    await expect(refusal(filesystem)).resolves.toBe("unreadable");
   });
 
   it("refuses an empty root nobody marked", async () => {
@@ -169,7 +249,7 @@ describe("ensureOwnedRoot", () => {
     filesystem.defineAttributes(root, { uid: uid + 1 });
 
     await expect(
-      ensureOwnedRoot({ filesystem, instanceId, path: root, platform: "ios" }),
+      ensureOwnedRoot({ filesystem, idGenerator, instanceId, path: root, platform: "ios" }),
     ).resolves.toBe(root);
   });
 
@@ -187,6 +267,7 @@ describe("ensureOwnedRoot", () => {
     ["names another owner", marker({ owner: "somebody-else" })],
     ["names another platform", marker({ platform: "android" })],
     ["carries no instance id", marker({ instanceId: undefined })],
+    ["carries an empty instance id", marker({ instanceId: "" })],
     ["is not an object", JSON.stringify("simlock")],
   ])("refuses a root whose marker %s", async (_case, contents) => {
     const filesystem = createFilesystem();
@@ -243,14 +324,113 @@ describe("ensureOwnedRoot on a real filesystem", () => {
     await symlink(join(home, "real"), join(home, "link"));
     const path = join(home, "link", "ios");
 
-    const created = await ensureOwnedRoot({ filesystem, instanceId, path, platform: "ios" });
-    const revalidated = await ensureOwnedRoot({ filesystem, instanceId, path, platform: "ios" });
+    const created = await ensureOwnedRoot({
+      filesystem,
+      idGenerator,
+      instanceId,
+      path,
+      platform: "ios",
+    });
+    const revalidated = await ensureOwnedRoot({
+      filesystem,
+      idGenerator,
+      instanceId,
+      path,
+      platform: "ios",
+    });
 
     expect(created).toBe(path);
     expect(revalidated).toBe(path);
     expect(await filesystem.realpath(path)).not.toBe(path);
   });
+
+  it("gives every daemon racing to create one root the same root and marker", async () => {
+    // Three daemons starting at once on a fresh home, against a real kernel. Creating the
+    // root in place makes two of them refuse it -- the loser sees an unmarked directory,
+    // or the winner's half-written marker, and calls it somebody else's data.
+    const filesystem = new NodeFilesystem();
+    home = await mkdtemp(join(tmpdir(), "simlock-device-root-race-"));
+    const path = join(home, "devices", "ios");
+
+    const results = await Promise.allSettled(
+      [0, 1, 2].map(async () =>
+        ensureOwnedRoot({ filesystem, idGenerator, instanceId, path, platform: "ios" }),
+      ),
+    );
+
+    expect(
+      results.map((result) =>
+        result.status === "fulfilled" ? result.value : String(result.reason),
+      ),
+    ).toEqual([path, path, path]);
+    await expect(filesystem.readdir(path)).resolves.toEqual([OWNED_ROOT_MARKER_FILE]);
+    await expect(filesystem.readdir(join(home, "devices"))).resolves.toEqual(["ios"]);
+    await expect(
+      filesystem.readFile(join(path, OWNED_ROOT_MARKER_FILE)).then(JSON.parse),
+    ).resolves.toMatchObject({ instanceId, platform: "ios" });
+  });
 });
+
+/** Records what the root held the first moment it existed at all. */
+class ObservingFilesystem extends MemoryFilesystem {
+  rootContentsWhenItAppeared: readonly string[] | undefined;
+  readonly #root: string;
+
+  constructor(watched: string, owner: number) {
+    super(undefined, owner);
+    this.#root = watched;
+  }
+
+  async mkdir(path: string, options: { readonly mode?: number } = {}): Promise<void> {
+    await super.mkdir(path, options);
+    await this.#observe();
+  }
+
+  async writeFileAtomic(path: string, contents: string): Promise<void> {
+    await super.writeFileAtomic(path, contents);
+    await this.#observe();
+  }
+
+  async rename(from: string, to: string): Promise<void> {
+    await super.rename(from, to);
+    await this.#observe();
+  }
+
+  async #observe(): Promise<void> {
+    if (this.rootContentsWhenItAppeared === undefined && (await super.exists(this.#root))) {
+      this.rootContentsWhenItAppeared = await super.readdir(this.#root);
+    }
+  }
+}
+
+/** No room for the marker, so the create path has to unwind everything it built. */
+class FullDiskFilesystem extends MemoryFilesystem {
+  constructor(owner: number) {
+    super(undefined, owner);
+  }
+
+  async writeFileAtomic(path: string, contents: string): Promise<void> {
+    if (path.endsWith(OWNED_ROOT_MARKER_FILE)) {
+      const error: NodeJS.ErrnoException = new Error("No space left on device");
+      error.code = "ENOSPC";
+      throw error;
+    }
+
+    await super.writeFileAtomic(path, contents);
+  }
+}
+
+/** Something replaces the root in the instant between it being published and being used. */
+class SwappedRootFilesystem extends MemoryFilesystem {
+  constructor(owner: number) {
+    super(undefined, owner);
+  }
+
+  async rename(from: string, to: string): Promise<void> {
+    await super.rename(from, to);
+    this.defineAttributes(to, { mode: 0o777 });
+  }
+}
 
 /** `mkdir` under a restrictive umask: the mode is a request the umask subtracts from. */
 class UmaskedFilesystem extends MemoryFilesystem {

--- a/src/core/device-root.ts
+++ b/src/core/device-root.ts
@@ -1,0 +1,292 @@
+import { dirname, join, resolve } from "node:path";
+
+import type { Filesystem, PathDetails } from "../ports/index.js";
+import type { Platform } from "./domain.js";
+
+export const OWNED_ROOT_MARKER_FILE = ".simlock-owned.json";
+
+/** Owner-only. Group or other bits on a device root are grounds for refusing it. */
+const ROOT_MODE = 0o700;
+
+/**
+ * Why a root was refused. These strings are wire-visible: they travel in the
+ * `driver.root-rejected` event payload and are listed in `docs/EVENTS.md`, so the
+ * vocabulary is fixed and a new one cannot be invented here alone.
+ */
+export type RootRejectionReason =
+  | "missing-marker"
+  | "invalid-marker"
+  | "wrong-instance"
+  | "symlink"
+  | "wrong-owner"
+  | "wrong-permissions"
+  | "non-empty-unowned-root";
+
+export interface OwnedRootMarker {
+  readonly schemaVersion: 1;
+  readonly owner: "simlock";
+  readonly instanceId: string;
+  readonly platform: Platform;
+}
+
+export class OwnedRootError extends Error {
+  constructor(
+    message: string,
+    readonly reason: RootRejectionReason,
+    readonly path: string,
+    readonly platform: Platform,
+  ) {
+    super(message);
+    this.name = "OwnedRootError";
+  }
+}
+
+export interface EnsureOwnedRootOptions {
+  readonly filesystem: Filesystem;
+  readonly instanceId: string;
+  readonly path: string;
+  readonly platform: Platform;
+  /** `process.getuid?.()`; `undefined` skips the ownership check on platforms without uids. */
+  readonly uid?: number;
+}
+
+type RootContext = Omit<EnsureOwnedRootOptions, "path"> & { readonly root: string };
+
+/**
+ * Establishes that `path` is a device root this Simlock instance owns, creating it when
+ * nothing is there, and returns its resolved path.
+ *
+ * This is the whole of Simlock's structural ownership proof, and it is deliberately
+ * platform-agnostic: a driver supplies a path and nothing else. It fails closed in every
+ * ambiguous case -- there is no fallback to a default device location and no adoption of
+ * a directory Simlock did not create empty itself, because "empty right now" is not proof
+ * of "empty when marked" (ADR 0001, decision 2).
+ */
+export async function ensureOwnedRoot(options: EnsureOwnedRootOptions): Promise<string> {
+  const context: RootContext = { ...options, root: resolve(options.path) };
+
+  if (await createRoot(context)) {
+    return context.root;
+  }
+
+  await validateExistingRoot(context);
+  return context.root;
+}
+
+/**
+ * Creates the root with its marker, or reports `false` when something already occupies the
+ * path and validation has to decide about it instead.
+ */
+async function createRoot(context: RootContext): Promise<boolean> {
+  const { filesystem, root } = context;
+
+  if ((await pathDetails(filesystem, root)) !== undefined) {
+    return false;
+  }
+
+  await filesystem.mkdirp(dirname(root));
+
+  try {
+    await filesystem.mkdir(root, { mode: ROOT_MODE });
+  } catch (error: unknown) {
+    // Another process created the root between the check above and this call. Whatever it
+    // left behind is now an existing root like any other, so it gets validated rather than
+    // trusted -- and the retry happens exactly once, since validation never creates.
+    if (isExistingPathError(error)) {
+      return false;
+    }
+
+    throw error;
+  }
+
+  // `mkdir`'s mode is masked by the process umask, so the bits it asked for are not
+  // necessarily the bits it got. Setting them explicitly is what keeps a daemon started
+  // under a permissive umask from failing its own permission check on the next start.
+  await filesystem.chmod(root, ROOT_MODE);
+  await filesystem.writeFileAtomic(markerPath(root), serializeMarker(context));
+  return true;
+}
+
+async function validateExistingRoot(context: RootContext): Promise<void> {
+  const { filesystem, root, uid } = context;
+  // Only the root itself is read without following links. An *ancestor* symlink is
+  // ordinary -- `/tmp` is a link to `/private/tmp` on macOS, and every test home created
+  // with `mkdtemp` sits under it -- so comparing `realpath(root)` against `root` would
+  // fail closed on perfectly healthy machines. Do not "harden" this into a realpath check.
+  const details = await pathDetails(filesystem, root);
+
+  if (details === undefined) {
+    // The root existed a moment ago (that is why creation stood down) and is gone now.
+    // Creating it here would be the second attempt this function promises never to make.
+    throw rejected(context, "missing-marker", "it disappeared while it was being validated");
+  }
+
+  if (details.kind === "symlink") {
+    throw rejected(context, "symlink", "it is a symlink, so what it really contains is elsewhere");
+  }
+
+  if (details.kind !== "directory") {
+    // The reason vocabulary is fixed by the docs and has no separate "not a directory"
+    // member. This is the closest true statement it can make: something Simlock did not
+    // create is sitting where the root belongs.
+    throw rejected(context, "non-empty-unowned-root", "it is not a directory");
+  }
+
+  if (uid !== undefined && details.uid !== uid) {
+    throw rejected(context, "wrong-owner", `it is owned by uid ${details.uid}, not ${uid}`);
+  }
+
+  if ((details.mode & 0o077) !== 0) {
+    throw rejected(
+      context,
+      "wrong-permissions",
+      `its permissions are ${formatMode(details.mode)}, which grants access beyond its owner`,
+    );
+  }
+
+  await validateMarker(context);
+}
+
+async function validateMarker(context: RootContext): Promise<void> {
+  const { filesystem, instanceId, root } = context;
+  const path = markerPath(root);
+  const details = await pathDetails(filesystem, path);
+
+  if (details === undefined) {
+    throw await missingMarkerRejection(context);
+  }
+
+  if (details.kind === "symlink") {
+    throw rejected(context, "symlink", `its ${OWNED_ROOT_MARKER_FILE} marker is a symlink`);
+  }
+
+  const marker = await readMarker(context, path);
+  if (marker === undefined) {
+    throw rejected(context, "invalid-marker", `its ${OWNED_ROOT_MARKER_FILE} marker is unusable`);
+  }
+
+  if (marker.instanceId !== instanceId) {
+    throw rejected(
+      context,
+      "wrong-instance",
+      `it belongs to Simlock instance ${marker.instanceId}, not ${instanceId}`,
+    );
+  }
+}
+
+/**
+ * An unmarked root is refused either way; the two reasons differ only in what they tell
+ * the user. An empty one is most likely a path they created for Simlock by hand, and the
+ * fix is to remove it and let Simlock create it. A populated one holds someone's data.
+ */
+async function missingMarkerRejection(context: RootContext): Promise<OwnedRootError> {
+  const entries = await context.filesystem.readdir(context.root);
+
+  return entries.length > 0
+    ? rejected(
+        context,
+        "non-empty-unowned-root",
+        `it holds ${entries.length} entr${entries.length === 1 ? "y" : "ies"} and carries no ${OWNED_ROOT_MARKER_FILE} marker`,
+      )
+    : rejected(
+        context,
+        "missing-marker",
+        `it carries no ${OWNED_ROOT_MARKER_FILE} marker, and Simlock only marks a root it created itself`,
+      );
+}
+
+/** `undefined` for anything that is not this instance's marker shape -- see `invalid-marker`. */
+async function readMarker(
+  context: RootContext,
+  path: string,
+): Promise<OwnedRootMarker | undefined> {
+  let contents: string;
+  try {
+    contents = await context.filesystem.readFile(path);
+  } catch {
+    return undefined;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contents) as unknown;
+  } catch {
+    return undefined;
+  }
+
+  if (typeof parsed !== "object" || parsed === null) {
+    return undefined;
+  }
+
+  const marker = parsed as Record<string, unknown>;
+  const instanceId = marker["instanceId"];
+
+  if (
+    marker["schemaVersion"] !== 1 ||
+    marker["owner"] !== "simlock" ||
+    marker["platform"] !== context.platform ||
+    typeof instanceId !== "string" ||
+    instanceId === ""
+  ) {
+    return undefined;
+  }
+
+  return { schemaVersion: 1, owner: "simlock", instanceId, platform: context.platform };
+}
+
+function serializeMarker(context: RootContext): string {
+  const marker: OwnedRootMarker = {
+    schemaVersion: 1,
+    owner: "simlock",
+    instanceId: context.instanceId,
+    platform: context.platform,
+  };
+
+  return `${JSON.stringify(marker, null, 2)}\n`;
+}
+
+function markerPath(root: string): string {
+  return join(root, OWNED_ROOT_MARKER_FILE);
+}
+
+/** `undefined` only for a path that is absent; every other failure is the caller's problem. */
+async function pathDetails(filesystem: Filesystem, path: string): Promise<PathDetails | undefined> {
+  try {
+    return await filesystem.lstat(path);
+  } catch (error: unknown) {
+    if (isMissingPathError(error)) {
+      return undefined;
+    }
+
+    throw error;
+  }
+}
+
+function rejected(
+  context: RootContext,
+  reason: RootRejectionReason,
+  explanation: string,
+): OwnedRootError {
+  return new OwnedRootError(
+    `Refusing the ${context.platform} device root ${context.root}: ${explanation}`,
+    reason,
+    context.root,
+    context.platform,
+  );
+}
+
+function formatMode(mode: number): string {
+  return `0o${mode.toString(8).padStart(3, "0")}`;
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return errorCode(error) === "ENOENT";
+}
+
+function isExistingPathError(error: unknown): boolean {
+  return errorCode(error) === "EEXIST";
+}
+
+function errorCode(error: unknown): unknown {
+  return typeof error === "object" && error !== null && "code" in error ? error.code : undefined;
+}

--- a/src/core/device-root.ts
+++ b/src/core/device-root.ts
@@ -1,6 +1,6 @@
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 
-import type { Filesystem, PathDetails } from "../ports/index.js";
+import type { Filesystem, IdGenerator, PathDetails } from "../ports/index.js";
 import type { Platform } from "./domain.js";
 
 export const OWNED_ROOT_MARKER_FILE = ".simlock-owned.json";
@@ -14,13 +14,15 @@ const ROOT_MODE = 0o700;
  * vocabulary is fixed and a new one cannot be invented here alone.
  */
 export type RootRejectionReason =
+  | "not-absolute"
   | "missing-marker"
   | "invalid-marker"
   | "wrong-instance"
   | "symlink"
   | "wrong-owner"
   | "wrong-permissions"
-  | "non-empty-unowned-root";
+  | "non-empty-unowned-root"
+  | "unreadable";
 
 // fallow-ignore-next-line unused-type -- public shape of the on-disk ownership marker.
 export interface OwnedRootMarker {
@@ -44,6 +46,8 @@ export class OwnedRootError extends Error {
 
 export interface EnsureOwnedRootOptions {
   readonly filesystem: Filesystem;
+  /** Names the staging directory a root is assembled in, so two racing daemons never share one. */
+  readonly idGenerator: IdGenerator;
   readonly instanceId: string;
   readonly path: string;
   readonly platform: Platform;
@@ -61,12 +65,32 @@ type RootContext = Omit<EnsureOwnedRootOptions, "path"> & { readonly root: strin
  * platform-agnostic: a driver supplies a path and nothing else. It fails closed in every
  * ambiguous case -- there is no fallback to a default device location and no adoption of
  * a directory Simlock did not create empty itself, because "empty right now" is not proof
- * of "empty when marked" (ADR 0001, decision 2).
+ * of "empty when marked" (ADR 0001, decision 2). Every refusal is an `OwnedRootError`,
+ * including one that comes out of an unexpected filesystem failure, because the caller
+ * skips a single platform on this error and stops the whole daemon on any other.
  */
 export async function ensureOwnedRoot(options: EnsureOwnedRootOptions): Promise<string> {
+  if (!isAbsolute(options.path)) {
+    // `resolve` would make one up: a relative path lands wherever the process that
+    // launched the daemon happened to be standing, which for an auto-launched daemon is
+    // some agent's working directory rather than a place anyone chose to put tens of
+    // gigabytes of device data -- and in CP5 it is what `--purge-orphans` is aimed at.
+    // An empty path is not absolute either, so this covers it too.
+    throw refusal(
+      options.platform,
+      options.path,
+      "not-absolute",
+      "a device root has to be an absolute path, or it names a different directory to every process that reads the configuration",
+    );
+  }
+
   const context: RootContext = { ...options, root: resolve(options.path) };
 
   if (await createRoot(context)) {
+    // A root is never trusted on the strength of "we think we just made it": the checks
+    // cost one `lstat`, and they close the window in which what was published is not what
+    // is about to be used.
+    await validateRootDirectory(context);
     return context.root;
   }
 
@@ -77,50 +101,83 @@ export async function ensureOwnedRoot(options: EnsureOwnedRootOptions): Promise<
 /**
  * Creates the root with its marker, or reports `false` when something already occupies the
  * path and validation has to decide about it instead.
+ *
+ * The root is assembled under a sibling staging name and published with a single `rename`,
+ * so neither another daemon nor a crash can observe it half-made. Creating it in place
+ * would publish an unmarked directory first: every later start would refuse that as
+ * `non-empty-unowned-root` -- the temporary file `writeFileAtomic` leaves beside the marker
+ * is enough on its own -- and the only repair would be a hand-typed `rm -rf`. Staging is a
+ * *sibling* because `rename` is only atomic within one filesystem.
+ *
+ * One window survives and is accepted: POSIX `rename` replaces an empty directory at the
+ * destination, so a directory created by hand in the sliver between the check below and the
+ * rename is taken over. That is far narrower than publishing the root in three observable
+ * steps, and the alternatives (a Linux-only `renameat2`, or a lock file that becomes its
+ * own stale-state problem) are worse.
  */
 async function createRoot(context: RootContext): Promise<boolean> {
   const { filesystem, root } = context;
 
-  if ((await pathDetails(filesystem, root)) !== undefined) {
+  if ((await pathDetails(context, root, "it")) !== undefined) {
     return false;
   }
 
-  await filesystem.mkdirp(dirname(root));
+  await attempt(context, "its parent directory could not be created", () =>
+    filesystem.mkdirp(dirname(root)),
+  );
+
+  const staging = stagingPath(root, context.idGenerator);
+  try {
+    await filesystem.mkdir(staging, { mode: ROOT_MODE });
+    // `mkdir`'s mode is a request the process umask can only subtract from: under a
+    // restrictive one (`0o277`, say) the root comes back read-only to its own owner and
+    // every device written into it afterwards fails. `chmod` is the only way to end at the
+    // permissions validation demands of this root on the next start, and it cannot
+    // over-open it either, since it sets exactly the owner-only bits.
+    await filesystem.chmod(staging, ROOT_MODE);
+    await filesystem.writeFileAtomic(markerPath(staging), serializeMarker(context));
+  } catch (error: unknown) {
+    // Nothing partial may survive anywhere near the real path, so the staging directory
+    // goes before the failure is reported.
+    await discard(filesystem, staging);
+    throw unexpected(context, "it could not be assembled", error);
+  }
 
   try {
-    await filesystem.mkdir(root, { mode: ROOT_MODE });
+    await filesystem.rename(staging, root);
   } catch (error: unknown) {
-    // Another process created the root between the check above and this call. Whatever it
-    // left behind is now an existing root like any other, so it gets validated rather than
-    // trusted -- and the retry happens exactly once, since validation never creates.
-    if (isExistingPathError(error)) {
+    await discard(filesystem, staging);
+
+    // Something occupies the path now: another daemon published its root there first, or a
+    // directory of the user's appeared. Either way it is an existing root like any other,
+    // and validation -- which never creates -- is what decides about it.
+    if (isOccupiedPathError(error)) {
       return false;
     }
 
-    throw error;
+    throw unexpected(context, "it could not be published", error);
   }
 
-  // `mkdir`'s mode is a request the process umask can only subtract from: under a
-  // restrictive one (`0o277`, say) the root comes back read-only to its own owner and
-  // every device written into it afterwards fails. `chmod` is the only way to end at the
-  // permissions validation demands of this root on the next start, and it cannot
-  // over-open it either, since it sets exactly the owner-only bits.
-  await filesystem.chmod(root, ROOT_MODE);
-  await filesystem.writeFileAtomic(markerPath(root), serializeMarker(context));
   return true;
 }
 
 async function validateExistingRoot(context: RootContext): Promise<void> {
-  const { filesystem, root, uid } = context;
+  await validateRootDirectory(context);
+  await validateMarker(context);
+}
+
+async function validateRootDirectory(context: RootContext): Promise<void> {
+  const { root, uid } = context;
   // Only the root itself is read without following links. An *ancestor* symlink is
   // ordinary -- `/tmp` is a link to `/private/tmp` on macOS, and every test home created
   // with `mkdtemp` sits under it -- so comparing `realpath(root)` against `root` would
   // fail closed on perfectly healthy machines. Do not "harden" this into a realpath check.
-  const details = await pathDetails(filesystem, root);
+  const details = await pathDetails(context, root, "it");
 
   if (details === undefined) {
-    // The root existed a moment ago (that is why creation stood down) and is gone now.
-    // Creating it here would be the second attempt this function promises never to make.
+    // The root existed a moment ago (that is why creation stood down, or the rename that
+    // published it succeeded) and is gone now. Creating it here would be the second
+    // attempt this function promises never to make.
     throw rejected(context, "missing-marker", "it disappeared while it was being validated");
   }
 
@@ -146,14 +203,12 @@ async function validateExistingRoot(context: RootContext): Promise<void> {
       `its permissions are ${formatMode(details.mode)}, which grants access beyond its owner`,
     );
   }
-
-  await validateMarker(context);
 }
 
 async function validateMarker(context: RootContext): Promise<void> {
-  const { filesystem, instanceId, root } = context;
+  const { instanceId, root } = context;
   const path = markerPath(root);
-  const details = await pathDetails(filesystem, path);
+  const details = await pathDetails(context, path, `its ${OWNED_ROOT_MARKER_FILE} marker`);
 
   if (details === undefined) {
     throw await missingMarkerRejection(context);
@@ -183,7 +238,9 @@ async function validateMarker(context: RootContext): Promise<void> {
  * fix is to remove it and let Simlock create it. A populated one holds someone's data.
  */
 async function missingMarkerRejection(context: RootContext): Promise<OwnedRootError> {
-  const entries = await context.filesystem.readdir(context.root);
+  const entries = await attempt(context, "its contents could not be listed", () =>
+    context.filesystem.readdir(context.root),
+  );
 
   return entries.length > 0
     ? rejected(
@@ -204,7 +261,9 @@ async function readMarker(
   path: string,
 ): Promise<OwnedRootMarker | undefined> {
   // A marker that cannot be read and one that cannot be parsed are the same answer: this
-  // is not a root whose ownership Simlock can vouch for.
+  // is not a root whose ownership Simlock can vouch for. This catch stays narrow on
+  // purpose -- widening it to `unreadable` would demote a deliberate refusal to a
+  // filesystem accident.
   let parsed: unknown;
   try {
     parsed = JSON.parse(await context.filesystem.readFile(path)) as unknown;
@@ -250,17 +309,64 @@ function markerPath(root: string): string {
   return join(root, OWNED_ROOT_MARKER_FILE);
 }
 
-/** `undefined` only for a path that is absent; every other failure is the caller's problem. */
-async function pathDetails(filesystem: Filesystem, path: string): Promise<PathDetails | undefined> {
+/**
+ * Hidden, and unique to this attempt: two daemons racing to create one root must not land
+ * on the same staging directory, or the loser's cleanup would delete the winner's work
+ * mid-flight. The uniqueness comes from the injected generator rather than an ambient
+ * `randomUUID`, because this is core code and rule 9 admits no exception for entropy.
+ */
+function stagingPath(root: string, idGenerator: IdGenerator): string {
+  return join(dirname(root), `.${basename(root)}.${idGenerator.generate()}.staging`);
+}
+
+/** Best effort: the failure that brought us here is the one worth reporting. */
+async function discard(filesystem: Filesystem, path: string): Promise<void> {
   try {
-    return await filesystem.lstat(path);
+    await filesystem.rm(path);
+  } catch {
+    // A staging directory left behind is untidy and harmless -- it is not the root, and
+    // its name says what it is. Reporting the cleanup's failure instead of the one that
+    // caused it would hide the thing worth fixing.
+  }
+}
+
+/** `undefined` for a path that is absent; anything else that goes wrong is `unreadable`. */
+async function pathDetails(
+  context: RootContext,
+  path: string,
+  subject: string,
+): Promise<PathDetails | undefined> {
+  try {
+    return await context.filesystem.lstat(path);
   } catch (error: unknown) {
     if (isMissingPathError(error)) {
       return undefined;
     }
 
-    throw error;
+    throw unexpected(context, `${subject} could not be read`, error);
   }
+}
+
+async function attempt<T>(
+  context: RootContext,
+  explanation: string,
+  action: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await action();
+  } catch (error: unknown) {
+    throw unexpected(context, explanation, error);
+  }
+}
+
+/**
+ * A filesystem failure the validator has no answer for is still a refused root, never a
+ * raw errno escaping to the caller: the daemon skips one platform on an `OwnedRootError`
+ * and dies on anything else, so a mistyped `deviceRoot` whose parent is a file (`ENOTDIR`)
+ * would otherwise take down every driver instead of one (safety rule 9).
+ */
+function unexpected(context: RootContext, explanation: string, error: unknown): OwnedRootError {
+  return rejected(context, "unreadable", `${explanation}: ${describeError(error)}`);
 }
 
 function rejected(
@@ -268,12 +374,29 @@ function rejected(
   reason: RootRejectionReason,
   explanation: string,
 ): OwnedRootError {
+  return refusal(context.platform, context.root, reason, explanation);
+}
+
+function refusal(
+  platform: Platform,
+  path: string,
+  reason: RootRejectionReason,
+  explanation: string,
+): OwnedRootError {
   return new OwnedRootError(
-    `Refusing the ${context.platform} device root ${context.root}: ${explanation}`,
+    `Refusing the ${platform} device root ${path}: ${explanation}`,
     reason,
-    context.root,
-    context.platform,
+    path,
+    platform,
   );
+}
+
+/** The errno matters as much as the message: it is what tells a user what to go and fix. */
+function describeError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const code = errorCode(error);
+
+  return typeof code === "string" ? `${message} (${code})` : message;
 }
 
 function formatMode(mode: number): string {
@@ -284,8 +407,15 @@ function isMissingPathError(error: unknown): boolean {
   return errorCode(error) === "ENOENT";
 }
 
-function isExistingPathError(error: unknown): boolean {
-  return errorCode(error) === "EEXIST";
+/**
+ * `rename` reports an occupied destination three ways depending on the kernel and on what
+ * is sitting there: a non-empty directory, a directory replaced by a file, or a plain
+ * refusal to clobber.
+ */
+function isOccupiedPathError(error: unknown): boolean {
+  const code = errorCode(error);
+
+  return code === "EEXIST" || code === "ENOTEMPTY" || code === "ENOTDIR";
 }
 
 function errorCode(error: unknown): unknown {

--- a/src/core/device-root.ts
+++ b/src/core/device-root.ts
@@ -22,6 +22,7 @@ export type RootRejectionReason =
   | "wrong-permissions"
   | "non-empty-unowned-root";
 
+// fallow-ignore-next-line unused-type -- public shape of the on-disk ownership marker.
 export interface OwnedRootMarker {
   readonly schemaVersion: 1;
   readonly owner: "simlock";
@@ -99,9 +100,11 @@ async function createRoot(context: RootContext): Promise<boolean> {
     throw error;
   }
 
-  // `mkdir`'s mode is masked by the process umask, so the bits it asked for are not
-  // necessarily the bits it got. Setting them explicitly is what keeps a daemon started
-  // under a permissive umask from failing its own permission check on the next start.
+  // `mkdir`'s mode is a request the process umask can only subtract from: under a
+  // restrictive one (`0o277`, say) the root comes back read-only to its own owner and
+  // every device written into it afterwards fails. `chmod` is the only way to end at the
+  // permissions validation demands of this root on the next start, and it cannot
+  // over-open it either, since it sets exactly the owner-only bits.
   await filesystem.chmod(root, ROOT_MODE);
   await filesystem.writeFileAtomic(markerPath(root), serializeMarker(context));
   return true;
@@ -200,38 +203,36 @@ async function readMarker(
   context: RootContext,
   path: string,
 ): Promise<OwnedRootMarker | undefined> {
-  let contents: string;
-  try {
-    contents = await context.filesystem.readFile(path);
-  } catch {
-    return undefined;
-  }
-
+  // A marker that cannot be read and one that cannot be parsed are the same answer: this
+  // is not a root whose ownership Simlock can vouch for.
   let parsed: unknown;
   try {
-    parsed = JSON.parse(contents) as unknown;
+    parsed = JSON.parse(await context.filesystem.readFile(path)) as unknown;
   } catch {
     return undefined;
   }
 
-  if (typeof parsed !== "object" || parsed === null) {
-    return undefined;
+  return isOwnedRootMarker(parsed, context.platform) ? parsed : undefined;
+}
+
+/**
+ * The platform is part of the identity check, not just of the payload: swapping the iOS
+ * and Android roots in config would otherwise hand each driver the other's devices.
+ */
+function isOwnedRootMarker(value: unknown, platform: Platform): value is OwnedRootMarker {
+  if (typeof value !== "object" || value === null) {
+    return false;
   }
 
-  const marker = parsed as Record<string, unknown>;
-  const instanceId = marker["instanceId"];
+  const marker = value as Record<string, unknown>;
 
-  if (
-    marker["schemaVersion"] !== 1 ||
-    marker["owner"] !== "simlock" ||
-    marker["platform"] !== context.platform ||
-    typeof instanceId !== "string" ||
-    instanceId === ""
-  ) {
-    return undefined;
-  }
-
-  return { schemaVersion: 1, owner: "simlock", instanceId, platform: context.platform };
+  return (
+    marker["schemaVersion"] === 1 &&
+    marker["owner"] === "simlock" &&
+    marker["platform"] === platform &&
+    typeof marker["instanceId"] === "string" &&
+    marker["instanceId"] !== ""
+  );
 }
 
 function serializeMarker(context: RootContext): string {

--- a/src/core/doctor.test.ts
+++ b/src/core/doctor.test.ts
@@ -1275,6 +1275,7 @@ function sequence() {
 function config(stalledTransitionOverrides: Partial<Config["stalledTransition"]> = {}): Config {
   return {
     diskPressure: { freeBytesThreshold: 1 },
+    drivers: {},
     eventBuffer: { capacity: 10 },
     health: {
       enabled: true,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -25,21 +25,16 @@ export {
   UnknownModelError,
 } from "./driver.js";
 export { Doctor } from "./doctor.js";
-export {
-  ensureOwnedRoot,
-  type EnsureOwnedRootOptions,
-  OWNED_ROOT_MARKER_FILE,
-  OwnedRootError,
-} from "./device-root.js";
+export { ensureOwnedRoot, OWNED_ROOT_MARKER_FILE, OwnedRootError } from "./device-root.js";
+// fallow-ignore-next-line unused-type -- public options contract for the drivers that own a root.
+export type { EnsureOwnedRootOptions } from "./device-root.js";
 // fallow-ignore-next-line unused-type -- wire-visible rejection vocabulary, carried in the driver.root-rejected payload.
 export type { RootRejectionReason } from "./device-root.js";
 // fallow-ignore-next-line unused-type -- public shape of the on-disk ownership marker.
 export type { OwnedRootMarker } from "./device-root.js";
-export {
-  InstanceIdentityError,
-  type InstanceIdentityOptions,
-  loadInstanceId,
-} from "./instance-identity.js";
+export { InstanceIdentityError, loadInstanceId } from "./instance-identity.js";
+// fallow-ignore-next-line unused-type -- public options contract for the daemon composition root.
+export type { InstanceIdentityOptions } from "./instance-identity.js";
 export {
   LeaseEngine,
   type LeaseProgress,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -26,6 +26,21 @@ export {
 } from "./driver.js";
 export { Doctor } from "./doctor.js";
 export {
+  ensureOwnedRoot,
+  type EnsureOwnedRootOptions,
+  OWNED_ROOT_MARKER_FILE,
+  OwnedRootError,
+} from "./device-root.js";
+// fallow-ignore-next-line unused-type -- wire-visible rejection vocabulary, carried in the driver.root-rejected payload.
+export type { RootRejectionReason } from "./device-root.js";
+// fallow-ignore-next-line unused-type -- public shape of the on-disk ownership marker.
+export type { OwnedRootMarker } from "./device-root.js";
+export {
+  InstanceIdentityError,
+  type InstanceIdentityOptions,
+  loadInstanceId,
+} from "./instance-identity.js";
+export {
   LeaseEngine,
   type LeaseProgress,
   NoCapacityError,

--- a/src/core/instance-identity.test.ts
+++ b/src/core/instance-identity.test.ts
@@ -1,6 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { type Filesystem, type IdGenerator, MemoryFilesystem } from "../ports/index.js";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  type Filesystem,
+  type IdGenerator,
+  MemoryFilesystem,
+  NodeFilesystem,
+} from "../ports/index.js";
 import { InstanceIdentityError, loadInstanceId } from "./index.js";
 
 const path = "/home/agent/.simlock/instance.json";
@@ -47,13 +56,16 @@ describe("loadInstanceId", () => {
     expect(second).toBe(first);
   });
 
-  it("returns the identity that reached disk rather than the one it generated", async () => {
-    // Two daemons starting for the first time at once: only one file survives, and the
-    // loser has to end up with the winner's id or it will mark roots with an id nobody
-    // else recognises.
+  it("adopts the identity another daemon wrote first rather than overwriting it", async () => {
+    // Two daemons starting for the first time at once: the loser has to end up with the
+    // winner's id, and must not put its own on top of one the winner has already stamped
+    // into its device roots.
     const filesystem = new LosingRaceFilesystem();
 
     await expect(load(filesystem)).resolves.toBe("won-the-race");
+    await expect(filesystem.readFile(path).then(JSON.parse)).resolves.toEqual({
+      instanceId: "won-the-race",
+    });
   });
 
   it.each([
@@ -79,9 +91,46 @@ describe("loadInstanceId", () => {
   });
 });
 
-/** Stands in for another daemon whose write landed last. */
+describe("loadInstanceId on a real filesystem", () => {
+  let home: string | undefined;
+
+  afterEach(async () => {
+    if (home !== undefined) {
+      await rm(home, { force: true, recursive: true });
+      home = undefined;
+    }
+  });
+
+  it("hands every daemon racing to write the first identity the same one", async () => {
+    // Against a real kernel this time, because the exclusive create is what makes the
+    // guarantee: with a check followed by a write, one daemon's id lands on top of one the
+    // other has already marked its roots with, and those roots read `wrong-instance` for
+    // ever afterwards.
+    const filesystem = new NodeFilesystem();
+    home = await mkdtemp(join(tmpdir(), "simlock-instance-identity-"));
+    const racedPath = join(home, "instance.json");
+    const idGenerator = sequence("racer");
+
+    const results = await Promise.allSettled(
+      [0, 1, 2].map(async () => loadInstanceId({ filesystem, idGenerator, path: racedPath })),
+    );
+
+    const identities = results.map((result) =>
+      result.status === "fulfilled" ? result.value : String(result.reason),
+    );
+    const onDisk = JSON.parse(await filesystem.readFile(racedPath)) as { instanceId: string };
+    expect(identities).toEqual([onDisk.instanceId, onDisk.instanceId, onDisk.instanceId]);
+    // Written once: the two that lost the race read the winner's file instead of writing.
+    await expect(filesystem.readdir(home)).resolves.toEqual(["instance.json"]);
+  });
+});
+
+/** Stands in for another daemon whose exclusive create landed first. */
 class LosingRaceFilesystem extends MemoryFilesystem {
-  async writeFileAtomic(target: string, _contents: string): Promise<void> {
+  async writeFileExclusive(target: string, _contents: string): Promise<void> {
     await super.writeFileAtomic(target, JSON.stringify({ instanceId: "won-the-race" }));
+    const error: NodeJS.ErrnoException = new Error(`File already exists: ${target}`);
+    error.code = "EEXIST";
+    throw error;
   }
 }

--- a/src/core/instance-identity.test.ts
+++ b/src/core/instance-identity.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { type Filesystem, type IdGenerator, MemoryFilesystem } from "../ports/index.js";
+import { InstanceIdentityError, loadInstanceId } from "./index.js";
+
+const path = "/home/agent/.simlock/instance.json";
+
+function sequence(prefix = "generated"): IdGenerator {
+  let next = 1;
+  return { generate: () => `${prefix}-${next++}` };
+}
+
+async function seed(contents: string): Promise<MemoryFilesystem> {
+  const filesystem = new MemoryFilesystem();
+  await filesystem.mkdirp("/home/agent/.simlock");
+  await filesystem.writeFileAtomic(path, contents);
+  return filesystem;
+}
+
+async function load(filesystem: Filesystem): Promise<string> {
+  return loadInstanceId({ filesystem, idGenerator: sequence(), path });
+}
+
+describe("loadInstanceId", () => {
+  it("returns the identity already on disk", async () => {
+    const filesystem = await seed(JSON.stringify({ instanceId: "written-long-ago" }));
+
+    await expect(load(filesystem)).resolves.toBe("written-long-ago");
+  });
+
+  it("generates an identity on first start and persists it", async () => {
+    const filesystem = new MemoryFilesystem();
+
+    await expect(load(filesystem)).resolves.toBe("generated-1");
+    await expect(filesystem.readFile(path).then(JSON.parse)).resolves.toEqual({
+      instanceId: "generated-1",
+    });
+  });
+
+  it("keeps returning the identity it generated on the first start", async () => {
+    const filesystem = new MemoryFilesystem();
+    const idGenerator = sequence();
+
+    const first = await loadInstanceId({ filesystem, idGenerator, path });
+    const second = await loadInstanceId({ filesystem, idGenerator, path });
+
+    expect(second).toBe(first);
+  });
+
+  it("returns the identity that reached disk rather than the one it generated", async () => {
+    // Two daemons starting for the first time at once: only one file survives, and the
+    // loser has to end up with the winner's id or it will mark roots with an id nobody
+    // else recognises.
+    const filesystem = new LosingRaceFilesystem();
+
+    await expect(load(filesystem)).resolves.toBe("won-the-race");
+  });
+
+  it.each([
+    ["is not valid JSON", "{ definitely not json"],
+    ["carries no instanceId", JSON.stringify({ instance: "typo" })],
+    ["carries an empty instanceId", JSON.stringify({ instanceId: "" })],
+    ["carries a non-string instanceId", JSON.stringify({ instanceId: 7 })],
+    ["is not an object at all", JSON.stringify("just-a-string")],
+  ])("refuses to regenerate an identity whose file %s", async (_case, contents) => {
+    const filesystem = await seed(contents);
+
+    await expect(load(filesystem)).rejects.toBeInstanceOf(InstanceIdentityError);
+    // The unusable file stays exactly as it was: overwriting it would strand every device
+    // already sitting in a root marked with the id it used to hold.
+    await expect(filesystem.readFile(path)).resolves.toBe(contents);
+  });
+
+  it("refuses an identity file it cannot read", async () => {
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp(path);
+
+    await expect(load(filesystem)).rejects.toBeInstanceOf(InstanceIdentityError);
+  });
+});
+
+/** Stands in for another daemon whose write landed last. */
+class LosingRaceFilesystem extends MemoryFilesystem {
+  async writeFileAtomic(target: string, _contents: string): Promise<void> {
+    await super.writeFileAtomic(target, JSON.stringify({ instanceId: "won-the-race" }));
+  }
+}

--- a/src/core/instance-identity.ts
+++ b/src/core/instance-identity.ts
@@ -1,0 +1,105 @@
+import { dirname } from "node:path";
+
+import type { Filesystem, IdGenerator } from "../ports/index.js";
+
+export interface InstanceIdentityOptions {
+  readonly filesystem: Filesystem;
+  readonly idGenerator: IdGenerator;
+  /** `${SIMLOCK_HOME}/instance.json`. */
+  readonly path: string;
+}
+
+export class InstanceIdentityError extends Error {
+  constructor(
+    message: string,
+    readonly path: string,
+  ) {
+    super(message);
+    this.name = "InstanceIdentityError";
+  }
+}
+
+/**
+ * Reads this Simlock installation's identity, generating it exactly once.
+ *
+ * The identity is what every device root's ownership marker is checked against, so losing
+ * it is not a recoverable inconvenience: a regenerated id strands every device already in
+ * the root behind `wrong-instance`, with no way back short of deleting tens of gigabytes
+ * by hand. That is why an unreadable or malformed file is a hard failure rather than a
+ * reason to write a fresh one, and why the id lives here instead of in `state.json` -- a
+ * corrupt registry is precisely the situation in which someone rebuilds state, and the
+ * identity has to survive that (ADR 0001, decision 2).
+ */
+export async function loadInstanceId(options: InstanceIdentityOptions): Promise<string> {
+  const existing = await readInstanceId(options);
+  if (existing !== undefined) {
+    return existing;
+  }
+
+  await options.filesystem.mkdirp(dirname(options.path));
+  await options.filesystem.writeFileAtomic(
+    options.path,
+    `${JSON.stringify({ instanceId: options.idGenerator.generate() }, null, 2)}\n`,
+  );
+
+  // Deliberately re-read rather than return what was just generated. Two daemons starting
+  // for the first time at once both write, and only one file survives; trusting the
+  // in-memory value would leave the loser marking roots with an id that is not on disk.
+  const written = await readInstanceId(options);
+  if (written === undefined) {
+    throw new InstanceIdentityError(
+      `Instance identity vanished immediately after it was written: ${options.path}`,
+      options.path,
+    );
+  }
+
+  return written;
+}
+
+/** `undefined` only when the file is genuinely absent -- unreadable is not the same as absent. */
+async function readInstanceId(options: InstanceIdentityOptions): Promise<string | undefined> {
+  const { filesystem, path } = options;
+
+  if (!(await filesystem.exists(path))) {
+    return undefined;
+  }
+
+  let contents: string;
+  try {
+    contents = await filesystem.readFile(path);
+  } catch (error: unknown) {
+    throw new InstanceIdentityError(
+      `Cannot read the instance identity at ${path}: ${describe(error)}`,
+      path,
+    );
+  }
+
+  return parseInstanceId(contents, path);
+}
+
+function parseInstanceId(contents: string, path: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contents) as unknown;
+  } catch {
+    throw new InstanceIdentityError(`The instance identity at ${path} is not valid JSON`, path);
+  }
+
+  const instanceId =
+    typeof parsed === "object" && parsed !== null
+      ? (parsed as Record<string, unknown>)["instanceId"]
+      : undefined;
+
+  if (typeof instanceId !== "string" || instanceId === "") {
+    throw new InstanceIdentityError(
+      `The instance identity at ${path} has no usable "instanceId"`,
+      path,
+    );
+  }
+
+  return instanceId;
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/core/instance-identity.ts
+++ b/src/core/instance-identity.ts
@@ -37,14 +37,31 @@ export async function loadInstanceId(options: InstanceIdentityOptions): Promise<
   }
 
   await options.filesystem.mkdirp(dirname(options.path));
-  await options.filesystem.writeFileAtomic(
-    options.path,
-    `${JSON.stringify({ instanceId: options.idGenerator.generate() }, null, 2)}\n`,
-  );
+  const generated = options.idGenerator.generate();
 
-  // Deliberately re-read rather than return what was just generated. Two daemons starting
-  // for the first time at once both write, and only one file survives; trusting the
-  // in-memory value would leave the loser marking roots with an id that is not on disk.
+  try {
+    // An exclusive create, never a plain write: checking that the file is absent and then
+    // writing it is a race two daemons starting at once do lose. The loser's write would
+    // land on top of an identity the winner had already stamped into its roots, and every
+    // one of them would read `wrong-instance` from then on. Here the kernel picks the
+    // winner and the loser is told so.
+    await options.filesystem.writeFileExclusive(options.path, serializeIdentity(generated));
+  } catch (error: unknown) {
+    if (!isExistingPathError(error)) {
+      throw new InstanceIdentityError(
+        `Cannot write the instance identity to ${options.path}: ${describe(error)}`,
+        options.path,
+      );
+    }
+
+    return requireWritten(options);
+  }
+
+  return generated;
+}
+
+/** The identity another process wrote first: this one adopts it rather than competing. */
+async function requireWritten(options: InstanceIdentityOptions): Promise<string> {
   const written = await readInstanceId(options);
   if (written === undefined) {
     throw new InstanceIdentityError(
@@ -60,14 +77,14 @@ export async function loadInstanceId(options: InstanceIdentityOptions): Promise<
 async function readInstanceId(options: InstanceIdentityOptions): Promise<string | undefined> {
   const { filesystem, path } = options;
 
-  if (!(await filesystem.exists(path))) {
-    return undefined;
-  }
-
   let contents: string;
   try {
     contents = await filesystem.readFile(path);
   } catch (error: unknown) {
+    if (isMissingPathError(error)) {
+      return undefined;
+    }
+
     throw new InstanceIdentityError(
       `Cannot read the instance identity at ${path}: ${describe(error)}`,
       path,
@@ -100,6 +117,22 @@ function parseInstanceId(contents: string, path: string): string {
   return instanceId;
 }
 
+function serializeIdentity(instanceId: string): string {
+  return `${JSON.stringify({ instanceId }, null, 2)}\n`;
+}
+
 function describe(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return errorCode(error) === "ENOENT";
+}
+
+function isExistingPathError(error: unknown): boolean {
+  return errorCode(error) === "EEXIST";
+}
+
+function errorCode(error: unknown): unknown {
+  return typeof error === "object" && error !== null && "code" in error ? error.code : undefined;
 }

--- a/src/core/lease-acquisition-coordinator.test.ts
+++ b/src/core/lease-acquisition-coordinator.test.ts
@@ -26,6 +26,7 @@ const request = { model: "iPhone 16", osVersion: "26.5", platform: "ios" } as co
 function config(maxDevices = 1): Config {
   return {
     diskPressure: { freeBytesThreshold: 10 * gibibyte },
+    drivers: {},
     eventBuffer: { capacity: 100 },
     health: {
       enabled: true,

--- a/src/core/lease-engine.test.ts
+++ b/src/core/lease-engine.test.ts
@@ -22,6 +22,7 @@ const request = { model: "iPhone 16", osVersion: "26.5", platform: "ios" } as co
 function config(overrides: Partial<Config["lease"]> = {}): Config {
   return {
     diskPressure: { freeBytesThreshold: 10 * gibibyte },
+    drivers: {},
     eventBuffer: { capacity: 100 },
     health: {
       enabled: true,

--- a/src/core/lease-health-monitor.test.ts
+++ b/src/core/lease-health-monitor.test.ts
@@ -18,6 +18,7 @@ const spec = { model: "iPhone 16", osVersion: "26.5", platform: "ios" } as const
 function config(overrides: Partial<Config["health"]> = {}): Config {
   return {
     diskPressure: { freeBytesThreshold: 10 * gibibyte },
+    drivers: {},
     eventBuffer: { capacity: 100 },
     warmPool: {
       quarantine: {

--- a/src/core/nuke.test.ts
+++ b/src/core/nuke.test.ts
@@ -146,6 +146,7 @@ function sequence() {
 function config(): Config {
   return {
     diskPressure: { freeBytesThreshold: 1 },
+    drivers: {},
     eventBuffer: { capacity: 10 },
     health: {
       enabled: true,

--- a/src/core/reaper.test.ts
+++ b/src/core/reaper.test.ts
@@ -45,6 +45,7 @@ class MutableFreeDiskFilesystem extends MemoryFilesystem {
 function config(): Config {
   return {
     diskPressure: { freeBytesThreshold: 10 * gibibyte },
+    drivers: {},
     eventBuffer: { capacity: 100 },
     health: {
       enabled: true,

--- a/src/core/warm-pool-coordinator.test.ts
+++ b/src/core/warm-pool-coordinator.test.ts
@@ -16,6 +16,7 @@ const gibibyte = 1024 ** 3;
 const spec = { model: "iPhone 16", osVersion: "26.5", platform: "ios" } as const;
 const config: Config = {
   diskPressure: { freeBytesThreshold: 10 * gibibyte },
+  drivers: {},
   eventBuffer: { capacity: 100 },
   health: {
     enabled: true,

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -1263,6 +1263,7 @@ function sequence() {
 function testConfig(leaseOverrides?: Partial<Config["lease"]>): Config {
   return {
     diskPressure: { freeBytesThreshold: 10 * gibibyte },
+    drivers: {},
     eventBuffer: { capacity: 100 },
     health: {
       enabled: true,

--- a/src/ports/filesystem.test.ts
+++ b/src/ports/filesystem.test.ts
@@ -1,3 +1,5 @@
+import { symlink } from "node:fs/promises";
+
 import { afterEach, describe, expect, it } from "vitest";
 
 import { type Filesystem, MemoryFilesystem, NodeFilesystem } from "./index.js";
@@ -48,10 +50,119 @@ describe.each(implementations)("Filesystem contract: $name", ({ create }) => {
   });
 });
 
+describe.each(implementations)("Filesystem ownership contract: $name", ({ create }) => {
+  it("reports what a path is, who owns it, and how exposed it is", async () => {
+    const filesystem = create();
+    const root = `${temporaryDirectory}/devices/ios`;
+
+    await filesystem.mkdirp(root);
+    await filesystem.chmod(root, 0o700);
+
+    await expect(filesystem.lstat(root)).resolves.toEqual({
+      kind: "directory",
+      mode: 0o700,
+      uid: process.getuid?.() ?? 0,
+    });
+  });
+
+  it("reports the permission bits a path was last given, not the ones it was created with", async () => {
+    const filesystem = create();
+    const root = `${temporaryDirectory}/devices/ios`;
+
+    await filesystem.mkdirp(`${temporaryDirectory}/devices`);
+    await filesystem.mkdir(root, { mode: 0o777 });
+    await filesystem.chmod(root, 0o700);
+
+    await expect(filesystem.lstat(root)).resolves.toMatchObject({ mode: 0o700 });
+  });
+
+  it("refuses to create a directory that already exists", async () => {
+    const filesystem = create();
+    const root = `${temporaryDirectory}/devices/ios`;
+
+    await filesystem.mkdirp(root);
+
+    await expect(filesystem.mkdir(root)).rejects.toMatchObject({ code: "EEXIST" });
+  });
+
+  it("creates only the final path segment", async () => {
+    const filesystem = create();
+
+    await expect(filesystem.mkdir(`${temporaryDirectory}/devices/ios`)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("resolves a path to one that resolves to itself", async () => {
+    const filesystem = create();
+    const root = `${temporaryDirectory}/devices/ios`;
+
+    await filesystem.mkdirp(root);
+    const resolved = await filesystem.realpath(root);
+
+    expect(resolved.endsWith("/devices/ios")).toBe(true);
+    await expect(filesystem.realpath(resolved)).resolves.toBe(resolved);
+  });
+});
+
 describe("MemoryFilesystem", () => {
   it("reports its configured free disk space", async () => {
     const filesystem = new MemoryFilesystem(42_000);
 
     await expect(filesystem.diskFree("/")).resolves.toBe(42_000);
+  });
+
+  it("reports a defined symlink as a symlink rather than as what it points at", async () => {
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp("/devices/real");
+    filesystem.defineSymlink("/devices/ios", "/devices/real");
+
+    await expect(filesystem.lstat("/devices/ios")).resolves.toMatchObject({ kind: "symlink" });
+    await expect(filesystem.stat("/devices/ios")).resolves.toMatchObject({ kind: "directory" });
+    await expect(filesystem.realpath("/devices/ios")).resolves.toBe("/devices/real");
+  });
+
+  it("resolves symlinked path components, not just the last one", async () => {
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp("/private/devices/ios");
+    filesystem.defineSymlink("/devices", "/private/devices");
+
+    await expect(filesystem.realpath("/devices/ios")).resolves.toBe("/private/devices/ios");
+  });
+
+  it("reports the ownership and permissions a test defines for a path", async () => {
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp("/devices/ios");
+    filesystem.defineAttributes("/devices/ios", { uid: 4242, mode: 0o755 });
+
+    await expect(filesystem.lstat("/devices/ios")).resolves.toEqual({
+      kind: "directory",
+      mode: 0o755,
+      uid: 4242,
+    });
+  });
+
+  it("gives a new directory owner-only permissions unless a mode says otherwise", async () => {
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp("/devices");
+
+    await filesystem.mkdir("/devices/ios");
+
+    await expect(filesystem.lstat("/devices/ios")).resolves.toMatchObject({ mode: 0o700 });
+  });
+});
+
+describe("NodeFilesystem", () => {
+  it("reports a symlink without following it", async () => {
+    const filesystem = new NodeFilesystem();
+    await filesystem.mkdirp(`${temporaryDirectory}/devices/real`);
+    await symlink(`${temporaryDirectory}/devices/real`, `${temporaryDirectory}/devices/ios`);
+
+    await expect(filesystem.lstat(`${temporaryDirectory}/devices/ios`)).resolves.toMatchObject({
+      kind: "symlink",
+    });
+    await expect(filesystem.realpath(`${temporaryDirectory}/devices/ios`)).resolves.toBe(
+      await filesystem.realpath(`${temporaryDirectory}/devices/real`),
+    );
   });
 });

--- a/src/ports/filesystem.test.ts
+++ b/src/ports/filesystem.test.ts
@@ -9,14 +9,22 @@ const temporaryDirectory = `${process.cwd()}/.simlock-ports-test`;
 const implementations: Array<{
   name: string;
   create(): Filesystem;
+  /** Neither implementation creates symlinks through the port, and both have to be asked. */
+  link(filesystem: Filesystem, path: string, target: string): Promise<void>;
 }> = [
   {
     name: "memory filesystem",
     create: () => new MemoryFilesystem(),
+    link: async (filesystem, path, target) => {
+      (filesystem as MemoryFilesystem).defineSymlink(path, target);
+    },
   },
   {
     name: "node filesystem",
     create: () => new NodeFilesystem(),
+    link: async (_filesystem, path, target) => {
+      await symlink(target, path);
+    },
   },
 ];
 
@@ -24,7 +32,7 @@ afterEach(async () => {
   await new NodeFilesystem().rm(temporaryDirectory);
 });
 
-describe.each(implementations)("Filesystem contract: $name", ({ create }) => {
+describe.each(implementations)("Filesystem contract: $name", ({ create, link }) => {
   it("atomically writes and overwrites a complete file", async () => {
     const filesystem = create();
     const file = `${temporaryDirectory}/devices/registry.json`;
@@ -47,6 +55,81 @@ describe.each(implementations)("Filesystem contract: $name", ({ create }) => {
     await filesystem.mkdirp(directory);
 
     await expect(filesystem.stat(directory)).resolves.toMatchObject({ kind: "directory" });
+  });
+
+  it("writes a file exclusively, refusing the second writer rather than replacing", async () => {
+    const filesystem = create();
+    const file = `${temporaryDirectory}/instance.json`;
+
+    await filesystem.mkdirp(temporaryDirectory);
+    await filesystem.writeFileExclusive(file, "first writer");
+
+    await expect(filesystem.writeFileExclusive(file, "second writer")).rejects.toMatchObject({
+      code: "EEXIST",
+    });
+    await expect(filesystem.readFile(file)).resolves.toBe("first writer");
+  });
+
+  it("moves a directory and everything under it in one step", async () => {
+    const filesystem = create();
+    const staging = `${temporaryDirectory}/.ios.staging`;
+
+    await filesystem.mkdirp(`${staging}/nested`);
+    await filesystem.writeFileAtomic(`${staging}/nested/marker.json`, "{}");
+    await filesystem.rename(staging, `${temporaryDirectory}/ios`);
+
+    await expect(filesystem.readFile(`${temporaryDirectory}/ios/nested/marker.json`)).resolves.toBe(
+      "{}",
+    );
+    await expect(filesystem.exists(staging)).resolves.toBe(false);
+  });
+
+  it("refuses to move a directory onto one that holds something", async () => {
+    const filesystem = create();
+    const staging = `${temporaryDirectory}/.ios.staging`;
+    const occupied = `${temporaryDirectory}/ios`;
+
+    await filesystem.mkdirp(staging);
+    await filesystem.mkdirp(occupied);
+    await filesystem.writeFileAtomic(`${occupied}/someone-elses-work.txt`, "");
+
+    await expect(filesystem.rename(staging, occupied)).rejects.toMatchObject({
+      code: "ENOTEMPTY",
+    });
+  });
+
+  it("reports whether a path is there", async () => {
+    const filesystem = create();
+
+    await filesystem.mkdirp(temporaryDirectory);
+    await filesystem.writeFileAtomic(`${temporaryDirectory}/instance.json`, "{}");
+
+    await expect(filesystem.exists(`${temporaryDirectory}/instance.json`)).resolves.toBe(true);
+    await expect(filesystem.exists(`${temporaryDirectory}/absent.json`)).resolves.toBe(false);
+  });
+
+  it("answers about what a symlink points at, not about the link", async () => {
+    const filesystem = create();
+
+    await filesystem.mkdirp(`${temporaryDirectory}/real`);
+    await link(filesystem, `${temporaryDirectory}/live`, `${temporaryDirectory}/real`);
+    await link(filesystem, `${temporaryDirectory}/dangling`, `${temporaryDirectory}/gone`);
+
+    await expect(filesystem.exists(`${temporaryDirectory}/live`)).resolves.toBe(true);
+    await expect(filesystem.exists(`${temporaryDirectory}/dangling`)).resolves.toBe(false);
+  });
+
+  it("refuses to answer for a path that runs through a file", async () => {
+    // A mistyped device root -- `<home>/notes.txt/ios` -- is a different problem from one
+    // that is simply not there yet, and callers can only tell them apart by the errno.
+    const filesystem = create();
+
+    await filesystem.mkdirp(temporaryDirectory);
+    await filesystem.writeFileAtomic(`${temporaryDirectory}/notes.txt`, "");
+
+    await expect(filesystem.exists(`${temporaryDirectory}/notes.txt/ios`)).rejects.toMatchObject({
+      code: "ENOTDIR",
+    });
   });
 });
 
@@ -140,6 +223,18 @@ describe("MemoryFilesystem", () => {
       mode: 0o755,
       uid: 4242,
     });
+  });
+
+  it("fails at a path a test declared broken, with the errno it declared", async () => {
+    // The only way to reach the branches that turn a filesystem failure into a typed
+    // rejection: an EACCES on a device root cannot be produced by writing to the double.
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp("/devices/ios");
+    filesystem.defineFailure("/devices/ios", "EACCES");
+
+    await expect(filesystem.lstat("/devices/ios")).rejects.toMatchObject({ code: "EACCES" });
+    await expect(filesystem.readdir("/devices/ios")).rejects.toMatchObject({ code: "EACCES" });
+    await expect(filesystem.mkdirp("/devices/ios")).rejects.toMatchObject({ code: "EACCES" });
   });
 
   it("gives a new directory owner-only permissions unless a mode says otherwise", async () => {

--- a/src/ports/filesystem.ts
+++ b/src/ports/filesystem.ts
@@ -34,7 +34,18 @@ export interface PathDetails {
 export interface Filesystem {
   readFile(path: string): Promise<string>;
   writeFileAtomic(path: string, contents: string): Promise<void>;
+  /**
+   * Writes a file only when nothing is there, failing `EEXIST` otherwise. The kernel
+   * decides who wins, which is the only way two processes racing to write one file both
+   * end up agreeing about what it says.
+   */
+  writeFileExclusive(path: string, contents: string): Promise<void>;
   mkdirp(path: string): Promise<void>;
+  /**
+   * Moves a path in one step, so what it names becomes visible complete or not at all.
+   * Fails when the destination is occupied by anything but an empty directory.
+   */
+  rename(from: string, to: string): Promise<void>;
   rm(path: string): Promise<void>;
   stat(path: string): Promise<FileStat>;
   /** Metadata read without following a final symlink, so a symlinked root is detectable. */
@@ -74,8 +85,16 @@ export class NodeFilesystem implements Filesystem {
     }
   }
 
+  async writeFileExclusive(path: string, contents: string): Promise<void> {
+    await writeFile(path, contents, { encoding: "utf8", flag: "wx" });
+  }
+
   async mkdirp(path: string): Promise<void> {
     await mkdir(path, { recursive: true });
+  }
+
+  async rename(from: string, to: string): Promise<void> {
+    await rename(from, to);
   }
 
   async rm(path: string): Promise<void> {
@@ -165,6 +184,7 @@ const MAX_SYMLINK_HOPS = 32;
 
 export class MemoryFilesystem implements Filesystem {
   readonly #entries = new Map<string, MemoryEntry>();
+  readonly #failures = new Map<string, string>();
 
   constructor(
     private readonly freeDiskBytes = Number.MAX_SAFE_INTEGER,
@@ -174,6 +194,7 @@ export class MemoryFilesystem implements Filesystem {
   }
 
   async readFile(path: string): Promise<string> {
+    this.#failIfDefined(path);
     const entry = this.#entryAt(path);
 
     if (entry.kind !== "file") {
@@ -184,11 +205,24 @@ export class MemoryFilesystem implements Filesystem {
   }
 
   async writeFileAtomic(path: string, contents: string): Promise<void> {
+    this.#failIfDefined(path);
+    this.#requireDirectory(parentPath(path));
+    this.#entries.set(path, this.#newEntry({ kind: "file", contents }));
+  }
+
+  async writeFileExclusive(path: string, contents: string): Promise<void> {
+    this.#failIfDefined(path);
+
+    if (this.#entries.has(path)) {
+      throw errnoError("EEXIST", `File already exists: ${path}`);
+    }
+
     this.#requireDirectory(parentPath(path));
     this.#entries.set(path, this.#newEntry({ kind: "file", contents }));
   }
 
   async mkdirp(path: string): Promise<void> {
+    this.#failIfDefined(path);
     let currentPath = "";
 
     for (const segment of path.split("/")) {
@@ -208,7 +242,49 @@ export class MemoryFilesystem implements Filesystem {
     }
   }
 
+  /**
+   * Publishes `from` at `to` the way POSIX does, because the create path in
+   * `ensureOwnedRoot` branches on exactly the failures it reports: an occupied destination
+   * is what tells it another process won the race.
+   */
+  async rename(from: string, to: string): Promise<void> {
+    this.#failIfDefined(from);
+    this.#failIfDefined(to);
+    const moved = this.#rawEntryAt(from);
+    const occupant = this.#entries.get(to);
+
+    if (occupant !== undefined) {
+      if (occupant.kind !== "directory" || moved.kind !== "directory") {
+        throw errnoError("ENOTDIR", `Not a directory: ${to}`);
+      }
+
+      if ((await this.readdir(to)).length > 0) {
+        throw errnoError("ENOTEMPTY", `Directory not empty: ${to}`);
+      }
+    }
+
+    this.#requireDirectory(parentPath(to));
+    const prefix = `${from}/`;
+    const moving = [...this.#entries.keys()].filter(
+      (entryPath) => entryPath === from || entryPath.startsWith(prefix),
+    );
+
+    for (const entryPath of moving) {
+      const entry = this.#entries.get(entryPath);
+      if (entry === undefined) {
+        continue;
+      }
+
+      this.#entries.delete(entryPath);
+      this.#entries.set(
+        entryPath === from ? to : joinMemoryPath(to, entryPath.slice(prefix.length)),
+        entry,
+      );
+    }
+  }
+
   async rm(path: string): Promise<void> {
+    this.#failIfDefined(path);
     const prefix = path.endsWith("/") ? path : `${path}/`;
 
     for (const entryPath of this.#entries.keys()) {
@@ -220,6 +296,7 @@ export class MemoryFilesystem implements Filesystem {
 
   // fallow-ignore-next-line unused-class-member -- Filesystem.stat contract; only tests reach this implementation of it.
   async stat(path: string): Promise<FileStat> {
+    this.#failIfDefined(path);
     const entry = this.#entryAt(path);
 
     return {
@@ -230,12 +307,15 @@ export class MemoryFilesystem implements Filesystem {
   }
 
   async lstat(path: string): Promise<PathDetails> {
+    this.#failIfDefined(path);
     const entry = this.#rawEntryAt(path);
 
     return { kind: entry.kind, uid: entry.uid, mode: entry.mode };
   }
 
   async mkdir(path: string, options: { readonly mode?: number } = {}): Promise<void> {
+    this.#failIfDefined(path);
+
     if (this.#entries.has(path)) {
       throw errnoError("EEXIST", `File already exists: ${path}`);
     }
@@ -247,11 +327,13 @@ export class MemoryFilesystem implements Filesystem {
   }
 
   async chmod(path: string, mode: number): Promise<void> {
+    this.#failIfDefined(path);
     this.#rawEntryAt(path).mode = mode & 0o777;
   }
 
   // fallow-ignore-next-line unused-class-member -- Filesystem.realpath contract; only tests reach this implementation of it.
   async realpath(path: string): Promise<string> {
+    this.#failIfDefined(path);
     const resolved = this.#resolveLinks(path, 0);
 
     if (!this.#entries.has(resolved)) {
@@ -262,6 +344,7 @@ export class MemoryFilesystem implements Filesystem {
   }
 
   async readdir(path: string): Promise<string[]> {
+    this.#failIfDefined(path);
     this.#requireDirectory(path);
     const prefix = path === "/" ? "/" : `${path}/`;
     const children = new Set<string>();
@@ -281,12 +364,38 @@ export class MemoryFilesystem implements Filesystem {
     return [...children].sort();
   }
 
+  /**
+   * Follows symlinks, like the `stat` the Node implementation answers with: a dangling
+   * link is absent, and a path whose parent is a file is a failure rather than a "no".
+   * A double that answered from its raw key set would let code that only works against
+   * the double pass for correct.
+   */
   async exists(path: string): Promise<boolean> {
-    return this.#entries.has(path);
+    this.#failIfDefined(path);
+
+    try {
+      this.#entryAt(path);
+      return true;
+    } catch (error: unknown) {
+      if (isMissingPathError(error)) {
+        return false;
+      }
+
+      throw error;
+    }
   }
 
   async diskFree(_path: string): Promise<number> {
     return this.freeDiskBytes;
+  }
+
+  /**
+   * Test-only: makes every operation on `path` fail with `code`, which is the only way to
+   * reach the branches that turn an unexpected filesystem failure into a typed rejection.
+   */
+  // fallow-ignore-next-line unused-class-member -- test-only state the port itself cannot create.
+  defineFailure(path: string, code: string): void {
+    this.#failures.set(path, code);
   }
 
   /** Test-only: places a symlink at `path`, whether or not `target` exists. */
@@ -309,6 +418,13 @@ export class MemoryFilesystem implements Filesystem {
 
     if (attributes.mode !== undefined) {
       entry.mode = attributes.mode & 0o777;
+    }
+  }
+
+  #failIfDefined(path: string): void {
+    const code = this.#failures.get(path);
+    if (code !== undefined) {
+      throw errnoError(code, `Injected ${code} failure: ${path}`);
     }
   }
 
@@ -345,10 +461,15 @@ export class MemoryFilesystem implements Filesystem {
       throw errnoError("ELOOP", `Too many levels of symbolic links: ${path}`);
     }
 
-    const resolved = joinMemoryPath(
-      this.#resolveLinks(parentPath(path), hops),
-      path.slice(path.lastIndexOf("/") + 1),
-    );
+    const parent = this.#resolveLinks(parentPath(path), hops);
+    // A component that exists but is not a directory cannot be walked through. Node says
+    // ENOTDIR here, and callers tell that apart from ENOENT -- "the path you configured
+    // runs through a file" is a different problem from "it is not there yet".
+    if (this.#entries.get(parent)?.kind === "file") {
+      throw errnoError("ENOTDIR", `Not a directory: ${parent}`);
+    }
+
+    const resolved = joinMemoryPath(parent, path.slice(path.lastIndexOf("/") + 1));
     const entry = this.#entries.get(resolved);
 
     return entry?.kind === "symlink" ? this.#resolveLinks(entry.target, hops + 1) : resolved;

--- a/src/ports/filesystem.ts
+++ b/src/ports/filesystem.ts
@@ -1,4 +1,16 @@
-import { mkdir, readdir, rename, rm, stat, statfs, writeFile, readFile } from "node:fs/promises";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  readdir,
+  readFile,
+  realpath,
+  rename,
+  rm,
+  stat,
+  statfs,
+  writeFile,
+} from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 
 export interface FileStat {
@@ -7,12 +19,35 @@ export interface FileStat {
   readonly modifiedAtMs: number;
 }
 
+/**
+ * What an un-followed `lstat` reports, narrowed to what ownership validation asks of a
+ * path: what it really is, who owns it, and how exposed it is. Anything richer would be
+ * a `fs.Stats` leak into the ports layer.
+ */
+export interface PathDetails {
+  readonly kind: "file" | "directory" | "symlink" | "other";
+  readonly uid: number;
+  /** Permission bits only (`mode & 0o777`). */
+  readonly mode: number;
+}
+
 export interface Filesystem {
   readFile(path: string): Promise<string>;
   writeFileAtomic(path: string, contents: string): Promise<void>;
   mkdirp(path: string): Promise<void>;
   rm(path: string): Promise<void>;
   stat(path: string): Promise<FileStat>;
+  /** Metadata read without following a final symlink, so a symlinked root is detectable. */
+  lstat(path: string): Promise<PathDetails>;
+  /**
+   * Creates exactly one directory and fails when the path already exists (no recursion).
+   * Failing on an existing path is the point: it is what makes "Simlock created this root
+   * itself, empty" provable rather than assumed.
+   */
+  mkdir(path: string, options?: { readonly mode?: number }): Promise<void>;
+  chmod(path: string, mode: number): Promise<void>;
+  /** Fully resolved real path. Used for diagnostics, never for rejection. */
+  realpath(path: string): Promise<string>;
   readdir(path: string): Promise<string[]>;
   exists(path: string): Promise<boolean>;
   diskFree(path: string): Promise<number>;
@@ -57,6 +92,31 @@ export class NodeFilesystem implements Filesystem {
     };
   }
 
+  async lstat(path: string): Promise<PathDetails> {
+    const details = await lstat(path);
+
+    return {
+      kind: nodeKind(details),
+      uid: details.uid,
+      mode: details.mode & 0o777,
+    };
+  }
+
+  async mkdir(path: string, options: { readonly mode?: number } = {}): Promise<void> {
+    await mkdir(path, {
+      recursive: false,
+      ...(options.mode === undefined ? {} : { mode: options.mode }),
+    });
+  }
+
+  async chmod(path: string, mode: number): Promise<void> {
+    await chmod(path, mode);
+  }
+
+  async realpath(path: string): Promise<string> {
+    return realpath(path);
+  }
+
   async readdir(path: string): Promise<string[]> {
     return readdir(path);
   }
@@ -80,14 +140,38 @@ export class NodeFilesystem implements Filesystem {
   }
 }
 
-type MemoryEntry =
-  | { readonly kind: "file"; contents: string; modifiedAtMs: number }
-  | { readonly kind: "directory"; modifiedAtMs: number };
+/** Attributes every in-memory entry carries, so callers can read them without a `kind` check. */
+interface MemoryAttributes {
+  modifiedAtMs: number;
+  uid: number;
+  mode: number;
+}
+
+type MemoryEntryKind =
+  | { readonly kind: "file"; contents: string }
+  | { readonly kind: "directory" }
+  | { readonly kind: "symlink"; readonly target: string };
+
+type MemoryEntry = MemoryAttributes & MemoryEntryKind;
+
+/**
+ * Owner-only, matching the permissions Simlock demands of a device root, so a test that
+ * says nothing about permissions describes a healthy path rather than a rejected one.
+ */
+const DEFAULT_MEMORY_MODE = 0o700;
+
+// A symlink cycle is a legitimate thing to model; resolving it forever is not.
+const MAX_SYMLINK_HOPS = 32;
 
 export class MemoryFilesystem implements Filesystem {
-  readonly #entries = new Map<string, MemoryEntry>([["/", { kind: "directory", modifiedAtMs: 0 }]]);
+  readonly #entries = new Map<string, MemoryEntry>();
 
-  constructor(private readonly freeDiskBytes = Number.MAX_SAFE_INTEGER) {}
+  constructor(
+    private readonly freeDiskBytes = Number.MAX_SAFE_INTEGER,
+    private readonly uid = process.getuid?.() ?? 0,
+  ) {
+    this.#entries.set("/", this.#newEntry({ kind: "directory" }));
+  }
 
   async readFile(path: string): Promise<string> {
     const entry = this.#entryAt(path);
@@ -101,7 +185,7 @@ export class MemoryFilesystem implements Filesystem {
 
   async writeFileAtomic(path: string, contents: string): Promise<void> {
     this.#requireDirectory(parentPath(path));
-    this.#entries.set(path, { kind: "file", contents, modifiedAtMs: 0 });
+    this.#entries.set(path, this.#newEntry({ kind: "file", contents }));
   }
 
   async mkdirp(path: string): Promise<void> {
@@ -113,11 +197,11 @@ export class MemoryFilesystem implements Filesystem {
         continue;
       }
 
-      currentPath = currentPath === "/" ? `/${segment}` : `${currentPath}/${segment}`;
+      currentPath = joinMemoryPath(currentPath, segment);
       const entry = this.#entries.get(currentPath);
 
       if (entry === undefined) {
-        this.#entries.set(currentPath, { kind: "directory", modifiedAtMs: 0 });
+        this.#entries.set(currentPath, this.#newEntry({ kind: "directory" }));
       } else if (entry.kind !== "directory") {
         throw new Error(`Cannot create directory over file: ${currentPath}`);
       }
@@ -138,10 +222,41 @@ export class MemoryFilesystem implements Filesystem {
     const entry = this.#entryAt(path);
 
     return {
-      kind: entry.kind,
+      kind: entry.kind === "file" ? "file" : "directory",
       size: entry.kind === "file" ? Buffer.byteLength(entry.contents) : 0,
       modifiedAtMs: entry.modifiedAtMs,
     };
+  }
+
+  async lstat(path: string): Promise<PathDetails> {
+    const entry = this.#rawEntryAt(path);
+
+    return { kind: entry.kind, uid: entry.uid, mode: entry.mode };
+  }
+
+  async mkdir(path: string, options: { readonly mode?: number } = {}): Promise<void> {
+    if (this.#entries.has(path)) {
+      throw errnoError("EEXIST", `File already exists: ${path}`);
+    }
+
+    this.#requireDirectory(parentPath(path));
+    const entry = this.#newEntry({ kind: "directory" });
+    entry.mode = (options.mode ?? DEFAULT_MEMORY_MODE) & 0o777;
+    this.#entries.set(path, entry);
+  }
+
+  async chmod(path: string, mode: number): Promise<void> {
+    this.#rawEntryAt(path).mode = mode & 0o777;
+  }
+
+  async realpath(path: string): Promise<string> {
+    const resolved = this.#resolveLinks(path, 0);
+
+    if (!this.#entries.has(resolved)) {
+      throw errnoError("ENOENT", `No such file or directory: ${path}`);
+    }
+
+    return resolved;
   }
 
   async readdir(path: string): Promise<string[]> {
@@ -172,26 +287,105 @@ export class MemoryFilesystem implements Filesystem {
     return this.freeDiskBytes;
   }
 
+  /** Test-only: places a symlink at `path`, whether or not `target` exists. */
+  defineSymlink(path: string, target: string): void {
+    this.#entries.set(path, this.#newEntry({ kind: "symlink", target }));
+  }
+
+  /** Test-only: rewrites an existing entry's ownership or permission bits. */
+  defineAttributes(
+    path: string,
+    attributes: { readonly uid?: number; readonly mode?: number },
+  ): void {
+    const entry = this.#rawEntryAt(path);
+
+    if (attributes.uid !== undefined) {
+      entry.uid = attributes.uid;
+    }
+
+    if (attributes.mode !== undefined) {
+      entry.mode = attributes.mode & 0o777;
+    }
+  }
+
+  #newEntry(kind: MemoryEntryKind): MemoryEntry {
+    return { ...kind, modifiedAtMs: 0, mode: DEFAULT_MEMORY_MODE, uid: this.uid };
+  }
+
+  /** The entry a following call (`stat`, `readFile`) sees: symlinks resolved. */
   #entryAt(path: string): MemoryEntry {
+    return this.#rawEntryAt(this.#resolveLinks(path, 0));
+  }
+
+  /** The entry itself, symlink or not, as `lstat` and `chmod` address it. */
+  #rawEntryAt(path: string): MemoryEntry {
     const entry = this.#entries.get(path);
     if (entry === undefined) {
-      throw new Error(`No such file or directory: ${path}`);
+      throw errnoError("ENOENT", `No such file or directory: ${path}`);
     }
 
     return entry;
   }
 
+  /**
+   * Resolves symlinks in every component, not just the last one, because that is what
+   * makes the "an ancestor symlink is normal, and not grounds for rejection" case
+   * expressible in a test at all.
+   */
+  #resolveLinks(path: string, hops: number): string {
+    if (path === "/") {
+      return "/";
+    }
+
+    if (hops > MAX_SYMLINK_HOPS) {
+      throw errnoError("ELOOP", `Too many levels of symbolic links: ${path}`);
+    }
+
+    const resolved = joinMemoryPath(
+      this.#resolveLinks(parentPath(path), hops),
+      path.slice(path.lastIndexOf("/") + 1),
+    );
+    const entry = this.#entries.get(resolved);
+
+    return entry?.kind === "symlink" ? this.#resolveLinks(entry.target, hops + 1) : resolved;
+  }
+
   #requireDirectory(path: string): void {
     const entry = this.#entryAt(path);
     if (entry.kind !== "directory") {
-      throw new Error(`Not a directory: ${path}`);
+      throw errnoError("ENOTDIR", `Not a directory: ${path}`);
     }
   }
+}
+
+function joinMemoryPath(parent: string, child: string): string {
+  return parent === "/" || parent === "" ? `/${child}` : `${parent}/${child}`;
 }
 
 function parentPath(path: string): string {
   const lastSeparator = path.lastIndexOf("/");
   return lastSeparator <= 0 ? "/" : path.slice(0, lastSeparator);
+}
+
+function nodeKind(details: {
+  isDirectory(): boolean;
+  isFile(): boolean;
+  isSymbolicLink(): boolean;
+}): PathDetails["kind"] {
+  if (details.isSymbolicLink()) return "symlink";
+  if (details.isDirectory()) return "directory";
+  return details.isFile() ? "file" : "other";
+}
+
+/**
+ * Callers branch on `code` -- an existing root is only "somebody won the race" when the
+ * failure is `EEXIST`, and a path is only absent when the failure is `ENOENT` -- so the
+ * in-memory double has to speak Node's errno vocabulary, not just fail.
+ */
+function errnoError(code: string, message: string): NodeJS.ErrnoException {
+  const error: NodeJS.ErrnoException = new Error(message);
+  error.code = code;
+  return error;
 }
 
 function isMissingPathError(error: unknown): error is NodeJS.ErrnoException {

--- a/src/ports/filesystem.ts
+++ b/src/ports/filesystem.ts
@@ -218,6 +218,7 @@ export class MemoryFilesystem implements Filesystem {
     }
   }
 
+  // fallow-ignore-next-line unused-class-member -- Filesystem.stat contract; only tests reach this implementation of it.
   async stat(path: string): Promise<FileStat> {
     const entry = this.#entryAt(path);
 
@@ -249,6 +250,7 @@ export class MemoryFilesystem implements Filesystem {
     this.#rawEntryAt(path).mode = mode & 0o777;
   }
 
+  // fallow-ignore-next-line unused-class-member -- Filesystem.realpath contract; only tests reach this implementation of it.
   async realpath(path: string): Promise<string> {
     const resolved = this.#resolveLinks(path, 0);
 
@@ -288,11 +290,13 @@ export class MemoryFilesystem implements Filesystem {
   }
 
   /** Test-only: places a symlink at `path`, whether or not `target` exists. */
+  // fallow-ignore-next-line unused-class-member -- test-only state the port itself cannot create.
   defineSymlink(path: string, target: string): void {
     this.#entries.set(path, this.#newEntry({ kind: "symlink", target }));
   }
 
   /** Test-only: rewrites an existing entry's ownership or permission bits. */
+  // fallow-ignore-next-line unused-class-member -- test-only state the port itself cannot create.
   defineAttributes(
     path: string,
     attributes: { readonly uid?: number; readonly mode?: number },

--- a/src/ports/index.ts
+++ b/src/ports/index.ts
@@ -1,4 +1,6 @@
 export { type Filesystem, MemoryFilesystem, NodeFilesystem } from "./filesystem.js";
+// fallow-ignore-next-line unused-type -- public shape of an un-followed path read, for consumers of Filesystem.lstat.
+export type { PathDetails } from "./filesystem.js";
 export { resolveSimlockHome } from "./paths.js";
 export { type DaemonLauncher, FakeDaemonLauncher, NodeDaemonLauncher } from "./daemon-launcher.js";
 export {
@@ -31,6 +33,14 @@ export { FakeSystemStats, NodeSystemStats, type SystemStats } from "./system-sta
 export { FakeParentWatch, NodeParentWatch, type ParentWatch } from "./parent-watch.js";
 // fallow-ignore-next-line unused-type -- public handle contract returned by ParentWatch.watch().
 export type { ParentWatchHandle } from "./parent-watch.js";
+export {
+  FakeProcessSupervisor,
+  NodeProcessSupervisor,
+  type ProcessSupervisor,
+} from "./process-supervisor.js";
+// fallow-ignore-next-line unused-type -- public shape of FakeProcessSupervisor.signals.
+export type { SignalRecord } from "./process-supervisor.js";
+export { FakeTcpProbe, NodeTcpProbe, type TcpProbe } from "./tcp-probe.js";
 export {
   NodeProcessRunner,
   type ProcessHandle,

--- a/src/ports/index.ts
+++ b/src/ports/index.ts
@@ -1,5 +1,4 @@
 export { type Filesystem, MemoryFilesystem, NodeFilesystem } from "./filesystem.js";
-// fallow-ignore-next-line unused-type -- public shape of an un-followed path read, for consumers of Filesystem.lstat.
 export type { PathDetails } from "./filesystem.js";
 export { resolveSimlockHome } from "./paths.js";
 export { type DaemonLauncher, FakeDaemonLauncher, NodeDaemonLauncher } from "./daemon-launcher.js";
@@ -31,16 +30,15 @@ export type { LogRecord } from "./logger.js";
 export { CryptoIdGenerator, type IdGenerator } from "./id-generator.js";
 export { FakeSystemStats, NodeSystemStats, type SystemStats } from "./system-stats.js";
 export { FakeParentWatch, NodeParentWatch, type ParentWatch } from "./parent-watch.js";
-// fallow-ignore-next-line unused-type -- public handle contract returned by ParentWatch.watch().
 export type { ParentWatchHandle } from "./parent-watch.js";
-export {
-  FakeProcessSupervisor,
-  NodeProcessSupervisor,
-  type ProcessSupervisor,
-} from "./process-supervisor.js";
+export { FakeProcessSupervisor, NodeProcessSupervisor } from "./process-supervisor.js";
+// fallow-ignore-next-line unused-type -- public port contract for consumers that address a process by pid.
+export type { ProcessSupervisor } from "./process-supervisor.js";
 // fallow-ignore-next-line unused-type -- public shape of FakeProcessSupervisor.signals.
 export type { SignalRecord } from "./process-supervisor.js";
-export { FakeTcpProbe, NodeTcpProbe, type TcpProbe } from "./tcp-probe.js";
+export { FakeTcpProbe, NodeTcpProbe } from "./tcp-probe.js";
+// fallow-ignore-next-line unused-type -- public port contract for consumers that probe a port.
+export type { TcpProbe } from "./tcp-probe.js";
 export {
   NodeProcessRunner,
   type ProcessHandle,

--- a/src/ports/process-runner.test.ts
+++ b/src/ports/process-runner.test.ts
@@ -87,6 +87,35 @@ describe("NodeProcessRunner", () => {
     });
   });
 
+  it("captures nothing and ends its line streams when output is ignored", async () => {
+    const runner = new NodeProcessRunner();
+
+    const handle = runner.spawn(
+      process.execPath,
+      ["-e", "process.stdout.write('noise'); process.stderr.write('more noise'); process.exit(0)"],
+      { stdio: "ignore" },
+    );
+    const lines: string[] = [];
+    for await (const line of handle.stdout) {
+      lines.push(line);
+    }
+
+    expect(lines).toEqual([]);
+    expect(handle.pid).toBeGreaterThan(0);
+    await expect(handle.wait()).resolves.toEqual({ code: 0, stderr: "", stdout: "" });
+  });
+
+  it("still kills a process whose output is ignored", async () => {
+    const runner = new NodeProcessRunner();
+
+    const handle = runner.spawn(process.execPath, ["-e", "setInterval(() => {}, 1_000)"], {
+      stdio: "ignore",
+    });
+    handle.kill("SIGKILL");
+
+    await expect(handle.wait()).resolves.toMatchObject({ stderr: "", stdout: "" });
+  });
+
   it("kills a process that exceeds its timeout", async () => {
     const runner = new NodeProcessRunner();
 

--- a/src/ports/process-runner.ts
+++ b/src/ports/process-runner.ts
@@ -24,6 +24,12 @@ export interface ProcessRunOptions {
   readonly timeoutMs?: number;
   readonly env?: NodeJS.ProcessEnv;
   readonly cwd?: string;
+  /**
+   * `"ignore"` detaches the child's output entirely: nothing is captured and nothing is
+   * iterable. A long-lived supervised process (Simlock's own adb server) would otherwise
+   * accumulate every line it ever wrote in this handle's buffers for as long as it runs.
+   */
+  readonly stdio?: "pipe" | "ignore";
 }
 
 export interface ProcessResult {
@@ -81,7 +87,7 @@ export class NodeProcessRunner implements ProcessRunner {
       ...(options.cwd === undefined ? {} : { cwd: options.cwd }),
       ...(options.env === undefined ? {} : { env: options.env }),
       detached: process.platform !== "win32",
-      stdio: "pipe",
+      stdio: options.stdio ?? "pipe",
     });
 
     return new NodeProcessHandle(child);
@@ -99,10 +105,6 @@ class NodeProcessHandle implements ProcessHandle {
   constructor(private readonly child: ChildProcess) {
     if (child.pid === undefined) {
       throw new Error("Process did not provide a pid");
-    }
-
-    if (child.stdout === null || child.stderr === null) {
-      throw new Error("Process was not started with stdout and stderr pipes");
     }
 
     this.pid = child.pid;
@@ -312,10 +314,18 @@ class LineBuffer implements AsyncIterable<string> {
 }
 
 function captureLines(
-  stream: NodeJS.ReadableStream,
+  stream: NodeJS.ReadableStream | null,
   destination: LineBuffer,
   chunks: string[],
 ): void {
+  // No pipe means the child was spawned with `stdio: "ignore"`. Closing the buffer
+  // straight away is what keeps `for await (const line of handle.stdout)` a loop that
+  // ends immediately rather than one that never yields and never returns.
+  if (stream === null) {
+    destination.close();
+    return;
+  }
+
   let remainder = "";
   stream.setEncoding("utf8");
   stream.on("data", (chunk: string) => {

--- a/src/ports/process-supervisor.test.ts
+++ b/src/ports/process-supervisor.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { FakeProcessSupervisor, NodeProcessRunner, NodeProcessSupervisor } from "./index.js";
+
+/**
+ * Runs a process to completion and hands back the pid it no longer occupies. `wait()` can
+ * settle on the stdio close that precedes the OS reaping the child, so callers still have
+ * to wait for the pid itself to go.
+ */
+async function retiredPid(): Promise<number> {
+  const handle = new NodeProcessRunner().spawn(process.execPath, ["-e", ""]);
+  await handle.wait();
+  return handle.pid;
+}
+
+async function goneFrom(supervisor: NodeProcessSupervisor, pid: number): Promise<void> {
+  await vi.waitFor(() => {
+    expect(supervisor.isAlive(pid)).toBe(false);
+  });
+}
+
+describe("NodeProcessSupervisor", () => {
+  it("reports a running process as alive", () => {
+    expect(new NodeProcessSupervisor().isAlive(process.pid)).toBe(true);
+  });
+
+  it("reports a process that has exited as gone", async () => {
+    const supervisor = new NodeProcessSupervisor();
+
+    await goneFrom(supervisor, await retiredPid());
+  });
+
+  it("treats signalling a process that is already gone as a no-op", async () => {
+    const supervisor = new NodeProcessSupervisor();
+    const pid = await retiredPid();
+    await goneFrom(supervisor, pid);
+
+    expect(() => supervisor.signal(pid, "SIGTERM")).not.toThrow();
+  });
+});
+
+describe("FakeProcessSupervisor", () => {
+  it("answers with the liveness a test gave it", () => {
+    const supervisor = new FakeProcessSupervisor([17]);
+
+    expect(supervisor.isAlive(17)).toBe(true);
+    expect(supervisor.isAlive(18)).toBe(false);
+
+    supervisor.markDead(17);
+    supervisor.markAlive(18);
+
+    expect(supervisor.isAlive(17)).toBe(false);
+    expect(supervisor.isAlive(18)).toBe(true);
+  });
+
+  it("records signals without deciding whether they killed anything", () => {
+    const supervisor = new FakeProcessSupervisor([17]);
+
+    supervisor.signal(17, "SIGTERM");
+    supervisor.signal(17, "SIGKILL");
+
+    expect(supervisor.signals).toEqual([
+      { pid: 17, signal: "SIGTERM" },
+      { pid: 17, signal: "SIGKILL" },
+    ]);
+    // Whether a process dies on SIGTERM, ignores it, or dies only on SIGKILL is what the
+    // code under test has to cope with, so the test says which happened -- not the double.
+    expect(supervisor.isAlive(17)).toBe(true);
+  });
+});

--- a/src/ports/process-supervisor.test.ts
+++ b/src/ports/process-supervisor.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { FakeProcessSupervisor, NodeProcessRunner, NodeProcessSupervisor } from "./index.js";
 
@@ -19,6 +19,10 @@ async function goneFrom(supervisor: NodeProcessSupervisor, pid: number): Promise
   });
 }
 
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe("NodeProcessSupervisor", () => {
   it("reports a running process as alive", () => {
     expect(new NodeProcessSupervisor().isAlive(process.pid)).toBe(true);
@@ -28,6 +32,25 @@ describe("NodeProcessSupervisor", () => {
     const supervisor = new NodeProcessSupervisor();
 
     await goneFrom(supervisor, await retiredPid());
+  });
+
+  it.each([0, -1, -4242, 7.5, Number.NaN, 2 ** 31])(
+    "reports a pid that addresses no single process as not alive (%s)",
+    (pid) => {
+      // `process.kill(0, ...)` signals this daemon's whole process group and `-1` every
+      // process the user owns, so a pid read back from a corrupt record on disk must never
+      // reach it. Answering "alive" is what would send the caller looking for it with a
+      // SIGKILL.
+      expect(new NodeProcessSupervisor().isAlive(pid)).toBe(false);
+    },
+  );
+
+  it.each([0, -1, 7.5])("refuses to signal anything for the pid %s", (pid) => {
+    const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    new NodeProcessSupervisor().signal(pid, "SIGKILL");
+
+    expect(kill).not.toHaveBeenCalled();
   });
 
   it("treats signalling a process that is already gone as a no-op", async () => {

--- a/src/ports/process-supervisor.ts
+++ b/src/ports/process-supervisor.ts
@@ -14,25 +14,37 @@ export interface ProcessSupervisor {
 
 export class NodeProcessSupervisor implements ProcessSupervisor {
   isAlive(pid: number): boolean {
+    if (!isAddressablePid(pid)) {
+      return false;
+    }
+
     try {
       process.kill(pid, 0);
       return true;
-    } catch {
+    } catch (error: unknown) {
       // Both ESRCH (gone) and EPERM (alive, but another user's) answer "no" here, and
       // deliberately so: this port exists to decide whether a recorded pid is a process
       // this daemon can still reap. One it may not signal is not that, whatever it is --
       // and reporting it alive would leave the caller waiting on a kill that can never
-      // land.
-      return false;
+      // land. Anything else is a bug rather than an answer about a process, and reporting
+      // it as "not alive" would hide it behind a plausible-looking result.
+      if (isFailureWithCode(error, NOT_ALIVE_CODES)) {
+        return false;
+      }
+
+      throw error;
     }
   }
 
-  // fallow-ignore-next-line unused-class-member -- ProcessSupervisor contract; the reaping side of it.
   signal(pid: number, signal: NodeJS.Signals): void {
+    if (!isAddressablePid(pid)) {
+      return;
+    }
+
     try {
       process.kill(pid, signal);
     } catch (error: unknown) {
-      if (isNoSuchProcessError(error)) {
+      if (isFailureWithCode(error, NO_SUCH_PROCESS_CODES)) {
         return;
       }
 
@@ -79,6 +91,32 @@ export class FakeProcessSupervisor implements ProcessSupervisor {
   }
 }
 
-function isNoSuchProcessError(error: unknown): error is NodeJS.ErrnoException {
-  return typeof error === "object" && error !== null && "code" in error && error.code === "ESRCH";
+/** The pid is gone, or belongs to a user this process may not signal. */
+const NOT_ALIVE_CODES = new Set(["ESRCH", "EPERM"]);
+
+const NO_SUCH_PROCESS_CODES = new Set(["ESRCH"]);
+
+/** `process.kill` refuses anything outside a signed 32-bit integer with a `RangeError`. */
+const MAX_PID = 2 ** 31 - 1;
+
+/**
+ * Whether this number addresses one process at all. `process.kill` reads `0` as "every
+ * process in my group" and a negative pid as a whole group -- `-1` as every process this
+ * user may signal -- so a pid read back from a corrupt record on disk could turn a
+ * routine `SIGKILL` of a stale child into the end of the user's login session. Guarding
+ * here rather than in each caller is the point: this port is the primitive they all pass
+ * through (safety rule 1).
+ */
+function isAddressablePid(pid: number): boolean {
+  return Number.isInteger(pid) && pid > 0 && pid <= MAX_PID;
+}
+
+function isFailureWithCode(error: unknown, codes: ReadonlySet<string>): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof error.code === "string" &&
+    codes.has(error.code)
+  );
 }

--- a/src/ports/process-supervisor.ts
+++ b/src/ports/process-supervisor.ts
@@ -27,6 +27,7 @@ export class NodeProcessSupervisor implements ProcessSupervisor {
     }
   }
 
+  // fallow-ignore-next-line unused-class-member -- ProcessSupervisor contract; the reaping side of it.
   signal(pid: number, signal: NodeJS.Signals): void {
     try {
       process.kill(pid, signal);

--- a/src/ports/process-supervisor.ts
+++ b/src/ports/process-supervisor.ts
@@ -1,0 +1,83 @@
+/**
+ * Liveness and signalling for a process addressed by pid rather than by a handle.
+ *
+ * `ProcessRunner` covers processes this daemon spawned and still holds; this port covers
+ * the ones it does not: a supervised child recorded on disk outlives the daemon that
+ * started it, so after a crash the only thing left to ask about it is its pid.
+ */
+export interface ProcessSupervisor {
+  /** True when a process with this pid exists and this user may signal it. */
+  isAlive(pid: number): boolean;
+  /** Best effort; a pid that is already gone is not an error. */
+  signal(pid: number, signal: NodeJS.Signals): void;
+}
+
+export class NodeProcessSupervisor implements ProcessSupervisor {
+  isAlive(pid: number): boolean {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch {
+      // Both ESRCH (gone) and EPERM (alive, but another user's) answer "no" here, and
+      // deliberately so: this port exists to decide whether a recorded pid is a process
+      // this daemon can still reap. One it may not signal is not that, whatever it is --
+      // and reporting it alive would leave the caller waiting on a kill that can never
+      // land.
+      return false;
+    }
+  }
+
+  signal(pid: number, signal: NodeJS.Signals): void {
+    try {
+      process.kill(pid, signal);
+    } catch (error: unknown) {
+      if (isNoSuchProcessError(error)) {
+        return;
+      }
+
+      throw error;
+    }
+  }
+}
+
+export interface SignalRecord {
+  readonly pid: number;
+  readonly signal: NodeJS.Signals;
+}
+
+/**
+ * Records signals instead of sending them, and lets a test decide which pids are alive.
+ * Signalling deliberately does not kill anything here: whether a process dies on SIGTERM,
+ * ignores it, or dies only on SIGKILL is exactly what the supervision code under test has
+ * to cope with, so the test says which of those happened.
+ */
+export class FakeProcessSupervisor implements ProcessSupervisor {
+  readonly signals: SignalRecord[] = [];
+  readonly #live = new Set<number>();
+
+  constructor(livePids: readonly number[] = []) {
+    for (const pid of livePids) {
+      this.#live.add(pid);
+    }
+  }
+
+  isAlive(pid: number): boolean {
+    return this.#live.has(pid);
+  }
+
+  signal(pid: number, signal: NodeJS.Signals): void {
+    this.signals.push({ pid, signal });
+  }
+
+  markAlive(pid: number): void {
+    this.#live.add(pid);
+  }
+
+  markDead(pid: number): void {
+    this.#live.delete(pid);
+  }
+}
+
+function isNoSuchProcessError(error: unknown): error is NodeJS.ErrnoException {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ESRCH";
+}

--- a/src/ports/tcp-probe.test.ts
+++ b/src/ports/tcp-probe.test.ts
@@ -46,6 +46,16 @@ describe("NodeTcpProbe", () => {
 
     await expect(new NodeTcpProbe().isListening(port)).resolves.toBe(false);
   });
+
+  it.each([-1, 0.5, 70_000])(
+    "reports a port nothing could listen on as free (%s)",
+    async (port) => {
+      // `createConnection` throws for these before a socket exists at all, and a probe that
+      // rejects instead of answering turns a misconfigured port into a daemon that cannot
+      // even report why it will not start.
+      await expect(new NodeTcpProbe().isListening(port)).resolves.toBe(false);
+    },
+  );
 });
 
 describe("FakeTcpProbe", () => {

--- a/src/ports/tcp-probe.test.ts
+++ b/src/ports/tcp-probe.test.ts
@@ -1,0 +1,64 @@
+import { createServer, type Server } from "node:net";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { FakeTcpProbe, NodeTcpProbe } from "./index.js";
+
+let server: Server | undefined;
+
+/** Listens on an ephemeral loopback port and reports which one it got. */
+async function listen(): Promise<number> {
+  server = createServer();
+
+  return new Promise<number>((resolve) => {
+    server?.listen(0, "127.0.0.1", () => {
+      const address = server?.address();
+      resolve(typeof address === "object" && address !== null ? address.port : 0);
+    });
+  });
+}
+
+async function close(): Promise<void> {
+  const closing = server;
+  server = undefined;
+  await new Promise<void>((resolve) => {
+    if (closing === undefined) {
+      resolve();
+      return;
+    }
+
+    closing.close(() => resolve());
+  });
+}
+
+afterEach(close);
+
+describe("NodeTcpProbe", () => {
+  it("reports a port something is listening on as taken", async () => {
+    const port = await listen();
+
+    await expect(new NodeTcpProbe().isListening(port)).resolves.toBe(true);
+  });
+
+  it("reports a port nothing answers on as free", async () => {
+    const port = await listen();
+    await close();
+
+    await expect(new NodeTcpProbe().isListening(port)).resolves.toBe(false);
+  });
+});
+
+describe("FakeTcpProbe", () => {
+  it("answers with the ports a test declared, as they come and go", async () => {
+    const probe = new FakeTcpProbe([5038]);
+
+    await expect(probe.isListening(5038)).resolves.toBe(true);
+    await expect(probe.isListening(5039)).resolves.toBe(false);
+
+    probe.stopListening(5038);
+    probe.startListening(5039);
+
+    await expect(probe.isListening(5038)).resolves.toBe(false);
+    await expect(probe.isListening(5039)).resolves.toBe(true);
+  });
+});

--- a/src/ports/tcp-probe.ts
+++ b/src/ports/tcp-probe.ts
@@ -1,0 +1,59 @@
+import { createConnection } from "node:net";
+
+/**
+ * Asks whether a loopback port is in use. Simlock needs this to decide whether the port
+ * it wants for its own server is already taken, which is a fail-closed decision rather
+ * than a diagnostic one -- see ADR 0001.
+ */
+export interface TcpProbe {
+  /** True when something is accepting connections on `127.0.0.1:<port>` right now. */
+  isListening(port: number, timeoutMs?: number): Promise<boolean>;
+}
+
+/**
+ * Short by design: this probes loopback, where a connection either completes almost
+ * immediately or is not going to. It is also called in a polling loop while waiting for a
+ * server to come up, so a generous timeout would slow that loop down for no information.
+ */
+const DEFAULT_TIMEOUT_MS = 250;
+
+export class NodeTcpProbe implements TcpProbe {
+  async isListening(port: number, timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      const socket = createConnection({ host: "127.0.0.1", port });
+      const settle = (listening: boolean): void => {
+        socket.destroy();
+        resolve(listening);
+      };
+
+      socket.setTimeout(timeoutMs);
+      socket.once("connect", () => settle(true));
+      socket.once("timeout", () => settle(false));
+      // A refused connection is the expected answer for a free port, not a failure to
+      // report: everything that goes wrong here means "nothing is serving this port".
+      socket.once("error", () => settle(false));
+    });
+  }
+}
+
+export class FakeTcpProbe implements TcpProbe {
+  readonly #listening = new Set<number>();
+
+  constructor(listeningPorts: readonly number[] = []) {
+    for (const port of listeningPorts) {
+      this.#listening.add(port);
+    }
+  }
+
+  async isListening(port: number): Promise<boolean> {
+    return this.#listening.has(port);
+  }
+
+  startListening(port: number): void {
+    this.#listening.add(port);
+  }
+
+  stopListening(port: number): void {
+    this.#listening.delete(port);
+  }
+}

--- a/src/ports/tcp-probe.ts
+++ b/src/ports/tcp-probe.ts
@@ -1,4 +1,4 @@
-import { createConnection } from "node:net";
+import { createConnection, type Socket } from "node:net";
 
 /**
  * Asks whether a loopback port is in use. Simlock needs this to decide whether the port
@@ -20,7 +20,19 @@ const DEFAULT_TIMEOUT_MS = 250;
 export class NodeTcpProbe implements TcpProbe {
   async isListening(port: number, timeoutMs: number = DEFAULT_TIMEOUT_MS): Promise<boolean> {
     return new Promise<boolean>((resolve) => {
-      const socket = createConnection({ host: "127.0.0.1", port });
+      let socket: Socket;
+      try {
+        socket = createConnection({ host: "127.0.0.1", port });
+      } catch {
+        // `createConnection` throws synchronously (`ERR_SOCKET_BAD_PORT`) for a port
+        // outside 0-65535 or one that is not an integer. That has to answer like every
+        // other failure here -- nothing is serving a port nothing can listen on -- or a
+        // misconfigured port number would reject out of a call whose whole contract is to
+        // report `true` or `false`.
+        resolve(false);
+        return;
+      }
+
       const settle = (listening: boolean): void => {
         socket.destroy();
         resolve(listening);


### PR DESCRIPTION
First of five stacked PRs implementing [ADR 0001](https://github.com/callstackincubator/simlock/blob/feat/owned-device-roots/docs/adr/0001-simlock-owned-device-roots.md). Base is the ADR branch; each later PR is based on the previous one.

1. **owned device root validation and its ports** ← this PR
2. iOS: `simctl --set`, membership-based `listManaged`, fail-closed discovery
3. Android: `ANDROID_AVD_HOME`, private supervised adb server
4. lease environment and the `simctl` / `adb` passthroughs
5. doctor: `--purge-orphans`, legacy pre-root devices, docs status

## What this is

The foundation both drivers need before either can own a device root. Nothing observable changes: `ensureOwnedRoot` and `loadInstanceId` have no production caller until PR 2 wires them.

- **`ensureOwnedRoot`** (`src/core/device-root.ts`) — the whole of Simlock's structural ownership proof. It creates a root only when it creates it empty itself, and refuses an existing one that is unmarked, marked for another instance, symlinked, or wrongly owned or permissioned. Validation is pure filesystem logic, so it lives in the core once rather than per driver (ADR decision 2).
- **`loadInstanceId`** (`src/core/instance-identity.ts`) — writes `instance.json` once and never regenerates it. A corrupt file fails loudly, because regenerating would strand every device in the root behind `wrong-instance`.
- **The `drivers` config section** — stored, merged and forwarded without the core interpreting a single key, so a driver owns its settings end to end (architecture rule 2).
- **Ports** — unfollowed `lstat`, exclusive `mkdir`, `chmod`, `realpath`, `rename`, `writeFileExclusive`, plus `ProcessSupervisor` and `TcpProbe` for PR 3's supervised adb server, and `stdio: "ignore"` so a long-lived child's output is not buffered forever.

## Decisions worth reviewing

**An ancestor symlink is deliberately not a rejection.** `/tmp` is a symlink on macOS and every test home lives under one, so rejecting on a `realpath` mismatch would fail closed on ordinary machines. Only the root itself and its marker are checked unfollowed — an attacker who can swap an ancestor can equally swap the root, and that case *is* caught.

**Two rejection reasons were added** beyond the list in `docs/EVENTS.md`: `not-absolute` and `unreadable` (the EVENTS.md row is updated). Both exist so a bad configuration skips one platform instead of stopping the daemon.

**Declined: binding the marker to the root it sits in.** A valid marker is portable, so a restored or copied root validates if `deviceRoot` is pointed at it. Fixing that means adding a field to the four-key schema the ADR fixes, for a risk that needs someone to aim `deviceRoot` at a copy that also holds their own files. Flagging rather than deviating from an accepted ADR — say the word and it goes in.

## Review round

The third commit is the fix round from an adversarial review of the first two. Four defects were confirmed against a real filesystem, not argued:

- **Root creation was not atomic with its marker**, which is the property ADR decision 1 promises. Three concurrent calls on a fresh path gave one success and two `non-empty-unowned-root` refusals — the "data" being Simlock's own marker tempfile mid-rename. A crash or ENOSPC between the steps bricked the root permanently. A root is now assembled in a staging sibling and published with one `rename`.
- **`loadInstanceId` could overwrite the identity it promises never to regenerate** (`exists()`-then-write over a clobbering `rename`), stranding every root the winner had just marked. Now an exclusive create.
- **`ProcessSupervisor` passed pid `0` and `-1` to `process.kill`** — a corrupt `adb-server.json` in PR 3 would have signalled the daemon's process group, or every process the user owns.
- **A relative `deviceRoot` resolved against the daemon's inherited cwd**, and unexpected errno errors escaped untyped.

Each fix has a test that fails against the old implementation (21 in total, verified by swapping the old files back in).

## Known residuals

- A crash between creating the staging directory and the rename leaves a hidden `.staging` sibling behind. It is outside the root, so it never affects validation or the emptiness count. Nothing sweeps it.
- POSIX `rename` replaces an existing *empty* destination directory, so a user directory created in the sliver between the `lstat` and the `rename` would be replaced. Strictly narrower than what it replaces; documented at the call site.
- The real-filesystem race test for `loadInstanceId` passes against the old code too — with three racers the old re-read converged every run. The double that seeds the winner's file and throws `EEXIST` is what catches that mutation.

## Verification

`pnpm run check` passes in full: typecheck, typecheck:e2e, lint, format, 786 unit tests (2 pre-existing skips), and the e2e lane (33 passed, 1 expected fail, 3 skipped — identical to the pre-change baseline). `pnpm exec fallow audit` reports no issues in 29 changed files.

Refs #73, #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BuTqSL7fKJVRbFytNvZP7X

---
_Generated by [Claude Code](https://claude.ai/code/session_01BuTqSL7fKJVRbFytNvZP7X)_