### PR TITLE
feat(android): Simlock's own AVD home and adb server (3/5)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -99,10 +99,24 @@ doctor` reports the reason.
 
 Android containment needs one more thing, because `adb` has no equivalent of
 `simctl --set`: Simlock runs its own adb server on `drivers.android.adbServerPort`
-and gives its emulators console ports above the range a default adb server
-scans. That server is started with USB and mDNS disabled, so it never competes
-with the shared server for physical devices or network targets, and it refuses
-`adb kill-server`.
+and gives its emulators console ports (5586–5682) above the range a default adb
+server scans. That server is started with USB and mDNS disabled, so it never
+competes with the shared server for physical devices or network targets, and it
+refuses `adb kill-server`.
+
+Containment runs in both directions, and the second half is easy to get wrong.
+Simlock's server also has its emulator scanner turned off (`ADB_EMU=0`), because
+the scan's lower bound is hard-coded at 5555: a server allowed to scan high
+enough to find Simlock's emulators would also connect to *yours*, leaving two
+adb servers driving one device. Simlock's emulators still attach, because an
+emulator announces itself to the server it was told about, and Simlock re-sends
+that announcement itself if one goes missing. So your emulators stay yours, and
+Simlock's stay Simlock's.
+
+If `drivers.android.adbServerPort` is occupied by a server Simlock did not
+start, or is not a usable port, the Android driver does not start and `simlock
+doctor` reports why (`occupied`, `start-failed`, `invalid-port`). Simlock never
+attaches to a server it did not start.
 
 Consequence worth knowing: your own `adb` will not see Simlock's emulators.
 A lease hands you the port to use — see

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -109,14 +109,22 @@ Simlock's server also has its emulator scanner turned off (`ADB_EMU=0`), because
 the scan's lower bound is hard-coded at 5555: a server allowed to scan high
 enough to find Simlock's emulators would also connect to *yours*, leaving two
 adb servers driving one device. Simlock's emulators still attach, because an
-emulator announces itself to the server it was told about, and Simlock re-sends
-that announcement itself if one goes missing. So your emulators stay yours, and
-Simlock's stay Simlock's.
+emulator announces itself to the server it was told about — once, at its own
+startup. Simlock re-sends that announcement itself for its own console range
+(5586–5682) whenever it starts or adopts a server, and again for an emulator
+that stays unreachable while booting; that is what keeps emulators that
+outlived a `simlock daemon stop` visible to the daemon that comes next. Your
+emulators are never announced, so they stay yours, and Simlock's stay
+Simlock's.
 
 If `drivers.android.adbServerPort` is occupied by a server Simlock did not
 start, or is not a usable port, the Android driver does not start and `simlock
 doctor` reports why (`occupied`, `start-failed`, `invalid-port`). Simlock never
-attaches to a server it did not start.
+attaches to a server it did not start. `occupied` is the one of those with no
+automatic way out — `adb kill-server` is refused by design — so the error names
+the two ways out: stop whatever holds the port (`lsof -nP -iTCP:<port>
+-sTCP:LISTEN` names the pid), or move Simlock's own server with `simlock config
+set drivers.android.adbServerPort <port>`.
 
 Consequence worth knowing: your own `adb` will not see Simlock's emulators.
 A lease hands you the port to use — see

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -51,7 +51,7 @@ in short: `subject.past-tense-fact`, emitted post-commit, facts not commands.
 | `cleanup.executed` | rule name, action, target, reason | cleanup executor committed a proposed action | CleanupExecutor | implemented |
 | `doctor.reconciled` | drift findings | daemon reconciliation completed | Doctor | implemented |
 | `driver.root-rejected` | platform, root path, reason (not-absolute/missing-marker/invalid-marker/wrong-instance/symlink/wrong-owner/wrong-permissions/non-empty-unowned-root/unreadable) | a driver's device root failed ownership validation at startup, so that platform's driver did not start | DaemonServer | implemented |
-| `driver.adb-server-rejected` | port, reason | Simlock's configured adb server port was occupied by a server it does not own, so the Android driver did not start | DaemonServer | planned |
+| `driver.adb-server-rejected` | port, reason (occupied/start-failed/invalid-port) | Simlock's own adb server could not be established — the port was occupied by a server it does not own, the server it started never began listening, or the configured port is not usable — so the Android driver did not start | DaemonServer | implemented |
 
 ## Conventions recap
 

--- a/docs/adr/0001-simlock-owned-device-roots.md
+++ b/docs/adr/0001-simlock-owned-device-roots.md
@@ -218,6 +218,56 @@ means the only way to stop it is by pid; a daemon that crashed must find and
 reap its own leftover server on restart. It is deliberately not in
 `state.json`, so process supervision does not depend on registry integrity.
 
+**Correction (implementation, 2026-09-02).** The command line above is
+incomplete, and raising `ADB_LOCAL_TRANSPORT_MAX_PORT` on its own is *worse*
+than leaving it alone. The emulator scan's lower bound is hard-coded — there is
+no minimum-port variable — so the ceiling only ever widens the sweep upward
+from 5555 (`packages/modules/adb`, LineageOS mirror of the AOSP module):
+
+```c
+for (int port = DEFAULT_ADB_LOCAL_TRANSPORT_PORT; port <= adb_local_transport_max_port; port += 2)
+    connect_emulator(port);   // Note, uses port and port-1
+```
+
+A ceiling of 5683 therefore makes Simlock's server scan 5555–5683 and connect
+to *the user's own emulators*, leaving two adb servers contending for one
+device — the accident this ADR exists to prevent, running in the other
+direction. What actually contains it is `ADB_EMU=0`, which skips the scanner
+entirely, next to the `ADB_USB` block quoted above in `client/main.cpp`:
+
+```c
+if (!getenv("ADB_EMU") || strcmp(getenv("ADB_EMU"), "0") != 0) {
+    init_emulator_scanner(StringPrintf("tcp:%d", DEFAULT_ADB_LOCAL_TRANSPORT_PORT));
+}
+```
+
+`transport_emulator.cpp` corroborates it (`// < DEFAULT_ADB_LOCAL_TRANSPORT_PORT
+harmlessly mimics ADB_EMU=0`). Simlock's emulators still attach, because an
+emulator announces itself to the server named by `ANDROID_ADB_SERVER_PORT`
+rather than waiting to be found (`adb.cpp`):
+
+```c
+// Indicates a new emulator instance has started.
+if (android::base::ConsumePrefix(&service, "emulator:")) { ... connect_emulator(port); }
+```
+
+That path produces a real `emulator-<console>` transport, so `adb emu avd
+snapshot …` and `adb emu kill` keep working. The cost, also verified: the
+reconnect queue (`retry_ports`, filled by `EmulatorConnection`'s destructor) is
+drained only by the scanner thread, so with the scanner off a kicked emulator
+is never re-attached automatically — Simlock sends the same
+`host:emulator:<adbPort>` announcement itself, after starting an emulator and
+again whenever a serial stays unreachable during the readiness wait.
+
+`ADB_LOCAL_TRANSPORT_MAX_PORT=5683` stays, as belt-and-braces for an adb build
+that ignores `ADB_EMU`: it bounds such a sweep to Simlock's own console range,
+and costs nothing when the scanner is off. Containment is then symmetric —
+Simlock's consoles sit above the user's 5585 ceiling so their server cannot see
+Simlock's emulators, and `ADB_EMU=0` means Simlock's server never looks at
+theirs. The server is also started with `nodaemon server` rather than
+`start-server`, so the pid recorded in `adb-server.json` is the server itself
+and not a launcher that exits immediately.
+
 ### 5. Containment replaces provenance *inference*, not the registry
 
 `listManaged()` stops matching names and starts reporting root membership.

--- a/docs/adr/0001-simlock-owned-device-roots.md
+++ b/docs/adr/0001-simlock-owned-device-roots.md
@@ -255,18 +255,44 @@ That path produces a real `emulator-<console>` transport, so `adb emu avd
 snapshot …` and `adb emu kill` keep working. The cost, also verified: the
 reconnect queue (`retry_ports`, filled by `EmulatorConnection`'s destructor) is
 drained only by the scanner thread, so with the scanner off a kicked emulator
-is never re-attached automatically — Simlock sends the same
-`host:emulator:<adbPort>` announcement itself, after starting an emulator and
-again whenever a serial stays unreachable during the readiness wait.
+is never re-attached automatically. An emulator also announces itself exactly
+once, at its own startup, to whichever server existed then — so a clean
+`simlock daemon stop`, which reaps that server, would leave every surviving
+emulator invisible to the next one: unreportable as an orphan, and sitting on a
+console port the allocator would read as free. Simlock therefore sends the same
+`host:emulator:<adbPort>` announcement itself, deliberately doing for its own
+range what the scanner would do for everyone's: once across the whole console
+range (5586–5682) after starting or adopting a server, and again whenever a
+serial stays unreachable during a readiness wait. `connect_emulator` is
+idempotent, so repeating it is free. Not immediately after spawning an emulator,
+though: adb answers the announcement by connecting *out* to that port, which the
+emulator has not opened yet.
 
-`ADB_LOCAL_TRANSPORT_MAX_PORT=5683` stays, as belt-and-braces for an adb build
-that ignores `ADB_EMU`: it bounds such a sweep to Simlock's own console range,
-and costs nothing when the scanner is off. Containment is then symmetric —
-Simlock's consoles sit above the user's 5585 ceiling so their server cannot see
-Simlock's emulators, and `ADB_EMU=0` means Simlock's server never looks at
-theirs. The server is also started with `nodaemon server` rather than
-`start-server`, so the pid recorded in `adb-server.json` is the server itself
-and not a launcher that exits immediately.
+`ADB_LOCAL_TRANSPORT_MAX_PORT=5683` stays, but not as a bound on the damage —
+that reading, in an earlier revision of this paragraph, was backwards. The sweep
+starts at the hard-coded 5555, so on a build that ignores `ADB_EMU` the default
+ceiling of 5585 already reaches the user's emulators; raising it to 5683 cannot
+prevent that and only extends the sweep upward over Simlock's own consoles.
+That is what it is for: on such a build it is the only thing that makes
+Simlock's own emulators discoverable and re-attachable by a scanner that cannot
+be turned off. Where `ADB_EMU=0` is honoured it does nothing in either
+direction. Containment is then symmetric — Simlock's consoles sit above the
+user's 5585 ceiling so their server cannot see Simlock's emulators, and
+`ADB_EMU=0` means Simlock's server never looks at theirs.
+
+The server is also started with `nodaemon server` rather than `start-server`,
+so the pid recorded in `adb-server.json` is the server itself and not a
+launcher that exits immediately. That record is written as soon as the pid
+exists, *before* the port is confirmed to be listening: the window in between
+is one a daemon can die in, and a listening server with no record on disk is
+the one state nothing automatic can recover — `adb kill-server` is refused by
+design and the next start can only report `occupied`. For the same reason the
+pid in a record is never signalled on the strength of the pid alone. Its full
+command line has to name an `adb` binary, this server's `-P <port>`, and
+`nodaemon`; a recycled pid usually belongs to *some* adb, and the machine's
+shared server is exactly the wrong thing to SIGKILL. A check that cannot
+conclude — no `ps` on the host, a stripped `PATH` — keeps the record rather
+than dropping it.
 
 ### 5. Containment replaces provenance *inference*, not the registry
 

--- a/docs/known-pitfalls.md
+++ b/docs/known-pitfalls.md
@@ -143,11 +143,19 @@ detach every leased emulator at once.
 against its own server returns `error: kill-server rejected by remote server`,
 for the life of the process. The only way to stop it is to kill the pid.
 
-So the pid is recorded in `~/.simlock/adb-server.json` when the server starts,
-the daemon reaps it by pid on shutdown, and a daemon that crashed must find
-that file on restart and adopt-or-kill the server it names. A stale entry — the
-pid is gone, or belongs to something else now — must be treated as no server,
-not as a server to kill blindly.
+So the pid is recorded in `~/.simlock/adb-server.json` as soon as the server
+has one — before it is known to be listening, since the gap between the two is
+a window a daemon can die in and a listening server with no record is
+unrecoverable. The daemon reaps it by pid on shutdown, and a daemon that
+crashed must find that file on restart and adopt-or-kill the server it names. A
+stale entry — the pid is gone, or belongs to something else now — must be
+treated as no server, not as a server to kill blindly. "Belongs to something
+else" is decided from the process's full command line (an `adb` binary, this
+server's `-P <port>`, and `nodaemon`), never from the command name alone: a
+recycled pid most often belongs to *some* adb, and the shared server every
+other tool on the machine is talking to is precisely the wrong thing to
+SIGKILL. Where the process table cannot be read at all, the record is kept —
+deleting it would strand a live server behind an `occupied` refusal forever.
 
 The file is deliberately *not* part of `state.json`: process supervision must
 not depend on registry integrity, since a corrupt registry is exactly when you

--- a/e2e/helpers/env.ts
+++ b/e2e/helpers/env.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { createServer } from "node:net";
 import { existsSync } from "node:fs";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -115,6 +116,13 @@ export interface WithDaemonOptions {
 
 export interface TestEnv {
   readonly home: string;
+  /**
+   * The port this env's Simlock runs its own adb server on, in the real-SDK lane. A TCP
+   * port is machine-global, so `SIMLOCK_HOME` alone no longer isolates two Simlocks and a
+   * test that shares one with the developer's own daemon would fail closed on `occupied`.
+   * `undefined` in the fake-driver lane, which has no adb server at all.
+   */
+  readonly adbServerPort: number | undefined;
   readonly socketPath: string;
   readonly logPath: string;
   readonly configPath: string;
@@ -175,9 +183,10 @@ export async function withDaemon(options: WithDaemonOptions = {}): Promise<TestE
     ...(options.agentId === undefined ? {} : { SIMLOCK_AGENT_ID: options.agentId }),
   };
 
+  const adbServerPort = useFakeDriver ? undefined : await freeLoopbackPort();
   const seededConfig = useFakeDriver
     ? mergeDeep(FAKE_LANE_BASE_CONFIG, options.configOverrides ?? {})
-    : options.configOverrides;
+    : mergeDeep({ drivers: { android: { adbServerPort } } }, options.configOverrides ?? {});
   if (seededConfig !== undefined) {
     await writeFile(configPath, `${JSON.stringify(seededConfig, null, 2)}\n`, "utf8");
   }
@@ -186,6 +195,7 @@ export async function withDaemon(options: WithDaemonOptions = {}): Promise<TestE
   const mcpClients = new Set<McpClientHandle>();
 
   const testEnv: TestEnv = {
+    adbServerPort,
     home,
     socketPath,
     logPath,
@@ -375,6 +385,27 @@ async function readFileIfExists(path: string): Promise<string | undefined> {
     return await readFile(path, "utf8");
   } catch {
     return undefined;
+  }
+}
+
+/**
+ * Binds an ephemeral loopback port and immediately releases it. Inherently racy -- nothing
+ * stops another process taking it in between -- but it is the only way to pick a port no
+ * other test env on this machine is already using, and the alternative (a fixed port) fails
+ * every parallel run rather than an unlucky one.
+ */
+async function freeLoopbackPort(): Promise<number> {
+  const server = createServer();
+  try {
+    const port = await new Promise<number>((resolve) => {
+      server.listen(0, "127.0.0.1", () => {
+        const address = server.address();
+        resolve(typeof address === "object" && address !== null ? address.port : 0);
+      });
+    });
+    return port;
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
   }
 }
 

--- a/e2e/slow-android-smoke.test.ts
+++ b/e2e/slow-android-smoke.test.ts
@@ -16,9 +16,12 @@ const ANDROID_HOME =
 const hasAndroidSdk =
   existsSync(ANDROID_HOME) && existsSync(join(ANDROID_HOME, "platform-tools", "adb"));
 
-async function adbDevices(): Promise<string[]> {
+/** Simlock's emulators live on Simlock's own adb server, so that is the one to ask. */
+async function adbDevices(serverPort: number): Promise<string[]> {
   const adb = join(ANDROID_HOME, "platform-tools", "adb");
-  const { stdout } = await execFileAsync(adb, ["devices"]).catch(() => ({ stdout: "" }));
+  const { stdout } = await execFileAsync(adb, ["-P", String(serverPort), "devices"]).catch(() => ({
+    stdout: "",
+  }));
   return stdout
     .split("\n")
     .slice(1)
@@ -50,6 +53,10 @@ describe.skipIf(!hasAndroidSdk)(
           driver: "real",
           configOverrides: { idle: { shutdownAfterMs: 300 } },
         });
+        const { adbServerPort } = env;
+        if (adbServerPort === undefined) {
+          throw new Error("the real-SDK lane must allocate its own adb server port");
+        }
         try {
           const catalog = await env.cli(["catalog", "--json", "--platform", "android"]);
           expect(catalog.code).toBe(0);
@@ -84,17 +91,23 @@ describe.skipIf(!hasAndroidSdk)(
           // deliberately keeps opaque outside drivers/android (architecture.md #2) --
           // `grant.udid` is simlock's own AVD name, not the adb serial, so this only
           // asserts that *an* emulator is actually online, not which one by serial.
-          const onlineSerials = await adbDevices();
+          const onlineSerials = await adbDevices(adbServerPort);
           expect(
             onlineSerials.length,
-            "expected at least one booted emulator visible to adb",
+            "expected at least one booted emulator visible to Simlock's own adb server",
           ).toBeGreaterThan(0);
 
+          // Ownership is root membership, not a name: the AVD must be inside the root this
+          // env's Simlock owns, and must not be in the user's own AVD home at all.
+          expect(
+            existsSync(join(env.home, "devices", "android", `${grant.udid}.avd`)),
+            "expected the AVD to live inside Simlock's own device root",
+          ).toBe(true);
           const avdNames = await avdManagerList();
           expect(
-            avdNames.some((name) => name.startsWith("simlock_")),
-            "expected a simlock_-prefixed AVD",
-          ).toBe(true);
+            avdNames.includes(grant.udid),
+            "a Simlock AVD must not appear in the user's own AVD home",
+          ).toBe(false);
 
           await env.cli(["release", grant.lease]);
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -133,6 +133,7 @@ function defaultCliEnvironment(env: NodeJS.ProcessEnv = process.env): CliEnviron
           args: [join(dirname(fileURLToPath(import.meta.url)), "../daemon/main.js")],
           command: process.execPath,
           logPath,
+          simlockHome: dataDirectory,
         }),
         socketPath,
       }),

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -13,6 +13,7 @@ import type {
   Driver,
   DriverDevice,
   DriverRejection,
+  DriverRejectionReason,
   ObservedDevice,
   ObservedMark,
 } from "./driver.js";
@@ -45,7 +46,7 @@ export type DoctorFinding =
       /** A platform Simlock is running without, because its driver refused to start. */
       readonly kind: "driver-unavailable";
       readonly platform: Platform;
-      readonly reason: string;
+      readonly reason: DriverRejectionReason;
       readonly detail: string;
     }
   | {

--- a/src/core/driver.ts
+++ b/src/core/driver.ts
@@ -1,4 +1,5 @@
 import type { EventMap } from "../bus/index.js";
+import type { RootRejectionReason } from "./device-root.js";
 import type { DeviceSpec, Platform } from "./domain.js";
 
 export interface DeviceRequest {
@@ -133,10 +134,35 @@ export interface Driver {
    * nobody could address. The core forwards it verbatim; no key here means anything to it.
    */
   leaseEnvironment(): Readonly<Record<string, string>>;
+  /**
+   * Releases whatever this driver holds outside its own process -- Android supervises an
+   * adb server it must reap by pid, since nothing else can (`docs/known-pitfalls.md`).
+   * Optional because most drivers hold nothing; the daemon calls it on every shutdown
+   * path and never lets a failure here abort the rest of one.
+   */
+  dispose?(): Promise<void>;
 }
 
 /** The events a driver may refuse to start with; each pairs with its own payload below. */
 type DriverRejectionEvent = "driver.root-rejected" | "driver.adb-server-rejected";
+
+/**
+ * Why Simlock's own adb server could not be established. Wire-visible, like the root
+ * reasons: these travel in the `driver.adb-server-rejected` payload and are listed in
+ * `docs/EVENTS.md`, so the vocabulary is fixed and closed.
+ *
+ * It sits beside the event names rather than in `drivers/android` because the two are one
+ * contract: the core publishes neither without the other, and a driver module cannot be
+ * the place a core type is defined. Nothing here interprets a term (architecture rule 2).
+ */
+export type AdbServerRejectionReason = "occupied" | "start-failed" | "invalid-port";
+
+/**
+ * Every term a refusal may report. Typed rather than a bare `string` so a reason that no
+ * documented vocabulary contains cannot reach `doctor` output or the bus: the whole value
+ * of publishing these words is that a user who reads one can look it up.
+ */
+export type DriverRejectionReason = RootRejectionReason | AdbServerRejectionReason;
 
 /**
  * One refusal, with the payload the event it names is published with.
@@ -156,7 +182,7 @@ interface DriverRefusal<Event extends DriverRejectionEvent> {
    * rather than read back out of `payload`, which is a wire contract the core does not
    * open. `doctor` reports it as the failing reason.
    */
-  readonly reason: string;
+  readonly reason: DriverRejectionReason;
   /** One line, for `doctor` output and the startup log. */
   readonly summary: string;
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -25,6 +25,8 @@ export {
   RuntimeMissingError,
   UnknownModelError,
 } from "./driver.js";
+// fallow-ignore-next-line unused-type -- wire-visible rejection vocabulary for Simlock's own adb server.
+export type { AdbServerRejectionReason, DriverRejectionReason } from "./driver.js";
 export { Doctor } from "./doctor.js";
 export { ensureOwnedRoot, OWNED_ROOT_MARKER_FILE, OwnedRootError } from "./device-root.js";
 // fallow-ignore-next-line unused-type -- public options contract for the drivers that own a root.

--- a/src/daemon/main.test.ts
+++ b/src/daemon/main.test.ts
@@ -51,6 +51,24 @@ async function start(overrides: Partial<StartDaemonOptions> = {}) {
   return { daemon, sink };
 }
 
+/** A driver whose disposal is observable, which `FakeDriver` deliberately is not. */
+class DisposableFakeDriver extends FakeDriver {
+  constructor(
+    private readonly disposed: string[],
+    options: ConstructorParameters<typeof FakeDriver>[0],
+    private readonly failure?: Error,
+  ) {
+    super(options);
+  }
+
+  async dispose(): Promise<void> {
+    this.disposed.push(this.platform);
+    if (this.failure !== undefined) {
+      throw this.failure;
+    }
+  }
+}
+
 describe("startDaemon", () => {
   it("writes a structured start record with version, protocol version, socket path, and effective config", async () => {
     const { daemon, sink } = await start();
@@ -87,6 +105,40 @@ describe("startDaemon", () => {
     // marked with the first one (ADR 0001, decision 2).
     expect(written.instanceId).not.toBe("");
     expect(JSON.parse(await filesystem.readFile(identityPath))).toEqual(written);
+  });
+
+  it("disposes every driver on shutdown, and reports the one that failed without stopping", async () => {
+    // The wiring, not the halves: `DaemonServer` awaiting its `dispose` option is tested in
+    // `server.test.ts` and a driver reaping its adb server in the Android driver's own, and
+    // between them sat the composition that connects the two. Losing it silently abandons
+    // Simlock's adb server on every shutdown, and only `Driver.dispose` can stop one.
+    const disposed: string[] = [];
+    const clock = new FakeClock(1_000);
+    const { daemon, sink } = await start({
+      drivers: [
+        new DisposableFakeDriver(disposed, {
+          availableOsVersions: ["26.5"],
+          clock,
+          platform: "ios",
+        }),
+        new DisposableFakeDriver(
+          disposed,
+          { availableOsVersions: ["35"], clock, platform: "android" },
+          new Error("adb server would not die"),
+        ),
+      ],
+    });
+
+    await daemon.stop("test");
+
+    expect(disposed).toEqual(["ios", "android"]);
+    expect(sink.records).toContainEqual(
+      expect.objectContaining({
+        level: "error",
+        message: "Driver disposal failed",
+        fields: expect.objectContaining({ platform: "android" }),
+      }),
+    );
   });
 
   it("scopes child loggers under daemon.<module> so records are attributable", async () => {

--- a/src/daemon/main.test.ts
+++ b/src/daemon/main.test.ts
@@ -10,6 +10,8 @@ import { DAEMON_PROTOCOL_VERSION } from "../daemon-protocol/index.js";
 import {
   CryptoIdGenerator,
   FakeClock,
+  FakeProcessSupervisor,
+  FakeTcpProbe,
   JsonLinesLogger,
   MemoryFilesystem,
   MemoryLogSink,
@@ -177,7 +179,9 @@ describe("discoverDrivers", () => {
       instanceId: "instance-1",
       logger,
       processRunner: new ScriptedProcessRunner([]),
+      processSupervisor: new FakeProcessSupervisor(),
       simlockHome: "/home/.simlock",
+      tcpProbe: new FakeTcpProbe(),
     });
 
     expect(drivers.some((driver) => driver.platform === "android")).toBe(false);
@@ -266,6 +270,92 @@ describe("discoverDrivers", () => {
   });
 });
 
+describe("discoverDrivers on a host with an Android SDK", () => {
+  const previousAndroidHome = process.env.ANDROID_HOME;
+
+  afterEach(() => {
+    if (previousAndroidHome === undefined) {
+      delete process.env.ANDROID_HOME;
+    } else {
+      process.env.ANDROID_HOME = previousAndroidHome;
+    }
+  });
+
+  it("keeps the daemon up when Simlock's adb port is occupied, reporting the platform instead", async () => {
+    const filesystem = await androidSdk();
+
+    const { drivers, rejections } = await discoverAndroid(filesystem, new FakeTcpProbe([5038]));
+
+    expect(drivers.some((driver) => driver.platform === "android")).toBe(false);
+    // The payload is a wire contract `simlock events --json` publishes for
+    // `driver.adb-server-rejected`, so a renamed key has to fail here.
+    expect(rejections[0]).toMatchObject({
+      event: "driver.adb-server-rejected",
+      payload: { port: 5038, reason: "occupied" },
+      platform: "android",
+      reason: "occupied",
+    });
+  });
+
+  it("starts the Android driver on its own root once its adb server is established", async () => {
+    const filesystem = await androidSdk();
+    const probe = new FakeTcpProbe([5038]);
+    await filesystem.mkdirp(SIMLOCK_HOME);
+    // The server a previous daemon left behind, with the pid that proves it is Simlock's.
+    await filesystem.writeFileAtomic(
+      join(SIMLOCK_HOME, "adb-server.json"),
+      JSON.stringify({ pid: 4242, port: 5038, startedAt: 1 }),
+    );
+
+    const { drivers, rejections } = await discoverAndroid(filesystem, probe, [4242]);
+
+    expect(rejections).toEqual([]);
+    expect(drivers.find((driver) => driver.platform === "android")?.deviceRoot).toBe(
+      join(SIMLOCK_HOME, "devices", "android"),
+    );
+  });
+
+  /** The minimum layout `discoverSdk` accepts, in memory. */
+  async function androidSdk(): Promise<MemoryFilesystem> {
+    const filesystem = new MemoryFilesystem();
+    process.env.ANDROID_HOME = "/android-sdk";
+    for (const binary of [
+      "/android-sdk/platform-tools/adb",
+      "/android-sdk/emulator/emulator",
+      "/android-sdk/cmdline-tools/latest/bin/avdmanager",
+      "/android-sdk/cmdline-tools/latest/bin/sdkmanager",
+    ]) {
+      await filesystem.mkdirp(binary.slice(0, binary.lastIndexOf("/")));
+      await filesystem.writeFileAtomic(binary, "binary");
+    }
+    return filesystem;
+  }
+
+  function discoverAndroid(
+    filesystem: MemoryFilesystem,
+    tcpProbe: FakeTcpProbe,
+    livePids: readonly number[] = [],
+  ) {
+    return discoverDrivers({
+      clock: new FakeClock(),
+      driversConfig: {},
+      filesystem,
+      hostPlatform: "linux",
+      idGenerator: new CryptoIdGenerator(),
+      instanceId: INSTANCE_ID,
+      logger: new JsonLinesLogger({
+        clock: new FakeClock(),
+        level: "debug",
+        sink: new MemoryLogSink(),
+      }),
+      processRunner: new ScriptedProcessRunner([]),
+      processSupervisor: new FakeProcessSupervisor(livePids),
+      simlockHome: SIMLOCK_HOME,
+      tcpProbe,
+    });
+  }
+});
+
 const SIMLOCK_HOME = "/home/.simlock";
 const IOS_ROOT = join(SIMLOCK_HOME, "devices", "ios");
 const INSTANCE_ID = "instance-1";
@@ -326,7 +416,9 @@ function discoverIos(
       sink: overrides.sink ?? new MemoryLogSink(),
     }),
     processRunner: new ScriptedProcessRunner([]),
+    processSupervisor: new FakeProcessSupervisor(),
     simlockHome: SIMLOCK_HOME,
+    tcpProbe: new FakeTcpProbe(),
   });
 }
 
@@ -360,7 +452,9 @@ describe("discoverDrivers with SIMLOCK_DRIVERS_MODULE", () => {
       instanceId: "instance-1",
       logger,
       processRunner: new ScriptedProcessRunner([]),
+      processSupervisor: new FakeProcessSupervisor(),
       simlockHome: "/home/.simlock",
+      tcpProbe: new FakeTcpProbe(),
     });
   }
 

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -17,7 +17,11 @@ import {
   Registry,
   Nuke,
 } from "../core/index.js";
-import { AndroidDriver, SdkMissingError } from "../drivers/android/index.js";
+import {
+  AdbServerUnavailableError,
+  AndroidDriver,
+  SdkMissingError,
+} from "../drivers/android/index.js";
 import { IosSimctlDriver } from "../drivers/ios/index.js";
 import {
   CryptoIdGenerator,
@@ -32,11 +36,15 @@ import {
   NodeFilesystem,
   NodeIpcTransport,
   NodeProcessRunner,
+  NodeProcessSupervisor,
   NodeSystemStats,
+  NodeTcpProbe,
   resolveSimlockHome,
   SystemClock,
   type SystemStats,
   type ProcessRunner,
+  type ProcessSupervisor,
+  type TcpProbe,
 } from "../ports/index.js";
 import { DaemonServer } from "./server.js";
 import { DaemonEndpointHost } from "./connection-host.js";
@@ -53,9 +61,11 @@ export interface StartDaemonOptions {
   readonly ipc?: IpcConnector & IpcListenerFactory;
   readonly logger?: Logger;
   readonly processRunner?: ProcessRunner;
+  readonly processSupervisor?: ProcessSupervisor;
   readonly socketPath?: string;
   readonly statePath?: string;
   readonly systemStats?: SystemStats;
+  readonly tcpProbe?: TcpProbe;
   readonly version?: string;
 }
 
@@ -69,6 +79,8 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
   const idGenerator = options.idGenerator ?? new CryptoIdGenerator();
   const ipc = options.ipc ?? new NodeIpcTransport();
   const processRunner = options.processRunner ?? new NodeProcessRunner();
+  const processSupervisor = options.processSupervisor ?? new NodeProcessSupervisor();
+  const tcpProbe = options.tcpProbe ?? new NodeTcpProbe();
   const configPath = options.configPath ?? join(dataDirectory, "config.json");
   const statePath = options.statePath ?? join(dataDirectory, "state.json");
   const socketPath = options.socketPath ?? join(dataDirectory, "daemon.sock");
@@ -108,7 +120,9 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
           instanceId,
           logger,
           processRunner,
+          processSupervisor,
           simlockHome: dataDirectory,
+          tcpProbe,
         })
       : { drivers: options.drivers, rejections: [] };
   const leaseEngine = new LeaseEngine({
@@ -185,7 +199,23 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
       await Promise.all([doctor.reconcile(), leaseEngine.convergeRunningCapacity()]);
     },
     settle: async () => leaseEngine.settle(),
-    dispose: () => leaseEngine.dispose(),
+    // Drivers are disposed after the lease subsystem, and every one of them is tried even
+    // when another throws: Android's disposal is the only thing that can stop the adb
+    // server it started (`ADB_REJECT_KILL_SERVER=1` refuses everything else), and a
+    // shutdown that abandoned it would leave a server nothing can reap holding the port
+    // the next daemon needs.
+    dispose: async () => {
+      leaseEngine.dispose();
+      const disposals = await Promise.allSettled(drivers.map((driver) => driver.dispose?.()));
+      for (const [index, disposal] of disposals.entries()) {
+        if (disposal.status === "rejected") {
+          logger.error("Driver disposal failed", {
+            platform: drivers[index]?.platform,
+            reason: disposal.reason instanceof Error ? disposal.reason.message : "unknown",
+          });
+        }
+      }
+    },
   });
   await daemon.start();
   return daemon;
@@ -207,7 +237,9 @@ export interface DriverDiscoveryContext {
   readonly instanceId: string;
   readonly logger: Logger;
   readonly processRunner: ProcessRunner;
+  readonly processSupervisor: ProcessSupervisor;
   readonly simlockHome: string;
+  readonly tcpProbe: TcpProbe;
 }
 
 /** Drivers that started, and the platforms that refused to -- both are startup outcomes. */
@@ -232,26 +264,10 @@ export async function discoverDrivers(options: DriverDiscoveryContext): Promise<
     if (ios.driver !== undefined) drivers.push(ios.driver);
     if (ios.rejection !== undefined) rejections.push(ios.rejection);
   }
-  try {
-    drivers.push(
-      await AndroidDriver.create({
-        clock: options.clock,
-        env: process.env,
-        filesystem: options.filesystem,
-        homeDirectory: homedir(),
-        idGenerator: options.idGenerator,
-        processRunner: options.processRunner,
-      }),
-    );
-    logger.info("Discovered driver", { platform: "android" });
-    return { drivers, rejections };
-  } catch (error: unknown) {
-    if (error instanceof SdkMissingError) {
-      logger.warn("Skipped Android driver: SDK missing", { reason: error.message });
-      return { drivers, rejections };
-    }
-    throw error;
-  }
+  const android = await discoverAndroidDriver(options, logger);
+  if (android.driver !== undefined) drivers.push(android.driver);
+  if (android.rejection !== undefined) rejections.push(android.rejection);
+  return { drivers, rejections };
 }
 
 /**
@@ -291,6 +307,71 @@ async function discoverIosDriver(
     });
     return { rejection: rootRejection(error) };
   }
+}
+
+/**
+ * Android refuses for one more reason than iOS does -- it needs a private adb server as
+ * well as an owned root -- and both refusals cost the platform rather than the daemon.
+ * A missing SDK is not a refusal at all: this host simply has no Android tooling, which is
+ * ordinary and reported by the absence of the platform.
+ */
+async function discoverAndroidDriver(
+  options: DriverDiscoveryContext,
+  logger: Logger,
+): Promise<{ readonly driver?: Driver; readonly rejection?: DriverRejection }> {
+  try {
+    const driver = await AndroidDriver.create({
+      clock: options.clock,
+      driverConfig: options.driversConfig["android"] ?? {},
+      env: process.env,
+      filesystem: options.filesystem,
+      homeDirectory: homedir(),
+      idGenerator: options.idGenerator,
+      instanceId: options.instanceId,
+      processRunner: options.processRunner,
+      processSupervisor: options.processSupervisor,
+      simlockHome: options.simlockHome,
+      tcpProbe: options.tcpProbe,
+      // Ambient like `homedir()` above, and read here rather than in the driver so the
+      // composition root stays the only place that touches process state.
+      ...(process.getuid === undefined ? {} : { uid: process.getuid() }),
+    });
+    logger.info("Discovered driver", { platform: "android" });
+    return { driver };
+  } catch (error: unknown) {
+    if (error instanceof SdkMissingError) {
+      logger.warn("Skipped Android driver: SDK missing", { reason: error.message });
+      return {};
+    }
+    if (error instanceof OwnedRootError) {
+      logger.error("Skipped Android driver: device root rejected", {
+        reason: error.reason,
+        root: error.path,
+        summary: error.message,
+      });
+      return { rejection: rootRejection(error) };
+    }
+    if (error instanceof AdbServerUnavailableError) {
+      logger.error("Skipped Android driver: adb server unavailable", {
+        port: error.port,
+        reason: error.reason,
+        summary: error.message,
+      });
+      return { rejection: adbServerRejection(error) };
+    }
+
+    throw error;
+  }
+}
+
+function adbServerRejection(error: AdbServerUnavailableError): DriverRejection {
+  return {
+    event: "driver.adb-server-rejected",
+    payload: { port: error.port, reason: error.reason },
+    platform: "android",
+    reason: error.reason,
+    summary: error.message,
+  };
 }
 
 function rootRejection(error: OwnedRootError): DriverRejection {

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -1093,7 +1093,9 @@ describe("DaemonServer lease heartbeat", () => {
         finishSettle = resolve;
       });
       const harness = await createHarness({
-        dispose: () => order.push("dispose"),
+        dispose: () => {
+          order.push("dispose");
+        },
         settle: async () => {
           order.push("settle-start");
           await settling;
@@ -1121,6 +1123,30 @@ describe("DaemonServer lease heartbeat", () => {
       // Disposal last: a reclaim that settles into a purge failure arms a quarantine
       // retry timer, and cancelling before the drain would strand it armed.
       expect(order).toEqual(["settle-start", "settle-end", "dispose"]);
+    });
+
+    it("waits for an asynchronous disposal before reporting the daemon stopped", async () => {
+      let disposed = false;
+      let finishDispose!: () => void;
+      const disposing = new Promise<void>((resolve) => {
+        finishDispose = resolve;
+      });
+      const harness = await createHarness({
+        dispose: async () => {
+          await disposing;
+          disposed = true;
+        },
+      });
+
+      const stopping = harness.daemon.stop("test-async-dispose");
+      await expect.poll(() => disposed).toBe(false);
+
+      // A driver's release is asynchronous -- Android's reaps the adb server it started --
+      // and a stop that returned before it finished would report a shutdown that had not
+      // happened, leaving the next daemon to find the port still held.
+      finishDispose();
+      await stopping;
+      expect(disposed).toBe(true);
     });
 
     it("logs a clean shutdown", async () => {
@@ -1196,7 +1222,7 @@ async function createHarness(
     readonly start?: boolean;
     readonly clock?: FakeClock;
     readonly converge?: () => Promise<void>;
-    readonly dispose?: () => void;
+    readonly dispose?: () => void | Promise<void>;
     readonly driver?: FakeDriver;
     readonly driverRejections?: readonly DriverRejection[];
     readonly logger?: Logger;

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -89,8 +89,13 @@ export interface DaemonServerOptions {
    * it for startup recovery. Runs after held leases are released and before `dispose`.
    */
   readonly settle?: () => Promise<void>;
-  /** Cancels any timers the lease subsystem armed (e.g. quarantine retries) on shutdown. */
-  readonly dispose?: () => void;
+  /**
+   * Releases what the daemon holds beyond its own state on shutdown: timers the lease
+   * subsystem armed (quarantine retries), and every driver's own external resources.
+   * Awaited, because a driver's release is asynchronous and a stop that returned before it
+   * finished would report a shutdown that had not happened.
+   */
+  readonly dispose?: () => void | Promise<void>;
 }
 
 type DaemonHealth = "starting" | "running" | "failed";
@@ -277,7 +282,7 @@ export class DaemonServer {
     // was inline. Disposal follows rather than precedes it, so a retry timer armed by a
     // reclaim that settles into quarantine is still cancelled.
     await this.options.settle?.();
-    this.options.dispose?.();
+    await this.options.dispose?.();
     for (const connection of this.#connections) {
       await connection.socket.close();
     }

--- a/src/drivers/android/adb-registrar.test.ts
+++ b/src/drivers/android/adb-registrar.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { FakeTcpProbe } from "../../ports/index.js";
+import { AdbRegistrar } from "./adb-registrar.js";
+
+describe("AdbRegistrar", () => {
+  it("announces the emulator's adb port, not its console port, in adb's host framing", async () => {
+    const tcp = new FakeTcpProbe();
+    const registrar = new AdbRegistrar({ serverPort: 5038, tcp });
+
+    await registrar.register(5587);
+
+    // Four hex digits of length, big-endian, then the service: `host:emulator:5587`
+    // is 18 characters, so `0012`.
+    expect(tcp.sends).toEqual([{ payload: "0012host:emulator:5587", port: 5038 }]);
+  });
+
+  it("treats no reply at all as success", async () => {
+    const tcp = new FakeTcpProbe();
+
+    // adb's own source says of this service that "we don't even need to send a reply", so
+    // silence is the ordinary answer rather than a lost round trip.
+    await expect(
+      new AdbRegistrar({ serverPort: 5038, tcp }).register(5587),
+    ).resolves.toBeUndefined();
+  });
+
+  it("accepts adb's OKAY", async () => {
+    const tcp = new FakeTcpProbe();
+    tcp.replyWith("OKAY");
+
+    await expect(
+      new AdbRegistrar({ serverPort: 5038, tcp }).register(5587),
+    ).resolves.toBeUndefined();
+  });
+
+  it("reports a refusal the server actually sent", async () => {
+    const tcp = new FakeTcpProbe();
+    tcp.replyWith("FAIL0014unknown host service");
+
+    await expect(new AdbRegistrar({ serverPort: 5038, tcp }).register(5587)).rejects.toThrow(
+      /host:emulator:5587/,
+    );
+  });
+
+  it("propagates a connection that could not be made at all", async () => {
+    const tcp = new FakeTcpProbe();
+    tcp.failSendsWith(new Error("connect ECONNREFUSED"));
+
+    await expect(new AdbRegistrar({ serverPort: 5038, tcp }).register(5587)).rejects.toThrow(
+      /ECONNREFUSED/,
+    );
+  });
+});

--- a/src/drivers/android/adb-registrar.ts
+++ b/src/drivers/android/adb-registrar.ts
@@ -1,0 +1,51 @@
+import type { TcpProbe } from "../../ports/index.js";
+
+/** adb frames a host service as four hex digits of length, big-endian, then the service. */
+const LENGTH_PREFIX_DIGITS = 4;
+const SERVICE_PREFIX = "host:emulator:";
+/** An error reply is `FAIL<four hex digits><message>`; a success reply is `OKAY` or nothing. */
+const FAILURE_PREFIX = "FAIL";
+
+export interface AdbRegistrarOptions {
+  readonly serverPort: number;
+  readonly tcp: TcpProbe;
+}
+
+/**
+ * Attaches an emulator to Simlock's adb server the way the emulator itself does.
+ *
+ * Simlock's server runs with the emulator scanner off (`ADB_EMU=0`), because the scan's
+ * lower bound is hard-coded and a server that scanned far enough to see Simlock's console
+ * ports would also connect to the user's emulators. With the scanner off, an emulator
+ * attaches only by announcing itself -- and nothing re-announces it if that message is lost
+ * or its transport is later kicked, since adb's reconnect queue is drained by the scanner
+ * thread that is not running. So Simlock sends the same announcement itself, through the
+ * same host service, which is what makes `ADB_EMU=0` affordable at all.
+ */
+export class AdbRegistrar {
+  readonly #options: AdbRegistrarOptions;
+
+  constructor(options: AdbRegistrarOptions) {
+    this.#options = options;
+  }
+
+  /**
+   * `adbPort` is the console port + 1: the host service takes the port the emulator serves
+   * adb on, not the one it serves its console on. Safe to repeat -- adb keys transports by
+   * port, so re-announcing an attached emulator is a no-op.
+   */
+  async register(adbPort: number): Promise<void> {
+    const service = `${SERVICE_PREFIX}${adbPort}`;
+    const reply = await this.#options.tcp.send(this.#options.serverPort, frame(service));
+
+    // adb answers `OKAY`, or closes without answering at all ("we don't even need to send a
+    // reply" in its own source), so silence is success here rather than a timeout to report.
+    if (reply.startsWith(FAILURE_PREFIX)) {
+      throw new Error(`adb refused ${service}: ${reply.slice(FAILURE_PREFIX.length)}`);
+    }
+  }
+}
+
+function frame(service: string): string {
+  return `${service.length.toString(16).padStart(LENGTH_PREFIX_DIGITS, "0")}${service}`;
+}

--- a/src/drivers/android/adb-server.test.ts
+++ b/src/drivers/android/adb-server.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  FakeClock,
+  FakeProcessSupervisor,
+  FakeTcpProbe,
+  MemoryFilesystem,
+  ScriptedProcessRunner,
+  type ScriptedProcessExpectation,
+} from "../../ports/index.js";
+import { AdbServerSupervisor, AdbServerUnavailableError } from "./adb-server.js";
+
+const adb = "/android-sdk/platform-tools/adb";
+const home = "/home/simlock/.simlock";
+const recordPath = `${home}/adb-server.json`;
+const port = 5038;
+const recordedPid = 4242;
+
+describe("AdbServerSupervisor.start", () => {
+  it("adopts the server a previous daemon left listening on its own recorded pid", async () => {
+    const harness = await start({
+      listening: true,
+      livePids: [recordedPid],
+      record: { pid: recordedPid, port, startedAt: 17 },
+    });
+
+    await harness.started;
+
+    expect(harness.runner.calls).toEqual([]);
+    expect(harness.supervisor.signals).toEqual([]);
+    // Untouched, `startedAt` included: rewriting it would erase the only hint that a pid
+    // was recycled under a record Simlock is about to trust.
+    await expect(harness.filesystem.readFile(recordPath)).resolves.toContain('"startedAt":17');
+  });
+
+  it("refuses a port something else is already listening on", async () => {
+    const harness = await start({ listening: true });
+
+    await expect(harness.started).rejects.toMatchObject({
+      name: "AdbServerUnavailableError",
+      port,
+      reason: "occupied",
+    });
+  });
+
+  it("refuses a port whose recorded server is dead even though something answers there", async () => {
+    // The listener cannot be Simlock's -- the pid that would prove it is gone -- so this is
+    // somebody else's adb server, and attaching to it is what failing closed prevents.
+    const harness = await start({
+      listening: true,
+      record: { pid: recordedPid, port, startedAt: 1 },
+    });
+
+    await expect(harness.started).rejects.toMatchObject({ reason: "occupied" });
+  });
+
+  it.each([
+    ["the shared adb server's port", 5037],
+    ["a privileged port", 80],
+    ["a port outside the addressable range", 70_000],
+    ["a port that is not a whole number", 5038.5],
+  ])("refuses %s before probing it", async (_case, configured) => {
+    const probe = new FakeTcpProbe();
+    const isListening = vi.spyOn(probe, "isListening");
+    const harness = await start({ port: configured, probe });
+
+    await expect(harness.started).rejects.toMatchObject({
+      port: configured,
+      reason: "invalid-port",
+    });
+    // A probe answers `false` for a port nothing could listen on, which would read as
+    // "free" and hand an impossible port to a spawn that cannot work.
+    expect(isListening).not.toHaveBeenCalled();
+  });
+
+  it("starts a scoped, foregrounded server and records the pid that is the server", async () => {
+    const harness = await start({ expectations: [serverSpawn()], spawnStartsListening: true });
+
+    await harness.started;
+
+    expect(harness.runner.calls).toEqual([
+      {
+        args: ["-P", "5038", "nodaemon", "server"],
+        command: adb,
+        options: {
+          env: {
+            ADB_EMU: "0",
+            ADB_LOCAL_TRANSPORT_MAX_PORT: "5683",
+            ADB_MDNS: "0",
+            ADB_REJECT_KILL_SERVER: "1",
+            ADB_USB: "0",
+            ANDROID_ADB_SERVER_PORT: "5038",
+            ANDROID_HOME: "/android-sdk",
+            PATH: "/usr/bin",
+          },
+          stdio: "ignore",
+        },
+      },
+    ]);
+    await expect(harness.filesystem.readFile(recordPath)).resolves.toContain('"pid": 1');
+  });
+
+  it("kills the child and refuses when the server it started never listens", async () => {
+    const harness = await start({ expectations: [serverSpawn()] });
+
+    await expect(advancing(harness.clock, harness.started)).rejects.toMatchObject({
+      reason: "start-failed",
+    });
+    expect(harness.kills).toEqual(["SIGKILL"]);
+    await expect(harness.filesystem.exists(recordPath)).resolves.toBe(false);
+  });
+
+  it("reaps a recorded adb process that is alive but serving nothing, then starts its own", async () => {
+    const harness = await start({
+      expectations: [
+        processIdentity(recordedPid, "/android-sdk/platform-tools/adb"),
+        serverSpawn(),
+      ],
+      livePids: [recordedPid],
+      record: { pid: recordedPid, port, startedAt: 1 },
+      spawnStartsListening: true,
+    });
+    harness.supervisor.onSignal = (pid) => harness.supervisor.markDead(pid);
+
+    await harness.started;
+
+    expect(harness.supervisor.signals).toEqual([{ pid: recordedPid, signal: "SIGTERM" }]);
+  });
+
+  it("escalates to SIGKILL when a recorded server ignores SIGTERM", async () => {
+    const harness = await start({
+      expectations: [
+        processIdentity(recordedPid, "adb"),
+        processIdentity(recordedPid, "adb"),
+        serverSpawn(),
+      ],
+      livePids: [recordedPid],
+      record: { pid: recordedPid, port, startedAt: 1 },
+      spawnStartsListening: true,
+    });
+    // Dies only on the second signal, which is the case the escalation exists for.
+    harness.supervisor.onSignal = (pid, signal) => {
+      if (signal === "SIGKILL") harness.supervisor.markDead(pid);
+    };
+
+    await advancing(harness.clock, harness.started);
+
+    expect(harness.supervisor.signals).toEqual([
+      { pid: recordedPid, signal: "SIGTERM" },
+      { pid: recordedPid, signal: "SIGKILL" },
+    ]);
+  });
+
+  it("never signals a recorded pid that is no longer an adb process", async () => {
+    // The recycled-pid case: the number is alive, but it belongs to a stranger now, and a
+    // record is not a licence to kill whatever answers to its pid.
+    const harness = await start({
+      expectations: [processIdentity(recordedPid, "/usr/bin/vim"), serverSpawn()],
+      livePids: [recordedPid],
+      record: { pid: recordedPid, port, startedAt: 1 },
+      spawnStartsListening: true,
+    });
+
+    await harness.started;
+
+    expect(harness.supervisor.signals).toEqual([]);
+  });
+
+  it.each([
+    ["is unreadable", undefined],
+    ["is not JSON", "not json"],
+    ["carries no usable pid", JSON.stringify({ pid: 0, port, startedAt: 1 })],
+    ["names another port", JSON.stringify({ pid: recordedPid, port: 5999, startedAt: 1 })],
+  ])("treats a record that %s as no server at all", async (_case, contents) => {
+    const harness = await start({
+      expectations: [serverSpawn()],
+      livePids: [recordedPid],
+      ...(contents === undefined ? {} : { rawRecord: contents }),
+      spawnStartsListening: true,
+    });
+
+    await harness.started;
+
+    // Straight to the spawn: no identity read, no signal, nothing to adopt.
+    expect(harness.supervisor.signals).toEqual([]);
+    expect(harness.runner.calls).toHaveLength(1);
+  });
+});
+
+describe("AdbServerSupervisor.stop", () => {
+  it("stops the server it started by pid and drops the record", async () => {
+    const harness = await start({
+      expectations: [serverSpawn(), processIdentity(1, "adb")],
+      spawnStartsListening: true,
+    });
+    await harness.started;
+    // The spawned server is the pid the record now names, and only a live one can be stopped.
+    harness.supervisor.markAlive(1);
+    harness.supervisor.onSignal = (pid) => harness.supervisor.markDead(pid);
+
+    await harness.adbServer.stop();
+
+    expect(harness.supervisor.signals).toEqual([{ pid: 1, signal: "SIGTERM" }]);
+    await expect(harness.filesystem.exists(recordPath)).resolves.toBe(false);
+  });
+
+  it("does nothing when no server was ever established", async () => {
+    const harness = await start({ listening: true });
+    await expect(harness.started).rejects.toBeInstanceOf(AdbServerUnavailableError);
+
+    await harness.adbServer.stop();
+
+    expect(harness.supervisor.signals).toEqual([]);
+  });
+});
+
+interface StartOptions {
+  readonly expectations?: readonly ScriptedProcessExpectation[];
+  readonly listening?: boolean;
+  readonly livePids?: readonly number[];
+  readonly port?: number;
+  readonly probe?: FakeTcpProbe;
+  readonly rawRecord?: string;
+  readonly record?: { readonly pid: number; readonly port: number; readonly startedAt: number };
+  readonly spawnStartsListening?: boolean;
+}
+
+/**
+ * Builds a supervisor and calls `start()` without awaiting it, so a test can drive the
+ * clock and the signals while the call is still in flight.
+ */
+async function start(options: StartOptions = {}) {
+  const configuredPort = options.port ?? port;
+  const filesystem = new MemoryFilesystem();
+  await filesystem.mkdirp(home);
+  const contents =
+    options.rawRecord ??
+    (options.record === undefined ? undefined : JSON.stringify(options.record));
+  if (contents !== undefined) {
+    await filesystem.writeFileAtomic(recordPath, contents);
+  }
+
+  const clock = new FakeClock();
+  const probe =
+    options.probe ?? new FakeTcpProbe(options.listening === true ? [configuredPort] : []);
+  const runner = new ScriptedProcessRunner(options.expectations ?? []);
+  const supervisor = new SignallingSupervisor(options.livePids ?? []);
+  const kills: NodeJS.Signals[] = [];
+  const spawn = runner.spawn.bind(runner);
+  vi.spyOn(runner, "spawn").mockImplementation((command, args, spawnOptions) => {
+    const handle = spawn(command, args, spawnOptions);
+    if (options.spawnStartsListening === true) {
+      probe.startListening(configuredPort);
+    }
+    return {
+      pid: handle.pid,
+      stderr: handle.stderr,
+      stdout: handle.stdout,
+      kill(signal) {
+        kills.push(signal ?? "SIGTERM");
+        handle.kill(signal);
+      },
+      wait: () => handle.wait(),
+    };
+  });
+
+  const adbServer = new AdbServerSupervisor({
+    adbPath: adb,
+    clock,
+    env: { ANDROID_HOME: "/android-sdk", PATH: "/usr/bin" },
+    filesystem,
+    port: configuredPort,
+    processRunner: runner,
+    processSupervisor: supervisor,
+    recordPath,
+    tcpProbe: probe,
+  });
+  const started = adbServer.start();
+  // Nothing awaits a refusal until the test does, and an unobserved rejection in the
+  // meantime is noise vitest reports as a failure.
+  started.catch(() => undefined);
+
+  return { adbServer, clock, filesystem, kills, probe, runner, started, supervisor };
+}
+
+function serverSpawn(): ScriptedProcessExpectation {
+  return { hangs: true, match: { args: ["-P", "5038", "nodaemon", "server"], command: adb } };
+}
+
+/** The `ps` read that proves a recorded pid really is an adb server before it is signalled. */
+function processIdentity(pid: number, command: string): ScriptedProcessExpectation {
+  return {
+    match: { args: ["-o", "comm=", "-p", String(pid)], command: "ps" },
+    result: { code: 0, stderr: "", stdout: `${command}\n` },
+  };
+}
+
+/** A `FakeProcessSupervisor` whose test decides what a signal does to the process. */
+class SignallingSupervisor extends FakeProcessSupervisor {
+  onSignal: ((pid: number, signal: NodeJS.Signals) => void) | undefined;
+
+  override signal(pid: number, signal: NodeJS.Signals): void {
+    super.signal(pid, signal);
+    this.onSignal?.(pid, signal);
+  }
+}
+
+/**
+ * Drives a fake clock forward until the work settles. The supervisor's waits are timer
+ * loops, so each iteration schedules its next timer only after the previous one fires --
+ * a single `advance` would run one iteration and stop.
+ */
+async function advancing<T>(clock: FakeClock, work: Promise<T>): Promise<T> {
+  let settled = false;
+  const tracked = work.finally(() => {
+    settled = true;
+  });
+  tracked.catch(() => undefined);
+
+  for (let tick = 0; tick < 1_000 && !settled; tick += 1) {
+    await Promise.resolve();
+    await Promise.resolve();
+    clock.advance(100);
+  }
+
+  return tracked;
+}

--- a/src/drivers/android/adb-server.test.ts
+++ b/src/drivers/android/adb-server.test.ts
@@ -28,8 +28,7 @@ describe("AdbServerSupervisor.start", () => {
 
     expect(harness.runner.calls).toEqual([]);
     expect(harness.supervisor.signals).toEqual([]);
-    // Untouched, `startedAt` included: rewriting it would erase the only hint that a pid
-    // was recycled under a record Simlock is about to trust.
+    // Untouched: the record describes the adopted server, not the daemon that adopted it.
     await expect(harness.filesystem.readFile(recordPath)).resolves.toContain('"startedAt":17');
   });
 
@@ -112,10 +111,7 @@ describe("AdbServerSupervisor.start", () => {
 
   it("reaps a recorded adb process that is alive but serving nothing, then starts its own", async () => {
     const harness = await start({
-      expectations: [
-        processIdentity(recordedPid, "/android-sdk/platform-tools/adb"),
-        serverSpawn(),
-      ],
+      expectations: [processIdentity(recordedPid, ownServerCommand), serverSpawn()],
       livePids: [recordedPid],
       record: { pid: recordedPid, port, startedAt: 1 },
       spawnStartsListening: true,
@@ -130,8 +126,8 @@ describe("AdbServerSupervisor.start", () => {
   it("escalates to SIGKILL when a recorded server ignores SIGTERM", async () => {
     const harness = await start({
       expectations: [
-        processIdentity(recordedPid, "adb"),
-        processIdentity(recordedPid, "adb"),
+        processIdentity(recordedPid, ownServerCommand),
+        processIdentity(recordedPid, ownServerCommand),
         serverSpawn(),
       ],
       livePids: [recordedPid],
@@ -155,7 +151,7 @@ describe("AdbServerSupervisor.start", () => {
     // The recycled-pid case: the number is alive, but it belongs to a stranger now, and a
     // record is not a licence to kill whatever answers to its pid.
     const harness = await start({
-      expectations: [processIdentity(recordedPid, "/usr/bin/vim"), serverSpawn()],
+      expectations: [processIdentity(recordedPid, "/usr/bin/vim /etc/hosts"), serverSpawn()],
       livePids: [recordedPid],
       record: { pid: recordedPid, port, startedAt: 1 },
       spawnStartsListening: true,
@@ -185,12 +181,93 @@ describe("AdbServerSupervisor.start", () => {
     expect(harness.supervisor.signals).toEqual([]);
     expect(harness.runner.calls).toHaveLength(1);
   });
+
+  it("never signals another adb server that inherited the recorded pid", async () => {
+    // The dangerous half of the recycled-pid case: the machine's shared adb server is
+    // exactly the population a recycled pid most often lands in, and `adb` alone is not
+    // evidence of ownership -- `-P <our port>` and `nodaemon` are.
+    const harness = await start({
+      expectations: [
+        processIdentity(recordedPid, "/usr/local/bin/adb -P 5037 fork-server server"),
+        serverSpawn(),
+      ],
+      livePids: [recordedPid],
+      record: { pid: recordedPid, port, startedAt: 1 },
+      spawnStartsListening: true,
+    });
+
+    await harness.started;
+
+    expect(harness.supervisor.signals).toEqual([]);
+  });
+
+  it("records the pid before waiting for the port, so a crash in that window is recoverable", async () => {
+    const harness = await start({ expectations: [serverSpawn()] });
+
+    // Still waiting for the port here: a daemon that died now would otherwise leave a
+    // listening server with no record, which the next start can only report as `occupied`.
+    await vi.waitFor(async () => {
+      expect(await harness.filesystem.exists(recordPath)).toBe(true);
+    });
+
+    await expect(advancing(harness.clock, harness.started)).rejects.toMatchObject({
+      reason: "start-failed",
+    });
+  });
+
+  it("releases the daemon's hold on the server it starts", async () => {
+    // `adb nodaemon server` never exits, so a referenced child keeps the event loop alive
+    // and a daemon that has decided to stop simply never does.
+    const harness = await start({ expectations: [serverSpawn()], spawnStartsListening: true });
+
+    await harness.started;
+
+    expect(harness.unrefs).toEqual([1]);
+  });
+
+  it("kills the server it started and refuses the platform when the record cannot be written", async () => {
+    const harness = await start({
+      expectations: [serverSpawn()],
+      failRecordWrite: true,
+      spawnStartsListening: true,
+    });
+
+    // Typed, not a raw disk error: an untyped throw escapes the platform-scoped catch in
+    // discovery and takes the daemon -- iOS included -- down with Android.
+    await expect(advancing(harness.clock, harness.started)).rejects.toMatchObject({
+      name: "AdbServerUnavailableError",
+      reason: "start-failed",
+    });
+    // A server nothing recorded is a server nothing can ever reap.
+    expect(harness.kills).toEqual(["SIGKILL"]);
+  });
+
+  it("refuses when the port is served by something other than the child it spawned", async () => {
+    // Two daemons cold-start on one port, both probe it free, both spawn. This is the loser:
+    // its adb printed "cannot bind" and exited, and a bare loopback probe cannot tell the
+    // winner's server from its own.
+    const harness = await start({ expectations: [serverSpawn()], spawnDies: true });
+
+    await expect(advancing(harness.clock, harness.started)).rejects.toMatchObject({
+      reason: "start-failed",
+    });
+    // Writing one here would name a dead pid over the winner's record, and the next start
+    // would then find a listening port with a dead record and refuse Android outright.
+    await expect(harness.filesystem.exists(recordPath)).resolves.toBe(false);
+  });
+
+  it("reports how to recover from an occupied port, the one state nothing automatic can fix", async () => {
+    const harness = await start({ listening: true });
+
+    await expect(harness.started).rejects.toThrow(/lsof -nP -iTCP:5038/);
+    await expect(harness.started).rejects.toThrow(/drivers\.android\.adbServerPort/);
+  });
 });
 
 describe("AdbServerSupervisor.stop", () => {
   it("stops the server it started by pid and drops the record", async () => {
     const harness = await start({
-      expectations: [serverSpawn(), processIdentity(1, "adb")],
+      expectations: [serverSpawn(), processIdentity(1, ownServerCommand)],
       spawnStartsListening: true,
     });
     await harness.started;
@@ -202,6 +279,26 @@ describe("AdbServerSupervisor.stop", () => {
 
     expect(harness.supervisor.signals).toEqual([{ pid: 1, signal: "SIGTERM" }]);
     await expect(harness.filesystem.exists(recordPath)).resolves.toBe(false);
+  });
+
+  it.each([
+    ["answers with an error", [unreadableProcessTable(1)]],
+    ["cannot be run at all", []],
+  ])("keeps the record when the process table %s", async (_case, identity) => {
+    // A host with no `ps` (a slim container), a stripped `PATH`, or a `ps` too small to know
+    // `-o args=`. Dropping the record here would leave the server running with nothing left
+    // to reap it by, and the next start would find a listening port it has no claim on:
+    // Android dead on that host until somebody hunts down the pid.
+    const harness = await start({
+      expectations: [serverSpawn(), ...identity],
+      spawnStartsListening: true,
+    });
+    await harness.started;
+
+    await harness.adbServer.stop();
+
+    expect(harness.supervisor.signals).toEqual([]);
+    await expect(harness.filesystem.exists(recordPath)).resolves.toBe(true);
   });
 
   it("does nothing when no server was ever established", async () => {
@@ -216,11 +313,14 @@ describe("AdbServerSupervisor.stop", () => {
 
 interface StartOptions {
   readonly expectations?: readonly ScriptedProcessExpectation[];
+  readonly failRecordWrite?: boolean;
   readonly listening?: boolean;
   readonly livePids?: readonly number[];
   readonly port?: number;
   readonly probe?: FakeTcpProbe;
   readonly rawRecord?: string;
+  /** The child loses a race for the port: it exits, and the winner's server answers instead. */
+  readonly spawnDies?: boolean;
   readonly record?: { readonly pid: number; readonly port: number; readonly startedAt: number };
   readonly spawnStartsListening?: boolean;
 }
@@ -233,36 +333,18 @@ async function start(options: StartOptions = {}) {
   const configuredPort = options.port ?? port;
   const filesystem = new MemoryFilesystem();
   await filesystem.mkdirp(home);
-  const contents =
-    options.rawRecord ??
-    (options.record === undefined ? undefined : JSON.stringify(options.record));
-  if (contents !== undefined) {
-    await filesystem.writeFileAtomic(recordPath, contents);
-  }
+  await seedRecord(filesystem, options);
 
   const clock = new FakeClock();
   const probe =
     options.probe ?? new FakeTcpProbe(options.listening === true ? [configuredPort] : []);
   const runner = new ScriptedProcessRunner(options.expectations ?? []);
   const supervisor = new SignallingSupervisor(options.livePids ?? []);
-  const kills: NodeJS.Signals[] = [];
-  const spawn = runner.spawn.bind(runner);
-  vi.spyOn(runner, "spawn").mockImplementation((command, args, spawnOptions) => {
-    const handle = spawn(command, args, spawnOptions);
-    if (options.spawnStartsListening === true) {
-      probe.startListening(configuredPort);
-    }
-    return {
-      pid: handle.pid,
-      stderr: handle.stderr,
-      stdout: handle.stdout,
-      kill(signal) {
-        kills.push(signal ?? "SIGTERM");
-        handle.kill(signal);
-      },
-      wait: () => handle.wait(),
-    };
-  });
+  const spawned = observeSpawns({ configuredPort, options, probe, runner, supervisor });
+
+  if (options.failRecordWrite === true) {
+    vi.spyOn(filesystem, "writeFileAtomic").mockRejectedValue(new Error("ENOSPC"));
+  }
 
   const adbServer = new AdbServerSupervisor({
     adbPath: adb,
@@ -280,20 +362,93 @@ async function start(options: StartOptions = {}) {
   // meantime is noise vitest reports as a failure.
   started.catch(() => undefined);
 
-  return { adbServer, clock, filesystem, kills, probe, runner, started, supervisor };
+  return { adbServer, clock, filesystem, ...spawned, probe, runner, started, supervisor };
+}
+
+async function seedRecord(filesystem: MemoryFilesystem, options: StartOptions): Promise<void> {
+  const contents =
+    options.rawRecord ??
+    (options.record === undefined ? undefined : JSON.stringify(options.record));
+
+  if (contents !== undefined) {
+    await filesystem.writeFileAtomic(recordPath, contents);
+  }
+}
+
+/**
+ * Wraps the spawned handle so the test can see what was done to it, and gives the fake
+ * process supervisor the truth the real one would have: a child that spawned is a process
+ * that exists until something kills it. The supervisor asks, because a probe answering
+ * "listening" proves only that *something* is serving the port.
+ */
+function observeSpawns(context: {
+  readonly configuredPort: number;
+  readonly options: StartOptions;
+  readonly probe: FakeTcpProbe;
+  readonly runner: ScriptedProcessRunner;
+  readonly supervisor: SignallingSupervisor;
+}) {
+  const { configuredPort, options, probe, runner, supervisor } = context;
+  const kills: NodeJS.Signals[] = [];
+  const unrefs: number[] = [];
+  const spawn = runner.spawn.bind(runner);
+  const childSurvives = options.spawnDies !== true;
+
+  vi.spyOn(runner, "spawn").mockImplementation((command, args, spawnOptions) => {
+    const handle = spawn(command, args, spawnOptions);
+    if (childSurvives) {
+      supervisor.markAlive(handle.pid);
+    }
+    // A dying child models a lost race for the port, so somebody else is serving it.
+    if (options.spawnStartsListening === true || !childSurvives) {
+      probe.startListening(configuredPort);
+    }
+
+    return {
+      pid: handle.pid,
+      stderr: handle.stderr,
+      stdout: handle.stdout,
+      kill(signal) {
+        kills.push(signal ?? "SIGTERM");
+        supervisor.markDead(handle.pid);
+        handle.kill(signal);
+      },
+      unref: () => {
+        unrefs.push(handle.pid);
+        handle.unref();
+      },
+      wait: () => handle.wait(),
+    };
+  });
+
+  return { kills, unrefs };
 }
 
 function serverSpawn(): ScriptedProcessExpectation {
   return { hangs: true, match: { args: ["-P", "5038", "nodaemon", "server"], command: adb } };
 }
 
-/** The `ps` read that proves a recorded pid really is an adb server before it is signalled. */
-function processIdentity(pid: number, command: string): ScriptedProcessExpectation {
+/**
+ * The `ps` read that proves a recorded pid really is *this* server before it is signalled.
+ * The whole command line, because the arguments are the only thing that separates Simlock's
+ * server from the shared one every other tool on the machine is talking to.
+ */
+function processIdentity(pid: number, commandLine: string): ScriptedProcessExpectation {
   return {
-    match: { args: ["-o", "comm=", "-p", String(pid)], command: "ps" },
-    result: { code: 0, stderr: "", stdout: `${command}\n` },
+    match: { args: ["-o", "args=", "-p", String(pid)], command: "ps" },
+    result: { code: 0, stderr: "", stdout: `${commandLine}\n` },
   };
 }
+
+/** A `ps` that cannot answer: a BusyBox one that has never heard of `-o args=`, say. */
+function unreadableProcessTable(pid: number): ScriptedProcessExpectation {
+  return {
+    match: { args: ["-o", "args=", "-p", String(pid)], command: "ps" },
+    result: { code: 127, stderr: "ps: command not found", stdout: "" },
+  };
+}
+
+const ownServerCommand = `${adb} -P 5038 nodaemon server`;
 
 /** A `FakeProcessSupervisor` whose test decides what a signal does to the process. */
 class SignallingSupervisor extends FakeProcessSupervisor {

--- a/src/drivers/android/adb-server.ts
+++ b/src/drivers/android/adb-server.ts
@@ -1,0 +1,340 @@
+import { basename } from "node:path";
+
+import type { AdbServerRejectionReason } from "../../core/index.js";
+import type {
+  Clock,
+  Filesystem,
+  ProcessRunner,
+  ProcessSupervisor,
+  TcpProbe,
+} from "../../ports/index.js";
+
+/** How long a freshly spawned server gets to accept a connection before it counts as failed. */
+const START_TIMEOUT_MS = 10_000;
+/** How long a signalled server gets to disappear before the next, harder signal. */
+const STOP_TIMEOUT_MS = 5_000;
+const POLL_INTERVAL_MS = 100;
+const IDENTITY_TIMEOUT_MS = 5_000;
+/** Ports below this belong to the system, and 5037 is the shared server every tool finds. */
+const MIN_PORT = 1024;
+const MAX_PORT = 65_535;
+const SHARED_ADB_SERVER_PORT = 5037;
+
+/**
+ * The scoping this server is started with. Every entry is a containment decision, and
+ * three of them are load-bearing enough to state:
+ *
+ * - `ADB_EMU=0` turns off the emulator scanner. Without it the server sweeps
+ *   `DEFAULT_ADB_LOCAL_TRANSPORT_PORT`(5555)..`ADB_LOCAL_TRANSPORT_MAX_PORT` and *connects*
+ *   to whatever answers -- the lower bound is hard-coded in adb, so raising the ceiling to
+ *   reach Simlock's own console ports would also reach the user's emulators and leave two
+ *   servers contending for one device. That is the accident ADR 0001 exists to prevent,
+ *   running backwards. Simlock's own emulators still attach because they register
+ *   themselves with `host:emulator:<adbPort>` (see `AdbRegistrar`).
+ * - `ADB_LOCAL_TRANSPORT_MAX_PORT` stays as belt-and-braces: on an adb build that ignores
+ *   `ADB_EMU` it bounds the sweep to Simlock's own console range instead of the user's,
+ *   and it costs nothing when the scanner is off.
+ * - `ADB_REJECT_KILL_SERVER=1` makes `adb kill-server` refuse -- including for Simlock, which
+ *   is why this server is stopped by pid and why its pid is recorded on disk.
+ */
+const SCOPED_ENVIRONMENT = {
+  ADB_EMU: "0",
+  ADB_LOCAL_TRANSPORT_MAX_PORT: "5683",
+  ADB_MDNS: "0",
+  ADB_REJECT_KILL_SERVER: "1",
+  ADB_USB: "0",
+} as const;
+
+/** What `${SIMLOCK_HOME}/adb-server.json` holds: the only handle on a server that outlives us. */
+// fallow-ignore-next-line unused-type -- on-disk contract; documented in docs/known-pitfalls.md and read back by a later daemon.
+export interface AdbServerRecord {
+  readonly pid: number;
+  readonly port: number;
+  readonly startedAt: number;
+}
+
+export class AdbServerUnavailableError extends Error {
+  constructor(
+    message: string,
+    readonly reason: AdbServerRejectionReason,
+    readonly port: number,
+  ) {
+    super(message);
+    this.name = "AdbServerUnavailableError";
+  }
+}
+
+export interface AdbServerSupervisorOptions {
+  readonly adbPath: string;
+  readonly clock: Clock;
+  /**
+   * The environment the server is started on top of, injected rather than read from
+   * `process.env` here: `ProcessRunner` replaces a child's environment wholesale instead of
+   * merging into it, so an adb started from `SCOPED_ENVIRONMENT` alone would lose `PATH`,
+   * `HOME`, and `ANDROID_HOME` with it.
+   */
+  readonly env: Readonly<Record<string, string | undefined>>;
+  readonly filesystem: Filesystem;
+  readonly port: number;
+  readonly processRunner: ProcessRunner;
+  readonly processSupervisor: ProcessSupervisor;
+  /** `${SIMLOCK_HOME}/adb-server.json`. */
+  readonly recordPath: string;
+  readonly tcpProbe: TcpProbe;
+}
+
+/**
+ * Owns the private adb server Android containment is built on (ADR 0001, decision 4):
+ * starts one, adopts the one a previous daemon left behind, and reaps it on shutdown.
+ *
+ * Every ambiguous case fails closed. Attaching to whatever happens to be listening would
+ * silently hand Simlock's emulators to Android Studio's server, which is the guarantee this
+ * class exists to make -- and it would do so without producing a single error (safety
+ * rule 9).
+ */
+export class AdbServerSupervisor {
+  readonly #options: AdbServerSupervisorOptions;
+  #record: AdbServerRecord | undefined;
+
+  constructor(options: AdbServerSupervisorOptions) {
+    this.#options = options;
+  }
+
+  async start(): Promise<void> {
+    // Before the probe rather than after it: `NodeTcpProbe` answers `false` for a port
+    // nothing could listen on, so an out-of-range port would otherwise read as "free" and
+    // be handed to a spawn that cannot possibly work.
+    this.#requireUsablePort();
+
+    const record = await this.#liveRecord();
+    if (await this.#options.tcpProbe.isListening(this.#options.port)) {
+      if (record === undefined) {
+        throw this.#unavailable(
+          "occupied",
+          `something is already listening on port ${this.#options.port} and Simlock has no record of starting it`,
+        );
+      }
+
+      // Adopted: a daemon died, its server did not. The record is the proof of ownership,
+      // so it is kept exactly as it was -- rewriting `startedAt` would erase the one hint
+      // available for spotting a recycled pid later.
+      this.#record = record;
+      return;
+    }
+
+    if (record !== undefined) {
+      // Recorded, alive, and serving nothing: the pid is a leftover rather than a server.
+      await this.#reap(record);
+    }
+
+    await this.#startServer();
+  }
+
+  async stop(): Promise<void> {
+    const record = this.#record;
+    if (record === undefined) {
+      return;
+    }
+
+    this.#record = undefined;
+    await this.#reap(record);
+  }
+
+  #requireUsablePort(): void {
+    const { port } = this.#options;
+
+    if (!Number.isInteger(port) || port < MIN_PORT || port > MAX_PORT) {
+      throw this.#unavailable(
+        "invalid-port",
+        `${port} is not a usable TCP port (expected an integer between ${MIN_PORT} and ${MAX_PORT})`,
+      );
+    }
+
+    if (port === SHARED_ADB_SERVER_PORT) {
+      // Starting Simlock's server there would either fail or, worse, succeed and become
+      // *the* adb server for every tool on the machine.
+      throw this.#unavailable(
+        "invalid-port",
+        `port ${SHARED_ADB_SERVER_PORT} is the shared adb server every other tool uses, so Simlock will not take it over`,
+      );
+    }
+  }
+
+  /**
+   * The recorded server, or `undefined` when the record proves nothing. A record that does
+   * not parse, names another port, or names a pid nothing answers for is treated as no
+   * server at all -- never as something to go and kill.
+   */
+  async #liveRecord(): Promise<AdbServerRecord | undefined> {
+    const record = await this.#readRecord();
+
+    return record !== undefined &&
+      record.port === this.#options.port &&
+      this.#options.processSupervisor.isAlive(record.pid)
+      ? record
+      : undefined;
+  }
+
+  async #readRecord(): Promise<AdbServerRecord | undefined> {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await this.#options.filesystem.readFile(this.#options.recordPath));
+    } catch {
+      return undefined;
+    }
+
+    return isAdbServerRecord(parsed) ? parsed : undefined;
+  }
+
+  /**
+   * Ends the recorded process, but only once it has proven to be an adb server.
+   *
+   * A pid alone identifies nothing. After a reboot or heavy pid churn the number in a
+   * stale record belongs to somebody else's process, and `isAlive` says "yes" about it just
+   * as readily -- so signalling on the strength of the record would eventually SIGKILL a
+   * stranger's process on the user's machine. The identity check is repeated before the
+   * SIGKILL because the process may have exited and its pid been reused in between.
+   */
+  async #reap(record: AdbServerRecord): Promise<void> {
+    if (!(await this.#isAdbProcess(record.pid))) {
+      await this.#forgetRecord();
+      return;
+    }
+
+    this.#options.processSupervisor.signal(record.pid, "SIGTERM");
+    if (!(await this.#waitForExit(record.pid))) {
+      if (await this.#isAdbProcess(record.pid)) {
+        this.#options.processSupervisor.signal(record.pid, "SIGKILL");
+        await this.#waitForExit(record.pid);
+      }
+    }
+
+    await this.#forgetRecord();
+  }
+
+  /**
+   * Whether this pid is an adb server, read from the process table. `ps -o comm= -p` prints
+   * the command with no arguments and nothing else, and prints nothing at all for a pid
+   * that is gone; macOS reports it as a path, Linux as a bare name, so only the basename is
+   * comparable. Any failure answers "not adb", which is the fail-closed direction: it costs
+   * a leftover server, where the other direction costs somebody else's process.
+   */
+  async #isAdbProcess(pid: number): Promise<boolean> {
+    let result;
+    try {
+      result = await this.#options.processRunner.run("ps", ["-o", "comm=", "-p", String(pid)], {
+        timeoutMs: IDENTITY_TIMEOUT_MS,
+      });
+    } catch {
+      return false;
+    }
+
+    if (result.code !== 0) {
+      return false;
+    }
+
+    const command = result.stdout.split("\n")[0]?.trim() ?? "";
+    return command !== "" && basename(command) === "adb";
+  }
+
+  async #startServer(): Promise<void> {
+    const startedAt = this.#options.clock.now();
+    // `nodaemon server` runs the server in the foreground, so the pid recorded below is
+    // the server itself. `start-server` would fork one and hand back the pid of a launcher
+    // that exits immediately -- a pid that identifies nothing by the time it is needed.
+    // `stdio: "ignore"` because this child outlives every call made to it: captured output
+    // would accumulate in the handle's buffers for as long as the daemon runs, and there is
+    // nothing to read it. Diagnosis happens through the probe and the record instead.
+    const handle = this.#options.processRunner.spawn(
+      this.#options.adbPath,
+      ["-P", String(this.#options.port), "nodaemon", "server"],
+      {
+        env: {
+          ...this.#options.env,
+          ...SCOPED_ENVIRONMENT,
+          ANDROID_ADB_SERVER_PORT: String(this.#options.port),
+        },
+        stdio: "ignore",
+      },
+    );
+
+    if (!(await this.#waitForListening(startedAt))) {
+      handle.kill("SIGKILL");
+      throw this.#unavailable(
+        "start-failed",
+        `Simlock's adb server did not start listening on port ${this.#options.port} within ${START_TIMEOUT_MS}ms`,
+      );
+    }
+
+    const record: AdbServerRecord = { pid: handle.pid, port: this.#options.port, startedAt };
+    this.#record = record;
+    await this.#options.filesystem.writeFileAtomic(
+      this.#options.recordPath,
+      `${JSON.stringify(record, null, 2)}\n`,
+    );
+  }
+
+  async #waitForListening(startedAt: number): Promise<boolean> {
+    while (true) {
+      if (await this.#options.tcpProbe.isListening(this.#options.port)) {
+        return true;
+      }
+      if (this.#options.clock.now() - startedAt >= START_TIMEOUT_MS) {
+        return false;
+      }
+
+      await this.#delay(POLL_INTERVAL_MS);
+    }
+  }
+
+  async #waitForExit(pid: number): Promise<boolean> {
+    const startedAt = this.#options.clock.now();
+    while (this.#options.processSupervisor.isAlive(pid)) {
+      if (this.#options.clock.now() - startedAt >= STOP_TIMEOUT_MS) {
+        return false;
+      }
+
+      await this.#delay(POLL_INTERVAL_MS);
+    }
+
+    return true;
+  }
+
+  async #forgetRecord(): Promise<void> {
+    try {
+      await this.#options.filesystem.rm(this.#options.recordPath);
+    } catch {
+      // A record that cannot be removed is a stale file, not a reason to fail a shutdown:
+      // the next start re-reads it, finds nothing alive behind it, and drops it then.
+    }
+  }
+
+  #unavailable(reason: AdbServerRejectionReason, detail: string): AdbServerUnavailableError {
+    return new AdbServerUnavailableError(
+      `Refusing to run the android driver: ${detail}`,
+      reason,
+      this.#options.port,
+    );
+  }
+
+  #delay(milliseconds: number): Promise<void> {
+    return new Promise((resolve) => {
+      this.#options.clock.setTimer(milliseconds, resolve);
+    });
+  }
+}
+
+function isAdbServerRecord(value: unknown): value is AdbServerRecord {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record["pid"] === "number" &&
+    Number.isInteger(record["pid"]) &&
+    record["pid"] > 0 &&
+    typeof record["port"] === "number" &&
+    typeof record["startedAt"] === "number"
+  );
+}

--- a/src/drivers/android/adb-server.ts
+++ b/src/drivers/android/adb-server.ts
@@ -1,9 +1,8 @@
-import { basename } from "node:path";
-
 import type { AdbServerRejectionReason } from "../../core/index.js";
 import type {
   Clock,
   Filesystem,
+  ProcessHandle,
   ProcessRunner,
   ProcessSupervisor,
   TcpProbe,
@@ -31,9 +30,13 @@ const SHARED_ADB_SERVER_PORT = 5037;
  *   servers contending for one device. That is the accident ADR 0001 exists to prevent,
  *   running backwards. Simlock's own emulators still attach because they register
  *   themselves with `host:emulator:<adbPort>` (see `AdbRegistrar`).
- * - `ADB_LOCAL_TRANSPORT_MAX_PORT` stays as belt-and-braces: on an adb build that ignores
- *   `ADB_EMU` it bounds the sweep to Simlock's own console range instead of the user's,
- *   and it costs nothing when the scanner is off.
+ * - `ADB_LOCAL_TRANSPORT_MAX_PORT` is *not* a bound on the damage, and reading it that way
+ *   gets it backwards: the sweep starts at the hard-coded 5555, so on a build that ignores
+ *   `ADB_EMU` the user's emulators are reached at the default ceiling of 5585 already, and
+ *   5683 only extends the sweep upwards over Simlock's own consoles (5586-5682). That is
+ *   what it is for -- on such a build it is the only thing that makes Simlock's own
+ *   emulators discoverable and re-attachable by the scanner that cannot be turned off.
+ *   Where `ADB_EMU=0` is honoured it does nothing at all, in either direction.
  * - `ADB_REJECT_KILL_SERVER=1` makes `adb kill-server` refuse -- including for Simlock, which
  *   is why this server is stopped by pid and why its pid is recorded on disk.
  */
@@ -50,6 +53,12 @@ const SCOPED_ENVIRONMENT = {
 export interface AdbServerRecord {
   readonly pid: number;
   readonly port: number;
+  /**
+   * When this server was started, for a human reading the file or a bug report. Nothing
+   * decides anything from it, deliberately: identity is proven from the process's command
+   * line (`#identify`), and a timestamp compared against this daemon's own boot time would
+   * call every correctly adopted server stale, since an adopted one always predates it.
+   */
   readonly startedAt: number;
 }
 
@@ -109,15 +118,20 @@ export class AdbServerSupervisor {
     const record = await this.#liveRecord();
     if (await this.#options.tcpProbe.isListening(this.#options.port)) {
       if (record === undefined) {
+        // The one state with no automatic way out, so the message is the recovery
+        // documentation: `adb kill-server` is refused by design and the record file that
+        // would have carried the pid is not there, which leaves the port and a human.
         throw this.#unavailable(
           "occupied",
-          `something is already listening on port ${this.#options.port} and Simlock has no record of starting it`,
+          `something is already listening on port ${this.#options.port} and Simlock has no record of starting it, so it will not attach to it. ` +
+            `Either stop that server (\`lsof -nP -iTCP:${this.#options.port} -sTCP:LISTEN\` names the pid; \`adb kill-server\` will not work) ` +
+            `or move Simlock's own with \`simlock config set drivers.android.adbServerPort <port>\``,
         );
       }
 
-      // Adopted: a daemon died, its server did not. The record is the proof of ownership,
-      // so it is kept exactly as it was -- rewriting `startedAt` would erase the one hint
-      // available for spotting a recycled pid later.
+      // Adopted: a daemon died, its server did not. The record is kept byte for byte --
+      // it is what a later reap identifies this server by, and rewriting it here would
+      // replace a fact about the server with a fact about this daemon.
       this.#record = record;
       return;
     }
@@ -187,23 +201,33 @@ export class AdbServerSupervisor {
   }
 
   /**
-   * Ends the recorded process, but only once it has proven to be an adb server.
+   * Ends the recorded process, but only once it has proven to be *this* server.
    *
    * A pid alone identifies nothing. After a reboot or heavy pid churn the number in a
    * stale record belongs to somebody else's process, and `isAlive` says "yes" about it just
    * as readily -- so signalling on the strength of the record would eventually SIGKILL a
    * stranger's process on the user's machine. The identity check is repeated before the
    * SIGKILL because the process may have exited and its pid been reused in between.
+   *
+   * An inconclusive check keeps the record. The other direction looks tidier and is worse:
+   * the record is the only handle anything has on a server that refuses `adb kill-server`,
+   * and a start that finds the port listening with no record has nowhere left to go but
+   * `occupied` -- so deleting a record Simlock could not read the process table for would
+   * disable Android on that host until somebody found the pid by hand.
    */
   async #reap(record: AdbServerRecord): Promise<void> {
-    if (!(await this.#isAdbProcess(record.pid))) {
+    const identity = await this.#identify(record.pid);
+    if (identity === "unknown") {
+      return;
+    }
+    if (identity === "other") {
       await this.#forgetRecord();
       return;
     }
 
     this.#options.processSupervisor.signal(record.pid, "SIGTERM");
     if (!(await this.#waitForExit(record.pid))) {
-      if (await this.#isAdbProcess(record.pid)) {
+      if ((await this.#identify(record.pid)) === "own-server") {
         this.#options.processSupervisor.signal(record.pid, "SIGKILL");
         await this.#waitForExit(record.pid);
       }
@@ -213,28 +237,55 @@ export class AdbServerSupervisor {
   }
 
   /**
-   * Whether this pid is an adb server, read from the process table. `ps -o comm= -p` prints
-   * the command with no arguments and nothing else, and prints nothing at all for a pid
-   * that is gone; macOS reports it as a path, Linux as a bare name, so only the basename is
-   * comparable. Any failure answers "not adb", which is the fail-closed direction: it costs
-   * a leftover server, where the other direction costs somebody else's process.
+   * What the process table says this pid is, read as a full command line.
+   *
+   * `-o comm=` would be the obvious flag and is the wrong one: it strips the arguments,
+   * which are the only thing that separates Simlock's server from the machine's shared one.
+   * "Some adb" is exactly the population a recycled pid is most likely to land in on a
+   * developer's machine, and signalling on that evidence would SIGKILL the adb server
+   * Android Studio and every other tool are sharing. `-o args=` (`command` on some BSD
+   * `ps`) keeps them, so ownership can be required rather than assumed: an adb binary, the
+   * `-P <port>` this supervisor configured, and `nodaemon`.
+   *
+   * The three answers are deliberately distinct, and only a command line that was actually
+   * read counts as `"other"` -- the stale record to drop. Everything else is `"unknown"`,
+   * where the record must survive (see `#reap`): a `ps` that is missing, not on `PATH`, too
+   * slow, or too small to know `-o args=` (BusyBox) all report as failures indistinguishable
+   * from "no such pid", and guessing "gone" from an exit code would delete the record on
+   * every shutdown on such a host.
    */
-  async #isAdbProcess(pid: number): Promise<boolean> {
+  async #identify(pid: number): Promise<"own-server" | "other" | "unknown"> {
     let result;
     try {
-      result = await this.#options.processRunner.run("ps", ["-o", "comm=", "-p", String(pid)], {
+      result = await this.#options.processRunner.run("ps", ["-o", "args=", "-p", String(pid)], {
         timeoutMs: IDENTITY_TIMEOUT_MS,
       });
     } catch {
-      return false;
+      return "unknown";
     }
 
     if (result.code !== 0) {
-      return false;
+      return "unknown";
     }
 
-    const command = result.stdout.split("\n")[0]?.trim() ?? "";
-    return command !== "" && basename(command) === "adb";
+    const commandLine = result.stdout.split("\n")[0]?.trim() ?? "";
+    if (commandLine === "") {
+      return "unknown";
+    }
+
+    return this.#isOwnServerCommand(commandLine) ? "own-server" : "other";
+  }
+
+  /**
+   * Matched on the raw line rather than on split arguments because an SDK path may contain
+   * spaces, and `ps` gives no way to tell those apart from argument separators.
+   */
+  #isOwnServerCommand(commandLine: string): boolean {
+    return (
+      /(?:^|[\s/])adb(?:\.exe)?(?=\s)/.test(commandLine) &&
+      new RegExp(`(?:^|\\s)-P\\s+${this.#options.port}(?=\\s|$)`).test(commandLine) &&
+      /(?:^|\s)nodaemon(?=\s|$)/.test(commandLine)
+    );
   }
 
   async #startServer(): Promise<void> {
@@ -245,38 +296,97 @@ export class AdbServerSupervisor {
     // `stdio: "ignore"` because this child outlives every call made to it: captured output
     // would accumulate in the handle's buffers for as long as the daemon runs, and there is
     // nothing to read it. Diagnosis happens through the probe and the record instead.
-    const handle = this.#options.processRunner.spawn(
-      this.#options.adbPath,
-      ["-P", String(this.#options.port), "nodaemon", "server"],
-      {
-        env: {
-          ...this.#options.env,
-          ...SCOPED_ENVIRONMENT,
-          ANDROID_ADB_SERVER_PORT: String(this.#options.port),
+    let handle;
+    try {
+      handle = this.#options.processRunner.spawn(
+        this.#options.adbPath,
+        ["-P", String(this.#options.port), "nodaemon", "server"],
+        {
+          env: {
+            ...this.#options.env,
+            ...SCOPED_ENVIRONMENT,
+            ANDROID_ADB_SERVER_PORT: String(this.#options.port),
+          },
+          stdio: "ignore",
         },
-        stdio: "ignore",
-      },
-    );
+      );
+    } catch (error: unknown) {
+      // An `adb` that exists but cannot be executed is an Android configuration problem and
+      // must cost Android alone; letting it out untyped would take the daemon, and iOS with
+      // it, down over it.
+      throw this.#unavailable(
+        "start-failed",
+        `Simlock could not start an adb server from ${this.#options.adbPath}: ${messageOf(error)}`,
+      );
+    }
 
-    if (!(await this.#waitForListening(startedAt))) {
-      handle.kill("SIGKILL");
+    // This child is meant to outlive the daemon: it is reaped by pid, never awaited, and
+    // `nodaemon server` never exits on its own. Left referenced it would hold the event
+    // loop open forever, so a daemon that failed anywhere below would hang instead of
+    // exiting.
+    handle.unref();
+
+    const record: AdbServerRecord = { pid: handle.pid, port: this.#options.port, startedAt };
+    // Written before the wait, not after it: everything between the spawn and a listening
+    // port is a window in which this daemon can die, and without a record on disk the next
+    // one finds a listening port it has no claim on, answers `occupied`, and leaves Android
+    // dead until a human finds the pid.
+    try {
+      await this.#options.filesystem.writeFileAtomic(
+        this.#options.recordPath,
+        `${JSON.stringify(record, null, 2)}\n`,
+      );
+    } catch (error: unknown) {
+      // A server nothing can record is a server nothing can reap, so it is killed here
+      // rather than left running on the port the next start will need.
+      await this.#abandon(handle);
+      throw this.#unavailable(
+        "start-failed",
+        `Simlock started an adb server on port ${this.#options.port} but could not record it at ${this.#options.recordPath}: ${messageOf(error)}`,
+      );
+    }
+    this.#record = record;
+
+    if (!(await this.#waitForListening(startedAt, handle.pid))) {
+      this.#record = undefined;
+      await this.#abandon(handle);
       throw this.#unavailable(
         "start-failed",
         `Simlock's adb server did not start listening on port ${this.#options.port} within ${START_TIMEOUT_MS}ms`,
       );
     }
-
-    const record: AdbServerRecord = { pid: handle.pid, port: this.#options.port, startedAt };
-    this.#record = record;
-    await this.#options.filesystem.writeFileAtomic(
-      this.#options.recordPath,
-      `${JSON.stringify(record, null, 2)}\n`,
-    );
   }
 
-  async #waitForListening(startedAt: number): Promise<boolean> {
+  /**
+   * Kills a server this start is giving up on, and drops its record only once the process
+   * is confirmed gone -- while it might still be alive the record is the only handle
+   * anything has on it. A record that has since stopped naming this pid belongs to somebody
+   * else's server and is left where it is, for the same reason.
+   */
+  async #abandon(handle: ProcessHandle): Promise<void> {
+    handle.kill("SIGKILL");
+    if (!(await this.#waitForExit(handle.pid))) {
+      return;
+    }
+
+    if ((await this.#readRecord())?.pid === handle.pid) {
+      await this.#forgetRecord();
+    }
+  }
+
+  async #waitForListening(startedAt: number, pid: number): Promise<boolean> {
     while (true) {
-      if (await this.#options.tcpProbe.isListening(this.#options.port)) {
+      const listening = await this.#options.tcpProbe.isListening(this.#options.port);
+      // A loopback connect proves something is serving the port, not that it is the child
+      // just spawned. Two daemons cold-starting on one port both probe it free and both
+      // spawn; one binds, the other prints "cannot bind" and exits. Without this the loser
+      // reads the winner's server as its own success and writes a record naming its own
+      // dead pid over the winner's -- which is also how a foreign server gets adopted when
+      // two Simlock homes share a port (safety rule 9).
+      if (!this.#options.processSupervisor.isAlive(pid)) {
+        return false;
+      }
+      if (listening) {
         return true;
       }
       if (this.#options.clock.now() - startedAt >= START_TIMEOUT_MS) {
@@ -322,6 +432,10 @@ export class AdbServerSupervisor {
       this.#options.clock.setTimer(milliseconds, resolve);
     });
   }
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function isAdbServerRecord(value: unknown): value is AdbServerRecord {

--- a/src/drivers/android/index.test.ts
+++ b/src/drivers/android/index.test.ts
@@ -1,21 +1,42 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, expect, it, vi } from "vitest";
 
 import type { Driver } from "../../core/driver.js";
+import { OWNED_ROOT_MARKER_FILE, OwnedRootError } from "../../core/index.js";
 import {
   FakeClock,
+  FakeProcessSupervisor,
+  FakeTcpProbe,
   type Filesystem,
   MemoryFilesystem,
   NodeFilesystem,
   NodeProcessRunner,
+  NodeProcessSupervisor,
+  NodeTcpProbe,
   ScriptedProcessRunner,
   type ScriptedProcessExpectation,
   SystemClock,
 } from "../../ports/index.js";
-import { AndroidDriver, SdkMissingError } from "./index.js";
+import { AdbServerUnavailableError, AndroidDriver, SdkMissingError } from "./index.js";
 
 const sdk = "/android-sdk";
 const home = "/home/simlock";
-const avdDirectory = `${home}/.android/avd`;
+const simlockHome = "/home/simlock/.simlock";
+const instanceId = "instance-1";
+const adbServerPort = 5038;
+const adbServerPid = 4242;
+const adbRecordPath = `${simlockHome}/adb-server.json`;
+/** The AVD home this driver owns and proves ownership from, not the user's own. */
+const avdDirectory = `${simlockHome}/devices/android`;
+/** What every invocation the driver makes must be scoped with; see `AndroidDriver#env`. */
+const scopedEnv = {
+  ANDROID_ADB_SERVER_PORT: String(adbServerPort),
+  ANDROID_AVD_HOME: avdDirectory,
+  ANDROID_HOME: sdk,
+} as const;
+const scopedOptions = { env: scopedEnv } as const;
 const binaries = {
   adb: `${sdk}/platform-tools/adb`,
   avdmanager: `${sdk}/cmdline-tools/latest/bin/avdmanager`,
@@ -29,25 +50,37 @@ describe("AndroidDriver", () => {
     const filesystem = await androidFilesystem();
     const runner = new ScriptedProcessRunner([]);
 
+    await recordRunningAdbServer(filesystem);
     const driver = await AndroidDriver.create({
       clock: new FakeClock(),
+      driverConfig: {},
       env: {
         ANDROID_HOME: sdk,
         ANDROID_SDK_ROOT: "/ignored-sdk",
       },
       filesystem,
       homeDirectory: home,
+      instanceId,
       processRunner: runner,
+      processSupervisor: new FakeProcessSupervisor([adbServerPid]),
+      simlockHome,
+      tcpProbe: new FakeTcpProbe([adbServerPort]),
     });
 
     expect(driver.sdkPath).toBe(sdk);
+    expect(driver.deviceRoot).toBe(avdDirectory);
     await expect(
       AndroidDriver.create({
         clock: new FakeClock(),
+        driverConfig: {},
         env: {},
         filesystem: new MemoryFilesystem(),
         homeDirectory: home,
+        instanceId,
         processRunner: runner,
+        processSupervisor: new FakeProcessSupervisor(),
+        simlockHome,
+        tcpProbe: new FakeTcpProbe(),
       }),
     ).rejects.toBeInstanceOf(SdkMissingError);
   });
@@ -148,8 +181,8 @@ describe("AndroidDriver", () => {
       ]),
       processResult(binaries.emulator, ["-version"], "Android emulator version 36.1.9"),
       processResult(binaries.emulator, ["-version"], "Android emulator version 36.1.9"),
-      processResult(binaries.adb, ["devices"], "List of devices attached\nemulator-5554\tdevice\n"),
-      processResult(binaries.adb, ["devices"], "List of devices attached\nemulator-5554\tdevice\n"),
+      processResult(binaries.adb, ["devices"], "List of devices attached\nemulator-5586\tdevice\n"),
+      processResult(binaries.adb, ["devices"], "List of devices attached\nemulator-5586\tdevice\n"),
     ]);
     const first = await createDriver(firstFilesystem, runner, { ids: ["first"] });
     const second = await createDriver(secondFilesystem, runner, { ids: ["second"] });
@@ -164,21 +197,21 @@ describe("AndroidDriver", () => {
       second.provision(spec),
     ]);
 
-    expect(firstDevice.driverData).toMatchObject({ avdName: "simlock_first", port: 5556 });
-    expect(secondDevice.driverData).toMatchObject({ avdName: "simlock_second", port: 5558 });
+    expect(firstDevice.driverData).toMatchObject({ avdName: "simlock_first", port: 5588 });
+    expect(secondDevice.driverData).toMatchObject({ avdName: "simlock_second", port: 5590 });
   });
 
   it("cold boots without loading or automatically saving snapshots", async () => {
     const harness = await provisionedHarness();
 
     await expect(harness.driver.makeReady(harness.device)).resolves.toMatchObject({
-      address: "emulator-5554",
+      address: "emulator-5586",
       deviceId: "simlock_one",
     });
     expect(harness.runner.calls).toContainEqual({
-      args: ["-avd", "simlock_one", "-port", "5554", "-no-snapshot-save", "-no-snapshot-load"],
+      args: ["-avd", "simlock_one", "-port", "5586", "-no-snapshot-save", "-no-snapshot-load"],
       command: binaries.emulator,
-      options: {},
+      options: scopedOptions,
     });
   });
 
@@ -186,7 +219,7 @@ describe("AndroidDriver", () => {
     const harness = await provisionedHarness();
 
     await expect(harness.driver.makeReady(harness.device)).resolves.toMatchObject({
-      address: "emulator-5554",
+      address: "emulator-5586",
       deviceId: "simlock_one",
     });
 
@@ -195,13 +228,13 @@ describe("AndroidDriver", () => {
         "-avd",
         "simlock_one",
         "-port",
-        "5554",
+        "5586",
         "-no-snapshot-save",
         "-snapshot",
         "simlock_clean_baseline",
       ],
       command: binaries.emulator,
-      options: {},
+      options: scopedOptions,
     });
   });
 
@@ -227,9 +260,9 @@ describe("AndroidDriver", () => {
     const ready = harness.driver.makeReady(harness.device);
     await vi.waitFor(() =>
       expect(harness.runner.calls).toContainEqual({
-        args: ["-s", "emulator-5554", "shell", "getprop", "sys.boot_completed"],
+        args: ["-s", "emulator-5586", "shell", "getprop", "sys.boot_completed"],
         command: binaries.adb,
-        options: {},
+        options: scopedOptions,
       }),
     );
     harness.clock.advance(2_000);
@@ -239,19 +272,19 @@ describe("AndroidDriver", () => {
   });
 
   it("retries adb while the emulator is starting", async () => {
-    const harness = await provisionedHarness({ initialAdbFailure: true });
+    const harness = await provisionedHarness({ initialAdbFailures: 1 });
     const ready = harness.driver.makeReady(harness.device);
 
     await vi.waitFor(() =>
       expect(harness.runner.calls).toContainEqual({
-        args: ["-s", "emulator-5554", "shell", "getprop", "sys.boot_completed"],
+        args: ["-s", "emulator-5586", "shell", "getprop", "sys.boot_completed"],
         command: binaries.adb,
-        options: {},
+        options: scopedOptions,
       }),
     );
     harness.clock.advance(2_000);
 
-    await expect(ready).resolves.toMatchObject({ address: "emulator-5554" });
+    await expect(ready).resolves.toMatchObject({ address: "emulator-5586" });
   });
 
   it("invalidates stale quickboot snapshots and flags the next boot to wipe data", async () => {
@@ -286,13 +319,13 @@ describe("AndroidDriver", () => {
         "-avd",
         "simlock_one",
         "-port",
-        "5554",
+        "5586",
         "-no-snapshot-save",
         "-wipe-data",
         "-no-snapshot-load",
       ],
       command: binaries.emulator,
-      options: {},
+      options: scopedOptions,
     });
   });
 
@@ -306,9 +339,9 @@ describe("AndroidDriver", () => {
     });
 
     expect(harness.runner.calls).toContainEqual({
-      args: ["-s", "emulator-5554", "emu", "avd", "snapshot", "load", "simlock_clean_baseline"],
+      args: ["-s", "emulator-5586", "emu", "avd", "snapshot", "load", "simlock_clean_baseline"],
       command: binaries.adb,
-      options: {},
+      options: scopedOptions,
     });
     const saves = harness.runner.calls.filter((call) => call.args.includes("save"));
     expect(saves).toHaveLength(1);
@@ -329,9 +362,9 @@ describe("AndroidDriver", () => {
       strategy: "snapshot",
     });
     expect(harness.runner.calls.slice(reclaimCallStart)).not.toContainEqual({
-      args: ["-s", "emulator-5554", "emu", "kill"],
+      args: ["-s", "emulator-5586", "emu", "kill"],
       command: binaries.adb,
-      options: {},
+      options: scopedOptions,
     });
   });
 
@@ -347,20 +380,20 @@ describe("AndroidDriver", () => {
       processResult(binaries.emulator, ["-version"], "Android emulator version 36.1.9"),
       processResult(
         binaries.adb,
-        ["-s", "emulator-5554", "emu", "avd", "snapshot", "load", "simlock_clean_baseline"],
+        ["-s", "emulator-5586", "emu", "avd", "snapshot", "load", "simlock_clean_baseline"],
         "OK\n",
       ),
       processResult(
         binaries.adb,
-        ["-s", "emulator-5554", "shell", "getprop", "sys.boot_completed"],
+        ["-s", "emulator-5586", "shell", "getprop", "sys.boot_completed"],
         "1\n",
       ),
       processResult(
         binaries.adb,
-        ["-s", "emulator-5554", "shell", "getprop", "init.svc.bootanim"],
+        ["-s", "emulator-5586", "shell", "getprop", "init.svc.bootanim"],
         "",
       ),
-      markWriteExpectation("emulator-5554", "device-0"),
+      markWriteExpectation("emulator-5586", "device-0"),
     ]);
     const restartedDriver = await createDriver(harness.filesystem, restartedRunner);
 
@@ -383,7 +416,7 @@ describe("AndroidDriver", () => {
             "-avd",
             "simlock_one",
             "-port",
-            "5554",
+            "5586",
             "-no-snapshot-save",
             "-snapshot",
             "simlock_clean_baseline",
@@ -393,27 +426,27 @@ describe("AndroidDriver", () => {
       },
       processResult(
         binaries.adb,
-        ["-s", "emulator-5554", "shell", "getprop", "sys.boot_completed"],
+        ["-s", "emulator-5586", "shell", "getprop", "sys.boot_completed"],
         "1\n",
       ),
       processResult(
         binaries.adb,
-        ["-s", "emulator-5554", "shell", "getprop", "init.svc.bootanim"],
+        ["-s", "emulator-5586", "shell", "getprop", "init.svc.bootanim"],
         "",
       ),
-      markWriteExpectation("emulator-5554", "device-0"),
+      markWriteExpectation("emulator-5586", "device-0"),
     ]);
     const restartedDriver = await createDriver(harness.filesystem, restartedRunner);
 
     await expect(restartedDriver.makeReady(harness.device)).resolves.toMatchObject({
-      address: "emulator-5554",
+      address: "emulator-5586",
     });
     expect(restartedRunner.calls[1]).toMatchObject({
       args: [
         "-avd",
         "simlock_one",
         "-port",
-        "5554",
+        "5586",
         "-no-snapshot-save",
         "-snapshot",
         "simlock_clean_baseline",
@@ -439,7 +472,7 @@ describe("AndroidDriver", () => {
       processResult(binaries.emulator, ["-version"], "Android emulator version 36.1.9"),
       processResult(binaries.adb, ["devices"], "List of devices attached\n"),
       {
-        match: { args: ["-s", "emulator-5554", "emu", "kill"], command: binaries.adb },
+        match: { args: ["-s", "emulator-5586", "emu", "kill"], command: binaries.adb },
         result: { code: 1, stderr: "connection refused", stdout: "" },
       },
       processResult(binaries.avdmanager, ["delete", "avd", "-n", "simlock_delete-me"]),
@@ -534,12 +567,12 @@ describe("AndroidDriver", () => {
     await filesystem.mkdirp(`${avdDirectory}/simlock_running.avd`);
     await filesystem.mkdirp(`${avdDirectory}/simlock_stopped.avd`);
     const runner = new ScriptedProcessRunner([
-      processResult(binaries.adb, ["devices"], "List of devices attached\nemulator-5554\tdevice\n"),
+      processResult(binaries.adb, ["devices"], "List of devices attached\nemulator-5586\tdevice\n"),
       processResult(
         binaries.adb,
         [
           "-s",
-          "emulator-5554",
+          "emulator-5586",
           "shell",
           "getprop ro.boot.qemu.avd_name; cat /data/local/tmp/simlock-mark.json 2>/dev/null || true",
         ],
@@ -568,7 +601,7 @@ describe("AndroidDriver", () => {
       processResult(
         binaries.adb,
         ["devices"],
-        "List of devices attached\nemulator-5556\toffline\n",
+        "List of devices attached\nemulator-5588\toffline\n",
       ),
     ]);
     const driver = await createDriver(filesystem, runner);
@@ -616,20 +649,20 @@ describe("AndroidDriver", () => {
       processResult(binaries.emulator, ["-version"], "Android emulator version 36.1.9"),
       processResult(binaries.adb, ["devices"], "List of devices attached\n"),
       ...baselineBuildExpectations({ launchArgs: ["-no-snapshot-load"] }),
-      markWriteExpectation("emulator-5554", "device-2"),
+      markWriteExpectation("emulator-5586", "device-2"),
       // Second makeReady call: `state.handle` is still set from the first call, so this takes
       // the early-return branch -- it must still wait for readiness and rewrite the mark.
       processResult(
         binaries.adb,
-        ["-s", "emulator-5554", "shell", "getprop", "sys.boot_completed"],
+        ["-s", "emulator-5586", "shell", "getprop", "sys.boot_completed"],
         "1\n",
       ),
       processResult(
         binaries.adb,
-        ["-s", "emulator-5554", "shell", "getprop", "init.svc.bootanim"],
+        ["-s", "emulator-5586", "shell", "getprop", "init.svc.bootanim"],
         "",
       ),
-      markWriteExpectation("emulator-5554", "device-3"),
+      markWriteExpectation("emulator-5586", "device-3"),
     ]);
     const driver = await createDriver(filesystem, runner, { clock, ids: ["one"] });
     const spec = await driver.resolveSpec(
@@ -658,7 +691,7 @@ describe("AndroidDriver", () => {
     expect(config).toContain("simlock.mark=device-3");
     expect(harness.runner.calls).toContainEqual(
       expect.objectContaining({
-        args: markWriteExpectation("emulator-5554", "device-3").match.args,
+        args: markWriteExpectation("emulator-5586", "device-3").match.args,
       }),
     );
   });
@@ -710,12 +743,12 @@ describe("AndroidDriver", () => {
       config: "hw.ramSize=2048\nsimlock.mark=tok-123\n",
     });
     const runner = new ScriptedProcessRunner([
-      processResult(binaries.adb, ["devices"], "List of devices attached\nemulator-5554\tdevice\n"),
+      processResult(binaries.adb, ["devices"], "List of devices attached\nemulator-5586\tdevice\n"),
       processResult(
         binaries.adb,
         [
           "-s",
-          "emulator-5554",
+          "emulator-5586",
           "shell",
           "getprop ro.boot.qemu.avd_name; cat /data/local/tmp/simlock-mark.json 2>/dev/null || true",
         ],
@@ -739,12 +772,12 @@ describe("AndroidDriver", () => {
       config: "hw.ramSize=2048\nsimlock.mark=tok-123\n",
     });
     const runner = new ScriptedProcessRunner([
-      processResult(binaries.adb, ["devices"], "List of devices attached\nemulator-5554\tdevice\n"),
+      processResult(binaries.adb, ["devices"], "List of devices attached\nemulator-5586\tdevice\n"),
       processResult(
         binaries.adb,
         [
           "-s",
-          "emulator-5554",
+          "emulator-5586",
           "shell",
           "getprop ro.boot.qemu.avd_name; cat /data/local/tmp/simlock-mark.json 2>/dev/null || true",
         ],
@@ -768,18 +801,18 @@ describe("AndroidDriver", () => {
       config: "hw.ramSize=2048\nsimlock.mark=tok-123\n",
     });
     const runner = new ScriptedProcessRunner([
-      processResult(binaries.adb, ["devices"], "List of devices attached\nemulator-5554\tdevice\n"),
+      processResult(binaries.adb, ["devices"], "List of devices attached\nemulator-5586\tdevice\n"),
       {
         match: {
           args: [
             "-s",
-            "emulator-5554",
+            "emulator-5586",
             "shell",
             "getprop ro.boot.qemu.avd_name; cat /data/local/tmp/simlock-mark.json 2>/dev/null || true",
           ],
           command: binaries.adb,
         },
-        result: { code: 1, stderr: "device 'emulator-5554' not found", stdout: "" },
+        result: { code: 1, stderr: "device 'emulator-5586' not found", stdout: "" },
       },
     ]);
     const driver = await createDriver(filesystem, runner);
@@ -834,6 +867,209 @@ describe("AndroidDriver", () => {
   });
 });
 
+describe("AndroidDriver.create", () => {
+  it("creates and marks its own AVD home under SIMLOCK_HOME when none exists yet", async () => {
+    const filesystem = await androidFilesystem({ withDeviceRoot: false });
+    await recordRunningAdbServer(filesystem);
+
+    const driver = await createDriver(filesystem, new ScriptedProcessRunner([]));
+
+    expect(driver.deviceRoot).toBe(avdDirectory);
+    await expect(
+      filesystem.readFile(`${avdDirectory}/${OWNED_ROOT_MARKER_FILE}`),
+    ).resolves.toContain('"platform": "android"');
+  });
+
+  it("refuses a root that carries another instance's marker rather than using the user's AVDs", async () => {
+    const filesystem = await androidFilesystem({ withDeviceRoot: false });
+    await filesystem.mkdirp(avdDirectory);
+    await filesystem.writeFileAtomic(
+      `${avdDirectory}/${OWNED_ROOT_MARKER_FILE}`,
+      JSON.stringify({
+        instanceId: "someone-else",
+        owner: "simlock",
+        platform: "android",
+        schemaVersion: 1,
+      }),
+    );
+
+    await expect(createDriver(filesystem, new ScriptedProcessRunner([]))).rejects.toMatchObject({
+      name: "OwnedRootError",
+      reason: "wrong-instance",
+    });
+  });
+
+  it("refuses a deviceRoot that is not a path at all, costing android and not the daemon", async () => {
+    const filesystem = await androidFilesystem({ withDeviceRoot: false });
+
+    const refusal = await createDriver(filesystem, new ScriptedProcessRunner([]), {
+      driverConfig: { deviceRoot: true },
+    }).catch((error: unknown) => error);
+
+    expect(refusal).toBeInstanceOf(OwnedRootError);
+    expect(refusal).toMatchObject({ platform: "android", reason: "not-absolute" });
+  });
+
+  it("refuses an adbServerPort that is not a port number", async () => {
+    const filesystem = await androidFilesystem();
+
+    const refusal = await createDriver(filesystem, new ScriptedProcessRunner([]), {
+      driverConfig: { adbServerPort: "5038" },
+    }).catch((error: unknown) => error);
+
+    expect(refusal).toBeInstanceOf(AdbServerUnavailableError);
+    expect(refusal).toMatchObject({ reason: "invalid-port" });
+  });
+
+  it("refuses to attach to a server on its port that it has no record of starting", async () => {
+    const filesystem = await androidFilesystem();
+
+    const refusal = await AndroidDriver.create({
+      clock: new FakeClock(),
+      driverConfig: {},
+      env: { ANDROID_HOME: sdk },
+      filesystem,
+      homeDirectory: home,
+      instanceId,
+      processRunner: new ScriptedProcessRunner([]),
+      processSupervisor: new FakeProcessSupervisor(),
+      simlockHome,
+      // Listening, but nothing says it is Simlock's -- it could be Android Studio's.
+      tcpProbe: new FakeTcpProbe([adbServerPort]),
+    }).catch((error: unknown) => error);
+
+    expect(refusal).toMatchObject({ port: adbServerPort, reason: "occupied" });
+  });
+
+  it("hands a lease holder the adb server port, and scopes its own calls to a configured one", async () => {
+    const filesystem = await androidFilesystem();
+    const runner = new ScriptedProcessRunner([
+      processResult(binaries.avdmanager, ["list", "device"], pixelDevices),
+    ]);
+    const driver = await createDriver(filesystem, runner, {
+      driverConfig: { adbServerPort: 5199 },
+    });
+
+    expect(driver.leaseEnvironment()).toEqual({ ANDROID_ADB_SERVER_PORT: "5199" });
+    await driver.resolveSpec({ model: "Pixel 8", platform: "android" }, { allowDownload: false });
+    expect(runner.calls[0]?.options).toEqual({
+      env: { ...scopedEnv, ANDROID_ADB_SERVER_PORT: "5199" },
+    });
+  });
+
+  it("stops the adb server it adopted when the daemon disposes of it", async () => {
+    const filesystem = await androidFilesystem();
+    const processSupervisor = new FakeProcessSupervisor([adbServerPid]);
+    await recordRunningAdbServer(filesystem);
+    const driver = await AndroidDriver.create({
+      clock: new FakeClock(),
+      driverConfig: {},
+      env: { ANDROID_HOME: sdk },
+      filesystem,
+      homeDirectory: home,
+      instanceId,
+      processRunner: new ScriptedProcessRunner([
+        {
+          match: { args: ["-o", "comm=", "-p", String(adbServerPid)], command: "ps" },
+          result: { code: 0, stderr: "", stdout: "adb\n" },
+        },
+      ]),
+      processSupervisor,
+      simlockHome,
+      tcpProbe: new FakeTcpProbe([adbServerPort]),
+    });
+    processSupervisor.markDead(adbServerPid);
+
+    await driver.dispose();
+
+    // By pid, because `ADB_REJECT_KILL_SERVER=1` means `adb kill-server` refuses Simlock too.
+    expect(processSupervisor.signals).toEqual([{ pid: adbServerPid, signal: "SIGTERM" }]);
+    await expect(filesystem.exists(adbRecordPath)).resolves.toBe(false);
+  });
+});
+
+describe("AndroidDriver ownership", () => {
+  it("manages every AVD in its root, whatever the AVD is called", async () => {
+    const filesystem = await androidFilesystem();
+    await filesystem.mkdirp(`${avdDirectory}/a-name-nobody-prefixed.avd`);
+    const runner = new ScriptedProcessRunner([
+      processResult(binaries.adb, ["devices"], "List of devices attached\n"),
+    ]);
+    const driver = await createDriver(filesystem, runner);
+
+    const reality = await driver.listManaged();
+
+    expect(reality.devices.map((device) => device.deviceId)).toEqual(["a-name-nobody-prefixed"]);
+  });
+
+  it("ignores a running emulator whose AVD does not live in its root", async () => {
+    const filesystem = await androidFilesystem();
+    await filesystem.mkdirp(`${avdDirectory}/simlock_mine.avd`);
+    const runner = new ScriptedProcessRunner([
+      processResult(binaries.adb, ["devices"], "List of devices attached\nemulator-5586\tdevice\n"),
+      processResult(
+        binaries.adb,
+        ["-s", "emulator-5586", "shell", /getprop ro\.boot\.qemu\.avd_name/],
+        // Named exactly like one of Simlock's, and still not Simlock's: the AVD is not in
+        // the root, and ownership is proven from the root rather than from the name or from
+        // the fact that Simlock's own server can see it.
+        "simlock_impostor\n",
+      ),
+    ]);
+    const driver = await createDriver(filesystem, runner);
+
+    const reality = await driver.listManaged();
+
+    expect(reality.processes).toEqual([]);
+    expect(reality.devices).toEqual([
+      expect.objectContaining({ deviceId: "simlock_mine", runState: "stopped" }),
+    ]);
+  });
+});
+
+describe("AndroidDriver emulator registration", () => {
+  it("announces a freshly started emulator to Simlock's own adb server", async () => {
+    const harness = await provisionedHarness();
+
+    await harness.driver.makeReady(harness.device);
+
+    // The adb port is the console port + 1, and with the scanner off this announcement is
+    // what attaches the emulator at all.
+    expect(harness.tcpProbe.sends).toContainEqual({
+      payload: "0012host:emulator:5587",
+      port: adbServerPort,
+    });
+  });
+
+  it("re-announces an emulator that stays unreachable, since nothing else will", async () => {
+    const harness = await provisionedHarness({ initialAdbFailures: 2 });
+    const ready = harness.driver.makeReady(harness.device);
+    await vi.waitFor(() => expect(bootProbes(harness.runner)).toBe(1));
+
+    // Past the grace period on the second failure: adb's own reconnect queue is drained by
+    // the scanner thread, which `ADB_EMU=0` does not run.
+    harness.clock.advance(6_000);
+    await vi.waitFor(() => expect(bootProbes(harness.runner)).toBe(2));
+    await vi.waitFor(() => expect(harness.tcpProbe.sends).toHaveLength(2));
+
+    harness.clock.advance(2_000);
+    await expect(ready).resolves.toMatchObject({ address: "emulator-5586" });
+  });
+
+  it("never fails a boot because a registration failed", async () => {
+    const harness = await provisionedHarness();
+    harness.tcpProbe.failSendsWith(new Error("connect ECONNREFUSED"));
+
+    await expect(harness.driver.makeReady(harness.device)).resolves.toMatchObject({
+      deviceId: "simlock_one",
+    });
+  });
+});
+
+function bootProbes(runner: ScriptedProcessRunner): number {
+  return runner.calls.filter((call) => call.args.includes("sys.boot_completed")).length;
+}
+
 const live = process.env.SIMLOCK_LIVE_ANDROID === "1" ? it : it.skip;
 
 live(
@@ -841,10 +1077,15 @@ live(
   async () => {
     const driver = await AndroidDriver.create({
       clock: new SystemClock(),
+      driverConfig: {},
       env: process.env,
       filesystem: new NodeFilesystem(),
       homeDirectory: process.env.HOME ?? home,
+      instanceId: `live-${process.pid}`,
       processRunner: new NodeProcessRunner(),
+      processSupervisor: new NodeProcessSupervisor(),
+      simlockHome: join(tmpdir(), `simlock-live-android-${process.pid}`),
+      tcpProbe: new NodeTcpProbe(),
     });
     const spec = await driver.resolveSpec(
       {
@@ -881,11 +1122,12 @@ async function provisionedHarness(
     readonly forBaselineReclaim?: boolean;
     readonly forFullCleanBoot?: boolean;
     readonly forReclaim?: boolean;
-    readonly initialAdbFailure?: boolean;
+    readonly initialAdbFailures?: number;
     readonly readinessTimeoutMs?: number;
   } = {},
 ) {
   const filesystem = await androidFilesystem({ config: "hw.ramSize=2048\n" });
+  const tcpProbe = new FakeTcpProbe([adbServerPort]);
   const clock = new FakeClock();
   const expectations: ScriptedProcessExpectation[] = [
     processResult(binaries.avdmanager, ["list", "device"], pixelDevices),
@@ -911,26 +1153,26 @@ async function provisionedHarness(
   if (options.forReclaim === true) {
     expectations.push(
       processResult(binaries.emulator, ["-version"], "Android emulator version 36.1.9"),
-      processResult(binaries.adb, ["-s", "emulator-5554", "emu", "kill"]),
+      processResult(binaries.adb, ["-s", "emulator-5586", "emu", "kill"]),
       ...baselineBuildExpectations({ launchArgs: ["-wipe-data", "-no-snapshot-load"] }),
-      markWriteExpectation("emulator-5554", firstMarkToken),
+      markWriteExpectation("emulator-5586", firstMarkToken),
     );
   } else if (options.forFullCleanBoot === true) {
     expectations.push(
-      processResult(binaries.adb, ["-s", "emulator-5554", "emu", "kill"]),
+      processResult(binaries.adb, ["-s", "emulator-5586", "emu", "kill"]),
       ...baselineBuildExpectations({ launchArgs: ["-wipe-data", "-no-snapshot-load"] }),
-      markWriteExpectation("emulator-5554", firstMarkToken),
+      markWriteExpectation("emulator-5586", firstMarkToken),
     );
   } else {
     expectations.push(
       ...baselineBuildExpectations({
         bootCompleted: options.bootCompleted,
-        initialAdbFailure: options.initialAdbFailure,
+        initialAdbFailures: options.initialAdbFailures,
         launchArgs: ["-no-snapshot-load"],
       }),
     );
     if ((options.bootCompleted ?? "1\n").trim() === "1") {
-      expectations.push(markWriteExpectation("emulator-5554", firstMarkToken));
+      expectations.push(markWriteExpectation("emulator-5586", firstMarkToken));
     }
   }
 
@@ -939,20 +1181,20 @@ async function provisionedHarness(
       processResult(binaries.emulator, ["-version"], "Android emulator version 36.1.9"),
       processResult(
         binaries.adb,
-        ["-s", "emulator-5554", "emu", "avd", "snapshot", "load", "simlock_clean_baseline"],
+        ["-s", "emulator-5586", "emu", "avd", "snapshot", "load", "simlock_clean_baseline"],
         "OK\n",
       ),
       processResult(
         binaries.adb,
-        ["-s", "emulator-5554", "shell", "getprop", "sys.boot_completed"],
+        ["-s", "emulator-5586", "shell", "getprop", "sys.boot_completed"],
         "1\n",
       ),
       processResult(
         binaries.adb,
-        ["-s", "emulator-5554", "shell", "getprop", "init.svc.bootanim"],
+        ["-s", "emulator-5586", "shell", "getprop", "init.svc.bootanim"],
         "",
       ),
-      markWriteExpectation("emulator-5554", secondMarkToken),
+      markWriteExpectation("emulator-5586", secondMarkToken),
     );
   }
 
@@ -963,6 +1205,7 @@ async function provisionedHarness(
     ...(options.readinessTimeoutMs === undefined
       ? {}
       : { readinessTimeoutMs: options.readinessTimeoutMs }),
+    tcpProbe,
   });
   const spec = await driver.resolveSpec(
     { model: "Pixel 8", osVersion: "34", platform: "android" },
@@ -970,21 +1213,37 @@ async function provisionedHarness(
   );
   const device = await driver.provision(spec);
 
-  return { clock, device, driver, filesystem, runner };
+  return { clock, device, driver, filesystem, runner, tcpProbe };
 }
 
+/**
+ * A driver whose adb server is already running and recorded, so `create` adopts it: that is
+ * the one start-up path that spawns nothing, which keeps the scripted process expectations
+ * in every test about the behaviour the test is actually for. The start, reap, and refusal
+ * paths are covered against the supervisor itself in `adb-server.test.ts`, and end to end
+ * in this file's own `AndroidDriver.create` block.
+ */
 async function createDriver(
   filesystem: Filesystem,
   processRunner: ScriptedProcessRunner,
   options: {
     readonly clock?: FakeClock;
+    readonly driverConfig?: Readonly<Record<string, string | number | boolean>>;
     readonly ids?: readonly string[];
     readonly readinessTimeoutMs?: number;
+    readonly tcpProbe?: FakeTcpProbe;
   } = {},
 ) {
   let nextId = 0;
+  const driverConfig = options.driverConfig ?? {};
+  const configuredPort =
+    typeof driverConfig["adbServerPort"] === "number"
+      ? driverConfig["adbServerPort"]
+      : adbServerPort;
+  await recordRunningAdbServer(filesystem, configuredPort);
   return AndroidDriver.create({
     clock: options.clock ?? new FakeClock(),
+    driverConfig,
     env: { ANDROID_HOME: sdk },
     filesystem,
     homeDirectory: home,
@@ -992,17 +1251,31 @@ async function createDriver(
     idGenerator: {
       generate: () => options.ids?.[nextId++] ?? `device-${nextId}`,
     },
+    instanceId,
     ...(options.readinessTimeoutMs === undefined
       ? {}
       : { readinessTimeoutMs: options.readinessTimeoutMs }),
     processRunner,
+    processSupervisor: new FakeProcessSupervisor([adbServerPid]),
+    simlockHome,
+    tcpProbe: options.tcpProbe ?? new FakeTcpProbe([configuredPort]),
   });
+}
+
+/** The `adb-server.json` a previous daemon would have left behind for the adoption above. */
+async function recordRunningAdbServer(filesystem: Filesystem, port = adbServerPort): Promise<void> {
+  await filesystem.mkdirp(simlockHome);
+  await filesystem.writeFileAtomic(
+    adbRecordPath,
+    JSON.stringify({ pid: adbServerPid, port, startedAt: 1 }),
+  );
 }
 
 async function androidFilesystem(
   options: {
     readonly config?: string;
     readonly images?: readonly (readonly [string, string, string])[];
+    readonly withDeviceRoot?: boolean;
   } = {},
 ): Promise<MemoryFilesystem> {
   const filesystem = new MemoryFilesystem();
@@ -1010,7 +1283,16 @@ async function androidFilesystem(
     await filesystem.mkdirp(binary.slice(0, binary.lastIndexOf("/")));
     await filesystem.writeFileAtomic(binary, "binary");
   }
-  await filesystem.mkdirp(avdDirectory);
+  // Marked, so `ensureOwnedRoot` adopts it rather than creating one -- a root Simlock
+  // created in an earlier run is the ordinary case, and it keeps the id generator's first
+  // value available for the AVD name the tests assert on.
+  if (options.withDeviceRoot !== false) {
+    await filesystem.mkdirp(avdDirectory);
+    await filesystem.writeFileAtomic(
+      `${avdDirectory}/${OWNED_ROOT_MARKER_FILE}`,
+      JSON.stringify({ instanceId, owner: "simlock", platform: "android", schemaVersion: 1 }),
+    );
+  }
   for (const [api, tag, abi] of options.images ?? [["34", "google_apis", "arm64-v8a"]]) {
     await filesystem.mkdirp(`${sdk}/system-images/android-${api}/${tag}/${abi}`);
   }
@@ -1023,7 +1305,7 @@ async function androidFilesystem(
 
 function baselineBuildExpectations(options: {
   readonly bootCompleted?: string | undefined;
-  readonly initialAdbFailure?: boolean | undefined;
+  readonly initialAdbFailures?: number | undefined;
   readonly launchArgs: readonly string[];
 }): ScriptedProcessExpectation[] {
   const bootCompleted = options.bootCompleted ?? "1\n";
@@ -1031,15 +1313,15 @@ function baselineBuildExpectations(options: {
     {
       hangs: bootCompleted.trim() !== "1",
       match: {
-        args: ["-avd", "simlock_one", "-port", "5554", "-no-snapshot-save", ...options.launchArgs],
+        args: ["-avd", "simlock_one", "-port", "5586", "-no-snapshot-save", ...options.launchArgs],
         command: binaries.emulator,
       },
     },
   ];
-  if (options.initialAdbFailure === true) {
+  for (let failure = 0; failure < (options.initialAdbFailures ?? 0); failure += 1) {
     expectations.push({
       match: {
-        args: ["-s", "emulator-5554", "shell", "getprop", "sys.boot_completed"],
+        args: ["-s", "emulator-5586", "shell", "getprop", "sys.boot_completed"],
         command: binaries.adb,
       },
       result: { code: 1, stderr: "connection refused", stdout: "" },
@@ -1048,7 +1330,7 @@ function baselineBuildExpectations(options: {
   expectations.push(
     processResult(
       binaries.adb,
-      ["-s", "emulator-5554", "shell", "getprop", "sys.boot_completed"],
+      ["-s", "emulator-5586", "shell", "getprop", "sys.boot_completed"],
       bootCompleted,
     ),
   );
@@ -1059,12 +1341,12 @@ function baselineBuildExpectations(options: {
   expectations.push(
     processResult(
       binaries.adb,
-      ["-s", "emulator-5554", "shell", "getprop", "init.svc.bootanim"],
+      ["-s", "emulator-5586", "shell", "getprop", "init.svc.bootanim"],
       "",
     ),
     processResult(binaries.adb, [
       "-s",
-      "emulator-5554",
+      "emulator-5586",
       "emu",
       "avd",
       "snapshot",
@@ -1073,11 +1355,11 @@ function baselineBuildExpectations(options: {
     ]),
     processResult(
       binaries.adb,
-      ["-s", "emulator-5554", "emu", "avd", "snapshot", "list"],
+      ["-s", "emulator-5586", "emu", "avd", "snapshot", "list"],
       "simlock_clean_baseline\n",
     ),
     processResult(binaries.emulator, ["-version"], "Android emulator version 36.1.9"),
-    processResult(binaries.adb, ["-s", "emulator-5554", "emu", "kill"]),
+    processResult(binaries.adb, ["-s", "emulator-5586", "emu", "kill"]),
     {
       hangs: true,
       match: {
@@ -1085,7 +1367,7 @@ function baselineBuildExpectations(options: {
           "-avd",
           "simlock_one",
           "-port",
-          "5554",
+          "5586",
           "-no-snapshot-save",
           "-snapshot",
           "simlock_clean_baseline",
@@ -1095,12 +1377,12 @@ function baselineBuildExpectations(options: {
     },
     processResult(
       binaries.adb,
-      ["-s", "emulator-5554", "shell", "getprop", "sys.boot_completed"],
+      ["-s", "emulator-5586", "shell", "getprop", "sys.boot_completed"],
       "1\n",
     ),
     processResult(
       binaries.adb,
-      ["-s", "emulator-5554", "shell", "getprop", "init.svc.bootanim"],
+      ["-s", "emulator-5586", "shell", "getprop", "init.svc.bootanim"],
       "",
     ),
   );

--- a/src/drivers/android/index.test.ts
+++ b/src/drivers/android/index.test.ts
@@ -199,6 +199,13 @@ describe("AndroidDriver", () => {
 
     expect(firstDevice.driverData).toMatchObject({ avdName: "simlock_first", port: 5588 });
     expect(secondDevice.driverData).toMatchObject({ avdName: "simlock_second", port: 5590 });
+    // Occupancy is read from Simlock's own server, not the machine's shared one: an
+    // unscoped `adb devices` polls 5037, which reports the user's emulators and none of
+    // Simlock's, so every console port would read free and collide on the next boot.
+    expect(runner.calls.filter((call) => call.args[0] === "devices")).toEqual([
+      { args: ["devices"], command: binaries.adb, options: scopedOptions },
+      { args: ["devices"], command: binaries.adb, options: scopedOptions },
+    ]);
   });
 
   it("cold boots without loading or automatically saving snapshots", async () => {
@@ -253,6 +260,7 @@ describe("AndroidDriver", () => {
           kills.push(signal ?? "SIGTERM");
           kill(signal);
         },
+        unref: () => handle.unref(),
         wait: () => handle.wait(),
       };
     });
@@ -970,8 +978,12 @@ describe("AndroidDriver.create", () => {
       instanceId,
       processRunner: new ScriptedProcessRunner([
         {
-          match: { args: ["-o", "comm=", "-p", String(adbServerPid)], command: "ps" },
-          result: { code: 0, stderr: "", stdout: "adb\n" },
+          match: { args: ["-o", "args=", "-p", String(adbServerPid)], command: "ps" },
+          result: {
+            code: 0,
+            stderr: "",
+            stdout: `${binaries.adb} -P ${adbServerPort} nodaemon server\n`,
+          },
         },
       ]),
       processSupervisor,
@@ -1028,29 +1040,55 @@ describe("AndroidDriver ownership", () => {
 });
 
 describe("AndroidDriver emulator registration", () => {
-  it("announces a freshly started emulator to Simlock's own adb server", async () => {
-    const harness = await provisionedHarness();
+  it("sweeps its own console range when it takes over a server, and nobody else's", async () => {
+    // A running emulator announced itself exactly once, to a server a previous daemon has
+    // since reaped. With `ADB_EMU=0` nothing rediscovers it, so `simlock daemon stop` would
+    // otherwise orphan gigabytes of RSS the driver can no longer see, and hand the console
+    // port it is sitting on to the next emulator, which then cannot bind.
+    const filesystem = await androidFilesystem();
+    const tcpProbe = new FakeTcpProbe([adbServerPort]);
+    await createDriver(filesystem, new ScriptedProcessRunner([]), { tcpProbe });
 
-    await harness.driver.makeReady(harness.device);
+    const announced = tcpProbe.sends.map((send) => send.payload);
+    expect(announced).toHaveLength(49);
+    expect(announced[0]).toBe("0012host:emulator:5587");
+    expect(announced.at(-1)).toBe("0012host:emulator:5683");
+    // Every send goes to Simlock's own server, and every port is inside Simlock's range:
+    // one below 5587 would be adb connecting to an emulator of the user's.
+    expect(tcpProbe.sends.every((send) => send.port === adbServerPort)).toBe(true);
+  });
 
-    // The adb port is the console port + 1, and with the scanner off this announcement is
-    // what attaches the emulator at all.
-    expect(harness.tcpProbe.sends).toContainEqual({
-      payload: "0012host:emulator:5587",
-      port: adbServerPort,
-    });
+  it("finishes the sweep when a port refuses the announcement", async () => {
+    const filesystem = await androidFilesystem();
+    const tcpProbe = new FakeTcpProbe([adbServerPort]);
+    tcpProbe.failSendsWith(new Error("connect ECONNREFUSED"));
+
+    // The whole range is unreachable here; nothing about starting Android depends on it.
+    await expect(
+      createDriver(filesystem, new ScriptedProcessRunner([]), { tcpProbe }),
+    ).resolves.toBeDefined();
+    expect(tcpProbe.sends).toHaveLength(49);
   });
 
   it("re-announces an emulator that stays unreachable, since nothing else will", async () => {
     const harness = await provisionedHarness({ initialAdbFailures: 2 });
+    // Nothing is announced when an emulator is spawned: adb answers `host:emulator:<port>`
+    // by connecting out to that port, and the emulator has not opened it yet.
+    const afterSweep = harness.tcpProbe.sends.length;
     const ready = harness.driver.makeReady(harness.device);
     await vi.waitFor(() => expect(bootProbes(harness.runner)).toBe(1));
+    expect(harness.tcpProbe.sends).toHaveLength(afterSweep);
 
     // Past the grace period on the second failure: adb's own reconnect queue is drained by
     // the scanner thread, which `ADB_EMU=0` does not run.
     harness.clock.advance(6_000);
     await vi.waitFor(() => expect(bootProbes(harness.runner)).toBe(2));
-    await vi.waitFor(() => expect(harness.tcpProbe.sends).toHaveLength(2));
+    await vi.waitFor(() =>
+      expect(harness.tcpProbe.sends.slice(afterSweep)).toEqual([
+        // The adb port is the console port + 1.
+        { payload: "0012host:emulator:5587", port: adbServerPort },
+      ]),
+    );
 
     harness.clock.advance(2_000);
     await expect(ready).resolves.toMatchObject({ address: "emulator-5586" });

--- a/src/drivers/android/index.ts
+++ b/src/drivers/android/index.ts
@@ -1,3 +1,5 @@
+import { join } from "node:path";
+
 import type { DeviceSpec } from "../../core/domain.js";
 import {
   BootTimeoutError,
@@ -14,6 +16,7 @@ import {
   RuntimeMissingError,
   UnknownModelError,
 } from "../../core/driver.js";
+import { ensureOwnedRoot, OwnedRootError } from "../../core/index.js";
 import type {
   Clock,
   Filesystem,
@@ -21,14 +24,33 @@ import type {
   ProcessHandle,
   ProcessResult,
   ProcessRunner,
+  ProcessSupervisor,
+  TcpProbe,
 } from "../../ports/index.js";
+import { AdbRegistrar } from "./adb-registrar.js";
+import { AdbServerSupervisor, AdbServerUnavailableError } from "./adb-server.js";
 import { isAndroidDriverData, type AndroidDriverData } from "./data.js";
+
+export { AdbServerUnavailableError } from "./adb-server.js";
 
 const DEFAULT_READINESS_TIMEOUT_MS = 180_000;
 const COLD_BOOT_ESTIMATE_MS = 31_000;
+// Console ports, even ones only, each paired with the odd adb port above it. The range
+// starts above the 5585 ceiling a default adb server scans, so the user's server and
+// Android Studio cannot see, drive, or kill a Simlock emulator (ADR 0001, decision 4).
+// It also repairs the old 5554-5682 range, which was broken at both ends: the bottom
+// competed for the user's own emulators, and everything above 5585 read as free to the
+// allocator below -- which derives occupancy from `adb devices` -- because no server
+// could report a device up there. Simlock's own server scans to 5683, so it can.
 const PORT_MAX = 5682;
-const PORT_MIN = 5554;
+const PORT_MIN = 5586;
 const PORT_POLL_INTERVAL_MS = 2_000;
+const DEFAULT_ADB_SERVER_PORT = 5038;
+// After this long without an answer from a serial, the emulator's own registration is
+// assumed lost and Simlock re-sends it. Long enough that a normally-booting emulator has
+// already attached, short enough that a lost announcement costs seconds, not the whole
+// readiness timeout.
+const REGISTRATION_RETRY_AFTER_MS = 5_000;
 const SDK_DOWNLOAD_TIMEOUT_MS = 20 * 60_000;
 // A defense-in-depth bound on the wait that follows a SIGKILL: NodeProcessHandle#wait
 // already settles shortly after `exit`, but this keeps a pathologically slow reap
@@ -58,14 +80,25 @@ const ERASABLE_MARK_PATH = "/data/local/tmp/simlock-mark.json";
 
 export interface AndroidDriverOptions {
   readonly clock: Clock;
+  /** This driver's own `drivers.android` block, handed over unread by the core. */
+  readonly driverConfig: Readonly<Record<string, string | number | boolean>>;
+  /** The environment every scoped invocation is layered on top of; `process.env` in production. */
   readonly env: Readonly<Record<string, string | undefined>>;
   readonly filesystem: Filesystem;
   readonly homeDirectory: string;
   readonly hostAbi?: string;
   readonly idGenerator?: IdGenerator;
+  /** Identity this driver's device root ownership marker is checked against. */
+  readonly instanceId: string;
   readonly onDiagnostic?: (diagnostic: AndroidDriverDiagnostic) => void;
   readonly processRunner: ProcessRunner;
+  readonly processSupervisor: ProcessSupervisor;
   readonly readinessTimeoutMs?: number;
+  /** `SIMLOCK_HOME`: the default device root and the adb server record are derived here, not in the core. */
+  readonly simlockHome: string;
+  readonly tcpProbe: TcpProbe;
+  /** `process.getuid?.()`; `undefined` skips the root's ownership check. */
+  readonly uid?: number;
 }
 
 export interface AndroidDriverDiagnostic {
@@ -114,16 +147,12 @@ const allocationsByRunner = new WeakMap<ProcessRunner, PortAllocator>();
 
 export class AndroidDriver implements Driver {
   readonly platform = "android" as const;
-  /**
-   * Placeholder until this driver owns a validated AVD home and a private adb server
-   * (ADR 0001, decision 4). Deliberately not `#avdDirectory`: that is wherever the user's
-   * own AVDs already live, and naming it here would claim an ownership Simlock has not
-   * proven for it. Nothing reads either member yet.
-   */
-  // fallow-ignore-next-line unused-class-member -- Driver.deviceRoot contract; read by doctor --purge-orphans to say which root an orphan came from.
-  readonly deviceRoot = "/simlock-android-device-root-pending";
+  readonly #adbServer: AdbServerSupervisor;
+  readonly #adbServerPort: number;
+  readonly #baseEnv: Readonly<Record<string, string | undefined>>;
   readonly #clock: Clock;
   readonly #devices = new Map<string, DeviceState>();
+  readonly #deviceRoot: string;
   readonly #filesystem: Filesystem;
   readonly #hostAbi: string;
   readonly #idGenerator: IdGenerator;
@@ -133,34 +162,128 @@ export class AndroidDriver implements Driver {
   readonly #processRunner: ProcessRunner;
   readonly #profiles = new Map<string, DeviceProfile>();
   readonly #readinessTimeoutMs: number;
+  readonly #registrar: AdbRegistrar;
   readonly #sdk: AndroidSdkPaths;
-  readonly #avdDirectory: string;
 
-  private constructor(options: AndroidDriverOptions, sdk: AndroidSdkPaths) {
+  private constructor(
+    options: AndroidDriverOptions,
+    sdk: AndroidSdkPaths,
+    deviceRoot: string,
+    adbServer: AdbServerSupervisor,
+    adbServerPort: number,
+  ) {
+    this.#adbServer = adbServer;
+    this.#adbServerPort = adbServerPort;
+    this.#baseEnv = options.env;
     this.#clock = options.clock;
+    this.#deviceRoot = deviceRoot;
     this.#filesystem = options.filesystem;
     this.#hostAbi = options.hostAbi ?? hostAbiFor(process.arch);
     this.#idGenerator = options.idGenerator ?? new SequentialIdGenerator();
     this.#onDiagnostic = options.onDiagnostic;
     this.#processRunner = options.processRunner;
     this.#readinessTimeoutMs = options.readinessTimeoutMs ?? DEFAULT_READINESS_TIMEOUT_MS;
+    this.#registrar = new AdbRegistrar({ serverPort: adbServerPort, tcp: options.tcpProbe });
     this.#sdk = sdk;
-    this.#avdDirectory = options.env.ANDROID_AVD_HOME ?? `${options.homeDirectory}/.android/avd`;
     this.#portAllocator = portAllocatorFor(options.processRunner, sdk.adb);
   }
 
+  /**
+   * Establishes everything containment rests on before the driver can be asked to do
+   * anything: the AVD home this instance owns, and the private adb server its emulators
+   * are reachable through. Both fail closed -- an `OwnedRootError` or an
+   * `AdbServerUnavailableError` here costs the Android platform and nothing else, because
+   * the alternatives are the user's own AVD directory and the machine's shared adb server,
+   * which Simlock can prove nothing about (safety rule 9).
+   */
   static async create(options: AndroidDriverOptions): Promise<AndroidDriver> {
     const sdk = await discoverSdk(options);
-    return new AndroidDriver(options, sdk);
+    const adbServerPort = configuredAdbServerPort(options);
+    // Resolved once and shared: the root's staging directory, the AVD names, and the
+    // provenance tokens all come from the same generator, so a caller that injected one
+    // controls all three rather than two of them.
+    const idGenerator = options.idGenerator ?? new SequentialIdGenerator();
+    const deviceRoot = await ensureOwnedRoot({
+      filesystem: options.filesystem,
+      idGenerator,
+      instanceId: options.instanceId,
+      path: configuredDeviceRoot(options),
+      platform: "android",
+      ...(options.uid === undefined ? {} : { uid: options.uid }),
+    });
+    const adbServer = new AdbServerSupervisor({
+      adbPath: sdk.adb,
+      clock: options.clock,
+      env: options.env,
+      filesystem: options.filesystem,
+      port: adbServerPort,
+      processRunner: options.processRunner,
+      processSupervisor: options.processSupervisor,
+      recordPath: join(options.simlockHome, "adb-server.json"),
+      tcpProbe: options.tcpProbe,
+    });
+    await adbServer.start();
+
+    return new AndroidDriver(
+      { ...options, idGenerator },
+      sdk,
+      deviceRoot,
+      adbServer,
+      adbServerPort,
+    );
   }
 
   get sdkPath(): string {
     return this.#sdk.root;
   }
 
-  // fallow-ignore-next-line unused-class-member -- Driver.leaseEnvironment contract; read by the lease path when it builds a grant.
+  get deviceRoot(): string {
+    return this.#deviceRoot;
+  }
+
   leaseEnvironment(): Readonly<Record<string, string>> {
-    return {};
+    // `adb` reads this variable natively, so a lease holder needs nothing else to reach the
+    // device: without it their `adb` talks to the shared server, which cannot see it.
+    return { ANDROID_ADB_SERVER_PORT: String(this.#adbServerPort) };
+  }
+
+  /**
+   * Stops the adb server this driver started. Nothing else can: `ADB_REJECT_KILL_SERVER=1`
+   * makes `adb kill-server` refuse Simlock too, and the spawned child is not unref'd, so a
+   * shutdown that skipped this would leave both a server and a daemon that cannot exit.
+   */
+  async dispose(): Promise<void> {
+    await this.#adbServer.stop();
+  }
+
+  /**
+   * The single insertion point for Android's scoping, the way `--set` is iOS's: every
+   * `adb`, `emulator`, and `avdmanager` invocation this driver makes carries both keys, so
+   * a call that slipped past here would address the user's AVD home and the shared adb
+   * server. Layered over the injected environment because `ProcessRunner` replaces a
+   * child's environment wholesale rather than merging into it -- a scoped env alone would
+   * drop `PATH` and `ANDROID_HOME` and break every tool it scopes.
+   */
+  #env(): NodeJS.ProcessEnv {
+    return {
+      ...this.#baseEnv,
+      ANDROID_ADB_SERVER_PORT: String(this.#adbServerPort),
+      ANDROID_AVD_HOME: this.#deviceRoot,
+    };
+  }
+
+  /**
+   * Announces an emulator to Simlock's adb server, which with the scanner off is what
+   * attaches it (see `AdbRegistrar`). Always best-effort: the emulator announces itself
+   * too, so a failure here is usually a duplicate of something that already worked, and
+   * failing a boot over it would trade a working device for a redundant message.
+   */
+  async #register(consolePort: number): Promise<void> {
+    try {
+      await this.#registrar.register(consolePort + 1);
+    } catch {
+      // Nothing to do but wait for the readiness loop, which retries this itself.
+    }
   }
 
   async resolveSpec(
@@ -197,6 +320,9 @@ export class AndroidDriver implements Driver {
     this.#assertAndroidSpec(spec);
     const profile = await this.#profileFor(spec.model);
     const image = await this.#requireImage(spec.osVersion);
+    // Cosmetic only, and worth saying so: the prefix is a label that makes an emulator
+    // recognisable in `adb devices` and in its window title. Nothing reads it back as
+    // evidence of anything -- ownership comes from the root this AVD is created in.
     const avdName = `simlock_${this.#idGenerator.generate()}`;
     const packageName = systemImagePackage(image.apiLevel, image.tag, image.abi);
 
@@ -212,7 +338,7 @@ export class AndroidDriver implements Driver {
     ]);
 
     const configHash = await this.#configHash(avdName, image);
-    const port = await this.#portAllocator.allocate();
+    const port = await this.#portAllocator.allocate(this.#env());
     const driverData: AndroidDriverData = {
       avdName,
       configHash,
@@ -253,7 +379,7 @@ export class AndroidDriver implements Driver {
           state.baselineCaptured = true;
           state.snapshotExpected = true;
         } else {
-          await this.#filesystem.rm(`${this.#avdDirectory}/${data.avdName}.avd/snapshots`);
+          await this.#filesystem.rm(`${this.#deviceRoot}/${data.avdName}.avd/snapshots`);
           state.baselineCaptured = false;
           state.needsWipe = true;
           state.snapshotExpected = false;
@@ -308,7 +434,7 @@ export class AndroidDriver implements Driver {
       const baselineHash = await this.#baselineHash(data.avdName);
       if (baselineHash !== currentHash) {
         await this.#shutdown(data, state);
-        await this.#filesystem.rm(`${this.#avdDirectory}/${data.avdName}.avd/snapshots`);
+        await this.#filesystem.rm(`${this.#deviceRoot}/${data.avdName}.avd/snapshots`);
         state.needsWipe = true;
         state.snapshotExpected = false;
         state.baselineCaptured = false;
@@ -366,7 +492,7 @@ export class AndroidDriver implements Driver {
     const avdNames = await this.#listAvdNames();
     const { settledSerials, unattributableTransitionalSerial } = await this.#scanAdbSerials();
     const { processes, runningByAvdName, erasableMarkByAvdName, unreadableSerial } =
-      await this.#resolveRunningAvds(settledSerials);
+      await this.#resolveRunningAvds(settledSerials, new Set(avdNames));
     const unattributable = unattributableTransitionalSerial || unreadableSerial;
 
     const devices: ObservedDevice[] = await Promise.all(
@@ -391,11 +517,16 @@ export class AndroidDriver implements Driver {
     return mark === undefined ? base : { ...base, mark };
   }
 
+  /**
+   * Every AVD in the root, whatever it is called. The name is a cosmetic label with no
+   * authority: what makes these AVDs Simlock's is that they sit inside a root Simlock
+   * created empty and marked, which nothing else can put an AVD into (safety rule 8).
+   */
   async #listAvdNames(): Promise<string[]> {
     const avdNames: string[] = [];
-    if (await this.#filesystem.exists(this.#avdDirectory)) {
-      for (const entry of await this.#filesystem.readdir(this.#avdDirectory)) {
-        const match = /^(simlock_.+)\.avd$/.exec(entry);
+    if (await this.#filesystem.exists(this.#deviceRoot)) {
+      for (const entry of await this.#filesystem.readdir(this.#deviceRoot)) {
+        const match = /^(.+)\.avd$/.exec(entry);
         if (match?.[1] === undefined) continue;
         avdNames.push(match[1]);
       }
@@ -434,7 +565,10 @@ export class AndroidDriver implements Driver {
    * per serial -- the mark read is folded into the `getprop` call that this method already
    * makes, so it costs nothing extra.
    */
-  async #resolveRunningAvds(settledSerials: readonly string[]): Promise<{
+  async #resolveRunningAvds(
+    settledSerials: readonly string[],
+    avdNamesInRoot: ReadonlySet<string>,
+  ): Promise<{
     readonly erasableMarkByAvdName: ReadonlyMap<string, string | undefined>;
     readonly processes: readonly DriverDevice[];
     readonly runningByAvdName: ReadonlySet<string>;
@@ -464,7 +598,11 @@ export class AndroidDriver implements Driver {
       }
       const [nameLine = "", ...markLines] = output.stdout.split(/\r?\n/);
       const avdName = nameLine.trim();
-      if (!avdName.startsWith("simlock_")) continue;
+      // Root membership, never the name and never "our server can see it". `ADB_EMU=0`
+      // should mean this server only holds transports Simlock registered itself, but a
+      // device is Simlock's because of where its AVD lives -- ownership is proven, not
+      // inferred from who happens to be looking at it (safety rule 8).
+      if (!avdNamesInRoot.has(avdName)) continue;
       runningByAvdName.add(avdName);
       erasableMarkByAvdName.set(avdName, parseErasableMark(markLines.join("\n")));
       const port = Number(candidate.slice("emulator-".length));
@@ -627,7 +765,7 @@ export class AndroidDriver implements Driver {
   }
 
   #configIniPath(avdName: string): string {
-    return `${this.#avdDirectory}/${avdName}.avd/config.ini`;
+    return `${this.#deviceRoot}/${avdName}.avd/config.ini`;
   }
 
   /**
@@ -693,14 +831,19 @@ export class AndroidDriver implements Driver {
         throw new BootTimeoutError(data.avdName);
       }
 
-      const completed = await this.#processRunner.run(this.#sdk.adb, [
-        "-s",
-        data.serial,
-        "shell",
-        "getprop",
-        "sys.boot_completed",
-      ]);
+      const completed = await this.#processRunner.run(
+        this.#sdk.adb,
+        ["-s", data.serial, "shell", "getprop", "sys.boot_completed"],
+        { env: this.#env() },
+      );
       if (completed.code !== 0) {
+        // A serial that will not answer is a serial the server has no transport for, which
+        // is the same evidence "absent from `adb devices`" would give and costs no extra
+        // round trip. Past the grace period, assume the emulator's own announcement was
+        // lost -- with the scanner off nothing else will ever re-send it -- and re-announce.
+        if (this.#clock.now() - startedAt >= REGISTRATION_RETRY_AFTER_MS) {
+          await this.#register(data.port);
+        }
         await this.#delay(
           Math.min(
             PORT_POLL_INTERVAL_MS,
@@ -735,15 +878,16 @@ export class AndroidDriver implements Driver {
     fromSnapshot: boolean,
   ): Promise<void> {
     const startedAt = this.#clock.now();
-    const handle = this.#processRunner.spawn(this.#sdk.emulator, [
-      "-avd",
-      data.avdName,
-      "-port",
-      String(data.port),
-      "-no-snapshot-save",
-      ...launchArgs,
-    ]);
+    const handle = this.#processRunner.spawn(
+      this.#sdk.emulator,
+      ["-avd", data.avdName, "-port", String(data.port), "-no-snapshot-save", ...launchArgs],
+      { env: this.#env() },
+    );
     state.handle = handle;
+    // Immediately, not after the boot: the emulator announces itself to the server named by
+    // `ANDROID_ADB_SERVER_PORT` as soon as it is up, and this second announcement is the
+    // one that covers a lost first one.
+    await this.#register(data.port);
 
     try {
       await this.#waitForReadiness(data, startedAt);
@@ -806,11 +950,13 @@ export class AndroidDriver implements Driver {
   }
 
   #baselineMetadataPath(avdName: string): string {
-    return `${this.#avdDirectory}/${avdName}.avd/simlock-clean-baseline.json`;
+    return `${this.#deviceRoot}/${avdName}.avd/simlock-clean-baseline.json`;
   }
 
   async #shutdown(data: AndroidDriverData, state: DeviceState): Promise<void> {
-    await this.#processRunner.run(this.#sdk.adb, ["-s", data.serial, "emu", "kill"]);
+    await this.#processRunner.run(this.#sdk.adb, ["-s", data.serial, "emu", "kill"], {
+      env: this.#env(),
+    });
     const handle = state.handle;
     if (handle === undefined) {
       return;
@@ -844,7 +990,7 @@ export class AndroidDriver implements Driver {
     args: readonly string[],
     options: { readonly timeoutMs?: number } = {},
   ) {
-    const result = await this.#processRunner.run(command, args, options);
+    const result = await this.#processRunner.run(command, args, { ...options, env: this.#env() });
     if (result.code !== 0) {
       throw new DriverCrashError(
         `${command} ${args.join(" ")} failed: ${result.stderr || result.stdout}`,
@@ -923,7 +1069,13 @@ class PortAllocator {
     private readonly processRunner: ProcessRunner,
   ) {}
 
-  async allocate(): Promise<number> {
+  /**
+   * The scoped environment is passed per call rather than held, because one allocator is
+   * shared by every driver on a runner (see `portAllocatorFor`) while the environment
+   * belongs to one driver instance -- a stored one would go stale the moment a second
+   * driver appeared and would silently poll the wrong adb server.
+   */
+  async allocate(env: NodeJS.ProcessEnv): Promise<number> {
     const previous = this.#lock;
     let release!: () => void;
     this.#lock = new Promise((resolve) => {
@@ -931,7 +1083,7 @@ class PortAllocator {
     });
     await previous;
     try {
-      const result = await this.processRunner.run(this.adb, ["devices"]);
+      const result = await this.processRunner.run(this.adb, ["devices"], { env });
       if (result.code !== 0) {
         throw new DriverCrashError(`adb devices failed: ${result.stderr || result.stdout}`);
       }
@@ -961,6 +1113,49 @@ class SequentialIdGenerator implements IdGenerator {
     this.#next += 1;
     return String(value);
   }
+}
+
+/**
+ * A `deviceRoot` that is not a usable path refuses this platform's *configuration*, which
+ * costs Android and nothing else -- not the daemon. `"deviceRoot": true` and
+ * `"deviceRoot": "devices/android"` are one keystroke apart, and killing the process over
+ * the first would take iOS down with it and leave the reason unreachable, since `doctor`
+ * needs a daemon to answer. `not-absolute` is the published vocabulary term for "this
+ * names no usable directory"; nothing new is invented here.
+ */
+function configuredDeviceRoot(options: AndroidDriverOptions): string {
+  const configured = options.driverConfig["deviceRoot"];
+
+  if (configured !== undefined && typeof configured !== "string") {
+    throw new OwnedRootError(
+      `Refusing the android device root: drivers.android.deviceRoot must be an absolute path, but it is the ${typeof configured} ${JSON.stringify(configured)}`,
+      "not-absolute",
+      String(configured),
+      "android",
+    );
+  }
+
+  return configured ?? join(options.simlockHome, "devices", "android");
+}
+
+/**
+ * The port is only read here; whether it can actually carry a server is the supervisor's
+ * decision, so range and reserved-port checks are not duplicated. A value that is not a
+ * number at all cannot reach that check as itself, and the event payload has nowhere to
+ * put it -- hence the `0` stand-in, with the configured value named in the message.
+ */
+function configuredAdbServerPort(options: AndroidDriverOptions): number {
+  const configured = options.driverConfig["adbServerPort"];
+
+  if (configured !== undefined && typeof configured !== "number") {
+    throw new AdbServerUnavailableError(
+      `Refusing to run the android driver: drivers.android.adbServerPort must be a TCP port number, but it is the ${typeof configured} ${JSON.stringify(configured)}`,
+      "invalid-port",
+      0,
+    );
+  }
+
+  return configured ?? DEFAULT_ADB_SERVER_PORT;
 }
 
 async function discoverSdk(options: AndroidDriverOptions): Promise<AndroidSdkPaths> {

--- a/src/drivers/android/index.ts
+++ b/src/drivers/android/index.ts
@@ -40,8 +40,10 @@ const COLD_BOOT_ESTIMATE_MS = 31_000;
 // Android Studio cannot see, drive, or kill a Simlock emulator (ADR 0001, decision 4).
 // It also repairs the old 5554-5682 range, which was broken at both ends: the bottom
 // competed for the user's own emulators, and everything above 5585 read as free to the
-// allocator below -- which derives occupancy from `adb devices` -- because no server
-// could report a device up there. Simlock's own server scans to 5683, so it can.
+// allocator below -- which derives occupancy from `adb devices` -- because no server could
+// report a device up there. Simlock's server can, and not because it scans: with the
+// scanner off, a transport exists for every port an emulator announced itself on or
+// `#reattachRunningEmulators` swept, which is exactly this range.
 const PORT_MAX = 5682;
 const PORT_MIN = 5586;
 const PORT_POLL_INTERVAL_MS = 2_000;
@@ -224,13 +226,15 @@ export class AndroidDriver implements Driver {
     });
     await adbServer.start();
 
-    return new AndroidDriver(
+    const driver = new AndroidDriver(
       { ...options, idGenerator },
       sdk,
       deviceRoot,
       adbServer,
       adbServerPort,
     );
+    await driver.#reattachRunningEmulators();
+    return driver;
   }
 
   get sdkPath(): string {
@@ -270,6 +274,35 @@ export class AndroidDriver implements Driver {
       ANDROID_ADB_SERVER_PORT: String(this.#adbServerPort),
       ANDROID_AVD_HOME: this.#deviceRoot,
     };
+  }
+
+  /**
+   * Announces every console port Simlock may have an emulator on to the server that was
+   * just started or adopted -- deliberately doing, for Simlock's own range only, what adb's
+   * scanner would do for everyone's.
+   *
+   * An emulator announces itself exactly once, at its own startup, to the server that
+   * existed then. A clean `daemon stop` reaps that server, and with `ADB_EMU=0` the next one
+   * has no scanner to rediscover anything -- so every emulator that survived the restart
+   * (which is by design: releasing a lease hands a device to the warm pool) would be
+   * invisible forever. Invisible is worse than gone: `listManaged` reports no process, so
+   * `doctor` can never call it an orphan and several gigabytes of RSS leak permanently; the
+   * port allocator derives occupancy from `adb devices` and hands out a console port that is
+   * already in use, whose emulator then cannot bind and is quarantined for it.
+   *
+   * `connect_emulator` is idempotent (adb keys transports by port), a port with nothing on
+   * it is a cheap failed connect, and the range is bounded and Simlock's own -- so this is
+   * safe to do unconditionally, and it never touches the user's emulators below 5586. It
+   * also makes the design independent of whether a running emulator re-announces itself.
+   */
+  async #reattachRunningEmulators(): Promise<void> {
+    const ports: number[] = [];
+    for (let consolePort = PORT_MIN; consolePort <= PORT_MAX; consolePort += 2) {
+      ports.push(consolePort);
+    }
+
+    // `#register` swallows its own failures, so one unreachable port cannot end the sweep.
+    await Promise.all(ports.map((consolePort) => this.#register(consolePort)));
   }
 
   /**
@@ -884,10 +917,11 @@ export class AndroidDriver implements Driver {
       { env: this.#env() },
     );
     state.handle = handle;
-    // Immediately, not after the boot: the emulator announces itself to the server named by
-    // `ANDROID_ADB_SERVER_PORT` as soon as it is up, and this second announcement is the
-    // one that covers a lost first one.
-    await this.#register(data.port);
+    // No announcement here, deliberately. adb answers `host:emulator:<port>` by connecting
+    // *out* to that port, and the emulator has not opened it yet a millisecond after the
+    // spawn -- so a call here could only ever fail, and with the scanner off nothing drains
+    // adb's retry queue afterwards. The announcement that can land is the one in
+    // `#waitForReadiness`, once the serial has stayed silent past the grace period.
 
     try {
       await this.#waitForReadiness(data, startedAt);

--- a/src/mcp/main.ts
+++ b/src/mcp/main.ts
@@ -156,6 +156,7 @@ function defaultEnvironment(): Required<Pick<McpStdioEnvironment, "connect" | "c
           args: [join(dirname(fileURLToPath(import.meta.url)), "../daemon/main.js")],
           command: process.execPath,
           logPath,
+          simlockHome: dataDirectory,
         }),
         socketPath,
       }),

--- a/src/ports/daemon-launcher.test.ts
+++ b/src/ports/daemon-launcher.test.ts
@@ -26,8 +26,32 @@ describe("NodeDaemonLauncher", () => {
           args: [],
           command: join(directory, "missing-command"),
           logPath: join(directory, "daemon.log"),
+          simlockHome: directory,
         }).launch(),
       ).rejects.toThrow();
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("hands the daemon the home the launching process already resolved", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "simlock-launcher-"));
+    const logPath = join(directory, "daemon.log");
+    // A relative SIMLOCK_HOME resolves against whatever directory reads it, so passing the
+    // variable through unresolved would let the daemon build its device roots somewhere the
+    // process that launched it never looks.
+    const launcher = new NodeDaemonLauncher({
+      args: ["-e", "console.log(process.env.SIMLOCK_HOME)"],
+      command: process.execPath,
+      logPath,
+      simlockHome: "/resolved/simlock/home",
+    });
+
+    try {
+      await launcher.launch();
+      await expect
+        .poll(async () => (await readFile(logPath, "utf8")).trim())
+        .toBe("/resolved/simlock/home");
     } finally {
       await rm(directory, { force: true, recursive: true });
     }
@@ -40,6 +64,7 @@ describe("NodeDaemonLauncher", () => {
       args: ["-e", "console.log('out'); console.error('err')"],
       command: process.execPath,
       logPath,
+      simlockHome: directory,
     });
     try {
       await launcher.launch();

--- a/src/ports/daemon-launcher.ts
+++ b/src/ports/daemon-launcher.ts
@@ -11,6 +11,16 @@ export interface NodeDaemonLauncherOptions {
   readonly args: readonly string[];
   readonly command: string;
   readonly logPath: string;
+  /**
+   * The *resolved* `SIMLOCK_HOME` the launching process is using. It is exported into the
+   * daemon's environment rather than left to be inherited, because a relative
+   * `SIMLOCK_HOME` resolves against whatever directory the process reading it happens to
+   * be standing in -- and the two processes agreeing only because one spawned the other
+   * from its own cwd is an assumption, not a guarantee. It now decides where tens of
+   * gigabytes of devices live, and a daemon that resolved it differently would build its
+   * device roots somewhere the CLI never looks.
+   */
+  readonly simlockHome: string;
 }
 
 export class NodeDaemonLauncher implements DaemonLauncher {
@@ -23,9 +33,9 @@ export class NodeDaemonLauncher implements DaemonLauncher {
       const child = spawn(this.options.command, this.options.args, {
         detached: true,
         // Explicit rather than relying on spawn's default: the daemon must inherit
-        // overrides like SIMLOCK_HOME and SIMLOCK_DRIVERS_MODULE from whichever
-        // frontend (CLI/MCP) auto-launched it.
-        env: process.env,
+        // overrides like SIMLOCK_DRIVERS_MODULE from whichever frontend (CLI/MCP)
+        // auto-launched it, and must be told the home this one already resolved.
+        env: { ...process.env, SIMLOCK_HOME: this.options.simlockHome },
         stdio: ["ignore", log.fd, log.fd],
       });
       await new Promise<void>((resolve, reject) => {

--- a/src/ports/index.ts
+++ b/src/ports/index.ts
@@ -42,6 +42,7 @@ export type { TcpProbe } from "./tcp-probe.js";
 export {
   NodeProcessRunner,
   type ProcessHandle,
+  ProcessSpawnError,
   type ProcessResult,
   type ProcessRunner,
   ScriptedProcessRunner,

--- a/src/ports/index.ts
+++ b/src/ports/index.ts
@@ -32,12 +32,12 @@ export { FakeSystemStats, NodeSystemStats, type SystemStats } from "./system-sta
 export { FakeParentWatch, NodeParentWatch, type ParentWatch } from "./parent-watch.js";
 export type { ParentWatchHandle } from "./parent-watch.js";
 export { FakeProcessSupervisor, NodeProcessSupervisor } from "./process-supervisor.js";
-// fallow-ignore-next-line unused-type -- public port contract for consumers that address a process by pid.
 export type { ProcessSupervisor } from "./process-supervisor.js";
 // fallow-ignore-next-line unused-type -- public shape of FakeProcessSupervisor.signals.
 export type { SignalRecord } from "./process-supervisor.js";
 export { FakeTcpProbe, NodeTcpProbe } from "./tcp-probe.js";
-// fallow-ignore-next-line unused-type -- public port contract for consumers that probe a port.
+// fallow-ignore-next-line unused-type -- public shape of FakeTcpProbe.sends.
+export type { FakeSend } from "./tcp-probe.js";
 export type { TcpProbe } from "./tcp-probe.js";
 export {
   NodeProcessRunner,

--- a/src/ports/process-runner.test.ts
+++ b/src/ports/process-runner.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { NodeProcessRunner, ScriptedProcessRunner } from "./index.js";
+import { NodeProcessRunner, ProcessSpawnError, ScriptedProcessRunner } from "./index.js";
 
 describe("ScriptedProcessRunner", () => {
   it("returns the scripted result for a matching invocation", async () => {
@@ -114,6 +114,25 @@ describe("NodeProcessRunner", () => {
     handle.kill("SIGKILL");
 
     await expect(handle.wait()).resolves.toMatchObject({ stderr: "", stdout: "" });
+  });
+
+  it("reports a spawn that never produced a process instead of crashing the daemon", async () => {
+    // Node reports a failed spawn by emitting `error` asynchronously, and an `error` with no
+    // listener ends the process outright -- no catch can help. So the listener is attached
+    // before anything throws, and the failure comes back as something a caller can handle:
+    // an `adb` that is not executable, `ETXTBSY` mid-update, or `EAGAIN` under the memory
+    // pressure of several running emulators must cost the Android driver, not the daemon.
+    const runner = new NodeProcessRunner();
+
+    expect(() => runner.spawn("/nonexistent/simlock-adb", ["-P", "5038"])).toThrow(
+      ProcessSpawnError,
+    );
+
+    // Past the tick the `error` event would arrive on: still here, still able to assert.
+    await new Promise((resolve) => setImmediate(resolve));
+    await expect(runner.run("/nonexistent/simlock-adb", [])).rejects.toBeInstanceOf(
+      ProcessSpawnError,
+    );
   });
 
   it("kills a process that exceeds its timeout", async () => {

--- a/src/ports/process-runner.ts
+++ b/src/ports/process-runner.ts
@@ -43,7 +43,29 @@ export interface ProcessHandle {
   readonly stdout: AsyncIterable<string>;
   readonly stderr: AsyncIterable<string>;
   kill(signal?: NodeJS.Signals): void;
+  /**
+   * Stops this child from keeping the parent's event loop alive. Only for a process that
+   * is meant to outlive the daemon and is reaped by pid instead of by exit (Simlock's adb
+   * server): everything else is awaited through `wait()` and must keep the loop open.
+   */
+  unref(): void;
   wait(): Promise<ProcessResult>;
+}
+
+/**
+ * A child that could not be started at all -- a binary that exists but is not executable,
+ * `ETXTBSY` while it is being rewritten, `EAGAIN` under memory pressure. Node reports this
+ * asynchronously, so it is raised here as a synchronous throw (and therefore a rejected
+ * promise out of `run`) rather than left to surface as an unhandled `error` event.
+ */
+export class ProcessSpawnError extends Error {
+  constructor(
+    readonly command: string,
+    readonly args: readonly string[],
+  ) {
+    super(`Failed to spawn ${command} ${args.join(" ")}`);
+    this.name = "ProcessSpawnError";
+  }
 }
 
 export interface ProcessRunner {
@@ -90,7 +112,17 @@ export class NodeProcessRunner implements ProcessRunner {
       stdio: options.stdio ?? "pipe",
     });
 
-    return new NodeProcessHandle(child);
+    if (child.pid === undefined) {
+      // The spawn failed, and Node will say why by emitting `error` on the next tick. An
+      // `error` with no listener is a hard, uncatchable process exit, so the listener is
+      // attached *before* this function leaves -- throwing first would take the daemon
+      // down over an unreadable `adb`. The reason is lost with it (it does not exist yet),
+      // which is the price of turning an asynchronous crash into a catchable failure.
+      child.once("error", () => undefined);
+      throw new ProcessSpawnError(command, args);
+    }
+
+    return new NodeProcessHandle(child, child.pid);
   }
 }
 
@@ -102,12 +134,11 @@ class NodeProcessHandle implements ProcessHandle {
   readonly #stderrChunks: string[] = [];
   readonly #result: Promise<ProcessResult>;
 
-  constructor(private readonly child: ChildProcess) {
-    if (child.pid === undefined) {
-      throw new Error("Process did not provide a pid");
-    }
-
-    this.pid = child.pid;
+  constructor(
+    private readonly child: ChildProcess,
+    pid: number,
+  ) {
+    this.pid = pid;
     captureLines(child.stdout, this.stdout, this.#stdoutChunks);
     captureLines(child.stderr, this.stderr, this.#stderrChunks);
     this.#result = new Promise<ProcessResult>((resolve, reject) => {
@@ -142,6 +173,10 @@ class NodeProcessHandle implements ProcessHandle {
         armGrace(capturedSoFar());
       });
     });
+    // A child nobody waits on (the supervised adb server) would otherwise turn a late
+    // `error` into an unhandled rejection, which ends the daemon. Marking the promise
+    // handled here changes nothing for a caller that does await `wait()`.
+    this.#result.catch(() => undefined);
   }
 
   kill(signal: NodeJS.Signals = "SIGTERM"): void {
@@ -159,6 +194,10 @@ class NodeProcessHandle implements ProcessHandle {
 
       throw error;
     }
+  }
+
+  unref(): void {
+    this.child.unref();
   }
 
   wait(): Promise<ProcessResult> {
@@ -216,6 +255,8 @@ export class ScriptedProcessRunner implements ProcessRunner {
 }
 
 class ScriptedProcessHandle implements ProcessHandle {
+  /** Whether the caller released the event loop, which only a supervised child should do. */
+  unreffed = false;
   readonly stdout = new LineBuffer();
   readonly stderr = new LineBuffer();
   readonly #result: Promise<ProcessResult>;
@@ -239,6 +280,10 @@ class ScriptedProcessHandle implements ProcessHandle {
 
   kill(_signal: NodeJS.Signals = "SIGTERM"): void {
     this.#finish({ code: null, stderr: "", stdout: "" });
+  }
+
+  unref(): void {
+    this.unreffed = true;
   }
 
   wait(): Promise<ProcessResult> {

--- a/src/ports/tcp-probe.test.ts
+++ b/src/ports/tcp-probe.test.ts
@@ -1,14 +1,16 @@
-import { createServer, type Server } from "node:net";
+import { createServer, type Server, type Socket } from "node:net";
 
 import { afterEach, describe, expect, it } from "vitest";
 
 import { FakeTcpProbe, NodeTcpProbe } from "./index.js";
 
 let server: Server | undefined;
+const accepted = new Set<Socket>();
 
 /** Listens on an ephemeral loopback port and reports which one it got. */
 async function listen(): Promise<number> {
   server = createServer();
+  server.on("connection", (socket) => accepted.add(socket));
 
   return new Promise<number>((resolve) => {
     server?.listen(0, "127.0.0.1", () => {
@@ -27,6 +29,10 @@ async function close(): Promise<void> {
       return;
     }
 
+    // `close` alone only stops accepting: a connection a probe opened and then abandoned
+    // keeps it pending, and the `send` tests deliberately leave one lying around.
+    for (const socket of accepted) socket.destroy();
+    accepted.clear();
     closing.close(() => resolve());
   });
 }
@@ -58,6 +64,40 @@ describe("NodeTcpProbe", () => {
   );
 });
 
+describe("NodeTcpProbe.send", () => {
+  it("delivers the payload and resolves with everything the peer said before closing", async () => {
+    const received: string[] = [];
+    const port = await listen();
+    server?.on("connection", (socket) => {
+      socket.setEncoding("utf8");
+      socket.on("data", (chunk: string) => {
+        received.push(chunk);
+        socket.end("OKAY");
+      });
+    });
+
+    await expect(new NodeTcpProbe().send(port, "0012host:emulator:5587")).resolves.toBe("OKAY");
+    expect(received).toEqual(["0012host:emulator:5587"]);
+  });
+
+  it("resolves empty when the peer answers nothing before the timeout", async () => {
+    const port = await listen();
+
+    // The one service this carries is answered by silence, so a timeout completes the call
+    // rather than failing it.
+    await expect(new NodeTcpProbe().send(port, "ping", 50)).resolves.toBe("");
+  });
+
+  it("rejects when there was no peer to send to", async () => {
+    const port = await listen();
+    await close();
+
+    // A refused connection must not read like a server that answered nothing: the caller
+    // decides what to do about a failed registration, and cannot if both look identical.
+    await expect(new NodeTcpProbe().send(port, "ping", 50)).rejects.toThrow();
+  });
+});
+
 describe("FakeTcpProbe", () => {
   it("answers with the ports a test declared, as they come and go", async () => {
     const probe = new FakeTcpProbe([5038]);
@@ -70,5 +110,13 @@ describe("FakeTcpProbe", () => {
 
     await expect(probe.isListening(5038)).resolves.toBe(false);
     await expect(probe.isListening(5039)).resolves.toBe(true);
+  });
+
+  it("records what was sent and answers with what the test scripted", async () => {
+    const probe = new FakeTcpProbe();
+    probe.replyWith("OKAY");
+
+    await expect(probe.send(5038, "0012host:emulator:5587")).resolves.toBe("OKAY");
+    expect(probe.sends).toEqual([{ payload: "0012host:emulator:5587", port: 5038 }]);
   });
 });

--- a/src/ports/tcp-probe.ts
+++ b/src/ports/tcp-probe.ts
@@ -8,6 +8,17 @@ import { createConnection, type Socket } from "node:net";
 export interface TcpProbe {
   /** True when something is accepting connections on `127.0.0.1:<port>` right now. */
   isListening(port: number, timeoutMs?: number): Promise<boolean>;
+  /**
+   * Writes `payload` to `127.0.0.1:<port>` and resolves with whatever came back before the
+   * peer closed or the timeout elapsed -- an empty string when it answered nothing.
+   *
+   * Deliberately dumb: what the bytes mean belongs to the caller (adb's host-service
+   * framing is the Android driver's business), while opening a loopback socket is an
+   * external API and so belongs behind a port like every other one (architecture rule 9).
+   * Rejects only when the connection itself failed, because a caller cannot tell "the
+   * server said nothing" from "there was no server" if both resolve the same way.
+   */
+  send(port: number, payload: string, timeoutMs?: number): Promise<string>;
 }
 
 /**
@@ -46,10 +57,59 @@ export class NodeTcpProbe implements TcpProbe {
       socket.once("error", () => settle(false));
     });
   }
+
+  async send(
+    port: number,
+    payload: string,
+    timeoutMs: number = DEFAULT_TIMEOUT_MS,
+  ): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      let socket: Socket;
+      try {
+        socket = createConnection({ host: "127.0.0.1", port });
+      } catch (error: unknown) {
+        reject(error instanceof Error ? error : new Error(String(error)));
+        return;
+      }
+
+      let received = "";
+      let settled = false;
+      const settle = (outcome: () => void): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        socket.destroy();
+        outcome();
+      };
+
+      socket.setEncoding("utf8");
+      socket.setTimeout(timeoutMs);
+      socket.once("connect", () => socket.write(payload));
+      socket.on("data", (chunk: string) => {
+        received += chunk;
+      });
+      // A peer that answers and then holds the connection open is the normal case for the
+      // one service this carries, so the timeout is a completion condition rather than a
+      // failure: whatever arrived by then is the answer.
+      socket.once("timeout", () => settle(() => resolve(received)));
+      socket.once("close", () => settle(() => resolve(received)));
+      socket.once("error", (error) => settle(() => reject(error)));
+    });
+  }
+}
+
+export interface FakeSend {
+  readonly port: number;
+  readonly payload: string;
 }
 
 export class FakeTcpProbe implements TcpProbe {
+  /** Every `send` this probe was asked to make, in order. */
+  readonly sends: FakeSend[] = [];
   readonly #listening = new Set<number>();
+  #reply = "";
+  #sendFailure: Error | undefined;
 
   constructor(listeningPorts: readonly number[] = []) {
     for (const port of listeningPorts) {
@@ -59,6 +119,24 @@ export class FakeTcpProbe implements TcpProbe {
 
   async isListening(port: number): Promise<boolean> {
     return this.#listening.has(port);
+  }
+
+  async send(port: number, payload: string): Promise<string> {
+    this.sends.push({ payload, port });
+
+    if (this.#sendFailure !== undefined) {
+      throw this.#sendFailure;
+    }
+
+    return this.#reply;
+  }
+
+  replyWith(reply: string): void {
+    this.#reply = reply;
+  }
+
+  failSendsWith(error: Error): void {
+    this.#sendFailure = error;
   }
 
   startListening(port: number): void {


### PR DESCRIPTION
Third of five stacked PRs implementing [ADR 0001](https://github.com/callstackincubator/simlock/blob/feat/owned-device-roots/docs/adr/0001-simlock-owned-device-roots.md). Based on #81.

1. [#80](https://github.com/callstackincubator/simlock/pull/80) owned device root validation and its ports
2. [#81](https://github.com/callstackincubator/simlock/pull/81) iOS: `simctl --set`, membership-based `listManaged`
3. **Android: `ANDROID_AVD_HOME`, private supervised adb server** ← this PR
4. lease environment and the `simctl` / `adb` passthroughs
5. doctor: `--purge-orphans`, legacy pre-root devices, docs status

## What this is

Android has no `simctl --set`, so containment is built rather than inherited. AVDs live in a root this driver created and proved; every `adb`, `emulator` and `avdmanager` call carries `ANDROID_AVD_HOME` and `ANDROID_ADB_SERVER_PORT` through one insertion point; console ports move to 5586–5682, above the 5585 ceiling a default adb server scans. `listManaged` answers from membership in that root — a name prefix is not evidence, and neither is being visible to our server.

The server is supervised by pid because it has to be: `ADB_REJECT_KILL_SERVER=1` means an agent's reflexive `adb kill-server` cannot detach every leased emulator at once, and neither can Simlock. It runs as `nodaemon server` so the recorded pid is the server rather than a launcher that exits, and `adb-server.json` lives outside `state.json` because a corrupt registry is exactly when a leftover server must still be reapable. An occupied port refuses the platform rather than attaching to whatever is listening, which could be Android Studio's.

## This PR amends ADR decision 4

The record specifies `ADB_LOCAL_TRANSPORT_MAX_PORT=5683` alone. Verified against adb's source, that is **incomplete and actively harmful**: the emulator scan has no minimum-port variable, so the ceiling only widens a sweep that always starts at 5555.

```c
for (int port = DEFAULT_ADB_LOCAL_TRANSPORT_PORT; port <= adb_local_transport_max_port; port += 2)
    connect_emulator(port);   // Note, uses port and port-1
```

Simlock's server would therefore have discovered and connected to *the user's own emulators*, leaving two adb servers contending for one device — the accident this ADR exists to prevent, running the other way. `ADB_EMU=0` is what actually contains it, and our emulators still attach because the emulator announces itself with `host:emulator:<port>`. The ADR carries a dated Correction with the citations; `CONFIGURATION.md` and `known-pitfalls.md` match.

Containment is now symmetric: our consoles sit above the user's default ceiling so their server cannot see ours, and the scanner is off so ours never looks at theirs.

## Review round (second commit)

An adversarial review found eight defects. The worst was a design flaw, not a slip:

**A clean `daemon stop` orphaned every running emulator, permanently.** Devices are *meant* to survive a restart — releasing a lease hands the device to the warm pool. But shutdown reaps the adb server, and an emulator announces itself exactly once, to the server running when it booted. With the scanner off nothing found them again: `adb devices` empty, every running AVD reporting `stopped`, no orphan finding able to name them (several GB of RSS each, forever), and the allocator re-issuing 5586 to a device that then could not bind — the occupancy defect this ADR set out to fix, arriving from the other side. The design defended the crash it anticipated and broke on the orderly shutdown it did not.

Simlock now does deliberately, for its own bounded range, what adb's scanner would have done for everyone's: after starting or adopting a server it announces every console port in 5586–5682. That also makes the design independent of whether a running emulator re-announces itself, which cannot be tested here.

**The pid identity check would have killed the user's adb server.** `ps -o comm=` strips the arguments that make a server ours, so it proved "some adb" — and on a developer's machine a recycled pid most likely belongs to the user's own server. It now requires an adb binary, our port, and `nodaemon`.

Also fixed: a failure after spawn hung the daemon (the child was never `unref`ed) *and* disabled Android permanently, because the record was written after the wait; a disk error writing that record took iOS down too; a spawn that never produced a process crashed the daemon through an unhandled `error` event no caller could catch; the port probe believed any listener, so a cold-start race let the loser clobber the winner's record; and an inconclusive `ps` at shutdown deleted the record while leaving the server alive, turning the first clean shutdown on a host without `ps` into a permanently dead platform.

## Not verified here

No macOS, no Android SDK, no `adb` — every branch is unit-tested against fakes. Specifically unverified on real tooling: that `host:emulator:<port>` re-attaches an emulator started under a *previous* server (the restart-recovery path — the first experiment worth running on a Mac); that `ps -o args=` renders the command line as assumed under BSD `ps`; that `unref()` lets the daemon exit with the server running; and both slow lanes.

## Verification

`pnpm run check` green: typecheck, typecheck:e2e, lint, format, 865 unit tests, e2e (33 passed, 1 expected fail, 3 skipped — matching baseline). `fallow audit` clean across 28 changed files.

Refs #73, #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BuTqSL7fKJVRbFytNvZP7X

---
_Generated by [Claude Code](https://claude.ai/code/session_01BuTqSL7fKJVRbFytNvZP7X)_