### PR TITLE
feat(ios): scope every simctl call to a device set Simlock owns (2/5)

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -379,8 +379,15 @@ registry. They are not migrated: neither CoreSimulator nor the Android SDK
 supports relocating a device, so those are re-provisioned.
 
 A root that fails ownership validation at startup — missing or foreign marker,
-symlink, wrong owner or permissions — stops that platform's driver and is
-reported here with the failing reason.
+symlink, wrong owner or permissions, or a `deviceRoot` that is not an absolute
+path — stops that platform's driver and is reported here with the failing
+reason. Driver discovery runs once, at daemon startup, so re-running `doctor`
+after repairing the root reports the same finding until the daemon is
+restarted; the finding says so.
+
+Nothing else is reported about a platform whose driver did not start. Its
+devices are unobservable, not missing, and `--fix` must never mark a registry
+device deleted on the strength of a reality nobody could read.
 
 A `provisioning` or `reclaiming` device is normally in-flight work Simlock
 itself is driving and is not reported — but only up to a driver-derived
@@ -453,8 +460,9 @@ process inherits the variable like the rest of the environment.
 Overrides driver discovery (`discoverDrivers` in `src/daemon/main.ts`) with a
 JavaScript module of your own instead of the real iOS/Android drivers. Point
 it at a file path; the daemon dynamically imports that module and calls its
-exported `createDrivers(context)` (the same `{ clock, filesystem,
-idGenerator, logger, processRunner }` context real discovery receives),
+exported `createDrivers(context)` (the same `{ clock, driversConfig,
+filesystem, hostPlatform, idGenerator, instanceId, logger, processRunner,
+simlockHome }` context real discovery receives),
 which must return `Driver[]` (or a promise of it, matching
 `src/core/driver.ts`). This exists so tests — and anyone reproducing a bug
 without real hardware — can run the full daemon against a scripted driver

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -73,6 +73,12 @@ belongs on another volume — device data runs to tens of gigabytes:
 }
 ```
 
+A `deviceRoot` must be an absolute path. A relative one — or a value that is
+not a string at all, such as `true` — refuses that one platform with reason
+`not-absolute` rather than being resolved against whatever directory the daemon
+happened to be started from; the daemon still comes up, and the other platform
+is unaffected.
+
 Roots hold device instances only. Runtimes and system images stay where Xcode
 and the Android SDK put them.
 

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -50,7 +50,7 @@ in short: `subject.past-tense-fact`, emitted post-commit, facts not commands.
 | `disk.pressure-detected` | free bytes, threshold | free disk crossed under the configured threshold (edge-triggered: once per crossing, not once per tick while it persists) | CleanupReaper | implemented |
 | `cleanup.executed` | rule name, action, target, reason | cleanup executor committed a proposed action | CleanupExecutor | implemented |
 | `doctor.reconciled` | drift findings | daemon reconciliation completed | Doctor | implemented |
-| `driver.root-rejected` | platform, root path, reason (not-absolute/missing-marker/invalid-marker/wrong-instance/symlink/wrong-owner/wrong-permissions/non-empty-unowned-root/unreadable) | a driver's device root failed ownership validation at startup, so that platform's driver did not start | DaemonServer | planned |
+| `driver.root-rejected` | platform, root path, reason (not-absolute/missing-marker/invalid-marker/wrong-instance/symlink/wrong-owner/wrong-permissions/non-empty-unowned-root/unreadable) | a driver's device root failed ownership validation at startup, so that platform's driver did not start | DaemonServer | implemented |
 | `driver.adb-server-rejected` | port, reason | Simlock's configured adb server port was occupied by a server it does not own, so the Android driver did not start | DaemonServer | planned |
 
 ## Conventions recap

--- a/e2e/fake-driver/fake-driver.ts
+++ b/e2e/fake-driver/fake-driver.ts
@@ -53,15 +53,19 @@ const DEFAULT_SCRIPT: FakeDriverPlatformScript = {
  */
 export class OutOfProcessFakeDriver implements Driver {
   readonly platform: Platform;
+  /** Synthetic: this driver owns no real devices, and nothing validates or creates it. */
+  readonly deviceRoot: string;
   readonly #clock: FakeDriverClock;
   readonly #logPath: string | undefined;
   readonly #scriptPath: string | undefined;
   readonly #devices = new Map<string, "provisioned" | "ready" | "shutdown">();
   #lastKnownEstimateMs: FakeDriverPlatformScript["estimateMs"];
+  #lastKnownLeaseEnvironment: FakeDriverPlatformScript["leaseEnvironment"];
   #nextDeviceNumber = 1;
 
   constructor(options: OutOfProcessFakeDriverOptions) {
     this.platform = options.platform;
+    this.deviceRoot = `/fake/${options.platform}`;
     this.#clock = options.clock;
     this.#logPath = options.logPath;
     this.#scriptPath = options.scriptPath;
@@ -194,12 +198,19 @@ export class OutOfProcessFakeDriver implements Driver {
     return this.#lastKnownEstimateMs?.[estimate.operation] ?? 0;
   }
 
+  /** Synchronous like `estimate`, and cached the same way: the last script read wins. */
+  // fallow-ignore-next-line unused-class-member -- Driver.leaseEnvironment contract; read by the lease path when it builds a grant.
+  leaseEnvironment(): Readonly<Record<string, string>> {
+    return this.#lastKnownLeaseEnvironment ?? {};
+  }
+
   async #beforeCall(
     operation: FakeDriverOperation,
     arguments_: readonly unknown[],
   ): Promise<FakeDriverPlatformScript> {
     const script = await this.#readScript();
     this.#lastKnownEstimateMs = script.estimateMs;
+    this.#lastKnownLeaseEnvironment = script.leaseEnvironment;
     await this.#appendLog(operation, arguments_);
 
     const latency = script.latencyMs?.[operation] ?? 0;

--- a/e2e/fake-driver/types.ts
+++ b/e2e/fake-driver/types.ts
@@ -61,6 +61,12 @@ export interface FakeDriverPlatformScript {
   readonly failures?: Partial<Record<FakeDriverOperation, FakeDriverErrorSpec>>;
   readonly managedReality?: ScriptedManagedReality;
   /**
+   * Environment the grant for this platform's devices should carry, standing in for the
+   * device-set path / adb port a real driver contributes. Read on every operation like
+   * everything else here, so a test can set it before the lease it wants to assert on.
+   */
+  readonly leaseEnvironment?: Readonly<Record<string, string>>;
+  /**
    * Overrides the `address` a `makeReady` boot returns (the script is re-read fresh on every
    * call, so a test can change this between two boots of the same device to simulate the real
    * drivers reassigning it -- e.g. Android's console port on a `shutdown` -> boot cycle).

--- a/e2e/slow-ios-smoke.test.ts
+++ b/e2e/slow-ios-smoke.test.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { join } from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 
@@ -13,12 +14,33 @@ interface SimctlDevice {
   readonly state: string;
 }
 
-async function simctlDevices(): Promise<SimctlDevice[]> {
+/**
+ * Devices in one device set. Every simctl call here carries `--set`, exactly as the
+ * driver's do: a device in a custom set is not addressable, or even listable, without it.
+ * Omitting the flag is how this lane checks the *other* half of containment -- see
+ * `defaultSetDevices`.
+ */
+async function setDevices(deviceSet: string): Promise<SimctlDevice[]> {
+  const { stdout } = await execFileAsync("xcrun", [
+    "simctl",
+    "--set",
+    deviceSet,
+    "list",
+    "devices",
+    "-j",
+  ]);
+  const parsed = JSON.parse(stdout) as { devices: Record<string, SimctlDevice[]> };
+  return Object.values(parsed.devices).flat();
+}
+
+/** The machine's own device set -- the one Xcode shows. Simlock's devices must never be in it. */
+async function defaultSetDevices(): Promise<SimctlDevice[]> {
   const { stdout } = await execFileAsync("xcrun", ["simctl", "list", "devices", "-j"]);
   const parsed = JSON.parse(stdout) as { devices: Record<string, SimctlDevice[]> };
   return Object.values(parsed.devices).flat();
 }
 
+/** Runtimes are global: a custom set lists the same ones the default set does. */
 async function simctlRuntimes(): Promise<string[]> {
   const { stdout } = await execFileAsync("xcrun", ["simctl", "list", "runtimes", "-j"]);
   const parsed = JSON.parse(stdout) as {
@@ -27,12 +49,16 @@ async function simctlRuntimes(): Promise<string[]> {
   return parsed.runtimes.filter((runtime) => runtime.isAvailable).map((runtime) => runtime.version);
 }
 
-async function deleteStraySimlockSimulators(): Promise<void> {
-  const devices = await simctlDevices();
-  for (const device of devices) {
-    if (device.name.startsWith("simlock-")) {
-      await execFileAsync("xcrun", ["simctl", "delete", device.udid]).catch(() => undefined);
-    }
+/**
+ * Everything in the set, by membership rather than by name: the set is Simlock's own, so
+ * nothing else can be in it, and CoreSimulator has to be told to forget these devices
+ * before the temporary home holding them is removed.
+ */
+async function deleteSetDevices(deviceSet: string): Promise<void> {
+  for (const device of await setDevices(deviceSet).catch(() => [])) {
+    await execFileAsync("xcrun", ["simctl", "--set", deviceSet, "delete", device.udid]).catch(
+      () => undefined,
+    );
   }
 }
 
@@ -43,7 +69,7 @@ describe.skipIf(process.platform !== "darwin")(
   { tags: ["slow", "ios"] },
   () => {
     it(
-      "catalog agrees with simctl, a cold lease boots a real Booted simulator with matching provenance, release keeps it warm, and nuke leaves no simlock- simulator",
+      "catalog agrees with simctl, a cold lease boots a real Booted simulator inside Simlock's own device set with matching provenance, release keeps it warm, and nuke empties the set",
       { timeout: 300_000 },
       async () => {
         const availableRuntimes = await simctlRuntimes();
@@ -52,6 +78,7 @@ describe.skipIf(process.platform !== "darwin")(
         }
 
         const env = await withDaemon({ driver: "real" });
+        const deviceSet = join(env.home, "devices", "ios");
         try {
           const catalog = await env.cli(["catalog", "--json", "--platform", "ios"]);
           expect(catalog.code).toBe(0);
@@ -90,14 +117,24 @@ describe.skipIf(process.platform !== "darwin")(
           expect(lease.code, `lease failed: ${lease.stderr}`).toBe(0);
           const grant = lease.json as { lease: string; udid: string; device: string };
 
-          const booted = await simctlDevices();
+          const booted = await setDevices(deviceSet);
           const bootedDevice = booted.find((device) => device.udid === grant.udid);
-          expect(bootedDevice, `simctl does not know about udid ${grant.udid}`).toBeDefined();
+          expect(
+            bootedDevice,
+            `simctl --set ${deviceSet} does not know about udid ${grant.udid}`,
+          ).toBeDefined();
           expect(bootedDevice?.state).toBe("Booted");
+          // The naming is a label with no authority behind it (safety rule 8) -- what
+          // proves ownership is the set the device was just found in -- but it is still
+          // what a human reads in the simulator window title, so it stays checked.
           expect(
             bootedDevice?.name.startsWith("simlock-"),
             "device name must carry the simlock- prefix",
           ).toBe(true);
+          expect(
+            (await defaultSetDevices()).some((device) => device.udid === grant.udid),
+            "a Simlock simulator must be invisible in the machine's default device set",
+          ).toBe(false);
 
           // Provenance: both marks exist with the same token. `doctor` is the
           // documented way to observe this -- a foreign-provenance-change finding
@@ -119,6 +156,10 @@ describe.skipIf(process.platform !== "darwin")(
             ),
             "expected no provenance drift for a device simlock just created",
           ).toBe(false);
+          expect(
+            findings.some((finding) => finding.kind === "driver-unavailable"),
+            "the iOS driver must have started, with a root it owns",
+          ).toBe(false);
 
           const release = await env.cli(["release", grant.lease]);
           expect(release.code).toBe(0);
@@ -135,19 +176,18 @@ describe.skipIf(process.platform !== "darwin")(
             },
             { timeout: 60_000, label: "device returns to ready after release" },
           );
-          const stillBooted = await simctlDevices();
+          const stillBooted = await setDevices(deviceSet);
           expect(stillBooted.find((device) => device.udid === grant.udid)?.state).toBe("Booted");
 
           const nuke = await env.cli(["nuke", "--delete-devices", "--yes"], { timeout: 60_000 });
           expect(nuke.code).toBe(0);
 
-          await waitFor(
-            async () =>
-              !(await simctlDevices()).some((device) => device.name.startsWith("simlock-")),
-            { timeout: 60_000, label: "no simlock- simulator remains after nuke --delete-devices" },
-          );
+          await waitFor(async () => (await setDevices(deviceSet)).length === 0, {
+            timeout: 60_000,
+            label: "no simulator remains in Simlock's device set after nuke --delete-devices",
+          });
         } finally {
-          await deleteStraySimlockSimulators();
+          await deleteSetDevices(deviceSet);
         }
       },
     );

--- a/e2e/slow-ios-smoke.test.ts
+++ b/e2e/slow-ios-smoke.test.ts
@@ -1,4 +1,6 @@
 import { execFile } from "node:child_process";
+import { readdir, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
@@ -53,12 +55,43 @@ async function simctlRuntimes(): Promise<string[]> {
  * Everything in the set, by membership rather than by name: the set is Simlock's own, so
  * nothing else can be in it, and CoreSimulator has to be told to forget these devices
  * before the temporary home holding them is removed.
+ *
+ * Shut down first, always. `simctl delete` refuses a booted device, and this runs on the
+ * failure path too -- a `waitFor` that gave up leaves devices booted -- so deleting
+ * without shutting down would leave a running `launchd_sim` attached to a set directory
+ * that `withDaemon`'s teardown is about to remove recursively.
  */
-async function deleteSetDevices(deviceSet: string): Promise<void> {
+async function emptyDeviceSet(deviceSet: string): Promise<void> {
   for (const device of await setDevices(deviceSet).catch(() => [])) {
+    await execFileAsync("xcrun", ["simctl", "--set", deviceSet, "shutdown", device.udid]).catch(
+      () => undefined,
+    );
     await execFileAsync("xcrun", ["simctl", "--set", deviceSet, "delete", device.udid]).catch(
       () => undefined,
     );
+  }
+}
+
+/** Older than any run of this lane can be: its own timeout is five minutes. */
+const STALE_SET_AGE_MS = 60 * 60 * 1000;
+
+/**
+ * Device sets left behind by a run that died before its own cleanup -- a killed vitest, a
+ * crashed machine. Nothing else reclaims them now that the set lives inside a per-test
+ * temporary home instead of the shared default set the old prefix sweep covered, so the
+ * tens of gigabytes each holds would sit in `$TMPDIR` forever. Age-gated rather than
+ * scoped to this run so it can never sweep a set out from under a live one, including a
+ * sibling running in parallel.
+ */
+async function sweepStaleDeviceSets(): Promise<void> {
+  const entries = await readdir(tmpdir(), { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !entry.name.startsWith("simlock-e2e-")) continue;
+    const deviceSet = join(tmpdir(), entry.name, "devices", "ios");
+    const details = await stat(deviceSet).catch(() => undefined);
+    if (details === undefined || Date.now() - details.mtimeMs < STALE_SET_AGE_MS) continue;
+    await emptyDeviceSet(deviceSet);
+    await rm(deviceSet, { force: true, recursive: true });
   }
 }
 
@@ -72,6 +105,7 @@ describe.skipIf(process.platform !== "darwin")(
       "catalog agrees with simctl, a cold lease boots a real Booted simulator inside Simlock's own device set with matching provenance, release keeps it warm, and nuke empties the set",
       { timeout: 300_000 },
       async () => {
+        await sweepStaleDeviceSets();
         const availableRuntimes = await simctlRuntimes();
         if (availableRuntimes.length === 0) {
           throw new Error("No installed, available iOS runtime -- cannot run the iOS smoke lane");
@@ -187,7 +221,7 @@ describe.skipIf(process.platform !== "darwin")(
             label: "no simulator remains in Simlock's device set after nuke --delete-devices",
           });
         } finally {
-          await deleteSetDevices(deviceSet);
+          await emptyDeviceSet(deviceSet);
         }
       },
     );

--- a/src/bus/index.test.ts
+++ b/src/bus/index.test.ts
@@ -141,6 +141,8 @@ describe("EventBus", () => {
       | "disk.pressure-detected"
       | "cleanup.executed"
       | "doctor.reconciled"
+      | "driver.root-rejected"
+      | "driver.adb-server-rejected"
     >();
     expectTypeOf<EventMap>().toMatchTypeOf<Record<EventName, object>>();
   });

--- a/src/bus/index.ts
+++ b/src/bus/index.ts
@@ -114,6 +114,13 @@ export interface EventMap {
     readonly reason: string;
   };
   "doctor.reconciled": { readonly driftFindings: unknown };
+  /** Payloads owned by the driver module that refused the root; see `DriverRejection`. */
+  "driver.root-rejected": {
+    readonly platform: string;
+    readonly root: string;
+    readonly reason: string;
+  };
+  "driver.adb-server-rejected": { readonly port: number; readonly reason: string };
 }
 
 export type EventName = keyof EventMap;

--- a/src/core/doctor.test.ts
+++ b/src/core/doctor.test.ts
@@ -6,6 +6,7 @@ import { FakeSystemStats } from "../ports/index.js";
 import type { Config } from "./config.js";
 import { DeviceOperationClaims } from "./device-operation-claims.js";
 import { Doctor } from "./doctor.js";
+import type { DriverRejection } from "./driver.js";
 import { DriverCatalog } from "./driver-catalog.js";
 import { FakeDriver } from "./fake-driver.js";
 import { LeaseEngine } from "./lease-engine.js";
@@ -1231,7 +1232,71 @@ describe("Doctor", () => {
     expect(firstForeignStateSeq).toBeGreaterThan(lastCommitSeq);
     expect(events.at(-1)?.event).toBe("doctor.reconciled");
   });
+
+  it("reports a platform whose driver refused to start, with the reason it refused", async () => {
+    const clock = new FakeClock(10_000);
+    const eventBus = new EventBus(clock);
+    const registry = await Registry.load({
+      clock,
+      eventBus,
+      filesystem: new MemoryFilesystem(),
+      idGenerator: sequence(),
+      statePath: "/state.json",
+    });
+
+    const report = await new Doctor({
+      clock,
+      config: config(),
+      drivers: [],
+      driverRejections: [rootRejection()],
+      eventBus,
+      registry,
+    }).reconcile();
+
+    expect(report.findings).toEqual([
+      {
+        detail: "Refusing the ios device root /Devices: it carries no marker",
+        kind: "driver-unavailable",
+        platform: "ios",
+        reason: "missing-marker",
+      },
+    ]);
+  });
+
+  it("leaves a refused driver alone under --fix, since adopting it is the refusal's point", async () => {
+    const clock = new FakeClock(10_000);
+    const eventBus = new EventBus(clock);
+    const registry = await Registry.load({
+      clock,
+      eventBus,
+      filesystem: new MemoryFilesystem(),
+      idGenerator: sequence(),
+      statePath: "/state.json",
+    });
+
+    const report = await new Doctor({
+      clock,
+      config: config(),
+      drivers: [],
+      driverRejections: [rootRejection()],
+      eventBus,
+      registry,
+    }).reconcile({ fix: true });
+
+    expect(report.findings.map((finding) => finding.kind)).toEqual(["driver-unavailable"]);
+    expect(registry.snapshot.devices).toEqual([]);
+  });
 });
+
+function rootRejection(): DriverRejection {
+  return {
+    event: "driver.root-rejected",
+    payload: { platform: "ios", reason: "missing-marker", root: "/Devices" },
+    platform: "ios",
+    reason: "missing-marker",
+    summary: "Refusing the ios device root /Devices: it carries no marker",
+  };
+}
 
 async function readyDevice(
   registry: Registry,

--- a/src/core/doctor.test.ts
+++ b/src/core/doctor.test.ts
@@ -1253,14 +1253,20 @@ describe("Doctor", () => {
       registry,
     }).reconcile();
 
-    expect(report.findings).toEqual([
-      {
-        detail: "Refusing the ios device root /Devices: it carries no marker",
-        kind: "driver-unavailable",
-        platform: "ios",
-        reason: "missing-marker",
-      },
-    ]);
+    expect(report.findings.map((finding) => finding.kind)).toEqual(["driver-unavailable"]);
+    expect(report.findings[0]).toMatchObject({
+      // Discovery happens once, at startup, so the finding has to say what actually
+      // retries the platform -- otherwise repairing the root and re-running `doctor`
+      // reports the identical line and reads as a repair that did not work.
+      detail: expect.stringContaining(
+        "Refusing the ios device root /Devices: it carries no marker",
+      ),
+      platform: "ios",
+      reason: "missing-marker",
+    });
+    expect(report.findings[0]).toMatchObject({
+      detail: expect.stringContaining("restart the daemon"),
+    });
   });
 
   it("leaves a refused driver alone under --fix, since adopting it is the refusal's point", async () => {
@@ -1287,6 +1293,68 @@ describe("Doctor", () => {
     expect(registry.snapshot.devices).toEqual([]);
   });
 });
+
+describe("Doctor with a platform it cannot observe", () => {
+  it("never reports a registry device missing because no driver could look for it", async () => {
+    const { eventBus, registry } = await readyIosDevice();
+
+    const report = await new Doctor({
+      clock: new FakeClock(10_000),
+      config: config(),
+      drivers: [],
+      driverRejections: [rootRejection()],
+      eventBus,
+      registry,
+    }).reconcile({ fix: true });
+
+    // "I could not look" is not "the device is gone". Marking these `deleted` would strand
+    // every simulator in the root behind a registry with no record of it -- the permanent
+    // multi-gigabyte leak ADR 0001 exists to prevent, reachable with a `chmod`.
+    expect(report.findings.map((finding) => finding.kind)).toEqual(["driver-unavailable"]);
+    expect(registry.snapshot.devices[0]?.state).toBe("ready");
+  });
+
+  it("stays silent about a platform that simply has no driver on this host", async () => {
+    const { eventBus, registry } = await readyIosDevice();
+
+    const report = await new Doctor({
+      clock: new FakeClock(10_000),
+      config: config(),
+      drivers: [],
+      eventBus,
+      registry,
+    }).reconcile({ fix: true });
+
+    // Same reasoning with no rejection to report: a missing Android SDK or a non-Mac host
+    // is just as unobservable as a refused root.
+    expect(report.findings).toEqual([]);
+    expect(registry.snapshot.devices[0]?.state).toBe("ready");
+  });
+});
+
+/** One `ready` iOS device in an otherwise empty registry. */
+async function readyIosDevice() {
+  const clock = new FakeClock(10_000);
+  const eventBus = new EventBus(clock);
+  const registry = await Registry.load({
+    clock,
+    eventBus,
+    filesystem: new MemoryFilesystem(),
+    idGenerator: sequence(),
+    statePath: "/state.json",
+  });
+  const registered = await registry.registerDevice({
+    driverData: { fakeDeviceId: "device-1" },
+    driverDeviceId: "device-1",
+    provisionDuration: 0,
+    spec: { model: "Phone", osVersion: "1", platform: "ios" },
+  });
+  await registry.transitionDevice(registered.id, "ready", {
+    event: "device.ready",
+    payload: { bootDuration: 0, deviceId: registered.id },
+  });
+  return { eventBus, registry };
+}
 
 function rootRejection(): DriverRejection {
   return {

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -9,7 +9,13 @@ import {
   transitionEnteredAt,
 } from "./domain.js";
 import type { DeviceOperationClaims } from "./device-operation-claims.js";
-import type { Driver, DriverDevice, ObservedDevice, ObservedMark } from "./driver.js";
+import type {
+  Driver,
+  DriverDevice,
+  DriverRejection,
+  ObservedDevice,
+  ObservedMark,
+} from "./driver.js";
 import type { LeaseExpirer } from "./lease-ports.js";
 import type { Registry } from "./registry.js";
 
@@ -34,6 +40,13 @@ export type DoctorFinding =
       readonly deviceId: string;
       readonly platform: Platform;
       readonly detail: ProvenanceDrift;
+    }
+  | {
+      /** A platform Simlock is running without, because its driver refused to start. */
+      readonly kind: "driver-unavailable";
+      readonly platform: Platform;
+      readonly reason: string;
+      readonly detail: string;
     }
   | {
       readonly kind: "stalled-transition";
@@ -79,6 +92,12 @@ export interface DoctorOptions {
    * backgrounded reclaim from being read as a stall -- see `stalledTransitionFinding`.
    */
   readonly claims?: Pick<DeviceOperationClaims, "isClaimed">;
+  /**
+   * Drivers that refused to start, as reported once at daemon startup. They are findings
+   * on every run, not just the first: the daemon has been serving without that platform
+   * ever since, and `doctor` is where `docs/CLI.md` promises the reason turns up.
+   */
+  readonly driverRejections?: readonly DriverRejection[];
   readonly registry: Registry;
 }
 
@@ -135,6 +154,7 @@ export class Doctor {
         findings.push(stalled);
       }
     }
+    findings.push(...driverUnavailableFindings(this.options.driverRejections ?? []));
     findings.push(...orphanFindings(realities, registryDeviceKeys));
     findings.push(...expiredLeaseFindings(snapshot.leases, this.options.clock.now()));
 
@@ -184,6 +204,7 @@ export class Doctor {
     }
   }
 
+  // fallow-ignore-next-line complexity -- one exhaustive arm per finding kind, each a single call or a documented no-op.
   async #applySafeFixes(findings: readonly DoctorFinding[]): Promise<void> {
     for (const finding of findings) {
       switch (finding.kind) {
@@ -204,6 +225,10 @@ export class Doctor {
           break;
         case "foreign-provenance-change":
           // Report-only: re-marking destroys the evidence, and the device may be leased.
+          break;
+        case "driver-unavailable":
+          // Nothing here can repair a refused root or an occupied port without doing the
+          // one thing failing closed exists to prevent: adopting what it refused.
           break;
         case "stalled-transition":
           await this.#fixStalledTransition(finding);
@@ -428,6 +453,15 @@ function provenanceDrift(mark: ObservedMark): ProvenanceDrift | undefined {
     return "erased";
   }
   return mark.erasable === mark.durable ? undefined : "mark-mismatch";
+}
+
+function driverUnavailableFindings(rejections: readonly DriverRejection[]): DoctorFinding[] {
+  return rejections.map((rejection) => ({
+    detail: rejection.summary,
+    kind: "driver-unavailable" as const,
+    platform: rejection.platform,
+    reason: rejection.reason,
+  }));
 }
 
 function orphanFindings(

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -113,6 +113,16 @@ export class Doctor {
     const realities = await Promise.all(
       this.options.drivers.map(async (driver) => ({ driver, reality: await driver.listManaged() })),
     );
+    // A platform with no driver has no observable reality: its driver refused to start,
+    // its SDK is missing, or this host has none. "I could not look" is not "the device is
+    // gone", and reading it as such is destructive -- every registry device of that
+    // platform would drift-report as missing and `--fix` would mark the lot `deleted`,
+    // stranding tens of gigabytes of simulators in a root with no record left to reach
+    // them. That is the permanent leak ADR 0001 exists to prevent, so existence, run
+    // state, provenance and orphans are all reported only for platforms a driver
+    // actually observed. What remains reportable is what needs no driver: expired
+    // leases, and the `driver-unavailable` finding that says why the platform is dark.
+    const observedPlatforms = new Set(this.options.drivers.map((driver) => driver.platform));
     const realDeviceKeys = new Set(
       realities.flatMap(({ driver, reality }) =>
         reality.devices.map((device) => key(driver.platform, device.deviceId)),
@@ -132,16 +142,18 @@ export class Doctor {
     const findings: DoctorFinding[] = [];
 
     for (const device of snapshot.devices) {
-      const deviceFindings = registryDriftFindings(device, realDeviceKeys, observedDevices);
-      findings.push(...deviceFindings);
-      if (deviceFindings.some((finding) => finding.kind === "foreign-state-change")) {
-        await this.options.registry.markForeignStateDetected(device.id, this.options.clock.now());
-      }
-      if (deviceFindings.some((finding) => finding.kind === "foreign-provenance-change")) {
-        await this.options.registry.markForeignProvenanceDetected(
-          device.id,
-          this.options.clock.now(),
-        );
+      if (observedPlatforms.has(device.spec.platform)) {
+        const deviceFindings = registryDriftFindings(device, realDeviceKeys, observedDevices);
+        findings.push(...deviceFindings);
+        if (deviceFindings.some((finding) => finding.kind === "foreign-state-change")) {
+          await this.options.registry.markForeignStateDetected(device.id, this.options.clock.now());
+        }
+        if (deviceFindings.some((finding) => finding.kind === "foreign-provenance-change")) {
+          await this.options.registry.markForeignProvenanceDetected(
+            device.id,
+            this.options.clock.now(),
+          );
+        }
       }
       const stalled = stalledTransitionFinding(
         device,
@@ -455,9 +467,18 @@ function provenanceDrift(mark: ObservedMark): ProvenanceDrift | undefined {
   return mark.erasable === mark.durable ? undefined : "mark-mismatch";
 }
 
+/**
+ * Discovery runs once, at daemon start, so a refusal is a frozen snapshot: repairing the
+ * root and running `doctor` again reports the identical finding, because nothing has
+ * looked at the root since. The finding therefore has to name the step that actually
+ * retries the platform, or it reads as a repair that did not work.
+ */
+const DRIVER_RETRY_REMEDY =
+  "Driver discovery runs once, at daemon startup: restart the daemon (`simlock daemon stop`, then any command relaunches it) once this is fixed, or the platform stays unavailable.";
+
 function driverUnavailableFindings(rejections: readonly DriverRejection[]): DoctorFinding[] {
   return rejections.map((rejection) => ({
-    detail: rejection.summary,
+    detail: `${rejection.summary}. ${DRIVER_RETRY_REMEDY}`,
     kind: "driver-unavailable" as const,
     platform: rejection.platform,
     reason: rejection.reason,

--- a/src/core/driver.ts
+++ b/src/core/driver.ts
@@ -12,9 +12,8 @@ export interface DriverDevice {
   /**
    * The opaque string platform tooling accepts right now -- a simctl UDID for iOS, an adb
    * serial (`emulator-<port>`) for Android. The core carries it without interpreting it; only
-   * the owning driver module knows what it means. Unlike `deviceId` (Simlock's own, stable
-   * `simlock-`/`simlock_`-prefixed name proving Simlock created the device), this can change
-   * across a boot -- see `Driver.makeReady`.
+   * the owning driver module knows what it means. Unlike `deviceId`, which identifies the
+   * device for as long as it exists, this can change across a boot -- see `Driver.makeReady`.
    */
   readonly address: string;
 }
@@ -58,9 +57,9 @@ export interface ObservedDevice extends DriverDevice {
 
 /** Reality observable by a driver without trusting the registry. */
 export interface DriverReality {
-  /** Devices whose platform-owned name proves that Simlock created them. */
+  /** Devices whose membership in the driver's root proves that Simlock created them. */
   readonly devices: readonly ObservedDevice[];
-  /** Running, Simlock-attributable device processes not necessarily in the registry. */
+  /** Running device processes from that same root, not necessarily in the registry. */
   readonly processes: readonly DriverDevice[];
 }
 
@@ -98,6 +97,12 @@ export interface DriverCatalogEntry {
 
 export interface Driver {
   readonly platform: Platform;
+  /**
+   * Absolute path of the root this driver owns and scopes every platform command to.
+   * Membership in it is what proves a device is Simlock's; the core carries the string
+   * around without interpreting it, the same way it carries `address`.
+   */
+  readonly deviceRoot: string;
   resolveSpec(
     request: DeviceRequest,
     options: { readonly allowDownload: boolean },
@@ -121,6 +126,32 @@ export interface Driver {
   /** Read-only: must never trigger a runtime / system-image download. */
   listCatalog(): Promise<DriverCatalogEntry>;
   estimate(estimate: DriverEstimate, spec: DeviceSpec): number;
+  /**
+   * Opaque environment a lease holder needs to reach a device in this driver's root --
+   * containment cuts both ways, so a grant that did not carry it would hand out a device
+   * nobody could address. The core forwards it verbatim; no key here means anything to it.
+   */
+  leaseEnvironment(): Readonly<Record<string, string>>;
+}
+
+/**
+ * Why a driver could not start. A driver that refuses to start fails closed and takes only
+ * its own platform with it (safety rule 9), so the daemon has to be able to report the
+ * refusal without understanding it: the driver module names the event and builds the
+ * payload, and the core carries both to the bus and to `doctor` unread.
+ */
+export interface DriverRejection {
+  readonly platform: Platform;
+  readonly event: "driver.root-rejected" | "driver.adb-server-rejected";
+  readonly payload: Readonly<Record<string, string | number>>;
+  /**
+   * The refusal's vocabulary term (`missing-marker`, `occupied`, ...), stated separately
+   * rather than read back out of `payload`, which is a wire contract the core does not
+   * open. `doctor` reports it as the failing reason.
+   */
+  readonly reason: string;
+  /** One line, for `doctor` output and the startup log. */
+  readonly summary: string;
 }
 
 export class RuntimeMissingError extends Error {

--- a/src/core/driver.ts
+++ b/src/core/driver.ts
@@ -1,3 +1,4 @@
+import type { EventMap } from "../bus/index.js";
 import type { DeviceSpec, Platform } from "./domain.js";
 
 export interface DeviceRequest {
@@ -134,16 +135,22 @@ export interface Driver {
   leaseEnvironment(): Readonly<Record<string, string>>;
 }
 
+/** The events a driver may refuse to start with; each pairs with its own payload below. */
+type DriverRejectionEvent = "driver.root-rejected" | "driver.adb-server-rejected";
+
 /**
- * Why a driver could not start. A driver that refuses to start fails closed and takes only
- * its own platform with it (safety rule 9), so the daemon has to be able to report the
- * refusal without understanding it: the driver module names the event and builds the
- * payload, and the core carries both to the bus and to `doctor` unread.
+ * One refusal, with the payload the event it names is published with.
+ *
+ * The pairing is the point. The core forwards `payload` to the bus without reading it, so
+ * this is the only place the wire contract in `docs/EVENTS.md` can still be checked -- a
+ * wider `Record<string, string | number>` would type-check an adb rejection carrying a
+ * string port, or a root rejection with no root at all, and it would reach
+ * `simlock events --json` unexamined.
  */
-export interface DriverRejection {
+interface DriverRefusal<Event extends DriverRejectionEvent> {
   readonly platform: Platform;
-  readonly event: "driver.root-rejected" | "driver.adb-server-rejected";
-  readonly payload: Readonly<Record<string, string | number>>;
+  readonly event: Event;
+  readonly payload: EventMap[Event];
   /**
    * The refusal's vocabulary term (`missing-marker`, `occupied`, ...), stated separately
    * rather than read back out of `payload`, which is a wire contract the core does not
@@ -153,6 +160,16 @@ export interface DriverRejection {
   /** One line, for `doctor` output and the startup log. */
   readonly summary: string;
 }
+
+/**
+ * Why a driver could not start. A driver that refuses to start fails closed and takes only
+ * its own platform with it (safety rule 9), so the daemon has to be able to report the
+ * refusal without understanding it: the driver module names the event and builds the
+ * payload, and the core carries both to the bus and to `doctor` unread.
+ */
+export type DriverRejection =
+  | DriverRefusal<"driver.root-rejected">
+  | DriverRefusal<"driver.adb-server-rejected">;
 
 export class RuntimeMissingError extends Error {
   constructor(

--- a/src/core/fake-driver.test.ts
+++ b/src/core/fake-driver.test.ts
@@ -67,6 +67,34 @@ describe("FakeDriver", () => {
     const driver: Driver = new FakeDriver({ clock: new FakeClock(), platform: "ios" });
 
     expect(driver.platform).toBe("ios");
+    expect(driver.deviceRoot).toBe("/fake/ios");
+    expect(driver.leaseEnvironment()).toEqual({});
+  });
+
+  it("carries the root and lease environment a test gives it", () => {
+    const driver = new FakeDriver({
+      clock: new FakeClock(),
+      deviceRoot: "/tmp/devices/ios",
+      leaseEnvironment: { SIMLOCK_IOS_DEVICE_SET: "/tmp/devices/ios" },
+      platform: "ios",
+    });
+
+    expect(driver.deviceRoot).toBe("/tmp/devices/ios");
+    expect(driver.leaseEnvironment()).toEqual({ SIMLOCK_IOS_DEVICE_SET: "/tmp/devices/ios" });
+  });
+
+  it("reports a staged reality entry whatever it is named, the way a root does", () => {
+    const driver = new FakeDriver({ clock: new FakeClock(), platform: "ios" });
+    driver.setManagedReality({
+      devices: [
+        { address: "addr", deviceId: "not-a-simlock-name", driverData: {}, runState: "running" },
+      ],
+      processes: [],
+    });
+
+    return expect(driver.listManaged()).resolves.toMatchObject({
+      devices: [{ deviceId: "not-a-simlock-name" }],
+    });
   });
 
   it("keeps makeReady pending until released when instructed to hang", async () => {

--- a/src/core/fake-driver.ts
+++ b/src/core/fake-driver.ts
@@ -32,6 +32,8 @@ export interface FakeDriverCall {
 export interface FakeDriverOptions {
   readonly availableOsVersions?: readonly string[];
   readonly clock: Clock;
+  /** Stands in for a real driver's owned root; nothing here validates or creates it. */
+  readonly deviceRoot?: string;
   readonly estimateMs?: Partial<Record<DriverEstimateOperation, number>>;
   /**
    * Reclaim estimate for a `full` clean, when a test needs the two clean levels priced apart
@@ -41,6 +43,8 @@ export interface FakeDriverOptions {
   readonly fullCleanReclaimEstimateMs?: number;
   readonly knownModels?: readonly string[];
   readonly latencyMs?: Partial<Record<FakeDriverOperation, number>>;
+  /** What a grant for this driver's devices should carry; empty unless a test says otherwise. */
+  readonly leaseEnvironment?: Readonly<Record<string, string>>;
   readonly platform: Platform;
   readonly reclaimResult?: "ready" | "shutdown";
   readonly reclaimStrategy?: "erase" | "snapshot" | "wipe";
@@ -55,6 +59,7 @@ export class FakeDriverUnknownDeviceError extends Error {
 
 export class FakeDriver implements Driver {
   readonly platform: Platform;
+  readonly deviceRoot: string;
   readonly #availableOsVersions: Set<string>;
   readonly #callCounts = new Map<FakeDriverOperation, number>();
   readonly #calls: FakeDriverCall[] = [];
@@ -65,6 +70,7 @@ export class FakeDriver implements Driver {
   #hangMakeReady = false;
   readonly #knownModels: Set<string> | undefined;
   readonly #latencyMs: FakeDriverOptions["latencyMs"];
+  readonly #leaseEnvironment: Readonly<Record<string, string>>;
   #nextDeviceNumber = 1;
   readonly #pendingMakeReady: (() => void)[] = [];
   readonly #reclaimResult: "ready" | "shutdown";
@@ -82,7 +88,9 @@ export class FakeDriver implements Driver {
     this.#knownModels =
       options.knownModels === undefined ? undefined : new Set(options.knownModels);
     this.#latencyMs = options.latencyMs;
+    this.#leaseEnvironment = options.leaseEnvironment ?? {};
     this.platform = options.platform;
+    this.deviceRoot = options.deviceRoot ?? `/fake/${options.platform}`;
     this.#reclaimResult = options.reclaimResult ?? "ready";
     this.#reclaimStrategy = options.reclaimStrategy ?? "wipe";
   }
@@ -214,6 +222,10 @@ export class FakeDriver implements Driver {
     return this.#estimateMs?.[estimate.operation] ?? 0;
   }
 
+  leaseEnvironment(): Readonly<Record<string, string>> {
+    return this.#leaseEnvironment;
+  }
+
   failOn(operation: FakeDriverOperation, callNumber: number, error: Error): void {
     this.#failures.set(failureKey(operation, callNumber), error);
   }
@@ -229,12 +241,14 @@ export class FakeDriver implements Driver {
     }
   }
 
+  /**
+   * Stages what `listManaged` reports. Everything passed in is reported back, name and
+   * all: a real driver answers from what sits inside the root it owns, so a double that
+   * screened entries by prefix would be modelling ownership Simlock stopped inferring
+   * (safety rule 8).
+   */
   setManagedReality(reality: DriverReality): void {
-    const managed = {
-      devices: reality.devices.filter(isSimlockManaged),
-      processes: reality.processes.filter(isSimlockManaged),
-    };
-    this.#managedReality = cloneReality(managed);
+    this.#managedReality = cloneReality(reality);
     for (const device of reality.devices) {
       this.#devices.set(device.deviceId, statusFor(device.runState));
     }
@@ -282,10 +296,6 @@ export class FakeDriver implements Driver {
 
 function addressFor(deviceId: string, bootCount: number): string {
   return `${deviceId}-addr-${bootCount}`;
-}
-
-function isSimlockManaged(device: DriverDevice): boolean {
-  return device.deviceId.startsWith("simlock-") || device.deviceId.startsWith("simlock_");
 }
 
 function runStateFor(status: "provisioned" | "ready" | "shutdown"): ObservedRunState {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -19,6 +19,7 @@ export {
   type DriverDevice,
   type DriverEstimate,
   type DriverReality,
+  type DriverRejection,
   type ObservedDevice,
   type ObservedRunState,
   RuntimeMissingError,

--- a/src/daemon/main.test.ts
+++ b/src/daemon/main.test.ts
@@ -66,6 +66,25 @@ describe("startDaemon", () => {
     expect(record?.fields?.config).toMatchObject({ log: { level: "info" } });
   });
 
+  it("establishes the instance identity once, and reuses it on the next start", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "simlock-main-identity-"));
+    temporaryDirectories.push(directory);
+    const filesystem = new MemoryFilesystem();
+    const identityPath = join(directory, "instance.json");
+
+    const first = await start({ dataDirectory: directory, filesystem });
+    const written = JSON.parse(await filesystem.readFile(identityPath)) as {
+      readonly instanceId: string;
+    };
+    await first.daemon.stop("test");
+    await start({ dataDirectory: directory, filesystem });
+
+    // Never regenerated: a second id would strand every device already sitting in a root
+    // marked with the first one (ADR 0001, decision 2).
+    expect(written.instanceId).not.toBe("");
+    expect(JSON.parse(await filesystem.readFile(identityPath))).toEqual(written);
+  });
+
   it("scopes child loggers under daemon.<module> so records are attributable", async () => {
     const { sink } = await start();
 
@@ -147,12 +166,15 @@ describe("discoverDrivers", () => {
     const logger = new JsonLinesLogger({ clock: new FakeClock(), level: "debug", sink });
     const filesystem = new MemoryFilesystem();
 
-    const drivers = await discoverDrivers({
+    const { drivers } = await discoverDrivers({
       clock: new FakeClock(),
+      driversConfig: {},
       filesystem,
       idGenerator: new CryptoIdGenerator(),
+      instanceId: "instance-1",
       logger,
       processRunner: new ScriptedProcessRunner([]),
+      simlockHome: "/home/.simlock",
     });
 
     expect(drivers.some((driver) => driver.platform === "android")).toBe(false);
@@ -189,10 +211,13 @@ describe("discoverDrivers with SIMLOCK_DRIVERS_MODULE", () => {
     const logger = new JsonLinesLogger({ clock: new FakeClock(), level: "debug", sink });
     return discoverDrivers({
       clock: new FakeClock(),
+      driversConfig: {},
       filesystem: new MemoryFilesystem(),
       idGenerator: new CryptoIdGenerator(),
+      instanceId: "instance-1",
       logger,
       processRunner: new ScriptedProcessRunner([]),
+      simlockHome: "/home/.simlock",
     });
   }
 
@@ -204,9 +229,10 @@ describe("discoverDrivers with SIMLOCK_DRIVERS_MODULE", () => {
     );
     const sink = new MemoryLogSink();
 
-    const drivers = await discover(sink);
+    const { drivers, rejections } = await discover(sink);
 
     expect(drivers).toEqual([{ platform: "ios", fromModule: true, sawContext: true }]);
+    expect(rejections).toEqual([]);
     expect(sink.records).toContainEqual(
       expect.objectContaining({
         level: "info",
@@ -229,7 +255,7 @@ describe("discoverDrivers with SIMLOCK_DRIVERS_MODULE", () => {
       `export function createDrivers() { return []; }`,
     );
 
-    await expect(discover(new MemoryLogSink())).resolves.toEqual([]);
+    await expect(discover(new MemoryLogSink())).resolves.toEqual({ drivers: [], rejections: [] });
   });
 
   it("fails loudly when the module has no createDrivers export", async () => {

--- a/src/daemon/main.test.ts
+++ b/src/daemon/main.test.ts
@@ -4,7 +4,8 @@ import { join } from "node:path";
 import { connect } from "node:net";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { FakeDriver } from "../core/index.js";
+import { FakeDriver, OWNED_ROOT_MARKER_FILE, type OwnedRootError } from "../core/index.js";
+import { IosSimctlDriver } from "../drivers/ios/index.js";
 import { DAEMON_PROTOCOL_VERSION } from "../daemon-protocol/index.js";
 import {
   CryptoIdGenerator,
@@ -13,6 +14,7 @@ import {
   MemoryFilesystem,
   MemoryLogSink,
   ScriptedProcessRunner,
+  type IdGenerator,
 } from "../ports/index.js";
 import { discoverDrivers, startDaemon, type StartDaemonOptions } from "./main.js";
 import type { DaemonServer } from "./server.js";
@@ -170,6 +172,7 @@ describe("discoverDrivers", () => {
       clock: new FakeClock(),
       driversConfig: {},
       filesystem,
+      hostPlatform: "linux",
       idGenerator: new CryptoIdGenerator(),
       instanceId: "instance-1",
       logger,
@@ -186,7 +189,146 @@ describe("discoverDrivers", () => {
       }),
     );
   });
+
+  it("does not look for simulators on a host that has no simctl", async () => {
+    const { drivers, rejections } = await discoverIos({ hostPlatform: "linux" });
+
+    expect(drivers.some((driver) => driver.platform === "ios")).toBe(false);
+    // Nothing refused anything here: a host without Xcode is not a fail-closed refusal
+    // and must not be reported as one.
+    expect(rejections).toEqual([]);
+  });
+
+  it("starts the iOS driver on a host with simctl, with the root it validated", async () => {
+    const filesystem = new MemoryFilesystem();
+
+    const { drivers, rejections } = await discoverIos({ filesystem });
+
+    expect(rejections).toEqual([]);
+    expect(drivers.find((driver) => driver.platform === "ios")?.deviceRoot).toBe(IOS_ROOT);
+  });
+
+  it("keeps the daemon up when the iOS device root is refused, reporting the platform instead", async () => {
+    const filesystem = await foreignOwnedRoot();
+
+    const { drivers, rejections } = await discoverIos({ filesystem });
+
+    // Safety rule 9: the platform goes, the daemon stays -- a daemon that will not start
+    // is a daemon that cannot tell anyone why.
+    expect(drivers.some((driver) => driver.platform === "ios")).toBe(false);
+    expect(rejections.map((rejection) => rejection.platform)).toEqual(["ios"]);
+  });
+
+  it("publishes the refusal as the payload docs/EVENTS.md documents for driver.root-rejected", async () => {
+    const filesystem = await foreignOwnedRoot();
+    const refusal = await refusedRoot(filesystem);
+
+    const { rejections } = await discoverIos({ filesystem });
+
+    // Built from a real `OwnedRootError`, key by key: the payload is a wire contract
+    // `simlock events --json` publishes, so renaming `root` has to fail here.
+    expect(rejections[0]).toEqual({
+      event: "driver.root-rejected",
+      payload: { platform: "ios", reason: "wrong-instance", root: IOS_ROOT },
+      platform: "ios",
+      reason: "wrong-instance",
+      summary: refusal.message,
+    });
+  });
+
+  it("logs the refused root, so the reason survives even if nobody runs doctor", async () => {
+    const sink = new MemoryLogSink();
+
+    await discoverIos({ filesystem: await foreignOwnedRoot(), sink });
+
+    expect(sink.records).toContainEqual(
+      expect.objectContaining({
+        level: "error",
+        message: "Skipped iOS driver: device root rejected",
+        module: "daemon.driver-discovery",
+        fields: expect.objectContaining({ reason: "wrong-instance", root: IOS_ROOT }),
+      }),
+    );
+  });
+
+  it("still fails startup when the iOS driver fails for a reason that is not a refusal", async () => {
+    // Anything that is not an `OwnedRootError` is a bug rather than a fail-closed
+    // decision, and swallowing it would hide it behind a silently missing platform.
+    await expect(
+      discoverIos({
+        idGenerator: {
+          generate: () => {
+            throw new Error("entropy exhausted");
+          },
+        },
+      }),
+    ).rejects.toThrow("entropy exhausted");
+  });
 });
+
+const SIMLOCK_HOME = "/home/.simlock";
+const IOS_ROOT = join(SIMLOCK_HOME, "devices", "ios");
+const INSTANCE_ID = "instance-1";
+
+/** A root marked by a different Simlock instance -- the cheapest real `OwnedRootError`. */
+async function foreignOwnedRoot(): Promise<MemoryFilesystem> {
+  const filesystem = new MemoryFilesystem();
+  await filesystem.mkdirp(IOS_ROOT);
+  await filesystem.writeFileAtomic(
+    join(IOS_ROOT, OWNED_ROOT_MARKER_FILE),
+    JSON.stringify({
+      instanceId: "someone-else",
+      owner: "simlock",
+      platform: "ios",
+      schemaVersion: 1,
+    }),
+  );
+  return filesystem;
+}
+
+/** The very `OwnedRootError` the driver raises for that root, never a hand-written copy. */
+async function refusedRoot(filesystem: MemoryFilesystem): Promise<OwnedRootError> {
+  try {
+    await IosSimctlDriver.create({
+      clock: new FakeClock(),
+      driverConfig: {},
+      filesystem,
+      idGenerator: new CryptoIdGenerator(),
+      instanceId: INSTANCE_ID,
+      processRunner: new ScriptedProcessRunner([]),
+      simlockHome: SIMLOCK_HOME,
+    });
+  } catch (error: unknown) {
+    return error as OwnedRootError;
+  }
+  throw new Error("expected the iOS device root to be refused");
+}
+
+/** Discovery as it runs on a Mac, with the host platform supplied rather than sniffed. */
+function discoverIos(
+  overrides: {
+    readonly filesystem?: MemoryFilesystem;
+    readonly hostPlatform?: NodeJS.Platform;
+    readonly idGenerator?: IdGenerator;
+    readonly sink?: MemoryLogSink;
+  } = {},
+) {
+  return discoverDrivers({
+    clock: new FakeClock(),
+    driversConfig: {},
+    filesystem: overrides.filesystem ?? new MemoryFilesystem(),
+    hostPlatform: overrides.hostPlatform ?? "darwin",
+    idGenerator: overrides.idGenerator ?? new CryptoIdGenerator(),
+    instanceId: INSTANCE_ID,
+    logger: new JsonLinesLogger({
+      clock: new FakeClock(),
+      level: "debug",
+      sink: overrides.sink ?? new MemoryLogSink(),
+    }),
+    processRunner: new ScriptedProcessRunner([]),
+    simlockHome: SIMLOCK_HOME,
+  });
+}
 
 describe("discoverDrivers with SIMLOCK_DRIVERS_MODULE", () => {
   const previousModule = process.env.SIMLOCK_DRIVERS_MODULE;
@@ -213,6 +355,7 @@ describe("discoverDrivers with SIMLOCK_DRIVERS_MODULE", () => {
       clock: new FakeClock(),
       driversConfig: {},
       filesystem: new MemoryFilesystem(),
+      hostPlatform: "linux",
       idGenerator: new CryptoIdGenerator(),
       instanceId: "instance-1",
       logger,

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -103,6 +103,7 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
           clock,
           driversConfig: config.drivers,
           filesystem,
+          hostPlatform: process.platform,
           idGenerator,
           instanceId,
           logger,
@@ -195,6 +196,13 @@ export interface DriverDiscoveryContext {
   /** Whole `drivers` config section: each driver is handed its own block, unread. */
   readonly driversConfig: Config["drivers"];
   readonly filesystem: Filesystem;
+  /**
+   * Which platform's tooling this host has, `process.platform` in production and supplied
+   * by the composition root rather than read here. Discovery's fail-closed branch -- the
+   * one that must cost a platform and never the daemon -- is otherwise reachable only on a
+   * Mac, and so is untestable everywhere Simlock's own CI runs.
+   */
+  readonly hostPlatform: NodeJS.Platform;
   readonly idGenerator: IdGenerator;
   readonly instanceId: string;
   readonly logger: Logger;
@@ -219,7 +227,7 @@ export async function discoverDrivers(options: DriverDiscoveryContext): Promise<
 
   const drivers: Driver[] = [];
   const rejections: DriverRejection[] = [];
-  if (process.platform === "darwin") {
+  if (options.hostPlatform === "darwin") {
     const ios = await discoverIosDriver(options, logger);
     if (ios.driver !== undefined) drivers.push(ios.driver);
     if (ios.rejection !== undefined) rejections.push(ios.rejection);

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -4,12 +4,16 @@ import { pathToFileURL } from "node:url";
 
 import { EventBus } from "../bus/index.js";
 import {
+  type Config,
   type ConfigOverrides,
   type Driver,
+  type DriverRejection,
   CleanupReaper,
   Doctor,
   LeaseEngine,
   loadConfig,
+  loadInstanceId,
+  OwnedRootError,
   Registry,
   Nuke,
 } from "../core/index.js";
@@ -86,9 +90,26 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
     });
   const eventBus = new EventBus(clock, config.eventBuffer.capacity);
   const registry = await Registry.load({ clock, eventBus, filesystem, idGenerator, statePath });
-  const drivers =
-    options.drivers ??
-    (await discoverDrivers({ clock, filesystem, idGenerator, logger, processRunner }));
+  // Before discovery, because every root a driver validates is checked against it, and it
+  // is written exactly once per home and never regenerated (ADR 0001, decision 2).
+  const instanceId = await loadInstanceId({
+    filesystem,
+    idGenerator,
+    path: join(dataDirectory, "instance.json"),
+  });
+  const { drivers, rejections } =
+    options.drivers === undefined
+      ? await discoverDrivers({
+          clock,
+          driversConfig: config.drivers,
+          filesystem,
+          idGenerator,
+          instanceId,
+          logger,
+          processRunner,
+          simlockHome: dataDirectory,
+        })
+      : { drivers: options.drivers, rejections: [] };
   const leaseEngine = new LeaseEngine({
     clock,
     config,
@@ -116,6 +137,7 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
     clock,
     config,
     drivers,
+    driverRejections: rejections,
     eventBus,
     leaseExpirer: leaseEngine,
     quarantine: leaseEngine,
@@ -128,6 +150,7 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
     clock,
     config,
     doctor,
+    driverRejections: rejections,
     defaultRequesterId:
       options.defaultRequesterId ?? process.env.SIMLOCK_AGENT_ID ?? String(process.pid),
     eventBus,
@@ -169,30 +192,37 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
 
 export interface DriverDiscoveryContext {
   readonly clock: Clock;
+  /** Whole `drivers` config section: each driver is handed its own block, unread. */
+  readonly driversConfig: Config["drivers"];
   readonly filesystem: Filesystem;
   readonly idGenerator: IdGenerator;
+  readonly instanceId: string;
   readonly logger: Logger;
   readonly processRunner: ProcessRunner;
+  readonly simlockHome: string;
 }
 
-export async function discoverDrivers(options: DriverDiscoveryContext): Promise<Driver[]> {
+/** Drivers that started, and the platforms that refused to -- both are startup outcomes. */
+export interface DriverDiscovery {
+  readonly drivers: readonly Driver[];
+  readonly rejections: readonly DriverRejection[];
+}
+
+export async function discoverDrivers(options: DriverDiscoveryContext): Promise<DriverDiscovery> {
   const logger = options.logger.child("driver-discovery");
   const driversModule = process.env.SIMLOCK_DRIVERS_MODULE;
   if (driversModule !== undefined) {
-    return loadDriversModule(driversModule, options, logger);
+    // A substituted driver set owns whatever roots it wants, so there is nothing here to
+    // refuse on its behalf.
+    return { drivers: await loadDriversModule(driversModule, options, logger), rejections: [] };
   }
 
   const drivers: Driver[] = [];
+  const rejections: DriverRejection[] = [];
   if (process.platform === "darwin") {
-    drivers.push(
-      new IosSimctlDriver({
-        clock: options.clock,
-        filesystem: options.filesystem,
-        idGenerator: options.idGenerator,
-        processRunner: options.processRunner,
-      }),
-    );
-    logger.info("Discovered driver", { platform: "ios" });
+    const ios = await discoverIosDriver(options, logger);
+    if (ios.driver !== undefined) drivers.push(ios.driver);
+    if (ios.rejection !== undefined) rejections.push(ios.rejection);
   }
   try {
     drivers.push(
@@ -206,14 +236,63 @@ export async function discoverDrivers(options: DriverDiscoveryContext): Promise<
       }),
     );
     logger.info("Discovered driver", { platform: "android" });
-    return drivers;
+    return { drivers, rejections };
   } catch (error: unknown) {
     if (error instanceof SdkMissingError) {
       logger.warn("Skipped Android driver: SDK missing", { reason: error.message });
-      return drivers;
+      return { drivers, rejections };
     }
     throw error;
   }
+}
+
+/**
+ * A refused root costs the daemon one platform, never the whole daemon: the other platform
+ * may be perfectly healthy, and a daemon that will not start is a daemon that cannot tell
+ * anyone why (safety rule 9). Every other failure still fails startup -- an unreadable root
+ * is already an `OwnedRootError`, so what is left is a genuine bug.
+ */
+async function discoverIosDriver(
+  options: DriverDiscoveryContext,
+  logger: Logger,
+): Promise<{ readonly driver?: Driver; readonly rejection?: DriverRejection }> {
+  try {
+    const driver = await IosSimctlDriver.create({
+      clock: options.clock,
+      driverConfig: options.driversConfig["ios"] ?? {},
+      filesystem: options.filesystem,
+      idGenerator: options.idGenerator,
+      instanceId: options.instanceId,
+      processRunner: options.processRunner,
+      simlockHome: options.simlockHome,
+      // Ambient like `homedir()` above, and read here rather than in the driver so the
+      // composition root stays the only place that touches process state.
+      ...(process.getuid === undefined ? {} : { uid: process.getuid() }),
+    });
+    logger.info("Discovered driver", { platform: "ios" });
+    return { driver };
+  } catch (error: unknown) {
+    if (!(error instanceof OwnedRootError)) {
+      throw error;
+    }
+
+    logger.error("Skipped iOS driver: device root rejected", {
+      reason: error.reason,
+      root: error.path,
+      summary: error.message,
+    });
+    return { rejection: rootRejection(error) };
+  }
+}
+
+function rootRejection(error: OwnedRootError): DriverRejection {
+  return {
+    event: "driver.root-rejected",
+    payload: { platform: error.platform, reason: error.reason, root: error.path },
+    platform: error.platform,
+    reason: error.reason,
+    summary: error.message,
+  };
 }
 
 /**
@@ -229,13 +308,15 @@ async function loadDriversModule(
   modulePath: string,
   context: DriverDiscoveryContext,
   logger: Logger,
-): Promise<Driver[]> {
+): Promise<readonly Driver[]> {
   logger.info("Substituting driver discovery via SIMLOCK_DRIVERS_MODULE", {
     module: modulePath,
   });
   const moduleUrl = pathToFileURL(resolve(modulePath)).href;
   const imported = (await import(moduleUrl)) as {
-    createDrivers?: (context: DriverDiscoveryContext) => Promise<Driver[]> | Driver[];
+    createDrivers?: (
+      context: DriverDiscoveryContext,
+    ) => Promise<readonly Driver[]> | readonly Driver[];
   };
   if (typeof imported.createDrivers !== "function") {
     throw new Error(

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -783,6 +783,75 @@ describe("DaemonServer driver rejections", () => {
     expect(started?.seq).toBeLessThan(rejected[0]?.seq ?? 0);
   });
 
+  it("names the refusal when a lease asks for a platform whose driver did not start", async () => {
+    const harness = await createHarness({
+      driverRejections: [
+        {
+          event: "driver.adb-server-rejected",
+          payload: { port: 5038, reason: "occupied" },
+          platform: "android",
+          reason: "occupied",
+          summary: "Refusing the Android driver: port 5038 is held by an adb server we do not own",
+        },
+      ],
+    });
+    const client = await createClient(harness.socketPath);
+    await hello(client);
+
+    const response = await client.request("lease.request", {
+      mode: "held",
+      requesterId: "agent-1",
+      request: { model: "Pixel 8", platform: "android" },
+    });
+
+    // Safety rule 9's other half: the platform's driver does not start *and Simlock
+    // reports why*. A bare `NO_DRIVER` reads exactly like "this host has no Android SDK".
+    expect(response.error?.code).toBe("NO_DRIVER");
+    expect(response.error?.message).toContain("port 5038 is held by an adb server we do not own");
+  });
+
+  it("leaves an ordinary missing platform unexplained, having nothing to explain", async () => {
+    const harness = await createHarness({
+      driverRejections: [
+        {
+          event: "driver.root-rejected",
+          payload: { platform: "ios", reason: "symlink", root: "/Devices" },
+          platform: "ios",
+          reason: "symlink",
+          summary: "Refusing the ios device root /Devices: it is a symlink",
+        },
+      ],
+    });
+    const client = await createClient(harness.socketPath);
+    await hello(client);
+
+    const response = await client.request("lease.request", {
+      mode: "held",
+      requesterId: "agent-1",
+      request: { model: "Pixel 8", platform: "android" },
+    });
+
+    // The refusal on file is another platform's; attaching it here would blame iOS for
+    // Android's absence.
+    expect(response.error?.code).toBe("NO_DRIVER");
+    expect(response.error?.message).toBe("No driver registered for platform: android");
+  });
+
+  it("refuses at compile time to pair an event with another event's payload", () => {
+    const rejection: DriverRejection = {
+      event: "driver.adb-server-rejected",
+      // @ts-expect-error -- `port` is a number on the wire (docs/EVENTS.md). The check has
+      // to happen where a refusal is written, because the daemon forwards `payload` to the
+      // ring buffer -- and to `simlock events --json` -- without ever reading it.
+      payload: { port: "5038", reason: "occupied" },
+      platform: "android",
+      reason: "occupied",
+      summary: "Refusing the Android driver: port 5038 is occupied",
+    };
+
+    expect(rejection.event).toBe("driver.adb-server-rejected");
+  });
+
   it("publishes nothing when every driver started", async () => {
     const harness = await createHarness();
 

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -5,7 +5,14 @@ import { Socket, connect } from "node:net";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { EventBus } from "../bus/index.js";
-import { type Config, CleanupReaper, FakeDriver, LeaseEngine, Registry } from "../core/index.js";
+import {
+  type Config,
+  type DriverRejection,
+  CleanupReaper,
+  FakeDriver,
+  LeaseEngine,
+  Registry,
+} from "../core/index.js";
 import {
   FakeClock,
   FakeSystemStats,
@@ -748,6 +755,43 @@ function deferred<T>(): {
   return { promise, reject, resolve };
 }
 
+describe("DaemonServer driver rejections", () => {
+  it("publishes one event per platform that refused to start, after the daemon is up", async () => {
+    const harness = await createHarness({
+      driverRejections: [
+        {
+          event: "driver.root-rejected",
+          payload: { platform: "ios", reason: "wrong-instance", root: "/Devices" },
+          platform: "ios",
+          reason: "wrong-instance",
+          summary: "Refusing the ios device root /Devices: it belongs to another instance",
+        },
+      ],
+    });
+
+    const events = harness.eventBus.replay();
+    const rejected = events.filter((event) => event.event === "driver.root-rejected");
+    expect(rejected).toEqual([
+      expect.objectContaining({
+        module: "daemon",
+        payload: { platform: "ios", reason: "wrong-instance", root: "/Devices" },
+      }),
+    ]);
+    // The daemon did come up -- the refusal costs one platform, not the process -- and
+    // the buffer says so in that order.
+    const started = events.find((event) => event.event === "daemon.started");
+    expect(started?.seq).toBeLessThan(rejected[0]?.seq ?? 0);
+  });
+
+  it("publishes nothing when every driver started", async () => {
+    const harness = await createHarness();
+
+    expect(harness.eventBus.replay().filter((event) => event.event.startsWith("driver."))).toEqual(
+      [],
+    );
+  });
+});
+
 describe("DaemonServer lease heartbeat", () => {
   it("slides a held lease's deadline past the backstop while its holder keeps ponging, and stops sliding once it stops", async () => {
     const harness = await createHarness({
@@ -1085,6 +1129,7 @@ async function createHarness(
     readonly converge?: () => Promise<void>;
     readonly dispose?: () => void;
     readonly driver?: FakeDriver;
+    readonly driverRejections?: readonly DriverRejection[];
     readonly logger?: Logger;
     readonly settle?: () => Promise<void>;
     readonly stateFilesystem?: MemoryFilesystem;
@@ -1143,6 +1188,9 @@ async function createHarness(
     clock,
     config,
     ...(options.converge === undefined ? {} : { converge: options.converge }),
+    ...(options.driverRejections === undefined
+      ? {}
+      : { driverRejections: options.driverRejections }),
     defaultRequesterId: "test-process",
     eventBus,
     host: new DaemonEndpointHost({

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -1,4 +1,4 @@
-import { type EventBus, type EventEnvelope } from "../bus/index.js";
+import { type EventBus, type EventEnvelope, type EventMap } from "../bus/index.js";
 import {
   type Config,
   type DeviceRecord,
@@ -15,6 +15,7 @@ import {
   UnknownModelError,
   type CleanupReaper,
   type Doctor,
+  type DriverRejection,
   type LeaseHealthMonitor,
   type Nuke,
   UnknownLeaseError,
@@ -57,6 +58,12 @@ export interface DaemonServerOptions {
   readonly config: Config;
   readonly doctor?: Doctor;
   readonly defaultRequesterId: string;
+  /**
+   * Platforms whose driver refused to start. The daemon serves without them rather than
+   * refusing to come up (safety rule 9), so the refusal has to be visible somewhere: one
+   * event each lands in the ring buffer here, and `Doctor` reports the same list.
+   */
+  readonly driverRejections?: readonly DriverRejection[];
   readonly eventBus: EventBus;
   readonly host: ConnectionHost;
   readonly leases: LeaseCommands;
@@ -198,6 +205,18 @@ export class DaemonServer {
       { configSnapshot: this.options.config, version: this.options.version },
       "daemon",
     );
+    // After `daemon.started`, because these are facts about the daemon that just started
+    // and a subscriber reading the buffer in order should see it come up first.
+    for (const rejection of this.options.driverRejections ?? []) {
+      // The driver module owns the name/payload pair; `EventMap` cannot check a pairing
+      // chosen at runtime, so the one assertion lives here, at the only place that
+      // forwards one, rather than being spread over the drivers that produce them.
+      this.options.eventBus.emit(
+        rejection.event,
+        rejection.payload as EventMap[typeof rejection.event],
+        "daemon",
+      );
+    }
     this.#logger.info("Daemon started", {
       config: this.options.config,
       protocolVersion: this.#protocolVersion,

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -1,4 +1,4 @@
-import { type EventBus, type EventEnvelope, type EventMap } from "../bus/index.js";
+import { type EventBus, type EventEnvelope } from "../bus/index.js";
 import {
   type Config,
   type DeviceRecord,
@@ -208,14 +208,10 @@ export class DaemonServer {
     // After `daemon.started`, because these are facts about the daemon that just started
     // and a subscriber reading the buffer in order should see it come up first.
     for (const rejection of this.options.driverRejections ?? []) {
-      // The driver module owns the name/payload pair; `EventMap` cannot check a pairing
-      // chosen at runtime, so the one assertion lives here, at the only place that
-      // forwards one, rather than being spread over the drivers that produce them.
-      this.options.eventBus.emit(
-        rejection.event,
-        rejection.payload as EventMap[typeof rejection.event],
-        "daemon",
-      );
+      // No assertion: `DriverRejection` pairs each event name with that event's own
+      // payload, so the contract is checked where the driver module builds the refusal
+      // rather than being taken on trust here, one step from the ring buffer.
+      this.options.eventBus.emit(rejection.event, rejection.payload, "daemon");
     }
     this.#logger.info("Daemon started", {
       config: this.options.config,
@@ -398,8 +394,25 @@ export class DaemonServer {
       } else {
         this.#logger.debug("Handled request error", { code, type: frame.type });
       }
-      await this.#respondError(connection.socket, frame.id, code, errorMessage(error));
+      await this.#respondError(connection.socket, frame.id, code, this.#describeError(error));
     }
+  }
+
+  /**
+   * A `NO_DRIVER` for a platform whose driver refused to start says nothing on its own:
+   * it reads identically to "this host has no Xcode". Safety rule 9 promises Simlock
+   * reports *why* a platform is missing, and the lease path is where a user meets that
+   * failure, so the refusal's own one-liner travels with the error.
+   */
+  #describeError(error: unknown): string {
+    const message = errorMessage(error);
+    if (!(error instanceof NoDriverError)) {
+      return message;
+    }
+    const rejection = (this.options.driverRejections ?? []).find(
+      (candidate) => candidate.platform === error.platform,
+    );
+    return rejection === undefined ? message : `${message} (${rejection.summary})`;
   }
 
   async #handleHello(connection: Connection, frame: RequestFrame): Promise<void> {

--- a/src/drivers/android/index.ts
+++ b/src/drivers/android/index.ts
@@ -114,6 +114,14 @@ const allocationsByRunner = new WeakMap<ProcessRunner, PortAllocator>();
 
 export class AndroidDriver implements Driver {
   readonly platform = "android" as const;
+  /**
+   * Placeholder until this driver owns a validated AVD home and a private adb server
+   * (ADR 0001, decision 4). Deliberately not `#avdDirectory`: that is wherever the user's
+   * own AVDs already live, and naming it here would claim an ownership Simlock has not
+   * proven for it. Nothing reads either member yet.
+   */
+  // fallow-ignore-next-line unused-class-member -- Driver.deviceRoot contract; read by doctor --purge-orphans to say which root an orphan came from.
+  readonly deviceRoot = "/simlock-android-device-root-pending";
   readonly #clock: Clock;
   readonly #devices = new Map<string, DeviceState>();
   readonly #filesystem: Filesystem;
@@ -148,6 +156,11 @@ export class AndroidDriver implements Driver {
 
   get sdkPath(): string {
     return this.#sdk.root;
+  }
+
+  // fallow-ignore-next-line unused-class-member -- Driver.leaseEnvironment contract; read by the lease path when it builds a grant.
+  leaseEnvironment(): Readonly<Record<string, string>> {
+    return {};
   }
 
   async resolveSpec(

--- a/src/drivers/ios/index.test.ts
+++ b/src/drivers/ios/index.test.ts
@@ -1,10 +1,14 @@
 import { readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
 import {
   BootTimeoutError,
   DriverCrashError,
+  OwnedRootError,
+  OWNED_ROOT_MARKER_FILE,
   RuntimeMissingError,
   UnknownModelError,
 } from "../../core/index.js";
@@ -24,14 +28,10 @@ const listDevicesFixture = readFileSync(
   new URL("./fixtures/simctl-list-devices.json", import.meta.url),
   "utf8",
 );
-const listInvocation = {
-  command: "xcrun",
-  args: ["simctl", "list", "-j", "devicetypes", "runtimes"],
-} as const;
-const listDevicesInvocation = {
-  command: "xcrun",
-  args: ["simctl", "list", "-j", "devices"],
-} as const;
+const deviceRoot = "/Devices";
+const instanceId = "instance-1";
+const listInvocation = simctl("list", "-j", "devicetypes", "runtimes");
+const listDevicesInvocation = simctl("list", "-j", "devices");
 const spec = { model: "iPhone 16", osVersion: "26.5", platform: "ios" } as const;
 const driverData = {
   deviceTypeId: "com.apple.CoreSimulator.SimDeviceType.iPhone-16",
@@ -39,9 +39,24 @@ const driverData = {
   runtimeId: "com.apple.CoreSimulator.SimRuntime.iOS-26-5",
   udid: "00000000-0000-0000-0000-000000000001",
 } as const;
-const dataPath = `/Devices/${driverData.udid}/data`;
-const durableMarkPath = `/Devices/${driverData.udid}/simlock-mark.json`;
+const createInvocation = simctl(
+  "create",
+  driverData.name,
+  driverData.deviceTypeId,
+  driverData.runtimeId,
+);
+const dataPath = `${deviceRoot}/${driverData.udid}/data`;
+const durableMarkPath = `${deviceRoot}/${driverData.udid}/simlock-mark.json`;
 const erasableMarkPath = `${dataPath}/simlock-mark.json`;
+
+/** Every simctl call the driver makes is scoped to its device set; so is every expectation. */
+function simctlArgs(...args: readonly string[]): string[] {
+  return ["simctl", "--set", deviceRoot, ...args];
+}
+
+function simctl(...args: readonly string[]): { readonly command: string; readonly args: string[] } {
+  return { args: simctlArgs(...args), command: "xcrun" };
+}
 
 function deviceListResponse(state: string): string {
   return JSON.stringify({
@@ -56,7 +71,7 @@ function deviceListResponse(state: string): string {
 describe("IosSimctlDriver", () => {
   it("resolves an exact model and requested installed runtime", async () => {
     const runner = scriptedListRunner();
-    const driver = createDriver(runner);
+    const driver = await createDriver(runner);
 
     await expect(
       driver.resolveSpec(
@@ -68,7 +83,7 @@ describe("IosSimctlDriver", () => {
   });
 
   it("selects the newest installed iOS runtime by default", async () => {
-    const driver = createDriver(scriptedListRunner());
+    const driver = await createDriver(scriptedListRunner());
 
     await expect(
       driver.resolveSpec({ model: "iPhone 16", platform: "ios" }, { allowDownload: false }),
@@ -76,7 +91,7 @@ describe("IosSimctlDriver", () => {
   });
 
   it("matches model names case-insensitively while preserving the simctl name", async () => {
-    const driver = createDriver(scriptedListRunner());
+    const driver = await createDriver(scriptedListRunner());
 
     await expect(
       driver.resolveSpec(
@@ -87,7 +102,7 @@ describe("IosSimctlDriver", () => {
   });
 
   it("rejects an unknown model", async () => {
-    const driver = createDriver(scriptedListRunner());
+    const driver = await createDriver(scriptedListRunner());
 
     await expect(
       driver.resolveSpec({ model: "iPhone 99", platform: "ios" }, { allowDownload: false }),
@@ -101,17 +116,15 @@ describe("IosSimctlDriver", () => {
         result: { code: 0, stderr: "", stdout: '{"devicetypes":[]}' },
       },
     ]);
+    const driver = await createDriver(runner);
 
     await expect(
-      createDriver(runner).resolveSpec(
-        { model: "iPhone 16", platform: "ios" },
-        { allowDownload: false },
-      ),
+      driver.resolveSpec({ model: "iPhone 16", platform: "ios" }, { allowDownload: false }),
     ).rejects.toBeInstanceOf(DriverCrashError);
   });
 
   it("rejects missing runtimes even when downloads are allowed", async () => {
-    const driver = createDriver(scriptedListRunner());
+    const driver = await createDriver(scriptedListRunner());
     const result = await driver
       .resolveSpec(
         { model: "iPhone 16", osVersion: "27", platform: "ios" },
@@ -130,26 +143,13 @@ describe("IosSimctlDriver", () => {
         result: { code: 0, stderr: "", stdout: listFixture },
       },
       {
-        match: {
-          command: "xcrun",
-          args: [
-            "simctl",
-            "create",
-            "simlock-device-1",
-            driverData.deviceTypeId,
-            driverData.runtimeId,
-          ],
-        },
+        match: createInvocation,
         result: { code: 0, stderr: "", stdout: `${driverData.udid}\n` },
-      },
-      {
-        match: listDevicesInvocation,
-        result: { code: 0, stderr: "", stdout: deviceListResponse("Shutdown") },
       },
     ]);
     const filesystem = new MemoryFilesystem();
+    const driver = await createDriver(runner, new FakeClock(), filesystem);
     await filesystem.mkdirp(dataPath);
-    const driver = createDriver(runner, new FakeClock(), filesystem);
     await driver.resolveSpec(
       { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
       { allowDownload: false },
@@ -162,18 +162,7 @@ describe("IosSimctlDriver", () => {
     });
     expect(runner.calls).toEqual([
       { ...listInvocation, options: { timeoutMs: 30_000 } },
-      {
-        args: [
-          "simctl",
-          "create",
-          "simlock-device-1",
-          driverData.deviceTypeId,
-          driverData.runtimeId,
-        ],
-        command: "xcrun",
-        options: { timeoutMs: 30_000 },
-      },
-      { ...listDevicesInvocation, options: { timeoutMs: 30_000 } },
+      { ...createInvocation, options: { timeoutMs: 30_000 } },
     ]);
   });
 
@@ -184,20 +173,11 @@ describe("IosSimctlDriver", () => {
         result: { code: 0, stderr: "", stdout: listFixture },
       },
       {
-        match: {
-          command: "xcrun",
-          args: [
-            "simctl",
-            "create",
-            "simlock-device-1",
-            driverData.deviceTypeId,
-            driverData.runtimeId,
-          ],
-        },
+        match: createInvocation,
         result: { code: 1, stderr: "Invalid runtime", stdout: "" },
       },
     ]);
-    const driver = createDriver(runner);
+    const driver = await createDriver(runner);
     await driver.resolveSpec(
       { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
       { allowDownload: false },
@@ -213,42 +193,33 @@ describe("IosSimctlDriver", () => {
 
   it("boots then waits for bootstatus with the documented timeout", async () => {
     const runner = new ScriptedProcessRunner([
-      { match: { command: "xcrun", args: ["simctl", "boot", driverData.udid] } },
-      { match: { command: "xcrun", args: ["simctl", "bootstatus", driverData.udid, "-b"] } },
+      { match: simctl("boot", driverData.udid) },
+      { match: simctl("bootstatus", driverData.udid, "-b") },
     ]);
+    const driver = await createDriver(runner);
 
     await expect(
-      createDriver(runner).makeReady({
+      driver.makeReady({
         address: driverData.udid,
         deviceId: driverData.udid,
         driverData,
       }),
     ).resolves.toEqual({ address: driverData.udid, deviceId: driverData.udid, driverData });
     expect(runner.calls).toEqual([
-      {
-        args: ["simctl", "boot", driverData.udid],
-        command: "xcrun",
-        options: { timeoutMs: 30_000 },
-      },
-      {
-        args: ["simctl", "bootstatus", driverData.udid, "-b"],
-        command: "xcrun",
-        options: { timeoutMs: 120_000 },
-      },
+      { ...simctl("boot", driverData.udid), options: { timeoutMs: 30_000 } },
+      { ...simctl("bootstatus", driverData.udid, "-b"), options: { timeoutMs: 120_000 } },
     ]);
   });
 
   it("times out bootstatus and issues a best-effort shutdown", async () => {
     const clock = new FakeClock();
     const runner = new ScriptedProcessRunner([
-      { match: { command: "xcrun", args: ["simctl", "boot", driverData.udid] } },
-      {
-        hangs: true,
-        match: { command: "xcrun", args: ["simctl", "bootstatus", driverData.udid, "-b"] },
-      },
-      { match: { command: "xcrun", args: ["simctl", "shutdown", driverData.udid] } },
+      { match: simctl("boot", driverData.udid) },
+      { hangs: true, match: simctl("bootstatus", driverData.udid, "-b") },
+      { match: simctl("shutdown", driverData.udid) },
     ]);
-    const ready = createDriver(runner, clock).makeReady({
+    const driver = await createDriver(runner, clock);
+    const ready = driver.makeReady({
       address: driverData.udid,
       deviceId: driverData.udid,
       driverData,
@@ -261,125 +232,96 @@ describe("IosSimctlDriver", () => {
 
     await expect(ready).rejects.toBeInstanceOf(BootTimeoutError);
     expect(runner.calls.map((call) => call.args)).toEqual([
-      ["simctl", "boot", driverData.udid],
-      ["simctl", "bootstatus", driverData.udid, "-b"],
-      ["simctl", "shutdown", driverData.udid],
+      simctlArgs("boot", driverData.udid),
+      simctlArgs("bootstatus", driverData.udid, "-b"),
+      simctlArgs("shutdown", driverData.udid),
     ]);
   });
 
   it("reclaims by tolerating an already-shutdown response, then erasing", async () => {
     const runner = new ScriptedProcessRunner([
       {
-        match: { command: "xcrun", args: ["simctl", "shutdown", driverData.udid] },
+        match: simctl("shutdown", driverData.udid),
         result: {
           code: 149,
           stderr: "Unable to shutdown device in current state: Shutdown",
           stdout: "",
         },
       },
-      { match: { command: "xcrun", args: ["simctl", "erase", driverData.udid] } },
-      {
-        match: listDevicesInvocation,
-        result: { code: 0, stderr: "", stdout: deviceListResponse("Shutdown") },
-      },
+      { match: simctl("erase", driverData.udid) },
     ]);
     const filesystem = new MemoryFilesystem();
+    const driver = await createDriver(runner, new FakeClock(), filesystem);
     await filesystem.mkdirp(dataPath);
 
     await expect(
-      createDriver(runner, new FakeClock(), filesystem).reclaim(
+      driver.reclaim(
         { address: driverData.udid, deviceId: driverData.udid, driverData },
         { clean: "full" },
       ),
     ).resolves.toEqual({ state: "shutdown", strategy: "erase" });
     expect(runner.calls.map((call) => call.args)).toEqual([
-      ["simctl", "shutdown", driverData.udid],
-      ["simctl", "erase", driverData.udid],
-      ["simctl", "list", "-j", "devices"],
+      simctlArgs("shutdown", driverData.udid),
+      simctlArgs("erase", driverData.udid),
     ]);
   });
 
   it("writes a fresh, different token on reclaim than the one written on provision", async () => {
-    const filesystem = new MemoryFilesystem();
-    await filesystem.mkdirp(dataPath);
     const runner = new ScriptedProcessRunner([
       {
         match: listInvocation,
         result: { code: 0, stderr: "", stdout: listFixture },
       },
       {
-        match: {
-          command: "xcrun",
-          args: [
-            "simctl",
-            "create",
-            "simlock-device-1",
-            driverData.deviceTypeId,
-            driverData.runtimeId,
-          ],
-        },
+        match: createInvocation,
         result: { code: 0, stderr: "", stdout: `${driverData.udid}\n` },
       },
-      {
-        match: listDevicesInvocation,
-        result: { code: 0, stderr: "", stdout: deviceListResponse("Shutdown") },
-      },
-      { match: { command: "xcrun", args: ["simctl", "shutdown", driverData.udid] } },
-      { match: { command: "xcrun", args: ["simctl", "erase", driverData.udid] } },
-      {
-        match: listDevicesInvocation,
-        result: { code: 0, stderr: "", stdout: deviceListResponse("Shutdown") },
-      },
+      { match: simctl("shutdown", driverData.udid) },
+      { match: simctl("erase", driverData.udid) },
     ]);
-    const driver = createTokenDriver(runner, filesystem);
+    const filesystem = new MemoryFilesystem();
+    const driver = await createTokenDriver(runner, filesystem);
+    await filesystem.mkdirp(dataPath);
     await driver.resolveSpec(
       { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
       { allowDownload: false },
     );
     await driver.provision(spec);
 
-    const provisionedDurable = JSON.parse(await filesystem.readFile(durableMarkPath)) as {
-      token: string;
-    };
-    const provisionedErasable = JSON.parse(await filesystem.readFile(erasableMarkPath)) as {
-      token: string;
-    };
-    expect(provisionedDurable.token).toBe(provisionedErasable.token);
+    const provisionedDurable = await readToken(filesystem, durableMarkPath);
+    const provisionedErasable = await readToken(filesystem, erasableMarkPath);
+    expect(provisionedDurable).toBe(provisionedErasable);
 
     await driver.reclaim(
       { address: driverData.udid, deviceId: driverData.udid, driverData },
       { clean: "full" },
     );
 
-    const reclaimedDurable = JSON.parse(await filesystem.readFile(durableMarkPath)) as {
-      token: string;
-    };
-    const reclaimedErasable = JSON.parse(await filesystem.readFile(erasableMarkPath)) as {
-      token: string;
-    };
-    expect(reclaimedDurable.token).toBe(reclaimedErasable.token);
-    expect(reclaimedDurable.token).not.toBe(provisionedDurable.token);
+    expect(await readToken(filesystem, durableMarkPath)).toBe(
+      await readToken(filesystem, erasableMarkPath),
+    );
+    expect(await readToken(filesystem, durableMarkPath)).not.toBe(provisionedDurable);
   });
 
   it("shuts down before deleting and uses benchmark estimates", async () => {
     const runner = new ScriptedProcessRunner([
-      { match: { command: "xcrun", args: ["simctl", "shutdown", driverData.udid] } },
-      { match: { command: "xcrun", args: ["simctl", "delete", driverData.udid] } },
+      { match: simctl("shutdown", driverData.udid) },
+      { match: simctl("delete", driverData.udid) },
     ]);
-    const driver = createDriver(runner);
+    const driver = await createDriver(runner);
 
     await driver.destroy({ address: driverData.udid, deviceId: driverData.udid, driverData });
 
     expect(runner.calls.map((call) => call.args)).toEqual([
-      ["simctl", "shutdown", driverData.udid],
-      ["simctl", "delete", driverData.udid],
+      simctlArgs("shutdown", driverData.udid),
+      simctlArgs("delete", driverData.udid),
     ]);
     expect(driver.estimate({ operation: "provision" }, spec)).toBe(500);
     expect(driver.estimate({ operation: "boot" }, spec)).toBe(60_000);
   });
 
-  it("prices reclaim as the erase it always runs, at either clean level", () => {
-    const driver = createDriver(new ScriptedProcessRunner([]));
+  it("prices reclaim as the erase it always runs, at either clean level", async () => {
+    const driver = await createDriver(new ScriptedProcessRunner([]));
 
     // `reclaimStrategy` answers `erase` for both levels, so both must be priced as one --
     // and as tens of seconds, not the ~1s the estimate used to claim (#56).
@@ -390,7 +332,7 @@ describe("IosSimctlDriver", () => {
   });
 
   it("lists resolvable models and installed runtimes, defaulting to the newest", async () => {
-    const driver = createDriver(scriptedListRunner());
+    const driver = await createDriver(scriptedListRunner());
 
     await expect(driver.listCatalog()).resolves.toEqual({
       defaultRuntime: "26.5",
@@ -401,21 +343,23 @@ describe("IosSimctlDriver", () => {
 
   it("shells out to simctl exactly once per listCatalog call, reusing the catalog parse", async () => {
     const runner = scriptedListRunner();
-    const driver = createDriver(runner);
+    const driver = await createDriver(runner);
 
     await driver.listCatalog();
 
     expect(runner.calls).toEqual([{ ...listInvocation, options: { timeoutMs: 30_000 } }]);
   });
 
-  it("maps simctl device state to runState and filters to simlock- devices", async () => {
+  it("reports every device in its set, whatever the device is named", async () => {
     const runner = new ScriptedProcessRunner([
       { match: listDevicesInvocation, result: { code: 0, stderr: "", stdout: listDevicesFixture } },
     ]);
-    const driver = createDriver(runner);
+    const driver = await createDriver(runner);
 
     const reality = await driver.listManaged();
 
+    // The fixture's last device carries no `simlock-` prefix. Membership in the set is the
+    // ownership proof (safety rule 8), so it is Simlock's like every other entry here.
     expect(
       reality.devices.map((device) => ({ deviceId: device.deviceId, runState: device.runState })),
     ).toEqual([
@@ -423,6 +367,7 @@ describe("IosSimctlDriver", () => {
       { deviceId: "00000000-0000-0000-0000-000000000102", runState: "stopped" },
       { deviceId: "00000000-0000-0000-0000-000000000103", runState: "transitioning" },
       { deviceId: "00000000-0000-0000-0000-000000000104", runState: "transitioning" },
+      { deviceId: "00000000-0000-0000-0000-000000000105", runState: "running" },
     ]);
   });
 
@@ -430,43 +375,35 @@ describe("IosSimctlDriver", () => {
     const runner = new ScriptedProcessRunner([
       { match: listDevicesInvocation, result: { code: 0, stderr: "", stdout: listDevicesFixture } },
     ]);
-    const driver = createDriver(runner);
+    const driver = await createDriver(runner);
 
     const reality = await driver.listManaged();
 
-    expect(reality.processes).toEqual([
-      expect.objectContaining({
-        deviceId: "00000000-0000-0000-0000-000000000101",
-        runState: "running",
-      }),
+    expect(reality.processes.map((device) => device.deviceId)).toEqual([
+      "00000000-0000-0000-0000-000000000101",
+      "00000000-0000-0000-0000-000000000105",
     ]);
   });
 
-  it("derives the data path from the cached devices root instead of re-listing", async () => {
+  it("derives mark paths from its own root without shelling out to locate a device", async () => {
     const filesystem = new MemoryFilesystem();
-    await filesystem.mkdirp(dataPath);
     const runner = new ScriptedProcessRunner([
-      {
-        match: listDevicesInvocation,
-        result: { code: 0, stderr: "", stdout: deviceListResponse("Shutdown") },
-      },
-      { match: { command: "xcrun", args: ["simctl", "shutdown", driverData.udid] } },
-      { match: { command: "xcrun", args: ["simctl", "erase", driverData.udid] } },
+      { match: simctl("shutdown", driverData.udid) },
+      { match: simctl("erase", driverData.udid) },
     ]);
-    const driver = createDriver(runner, new FakeClock(), filesystem);
+    const driver = await createDriver(runner, new FakeClock(), filesystem);
+    await filesystem.mkdirp(dataPath);
 
-    await driver.listManaged();
     await driver.reclaim(
       { address: driverData.udid, deviceId: driverData.udid, driverData },
       { clean: "full" },
     );
 
-    // `simctl list` costs ~260ms and reclaim runs on every release, so the
-    // devices root learned during listManaged must keep it off the lease path.
+    // Owning the set means the data container's path is known, so `reclaim` -- which runs
+    // on every release -- never pays for the `simctl list` it used to need to find it.
     expect(runner.calls.map((call) => call.args)).toEqual([
-      ["simctl", "list", "-j", "devices"],
-      ["simctl", "shutdown", driverData.udid],
-      ["simctl", "erase", driverData.udid],
+      simctlArgs("shutdown", driverData.udid),
+      simctlArgs("erase", driverData.udid),
     ]);
     expect(await filesystem.exists(erasableMarkPath)).toBe(true);
     expect(await filesystem.exists(durableMarkPath)).toBe(true);
@@ -474,17 +411,18 @@ describe("IosSimctlDriver", () => {
 
   it("reports matching provenance tokens for a healthy managed device", async () => {
     const filesystem = new MemoryFilesystem();
-    await filesystem.mkdirp(dataPath);
-    await filesystem.writeFileAtomic(durableMarkPath, JSON.stringify({ token: "tok-1" }));
-    await filesystem.writeFileAtomic(erasableMarkPath, JSON.stringify({ token: "tok-1" }));
     const runner = new ScriptedProcessRunner([
       {
         match: listDevicesInvocation,
         result: { code: 0, stderr: "", stdout: deviceListResponse("Shutdown") },
       },
     ]);
+    const driver = await createDriver(runner, new FakeClock(), filesystem);
+    await filesystem.mkdirp(dataPath);
+    await filesystem.writeFileAtomic(durableMarkPath, JSON.stringify({ token: "tok-1" }));
+    await filesystem.writeFileAtomic(erasableMarkPath, JSON.stringify({ token: "tok-1" }));
 
-    const reality = await createDriver(runner, new FakeClock(), filesystem).listManaged();
+    const reality = await driver.listManaged();
 
     expect(reality.devices).toEqual([
       expect.objectContaining({
@@ -495,16 +433,17 @@ describe("IosSimctlDriver", () => {
 
   it("reports erasable undefined when the data-container mark is gone (foreign erase)", async () => {
     const filesystem = new MemoryFilesystem();
-    await filesystem.mkdirp(dataPath);
-    await filesystem.writeFileAtomic(durableMarkPath, JSON.stringify({ token: "tok-1" }));
     const runner = new ScriptedProcessRunner([
       {
         match: listDevicesInvocation,
         result: { code: 0, stderr: "", stdout: deviceListResponse("Shutdown") },
       },
     ]);
+    const driver = await createDriver(runner, new FakeClock(), filesystem);
+    await filesystem.mkdirp(dataPath);
+    await filesystem.writeFileAtomic(durableMarkPath, JSON.stringify({ token: "tok-1" }));
 
-    const reality = await createDriver(runner, new FakeClock(), filesystem).listManaged();
+    const reality = await driver.listManaged();
 
     expect(reality.devices).toEqual([
       expect.objectContaining({
@@ -515,44 +454,110 @@ describe("IosSimctlDriver", () => {
 
   it("reports mark undefined when both provenance regions are absent (pre-upgrade device)", async () => {
     const filesystem = new MemoryFilesystem();
-    await filesystem.mkdirp(dataPath);
     const runner = new ScriptedProcessRunner([
       {
         match: listDevicesInvocation,
         result: { code: 0, stderr: "", stdout: deviceListResponse("Shutdown") },
       },
     ]);
+    const driver = await createDriver(runner, new FakeClock(), filesystem);
+    await filesystem.mkdirp(dataPath);
 
-    const reality = await createDriver(runner, new FakeClock(), filesystem).listManaged();
+    const reality = await driver.listManaged();
 
     expect(reality.devices[0]?.mark).toBeUndefined();
   });
 
   it("reads a corrupt mark file as undefined without throwing", async () => {
     const filesystem = new MemoryFilesystem();
-    await filesystem.mkdirp(dataPath);
-    await filesystem.writeFileAtomic(durableMarkPath, "not json");
-    await filesystem.writeFileAtomic(erasableMarkPath, JSON.stringify({ notAToken: true }));
     const runner = new ScriptedProcessRunner([
       {
         match: listDevicesInvocation,
         result: { code: 0, stderr: "", stdout: deviceListResponse("Shutdown") },
       },
     ]);
+    const driver = await createDriver(runner, new FakeClock(), filesystem);
+    await filesystem.mkdirp(dataPath);
+    await filesystem.writeFileAtomic(durableMarkPath, "not json");
+    await filesystem.writeFileAtomic(erasableMarkPath, JSON.stringify({ notAToken: true }));
 
-    const reality = await createDriver(runner, new FakeClock(), filesystem).listManaged();
+    const reality = await driver.listManaged();
 
     expect(reality.devices[0]?.mark).toBeUndefined();
+  });
+
+  it("creates and marks its device root under SIMLOCK_HOME when none is configured", async () => {
+    const filesystem = new MemoryFilesystem();
+
+    const driver = await IosSimctlDriver.create({
+      clock: new FakeClock(),
+      driverConfig: {},
+      filesystem,
+      idGenerator: { generate: () => "device-1" },
+      instanceId,
+      processRunner: new ScriptedProcessRunner([]),
+      simlockHome: "/home/.simlock",
+    });
+
+    expect(driver.deviceRoot).toBe("/home/.simlock/devices/ios");
+    await expect(
+      filesystem.exists(`/home/.simlock/devices/ios/${OWNED_ROOT_MARKER_FILE}`),
+    ).resolves.toBe(true);
+  });
+
+  it("does not start when its device root belongs to another Simlock instance", async () => {
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp(deviceRoot);
+    await filesystem.writeFileAtomic(
+      `${deviceRoot}/${OWNED_ROOT_MARKER_FILE}`,
+      JSON.stringify({
+        instanceId: "someone-else",
+        owner: "simlock",
+        platform: "ios",
+        schemaVersion: 1,
+      }),
+    );
+
+    const failure = await createDriver(new ScriptedProcessRunner([]), new FakeClock(), filesystem)
+      .then(() => undefined)
+      .catch((error: unknown) => error);
+
+    // Fails closed: no fallback to the machine's default device set (safety rule 9).
+    expect(failure).toBeInstanceOf(OwnedRootError);
+    expect(failure).toMatchObject({ platform: "ios", reason: "wrong-instance" });
+  });
+
+  it("does not start when the configured device root is not a path at all", async () => {
+    await expect(
+      IosSimctlDriver.create({
+        clock: new FakeClock(),
+        driverConfig: { deviceRoot: 42 },
+        filesystem: new MemoryFilesystem(),
+        idGenerator: { generate: () => "device-1" },
+        instanceId,
+        processRunner: new ScriptedProcessRunner([]),
+        simlockHome: "/home/.simlock",
+      }),
+    ).rejects.toBeInstanceOf(DriverCrashError);
+  });
+
+  it("hands a lease holder the device set its simulator cannot be addressed without", async () => {
+    const driver = await createDriver(new ScriptedProcessRunner([]));
+
+    expect(driver.leaseEnvironment()).toEqual({ SIMLOCK_IOS_DEVICE_SET: deviceRoot });
   });
 
   it.skipIf(process.env.SIMLOCK_LIVE_IOS !== "1")(
     "runs a provision-to-destroy smoke test against simctl",
     async () => {
-      const driver = new IosSimctlDriver({
+      const driver = await IosSimctlDriver.create({
         clock: new SystemClock(),
+        driverConfig: {},
         filesystem: new NodeFilesystem(),
         idGenerator: { generate: () => `test-${process.pid}` },
+        instanceId: `live-${process.pid}`,
         processRunner: new NodeProcessRunner(),
+        simlockHome: join(tmpdir(), `simlock-live-ios-${process.pid}`),
       });
       let device: Awaited<ReturnType<IosSimctlDriver["provision"]>> | undefined;
 
@@ -578,37 +583,48 @@ function createDriver(
   runner: ScriptedProcessRunner,
   clock = new FakeClock(),
   filesystem: Filesystem = new MemoryFilesystem(),
-): IosSimctlDriver {
-  return new IosSimctlDriver({
+): Promise<IosSimctlDriver> {
+  return IosSimctlDriver.create({
     clock,
+    driverConfig: { deviceRoot },
     filesystem,
     idGenerator: { generate: () => "device-1" },
+    instanceId,
     processRunner: runner,
+    simlockHome: "/home/.simlock",
   });
 }
 
 /**
- * `#idGenerator.generate()` names the device on its first call and mints
- * mark tokens on every later call, so the first call must stay "device-1"
- * to match `driverData.name` while later calls vary to prove the reclaim
- * token differs from the provision token.
+ * `#idGenerator.generate()` is called once while the root is being created, then names
+ * the device, then mints a mark token per write -- so the second call must stay
+ * "device-1" to match `driverData.name` while later ones vary, proving the reclaim token
+ * differs from the provision token.
  */
 function createTokenDriver(
   runner: ScriptedProcessRunner,
-  filesystem: Filesystem = new MemoryFilesystem(),
-): IosSimctlDriver {
+  filesystem: Filesystem,
+): Promise<IosSimctlDriver> {
   let calls = 0;
-  return new IosSimctlDriver({
+  return IosSimctlDriver.create({
     clock: new FakeClock(),
+    driverConfig: { deviceRoot },
     filesystem,
     idGenerator: {
       generate: () => {
         calls += 1;
-        return calls === 1 ? "device-1" : `tok-${String(calls)}`;
+        if (calls === 1) return "root-staging";
+        return calls === 2 ? "device-1" : `tok-${String(calls)}`;
       },
     },
+    instanceId,
     processRunner: runner,
+    simlockHome: "/home/.simlock",
   });
+}
+
+async function readToken(filesystem: Filesystem, path: string): Promise<string> {
+  return (JSON.parse(await filesystem.readFile(path)) as { readonly token: string }).token;
 }
 
 function scriptedListRunner(): ScriptedProcessRunner {

--- a/src/drivers/ios/index.test.ts
+++ b/src/drivers/ios/index.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   BootTimeoutError,
@@ -53,6 +53,24 @@ const erasableMarkPath = `${dataPath}/simlock-mark.json`;
 function simctlArgs(...args: readonly string[]): string[] {
   return ["simctl", "--set", deviceRoot, ...args];
 }
+
+/** Runners handed to a driver built by `createDriver`; drained by the invariant below. */
+const scopedRunners: ScriptedProcessRunner[] = [];
+
+/**
+ * The one global invariant, asserted over everything every test in this file recorded
+ * rather than per call site: scoping is what makes ownership provable, so a spawn that
+ * reached `xcrun` without `simctl --set <root>` in front of it would address the machine's
+ * default device set (safety rule 8). Per-test argv equality proves today's calls are
+ * scoped; only this proves the next one added is, whether or not it goes through
+ * `#invokeSimctl`.
+ */
+afterEach(() => {
+  for (const call of scopedRunners.splice(0).flatMap((runner) => runner.calls)) {
+    expect(call.command).toBe("xcrun");
+    expect(call.args.slice(0, 3)).toEqual(["simctl", "--set", deviceRoot]);
+  }
+});
 
 function simctl(...args: readonly string[]): { readonly command: string; readonly args: string[] } {
   return { args: simctlArgs(...args), command: "xcrun" };
@@ -224,10 +242,11 @@ describe("IosSimctlDriver", () => {
       deviceId: driverData.udid,
       driverData,
     });
+    // Handled up front so a failure below reports itself rather than surfacing as an
+    // unhandled rejection in whichever test happens to run next.
+    void ready.catch(() => undefined);
 
-    while (runner.calls.length < 2) {
-      await Promise.resolve();
-    }
+    await waitForCalls(runner, 2);
     clock.advance(120_000);
 
     await expect(ready).rejects.toBeInstanceOf(BootTimeoutError);
@@ -409,6 +428,31 @@ describe("IosSimctlDriver", () => {
     expect(await filesystem.exists(durableMarkPath)).toBe(true);
   });
 
+  it("leaves neither provenance mark when the erasable half cannot be written", async () => {
+    const filesystem = new MemoryFilesystem();
+    const runner = new ScriptedProcessRunner([
+      { match: simctl("shutdown", driverData.udid) },
+      { match: simctl("erase", driverData.udid) },
+    ]);
+    const driver = await createDriver(runner, new FakeClock(), filesystem);
+    // The device directory exists, its data container does not, and `writeFileAtomic`
+    // creates no parents -- the erasable write cannot land.
+    await filesystem.mkdirp(`${deviceRoot}/${driverData.udid}`);
+
+    await expect(
+      driver.reclaim(
+        { address: driverData.udid, deviceId: driverData.udid, driverData },
+        { clean: "full" },
+      ),
+    ).rejects.toThrow();
+
+    // A durable mark standing alone is exactly what `Doctor` reads as a foreign erase, so
+    // a half-written pair would have `doctor` accusing the user of erasing the device
+    // Simlock itself just erased. Neither half is what "never marked" looks like.
+    expect(await filesystem.exists(durableMarkPath)).toBe(false);
+    expect(await filesystem.exists(erasableMarkPath)).toBe(false);
+  });
+
   it("reports matching provenance tokens for a healthy managed device", async () => {
     const filesystem = new MemoryFilesystem();
     const runner = new ScriptedProcessRunner([
@@ -527,18 +571,25 @@ describe("IosSimctlDriver", () => {
     expect(failure).toMatchObject({ platform: "ios", reason: "wrong-instance" });
   });
 
-  it("does not start when the configured device root is not a path at all", async () => {
-    await expect(
-      IosSimctlDriver.create({
-        clock: new FakeClock(),
-        driverConfig: { deviceRoot: 42 },
-        filesystem: new MemoryFilesystem(),
-        idGenerator: { generate: () => "device-1" },
-        instanceId,
-        processRunner: new ScriptedProcessRunner([]),
-        simlockHome: "/home/.simlock",
-      }),
-    ).rejects.toBeInstanceOf(DriverCrashError);
+  it("refuses the platform, not the daemon, when the configured device root is not a path", async () => {
+    const failure = await IosSimctlDriver.create({
+      clock: new FakeClock(),
+      driverConfig: { deviceRoot: true },
+      filesystem: new MemoryFilesystem(),
+      idGenerator: { generate: () => "device-1" },
+      instanceId,
+      processRunner: new ScriptedProcessRunner([]),
+      simlockHome: "/home/.simlock",
+    })
+      .then(() => undefined)
+      .catch((error: unknown) => error);
+
+    // An `OwnedRootError` costs iOS alone; anything else takes the daemon down with it,
+    // and with it every way of finding out why -- `"deviceRoot": true` and
+    // `"deviceRoot": "devices/ios"` must not differ by that much.
+    expect(failure).toBeInstanceOf(OwnedRootError);
+    expect(failure).toMatchObject({ platform: "ios", reason: "not-absolute" });
+    expect(failure).toMatchObject({ message: expect.stringContaining("true") });
   });
 
   it("hands a lease holder the device set its simulator cannot be addressed without", async () => {
@@ -584,6 +635,7 @@ function createDriver(
   clock = new FakeClock(),
   filesystem: Filesystem = new MemoryFilesystem(),
 ): Promise<IosSimctlDriver> {
+  scopedRunners.push(runner);
   return IosSimctlDriver.create({
     clock,
     driverConfig: { deviceRoot },
@@ -606,6 +658,7 @@ function createTokenDriver(
   filesystem: Filesystem,
 ): Promise<IosSimctlDriver> {
   let calls = 0;
+  scopedRunners.push(runner);
   return IosSimctlDriver.create({
     clock: new FakeClock(),
     driverConfig: { deviceRoot },
@@ -621,6 +674,23 @@ function createTokenDriver(
     processRunner: runner,
     simlockHome: "/home/.simlock",
   });
+}
+
+/**
+ * Bounded on purpose. An unexpected invocation makes `ScriptedProcessRunner.spawn` throw
+ * synchronously, `#invokeSimctl` turns that into a `DriverCrashError`, and the call this
+ * is waiting for never arrives -- an unbounded spin then hangs the whole suite instead of
+ * reporting which argv the driver actually produced.
+ */
+async function waitForCalls(runner: ScriptedProcessRunner, count: number): Promise<void> {
+  for (let tick = 0; tick < 1_000 && runner.calls.length < count; tick += 1) {
+    await Promise.resolve();
+  }
+
+  expect(
+    runner.calls.map((call) => call.args),
+    `simctl never reached ${String(count)} calls`,
+  ).toHaveLength(count);
 }
 
 async function readToken(filesystem: Filesystem, path: string): Promise<string> {

--- a/src/drivers/ios/index.ts
+++ b/src/drivers/ios/index.ts
@@ -1,3 +1,5 @@
+import { join } from "node:path";
+
 import {
   BootTimeoutError,
   type DeviceRequest,
@@ -7,6 +9,7 @@ import {
   DriverCrashError,
   type DriverEstimate,
   type DriverReality,
+  ensureOwnedRoot,
   type ObservedDevice,
   type ObservedRunState,
   RuntimeMissingError,
@@ -46,9 +49,17 @@ interface IosDriverData {
 
 export interface IosSimctlDriverOptions {
   readonly clock: Clock;
+  /** This driver's own `drivers.ios` block, handed over unread by the core. */
+  readonly driverConfig: Readonly<Record<string, string | number | boolean>>;
   readonly filesystem: Filesystem;
   readonly idGenerator: IdGenerator;
+  /** Identity every device root's ownership marker is checked against. */
+  readonly instanceId: string;
   readonly processRunner: ProcessRunner;
+  /** `SIMLOCK_HOME`, from which the default device root is derived here rather than in the core. */
+  readonly simlockHome: string;
+  /** `process.getuid?.()`; `undefined` skips the root's ownership check. */
+  readonly uid?: number;
 }
 
 interface DeviceType {
@@ -86,13 +97,40 @@ export class IosSimctlDriver implements Driver {
   readonly #idGenerator: IdGenerator;
   readonly #processRunner: ProcessRunner;
   readonly #resolvedSpecs = new Map<string, ResolvedIosSpec>();
-  #devicesRoot: string | undefined;
+  readonly #deviceRoot: string;
 
-  constructor(options: IosSimctlDriverOptions) {
+  private constructor(options: IosSimctlDriverOptions, deviceRoot: string) {
     this.#clock = options.clock;
     this.#filesystem = options.filesystem;
     this.#idGenerator = options.idGenerator;
     this.#processRunner = options.processRunner;
+    this.#deviceRoot = deviceRoot;
+  }
+
+  /**
+   * Establishes the device set this driver owns before it can be asked to do anything,
+   * which is why construction is asynchronous: a driver that had not yet proven its root
+   * would be a driver that can address devices it cannot prove are Simlock's, and every
+   * later `--set` would be pointing at an unvalidated path. An `OwnedRootError` here is
+   * the fail-closed path -- the caller skips iOS entirely rather than falling back to the
+   * machine's default device set (safety rule 9).
+   */
+  static async create(options: IosSimctlDriverOptions): Promise<IosSimctlDriver> {
+    const deviceRoot = await ensureOwnedRoot({
+      filesystem: options.filesystem,
+      idGenerator: options.idGenerator,
+      instanceId: options.instanceId,
+      path: configuredDeviceRoot(options),
+      platform: "ios",
+      ...(options.uid === undefined ? {} : { uid: options.uid }),
+    });
+
+    return new IosSimctlDriver(options, deviceRoot);
+  }
+
+  // fallow-ignore-next-line unused-class-member -- Driver.deviceRoot contract; read by doctor --purge-orphans to say which root an orphan came from.
+  get deviceRoot(): string {
+    return this.#deviceRoot;
   }
 
   async resolveSpec(
@@ -131,6 +169,10 @@ export class IosSimctlDriver implements Driver {
   async provision(spec: DeviceSpec): Promise<DriverDevice> {
     this.#requireIosPlatform(spec.platform);
     const resolved = await this.#resolvedSpec(spec);
+    // Cosmetic, and deliberately so: what proves this device is Simlock's is that it
+    // lives in the device set every call below is scoped to, never what it is called
+    // (safety rule 8). The name exists because it is what a human reads in `simctl list`
+    // and in the simulator's window title.
     const name = `simlock-${this.#idGenerator.generate()}`;
     const result = await this.#simctl(
       ["create", name, resolved.deviceType.identifier, resolved.runtime.identifier],
@@ -142,10 +184,7 @@ export class IosSimctlDriver implements Driver {
       throw new DriverCrashError("simctl create returned no device UDID");
     }
 
-    const dataPath = await this.#dataPathFor(udid);
-    if (dataPath !== undefined) {
-      await this.#writeMark(udid, dataPath);
-    }
+    await this.#writeMark(udid);
 
     return {
       address: udid,
@@ -190,11 +229,7 @@ export class IosSimctlDriver implements Driver {
     const data = iosDriverData(device);
     await this.#shutdown(data.udid);
     await this.#simctl(["erase", data.udid], COMMAND_TIMEOUT_MS);
-
-    const dataPath = await this.#dataPathFor(data.udid);
-    if (dataPath !== undefined) {
-      await this.#writeMark(data.udid, dataPath);
-    }
+    await this.#writeMark(data.udid);
 
     return { state: "shutdown", strategy: "erase" };
   }
@@ -216,10 +251,9 @@ export class IosSimctlDriver implements Driver {
   async listManaged(): Promise<DriverReality> {
     const result = await this.#simctl(["list", "-j", "devices"], COMMAND_TIMEOUT_MS);
     const parsed = parseManagedDevices(JSON.parse(result.stdout) as unknown);
-    this.#rememberDevicesRoot(parsed);
     const devices: ObservedDevice[] = await Promise.all(
       parsed.map(async (device) => {
-        const mark = await this.#readMark(device.dataPath);
+        const mark = await this.#readMark(device.udid);
         return {
           address: device.udid,
           deviceId: device.udid,
@@ -262,30 +296,27 @@ export class IosSimctlDriver implements Driver {
   }
 
   /**
-   * Data-container path for a device. `simctl create` returns only the UDID,
-   * and a `simctl list` costs ~260ms -- enough to matter on `reclaim`, which
-   * runs on every release. So the devices root is learned once from simctl's
-   * own answer and every later lookup is derived from it, keeping the extra
-   * subprocess off the lease path. Falls back to listing until something has
-   * primed the root.
+   * The device-set path a lease holder needs to address its simulator at all: inside a
+   * custom set a UDID resolves to nothing without it. `docs/CLI.md` publishes the variable
+   * name, and `simlock simctl` reads it back.
    */
-  async #dataPathFor(udid: string): Promise<string | undefined> {
-    if (this.#devicesRoot !== undefined) {
-      return `${this.#devicesRoot}/${udid}/data`;
-    }
-    const result = await this.#simctl(["list", "-j", "devices"], COMMAND_TIMEOUT_MS);
-    const parsed = parseManagedDevices(JSON.parse(result.stdout) as unknown);
-    this.#rememberDevicesRoot(parsed);
-    return parsed.find((device) => device.udid === udid)?.dataPath;
+  // fallow-ignore-next-line unused-class-member -- Driver.leaseEnvironment contract; read by the lease path when it builds a grant.
+  leaseEnvironment(): Readonly<Record<string, string>> {
+    return { SIMLOCK_IOS_DEVICE_SET: this.#deviceRoot };
   }
 
-  /** `<devicesRoot>/<UDID>/data` -- two levels up from any device's data container. */
-  #rememberDevicesRoot(devices: readonly ParsedManagedDevice[]): void {
-    if (this.#devicesRoot !== undefined) return;
-    const dataPath = devices.find((device) => device.dataPath !== undefined)?.dataPath;
-    if (dataPath === undefined) return;
-    const root = parentDirectory(parentDirectory(dataPath));
-    if (root !== "/") this.#devicesRoot = root;
+  /** CoreSimulator lays a set out as `<set>/<UDID>`, so no subprocess can tell us more. */
+  #deviceDirectory(udid: string): string {
+    return join(this.#deviceRoot, udid);
+  }
+
+  /**
+   * Data-container path for a device, derived rather than looked up. The driver used to
+   * learn it from a `simctl list` (~260ms, on `reclaim`, which runs on every release)
+   * because it did not know where its devices lived; owning the set means it does.
+   */
+  #dataPathFor(udid: string): string {
+    return join(this.#deviceDirectory(udid), "data");
   }
 
   /**
@@ -294,15 +325,15 @@ export class IosSimctlDriver implements Driver {
    * (erasable -- destroyed by it). Both halves are written together so a
    * partial write never reads as drift.
    */
-  async #writeMark(udid: string, dataPath: string): Promise<void> {
+  async #writeMark(udid: string): Promise<void> {
     const token = this.#idGenerator.generate();
     const contents = JSON.stringify({
       token,
       udid,
       writtenAt: new Date(this.#clock.now()).toISOString(),
     });
-    const durablePath = `${parentDirectory(dataPath)}/${MARK_FILE_NAME}`;
-    const erasablePath = `${dataPath}/${MARK_FILE_NAME}`;
+    const durablePath = join(this.#deviceDirectory(udid), MARK_FILE_NAME);
+    const erasablePath = join(this.#dataPathFor(udid), MARK_FILE_NAME);
 
     await Promise.all([
       this.#filesystem.writeFileAtomic(durablePath, contents),
@@ -320,13 +351,9 @@ export class IosSimctlDriver implements Driver {
    * shipped) reports `undefined` rather than a half-empty mark, so it stays
    * quiet instead of classifying as tampered on every tick.
    */
-  async #readMark(dataPath: string | undefined): Promise<ObservedMark | undefined> {
-    if (dataPath === undefined) {
-      return undefined;
-    }
-
-    const durable = await this.#readToken(`${parentDirectory(dataPath)}/${MARK_FILE_NAME}`);
-    const erasable = await this.#readToken(`${dataPath}/${MARK_FILE_NAME}`);
+  async #readMark(udid: string): Promise<ObservedMark | undefined> {
+    const durable = await this.#readToken(join(this.#deviceDirectory(udid), MARK_FILE_NAME));
+    const erasable = await this.#readToken(join(this.#dataPathFor(udid), MARK_FILE_NAME));
 
     if (durable === undefined && erasable === undefined) {
       return undefined;
@@ -417,7 +444,13 @@ export class IosSimctlDriver implements Driver {
   async #invokeSimctl(args: readonly string[], timeoutMs: number): Promise<ProcessOutcome> {
     let process;
     try {
-      process = this.#processRunner.spawn("xcrun", ["simctl", ...args], { timeoutMs });
+      // The single insertion point for `--set`, which scopes every subcommand to the root
+      // this driver owns and must therefore precede the subcommand. Nothing in this file
+      // spawns simctl any other way: a call that slipped past here would address the
+      // machine's default set, where Simlock can prove nothing about what it touches.
+      process = this.#processRunner.spawn("xcrun", ["simctl", "--set", this.#deviceRoot, ...args], {
+        timeoutMs,
+      });
     } catch (error: unknown) {
       throw new DriverCrashError(
         `Could not start simctl ${args.join(" ")}: ${errorMessage(error)}`,
@@ -473,14 +506,33 @@ class IosRuntimeMissingError extends RuntimeMissingError {
   }
 }
 
+/**
+ * The configured root, or the per-home default. The default is computed here and not in
+ * the core because what `drivers.ios.deviceRoot` means is this module's business
+ * (architecture rule 2); the core only hands over the block and `SIMLOCK_HOME`.
+ */
+function configuredDeviceRoot(options: IosSimctlDriverOptions): string {
+  const configured = options.driverConfig["deviceRoot"];
+
+  if (configured !== undefined && typeof configured !== "string") {
+    // Not an `OwnedRootError`: that one skips a platform and keeps the daemon up, which is
+    // right for a root that failed validation but wrong for a value that is not a path at
+    // all. Nothing here can guess what was meant, and defaulting would quietly put tens of
+    // gigabytes somewhere the user did not choose.
+    throw new DriverCrashError(
+      `drivers.ios.deviceRoot must be a path, but it is a ${typeof configured}`,
+    );
+  }
+
+  return configured ?? join(options.simlockHome, "devices", "ios");
+}
+
 interface ParsedManagedDevice {
-  readonly dataPath: string | undefined;
   readonly name: string;
   readonly runState: ObservedRunState;
   readonly udid: string;
 }
 
-// fallow-ignore-next-line complexity -- runtime-keyed device JSON is walked and filtered in one pass by design.
 function parseManagedDevices(value: unknown): ParsedManagedDevice[] {
   if (!isRecord(value) || !isRecord(value.devices)) {
     throw new DriverCrashError("Invalid simctl device list JSON");
@@ -492,9 +544,7 @@ function parseManagedDevices(value: unknown): ParsedManagedDevice[] {
       if (!isRecord(device) || typeof device.name !== "string" || typeof device.udid !== "string") {
         continue;
       }
-      if (!device.name.startsWith("simlock-")) continue;
       devices.push({
-        dataPath: typeof device.dataPath === "string" ? device.dataPath : undefined,
         name: device.name,
         runState: simctlRunState(device.state),
         udid: device.udid,
@@ -502,12 +552,6 @@ function parseManagedDevices(value: unknown): ParsedManagedDevice[] {
     }
   }
   return devices;
-}
-
-/** Mirrors `parentPath` in the `Filesystem` port: the parent of a `dataPath` is the device root. */
-function parentDirectory(path: string): string {
-  const lastSeparator = path.lastIndexOf("/");
-  return lastSeparator <= 0 ? "/" : path.slice(0, lastSeparator);
 }
 
 /** `simctl` reports `Booting` / `Shutting Down` mid-transition; both must read as `transitioning`, never as drift. */

--- a/src/drivers/ios/index.ts
+++ b/src/drivers/ios/index.ts
@@ -11,6 +11,7 @@ import {
   type DriverReality,
   ensureOwnedRoot,
   type ObservedDevice,
+  OwnedRootError,
   type ObservedRunState,
   RuntimeMissingError,
   UnknownModelError,
@@ -322,8 +323,16 @@ export class IosSimctlDriver implements Driver {
   /**
    * Writes the same provenance token into both regions of a device: the
    * device root (durable -- survives `simctl erase`) and the data container
-   * (erasable -- destroyed by it). Both halves are written together so a
-   * partial write never reads as drift.
+   * (erasable -- destroyed by it).
+   *
+   * The erasable half goes first, and the two are not written concurrently, because a
+   * half-written pair is read by `Doctor` as tampering: durable-without-erasable is
+   * exactly the signature of a foreign erase. Writing the fragile half first means a
+   * failure (`<root>/<udid>/data` is not there, so `writeFileAtomic` -- which creates no
+   * parents -- cannot land) leaves *neither* mark, which reads as "never marked" and
+   * produces no finding at all. The write still throws, so the caller learns something
+   * was wrong with the device; what it must never do is accuse the user of erasing a
+   * device Simlock itself just erased.
    */
   async #writeMark(udid: string): Promise<void> {
     const token = this.#idGenerator.generate();
@@ -332,13 +341,12 @@ export class IosSimctlDriver implements Driver {
       udid,
       writtenAt: new Date(this.#clock.now()).toISOString(),
     });
-    const durablePath = join(this.#deviceDirectory(udid), MARK_FILE_NAME);
-    const erasablePath = join(this.#dataPathFor(udid), MARK_FILE_NAME);
 
-    await Promise.all([
-      this.#filesystem.writeFileAtomic(durablePath, contents),
-      this.#filesystem.writeFileAtomic(erasablePath, contents),
-    ]);
+    await this.#filesystem.writeFileAtomic(join(this.#dataPathFor(udid), MARK_FILE_NAME), contents);
+    await this.#filesystem.writeFileAtomic(
+      join(this.#deviceDirectory(udid), MARK_FILE_NAME),
+      contents,
+    );
   }
 
   /**
@@ -515,12 +523,18 @@ function configuredDeviceRoot(options: IosSimctlDriverOptions): string {
   const configured = options.driverConfig["deviceRoot"];
 
   if (configured !== undefined && typeof configured !== "string") {
-    // Not an `OwnedRootError`: that one skips a platform and keeps the daemon up, which is
-    // right for a root that failed validation but wrong for a value that is not a path at
-    // all. Nothing here can guess what was meant, and defaulting would quietly put tens of
-    // gigabytes somewhere the user did not choose.
-    throw new DriverCrashError(
-      `drivers.ios.deviceRoot must be a path, but it is a ${typeof configured}`,
+    // A `deviceRoot` that is not a usable path refuses this platform's *configuration*,
+    // which costs iOS and nothing else -- the same as every other refusal here. It is not
+    // a daemon-fatal error: `"deviceRoot": true` and `"deviceRoot": "devices/ios"` are one
+    // keystroke apart, and killing the process over the first would take Android down with
+    // it and leave the reason unreachable, since `doctor` -- where `docs/CLI.md` promises
+    // it appears -- needs a daemon to answer. `not-absolute` is the vocabulary term the
+    // docs already publish for "this names no usable directory"; nothing new is invented.
+    throw new OwnedRootError(
+      `Refusing the ios device root: drivers.ios.deviceRoot must be an absolute path, but it is the ${typeof configured} ${JSON.stringify(configured)}`,
+      "not-absolute",
+      String(configured),
+      "ios",
     );
   }
 

--- a/src/ports/paths.test.ts
+++ b/src/ports/paths.test.ts
@@ -12,4 +12,16 @@ describe("resolveSimlockHome", () => {
   it("uses SIMLOCK_HOME when set", () => {
     expect(resolveSimlockHome({ SIMLOCK_HOME: "/tmp/custom-home" })).toBe("/tmp/custom-home");
   });
+
+  it("makes a relative SIMLOCK_HOME absolute, since device roots derived from it must be", () => {
+    expect(resolveSimlockHome({ SIMLOCK_HOME: "custom-home" })).toBe(
+      join(process.cwd(), "custom-home"),
+    );
+  });
+
+  it("normalises a SIMLOCK_HOME that is absolute but not canonical", () => {
+    expect(resolveSimlockHome({ SIMLOCK_HOME: "/tmp/custom-home/../other-home" })).toBe(
+      "/tmp/other-home",
+    );
+  });
 });

--- a/src/ports/paths.ts
+++ b/src/ports/paths.ts
@@ -1,12 +1,20 @@
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 /**
- * Resolves simlock's data directory (config.json, state.json, daemon.sock, daemon.log).
- * `SIMLOCK_HOME` overrides the default `~/.simlock` -- used by tests that need an
- * isolated data directory per daemon instance, and by anyone running multiple
- * independent simlock installs on one machine.
+ * Resolves simlock's data directory (config.json, state.json, daemon.sock, daemon.log,
+ * and the device roots under `devices/`). `SIMLOCK_HOME` overrides the default
+ * `~/.simlock` -- used by tests that need an isolated data directory per daemon instance,
+ * and by anyone running multiple independent simlock installs on one machine.
+ *
+ * A relative `SIMLOCK_HOME` is resolved here, once, against the process that read it.
+ * Everything else derived from it would otherwise appear to work -- Node resolves a
+ * relative path against the cwd on every call -- while the device root derived from it
+ * would be refused `not-absolute`, silently costing a platform for a reason nobody is
+ * looking at. It also means the daemon and the CLI that auto-launched it agree on one
+ * directory even if they are standing somewhere different.
  */
 export function resolveSimlockHome(env: NodeJS.ProcessEnv = process.env): string {
-  return env.SIMLOCK_HOME ?? join(homedir(), ".simlock");
+  const configured = env.SIMLOCK_HOME;
+  return configured === undefined ? join(homedir(), ".simlock") : resolve(configured);
 }


### PR DESCRIPTION
Second of five stacked PRs implementing [ADR 0001](https://github.com/callstackincubator/simlock/blob/feat/owned-device-roots/docs/adr/0001-simlock-owned-device-roots.md). Based on #80.

1. [#80](https://github.com/callstackincubator/simlock/pull/80) owned device root validation and its ports
2. **iOS: `simctl --set`, membership-based `listManaged`, fail-closed discovery** ← this PR
3. Android: `ANDROID_AVD_HOME`, private supervised adb server
4. lease environment and the `simctl` / `adb` passthroughs
5. doctor: `--purge-orphans`, legacy pre-root devices, docs status

## What this is

Ownership stops being a guess about a name and becomes a fact about a location.

- **`listManaged` answers from set membership.** It used to report whatever was called `simlock-`, which adopts a user's identically-named simulator on sight. The naming survives only where devices are *created*, as the cosmetic label a human reads in `simctl list` (safety rule 8).
- **Every `simctl` invocation carries `--set <deviceRoot>`**, through the one spawn site the driver already funnelled them into.
- **The driver stops learning where its devices live** by parsing `dataPath` out of simctl output and reads the root from config, which is what lets the provenance mark paths be derived without a subprocess on the reclaim path.
- **Construction is asynchronous** because it has to be: a driver that has not proven its root can address devices it cannot prove are Simlock's. A refused root costs that platform and nothing else — never a fallback to the default device location (safety rule 9) — and is reported as a `driver.root-rejected` event at startup and a `doctor` finding on every run after.
- **`Driver` gains `deviceRoot` and `leaseEnvironment()`**, both opaque to the core (architecture rule 2). Android gets placeholder values here; PR 3 replaces them.

## Review round (second commit)

An adversarial review found ten defects. The worst two:

**`doctor --fix` deleted a platform's entire registry inventory when its driver refused to start.** Doctor builds reality from the drivers it *has*, so every device of a dark platform read as `registry-device-missing` and `--fix` marked each one `deleted`. The report contained both `driver-unavailable` ("this platform is unobservable") and `registry-device-missing` ("its devices are gone") and acted on the second — leaving the simulators on disk with no registry record able to reach them, which is the permanent multi-gigabyte leak the ADR opens by describing, reachable with a `chmod`, through a command `docs/CLI.md` expects to run unattended in CI. **You cannot conclude "the device is missing" from "I could not look."** A platform with no driver now produces no existence, run-state, provenance or orphan finding at all. Gated on driver *presence*, so it also closes the same hole for a missing Android SDK, which predates this stack.

**The fail-closed path had no executing test.** `throw new Error("MUTANT")` on the first line of `discoverIosDriver` passed all 797 tests, because the branch is gated on `process.platform === "darwin"` and CI is Linux. Discovery now takes the platform from its context, and the catch, the rethrow, the log and the rejection payload — built from a real `OwnedRootError`, so renaming `root` to `path` in the published payload now fails CI — are all covered.

Also fixed: a non-string `deviceRoot` took down the whole daemon including Android while `""` and a relative path cost only iOS; `NO_DRIVER` on a refused platform reported no reason despite safety rule 9 promising one; `#writeMark`'s `Promise.all` could leave a durable mark without its erasable half, making Doctor accuse the user of an erase Simlock itself performed; the runtime event-payload cast would have let PR 3 emit an Android payload contradicting `docs/EVENTS.md`; a relative `SIMLOCK_HOME` silently disabled iOS; and a mis-scoped `simctl` call made the suite hang for 100s instead of failing in 2ms.

## Known residuals

- **Ownership is proven at startup and trusted for the life of the process.** Replacing the root under a running daemon (a `mv`, a symlink) would have `listManaged` report the user's own simulators as ours. PR 5 re-validates before `--purge-orphans` destroys anything — reporting can live with a stale proof, destroying cannot — and documents the gap in `known-pitfalls.md`.
- **`driver-unavailable` is a startup snapshot**, re-reported until the daemon restarts. The finding now says so.
- The slow iOS lane was updated to the new contract but **cannot be executed here** (no macOS, no Xcode). It is the only part of this PR not covered by a run.

## Verification

`pnpm run check` green in full: typecheck, typecheck:e2e, lint, format, 811 unit tests, and the e2e lane (33 passed, 1 expected fail, 3 skipped — matching the pre-change baseline). `pnpm exec fallow audit` clean across 23 changed files.

Refs #73, #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BuTqSL7fKJVRbFytNvZP7X

---
_Generated by [Claude Code](https://claude.ai/code/session_01BuTqSL7fKJVRbFytNvZP7X)_