### PR TITLE
feat(lease): reach a contained device — grant environment and scoped wrappers (4/5)

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -77,7 +77,7 @@ and booting, then — in held mode — keeps running to hold the lease.
 ```
 simlock lease --platform <ios|android> --device <model> [--os <version>]
               [--agent-id <id>] [--timeout <duration>] [--no-wait] [--detach]
-              [--allow-download] [--bind-pid <pid>]
+              [--allow-download] [--export-env] [--bind-pid <pid>]
 ```
 
 - `--platform`, `--device` — required. `--os` defaults to the newest runtime

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -95,7 +95,9 @@ simlock lease --platform <ios|android> --device <model> [--os <version>]
   TTL-bound and must be renewed with `simlock lease renew`.
 - `--export-env` — print the grant's `environment` as shell `export` lines on
   stdout instead of the JSON line, for `eval "$(...)"`. See
-  [Reaching a leased device](#reaching-a-leased-device).
+  [Reaching a leased device](#reaching-a-leased-device). If the grant carries no
+  environment at all (an older daemon), stdout stays empty and a note naming the
+  lease id goes to stderr, so the lease can still be renewed or released.
 - `--bind-pid <pid>` — held mode only: watch this pid for death instead of
   the CLI's actual parent. For a holder spawned from a short-lived subshell,
   the immediate parent can die (and get reaped) while the owning agent is
@@ -238,11 +240,22 @@ simlock simctl install booted ./MyApp.app
 simlock simctl io booted screenshot shot.png
 ```
 
-Refused: `create`, `erase`, and `delete`. Those change a device's lifecycle
-behind the registry's back, so Simlock would report the device as drifted on
-the next reconcile. Use `simlock release` (which reclaims the device for you)
-or `simlock cleanup` instead. Exit 2 with `USAGE`, and the message names the
-command to use.
+Refused, all exit 2 with `USAGE` and a message naming what to run instead:
+
+- `create`, `erase`, `delete` — they change a device's lifecycle behind the
+  registry's back, so Simlock would report the device as drifted on the next
+  reconcile. Use `simlock release` (which reclaims the device for you) or
+  `simlock cleanup`.
+- `shutdown all` — it stops every device in the set, for every agent, and each
+  interrupted lease spends its recovery budget rebooting; one that runs out
+  ends as `lease_lost`. `shutdown <udid>` of a single device is allowed.
+- `runtime delete` — it deletes a runtime shared with Xcode, and Simlock will
+  not download one back. Delete it through Xcode if that is what you mean.
+- `--set` and `--profiles`, in any spelling — `simlock simctl` supplies the
+  device set itself. A caller-supplied one would point simctl outside what
+  Simlock manages, and (because their value is a separate argument) would let
+  a refused verb read as an ordinary operand. Run `xcrun simctl` directly if
+  you mean to leave Simlock's set.
 
 ## `simlock adb <args...>`
 
@@ -254,10 +267,20 @@ simlock adb shell input tap 100 200
 simlock adb logcat -d
 ```
 
-Refused: `emu kill` and `kill-server`, for the same reason as above — the
-first stops a device Simlock believes is running, the second would detach
-every leased emulator at once. (Simlock's server rejects `kill-server`
-outright in any case.)
+Refused, all exit 2 with `USAGE` and a message naming what to run instead.
+Each is matched anywhere in the arguments, so `-s <serial> emu kill` and
+`-P 1 kill-server` are caught too:
+
+- `kill-server` — it would detach every leased emulator at once. (Simlock's
+  server rejects `kill-server` outright in any case.)
+- `emu kill`, `emu avd stop` — they stop a device Simlock believes is
+  running, which reports as drift on the next reconcile.
+- `emu avd snapshot delete` — it destroys the clean-boot snapshot Simlock
+  restores from, turning every later reclaim of that device from a snapshot
+  load into a full wipe.
+
+Use `simlock release` (which reclaims the device for you) or `simlock cleanup`
+instead.
 
 ## `simlock release <lease-id> | --all`
 

--- a/e2e/fake-driver/fake-driver.ts
+++ b/e2e/fake-driver/fake-driver.ts
@@ -69,6 +69,12 @@ function refusedAdbVerb(args: readonly string[]): string | undefined {
  * The refusal rules, restated rather than imported: this one driver stands in for both
  * platforms, and the e2e lane is exactly where the published behaviour -- exit 2 with a
  * USAGE line naming what to run instead -- has to be exercised end to end.
+ *
+ * Because they are restated, these are a *mirror* of the real rules and never evidence
+ * for them: deleting the refusal branch from `src/drivers/ios/index.ts` would leave every
+ * e2e case here green. What the shipped drivers refuse is pinned in
+ * `src/drivers/ios/index.test.ts` and `src/drivers/android/index.test.ts`; this pair only
+ * has to be refusable, not complete.
  */
 const PASSTHROUGH_REFUSALS: Readonly<
   Record<Platform, (args: readonly string[]) => string | undefined>

--- a/e2e/fake-driver/fake-driver.ts
+++ b/e2e/fake-driver/fake-driver.ts
@@ -14,6 +14,8 @@ import {
   type DriverReality,
   type ObservedMark,
   type ObservedRunState,
+  type PassthroughCommand,
+  PassthroughRefusedError,
 } from "../../dist/core/driver.js";
 import type { DeviceSpec, Platform } from "../../dist/core/domain.js";
 import type {
@@ -42,6 +44,49 @@ const DEFAULT_SCRIPT: FakeDriverPlatformScript = {
   availableOsVersions: ["18.0"],
 };
 
+/** The `simlock <tool>` name each fake platform stands in for, matching the real drivers. */
+const PASSTHROUGH_TOOLS: Readonly<Record<Platform, string>> = {
+  android: "adb",
+  ios: "simctl",
+};
+
+const IOS_REFUSED_VERBS = ["create", "erase", "delete"];
+
+/** iOS refuses a lifecycle verb in first non-flag position, where a subcommand sits. */
+function refusedSimctlVerb(args: readonly string[]): string | undefined {
+  const verb = args.find((argument) => !argument.startsWith("-"));
+  return IOS_REFUSED_VERBS.find((candidate) => candidate === verb);
+}
+
+/** Android refuses either form anywhere in the arguments, `-s <serial> emu kill` included. */
+function refusedAdbVerb(args: readonly string[]): string | undefined {
+  if (args.includes("kill-server")) return "kill-server";
+  const pair = args.some((argument, index) => argument === "emu" && args[index + 1] === "kill");
+  return pair ? "emu kill" : undefined;
+}
+
+/**
+ * The refusal rules, restated rather than imported: this one driver stands in for both
+ * platforms, and the e2e lane is exactly where the published behaviour -- exit 2 with a
+ * USAGE line naming what to run instead -- has to be exercised end to end.
+ */
+const PASSTHROUGH_REFUSALS: Readonly<
+  Record<Platform, (args: readonly string[]) => string | undefined>
+> = {
+  android: refusedAdbVerb,
+  ios: refusedSimctlVerb,
+};
+
+/**
+ * The command a permitted passthrough resolves to: a node one-liner that prints the argv it
+ * was handed and exits with `SIMLOCK_FAKE_PASSTHROUGH_EXIT`. Deliberately reads that from
+ * its own environment rather than from the script file, so a test controls the exit code
+ * through the CLI invocation it is already making and this stays synchronous.
+ */
+const PASSTHROUGH_PROGRAM =
+  "process.stdout.write(JSON.stringify(process.argv.slice(1)));" +
+  "process.exit(Number(process.env.SIMLOCK_FAKE_PASSTHROUGH_EXIT ?? 0));";
+
 /**
  * Driver implementation for the daemon-spawned process the e2e suite drives out of
  * band. Every behaviour lives in a JSON script file re-read on each operation (env
@@ -55,6 +100,7 @@ export class OutOfProcessFakeDriver implements Driver {
   readonly platform: Platform;
   /** Synthetic: this driver owns no real devices, and nothing validates or creates it. */
   readonly deviceRoot: string;
+  readonly passthroughTool: string;
   readonly #clock: FakeDriverClock;
   readonly #logPath: string | undefined;
   readonly #scriptPath: string | undefined;
@@ -66,6 +112,7 @@ export class OutOfProcessFakeDriver implements Driver {
   constructor(options: OutOfProcessFakeDriverOptions) {
     this.platform = options.platform;
     this.deviceRoot = `/fake/${options.platform}`;
+    this.passthroughTool = PASSTHROUGH_TOOLS[options.platform];
     this.#clock = options.clock;
     this.#logPath = options.logPath;
     this.#scriptPath = options.scriptPath;
@@ -199,9 +246,28 @@ export class OutOfProcessFakeDriver implements Driver {
   }
 
   /** Synchronous like `estimate`, and cached the same way: the last script read wins. */
-  // fallow-ignore-next-line unused-class-member -- Driver.leaseEnvironment contract; read by the lease path when it builds a grant.
   leaseEnvironment(): Readonly<Record<string, string>> {
     return this.#lastKnownLeaseEnvironment ?? {};
+  }
+
+  /**
+   * Synchronous and script-free, unlike everything else here: the refusal rules are the
+   * behaviour under test, and a rule that depended on a prior script read would not be
+   * exercised by the very first command a test runs.
+   */
+  passthrough(args: readonly string[]): PassthroughCommand {
+    const refused = PASSTHROUGH_REFUSALS[this.platform](args);
+    if (refused !== undefined) {
+      throw new PassthroughRefusedError(
+        this.passthroughTool,
+        `Refusing \`simlock ${this.passthroughTool} ${refused}\`: use \`simlock release\` or \`simlock cleanup\` instead.`,
+      );
+    }
+    return {
+      args: ["-e", PASSTHROUGH_PROGRAM, this.deviceRoot, ...args],
+      command: process.execPath,
+      env: { SIMLOCK_FAKE_PASSTHROUGH_PLATFORM: this.platform },
+    };
   }
 
   async #beforeCall(

--- a/e2e/lease-environment-passthrough.test.ts
+++ b/e2e/lease-environment-passthrough.test.ts
@@ -66,6 +66,15 @@ describe("reaching a leased device", () => {
       `${exported.stdout}printf %s "$SIMLOCK_IOS_DEVICE_SET"`,
     ]);
     expect(evaluated.stdout).toBe("/Users/o'brien/My Sims/devices/ios");
+    // Released rather than left to the TTL because an outstanding detached lease keeps the
+    // daemon from exiting on `daemon stop` -- a defect that predates this work (it
+    // reproduces on the branch this stack is based on) and is not this test's subject.
+    const exportedGrant = JSON.parse((await env.cli(["status", "--json"])).stdout) as {
+      readonly leases: readonly { readonly id: string }[];
+    };
+    for (const lease of exportedGrant.leases) {
+      await env.cli(["release", lease.id]);
+    }
   });
 
   it("scopes a passthrough to the driver's root and returns the tool's own exit code", async () => {

--- a/e2e/lease-environment-passthrough.test.ts
+++ b/e2e/lease-environment-passthrough.test.ts
@@ -66,9 +66,9 @@ describe("reaching a leased device", () => {
       `${exported.stdout}printf %s "$SIMLOCK_IOS_DEVICE_SET"`,
     ]);
     expect(evaluated.stdout).toBe("/Users/o'brien/My Sims/devices/ios");
-    // Released rather than left to the TTL because an outstanding detached lease keeps the
-    // daemon from exiting on `daemon stop` -- a defect that predates this work (it
-    // reproduces on the branch this stack is based on) and is not this test's subject.
+    // Released rather than left to the TTL: this flow is about the grant, and leaving a
+    // lease outstanding would make it share a failure mode with the shutdown flow that
+    // covers that case deliberately (`daemon lifecycle & recovery`).
     const exportedGrant = JSON.parse((await env.cli(["status", "--json"])).stdout) as {
       readonly leases: readonly { readonly id: string }[];
     };

--- a/e2e/lease-environment-passthrough.test.ts
+++ b/e2e/lease-environment-passthrough.test.ts
@@ -1,0 +1,104 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import { describe, expect, it } from "vitest";
+
+import { withDaemon } from "./helpers/index.js";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * The half of containment that faces the lease holder. Everything a Simlock device lives
+ * in -- an iOS device set Xcode does not read, an adb server the user's `adb` does not talk
+ * to -- is also invisible to the agent that just leased it, so a grant that did not carry
+ * the scoping, and wrappers that did not inject it, would hand out an unreachable device.
+ */
+describe("reaching a leased device", () => {
+  it("carries the driver's environment on the grant, as JSON and as shell exports", async () => {
+    const env = await withDaemon();
+    await env.driverScript.set({
+      ios: {
+        knownModels: ["iPhone 16"],
+        availableOsVersions: ["18.4"],
+        // A device root is a configurable path: the quote and the space are the two
+        // characters a naive `--export-env` corrupts.
+        leaseEnvironment: { SIMLOCK_IOS_DEVICE_SET: "/Users/o'brien/My Sims/devices/ios" },
+      },
+    });
+
+    const lease = await env.cli([
+      "lease",
+      "--platform",
+      "ios",
+      "--device",
+      "iPhone 16",
+      "--agent-id",
+      "env-json-agent",
+      "--detach",
+    ]);
+    expect(lease.code).toBe(0);
+    const grant = lease.json as { lease: string; environment: Record<string, string> };
+    expect(grant.environment).toEqual({
+      SIMLOCK_IOS_DEVICE_SET: "/Users/o'brien/My Sims/devices/ios",
+    });
+    await env.cli(["release", grant.lease]);
+
+    const exported = await env.cli([
+      "lease",
+      "--platform",
+      "ios",
+      "--device",
+      "iPhone 16",
+      "--agent-id",
+      "env-export-agent",
+      "--detach",
+      "--export-env",
+    ]);
+    expect(exported.code).toBe(0);
+    expect(exported.stdout).toBe(
+      "export SIMLOCK_IOS_DEVICE_SET='/Users/o'\\''brien/My Sims/devices/ios'\n",
+    );
+    // The assertion that matters is a real shell's, not a string comparison: what
+    // `eval "$(simlock lease ... --export-env)"` puts in the environment has to be the
+    // path byte for byte, quote and space included.
+    const evaluated = await execFileAsync("/bin/sh", [
+      "-c",
+      `${exported.stdout}printf %s "$SIMLOCK_IOS_DEVICE_SET"`,
+    ]);
+    expect(evaluated.stdout).toBe("/Users/o'brien/My Sims/devices/ios");
+  });
+
+  it("scopes a passthrough to the driver's root and returns the tool's own exit code", async () => {
+    const env = await withDaemon();
+
+    const passthrough = await env.cli(["adb", "shell", "input", "tap", "100", "200"], {
+      env: { SIMLOCK_FAKE_PASSTHROUGH_EXIT: "7" },
+    });
+
+    expect(passthrough.code).toBe(7);
+    expect(JSON.parse(passthrough.stdout)).toEqual([
+      "/fake/android",
+      "shell",
+      "input",
+      "tap",
+      "100",
+      "200",
+    ]);
+  });
+
+  it.each([
+    [["simctl", "delete", "ABCD"], "simctl delete"],
+    [["adb", "kill-server"], "adb kill-server"],
+    [["adb", "-s", "emulator-5586", "emu", "kill"], "adb emu kill"],
+  ])("refuses %s with a usage error naming what to run instead", async (args, refused) => {
+    const env = await withDaemon();
+
+    const refusal = await env.cli(args);
+
+    expect(refusal.code).toBe(2);
+    expect(refusal.error?.code).toBe("USAGE");
+    expect(refusal.error?.message).toContain(refused);
+    expect(refusal.error?.message).toContain("simlock release");
+    expect(refusal.stdout).toBe("");
+  });
+});

--- a/e2e/slow-android-smoke.test.ts
+++ b/e2e/slow-android-smoke.test.ts
@@ -85,7 +85,27 @@ describe.skipIf(!hasAndroidSdk)(
             { timeout: 240_000 },
           );
           expect(lease.code, `lease failed: ${lease.stderr}`).toBe(0);
-          const grant = lease.json as { lease: string; udid: string };
+          const grant = lease.json as {
+            lease: string;
+            udid: string;
+            environment: Record<string, string>;
+          };
+
+          // Without this, a holder's `adb` talks to the shared server, which by design
+          // cannot see a Simlock emulator at all (ADR 0001, decision 7).
+          expect(grant.environment).toEqual({
+            ANDROID_ADB_SERVER_PORT: String(adbServerPort),
+          });
+
+          // `simlock adb` is the same scoping, made for the caller, and the refusals are
+          // what keep the wrapper from handing back the capability containment removed.
+          const wrapped = await env.cli(["adb", "devices"]);
+          expect(wrapped.code, `simlock adb failed: ${wrapped.stderr}`).toBe(0);
+          expect(wrapped.stdout).toContain("emulator-");
+
+          const refused = await env.cli(["adb", "kill-server"]);
+          expect(refused.code, "simlock adb kill-server must be refused, not run").toBe(2);
+          expect(refused.error?.code).toBe("USAGE");
 
           // The adb serial (e.g. "emulator-5554") is a driver-internal detail simlock
           // deliberately keeps opaque outside drivers/android (architecture.md #2) --

--- a/e2e/slow-ios-smoke.test.ts
+++ b/e2e/slow-ios-smoke.test.ts
@@ -6,6 +6,7 @@ import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 
 import { withDaemon } from "./helpers/index.js";
+import type { TestEnv } from "./helpers/env.js";
 import { waitFor } from "./helpers/wait.js";
 
 const execFileAsync = promisify(execFile);
@@ -97,6 +98,21 @@ async function sweepStaleDeviceSets(): Promise<void> {
 
 // This lane needs the real simctl toolchain, hence darwin-only and gated on an
 // installed runtime -- it never installs one itself (no --allow-download).
+/**
+ * `simlock simctl` against a real simctl, which is the only way to know the wrapper
+ * resolves a UDID a bare simctl cannot see -- and that the lifecycle verbs it must not
+ * proxy come back as a usage error instead of destroying the leased device.
+ */
+async function expectSimctlPassthrough(env: TestEnv, udid: string): Promise<void> {
+  const wrapped = await env.cli(["simctl", "list", "devices", "-j"]);
+  expect(wrapped.code, `simlock simctl failed: ${wrapped.stderr}`).toBe(0);
+  expect(wrapped.stdout).toContain(udid);
+
+  const refused = await env.cli(["simctl", "delete", udid]);
+  expect(refused.code, "simlock simctl delete must be refused, not run").toBe(2);
+  expect(refused.error).toMatchObject({ code: "USAGE" });
+}
+
 describe.skipIf(process.platform !== "darwin")(
   "iOS smoke (real simctl)",
   { tags: ["slow", "ios"] },
@@ -149,7 +165,18 @@ describe.skipIf(process.platform !== "darwin")(
             { timeout: 120_000 },
           );
           expect(lease.code, `lease failed: ${lease.stderr}`).toBe(0);
-          const grant = lease.json as { lease: string; udid: string; device: string };
+          const grant = lease.json as {
+            lease: string;
+            udid: string;
+            device: string;
+            environment: Record<string, string>;
+          };
+
+          // The grant has to say how to reach the device, because nothing else does: the
+          // UDID below resolves to nothing without this path (ADR 0001, decision 7).
+          expect(grant.environment).toEqual({ SIMLOCK_IOS_DEVICE_SET: deviceSet });
+
+          await expectSimctlPassthrough(env, grant.udid);
 
           const booted = await setDevices(deviceSet);
           const bootedDevice = booted.find((device) => device.udid === grant.udid);

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -692,7 +692,7 @@ describe("CLI boundary", () => {
     );
   });
 
-  it("prints nothing and succeeds when --export-env has no environment to export", async () => {
+  it("names the lease on stderr when --export-env has no environment to export", async () => {
     const output = outputCapture();
     const connection = new StubConnection();
     connection.response("lease.request", detachedGrant);
@@ -703,7 +703,31 @@ describe("CLI boundary", () => {
         output.environmentWith({ connect: async () => connection }),
       ),
     ).resolves.toBe(0);
+    // stdout stays empty so `eval "$(...)"` is unaffected, but the lease is committed and
+    // TTL-bound: a caller told nothing at all could neither renew nor release it.
     expect(output.stdout).toBe("");
+    expect(output.stderr).toContain(detachedGrant.lease.id);
+    expect(output.stderr).toContain("no environment");
+  });
+
+  it("fails loudly rather than exporting a key that would change what eval runs", async () => {
+    const output = outputCapture();
+    const connection = new StubConnection();
+    connection.response("lease.request", {
+      ...detachedGrant,
+      // Not reachable through the shipped drivers, whose keys are literals -- but
+      // `SIMLOCK_DRIVERS_MODULE` and the wire both accept whatever a driver returns.
+      environment: { "K=1; touch /tmp/probe/PWNED_KEY; X": "1" },
+    });
+
+    await expect(
+      runCli(
+        ["lease", "--platform", "ios", "--device", "iPhone 17 Pro", "--detach", "--export-env"],
+        output.environmentWith({ connect: async () => connection }),
+      ),
+    ).resolves.toBe(1);
+    expect(output.stdout).toBe("");
+    expect(output.stderr).toContain("PWNED_KEY");
   });
 
   it("keeps holding the lease after printing export lines in held mode", async () => {

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -30,6 +30,20 @@ import {
 } from "./index.js";
 
 const gibibyte = 1024 ** 3;
+/** A minimal daemon lease response, for the tests that only care what the CLI prints. */
+const detachedGrant = {
+  device: {
+    driverDeviceId: "ABCD",
+    spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
+  },
+  lease: { id: "lse_env", mode: "detached", ttlDeadline: 61_000 },
+  timing: {
+    estimatedBootMs: 0,
+    estimatedProvisionMs: 0,
+    estimatedReclaimMs: 0,
+    estimatedReadyMs: 0,
+  },
+};
 const runningDaemons: DaemonServer[] = [];
 const temporaryDirectories: string[] = [];
 
@@ -634,7 +648,7 @@ describe("CLI boundary", () => {
       ),
     ).resolves.toBe(0);
     expect(detached.stdout).toBe(
-      '{"device":"iPhone 17 Pro","expires_at_ms":61000,"lease":"lse_9f2c","os":"26.5","platform":"ios","state":"leased","timing":{"estimated_boot_ms":20,"estimated_provision_ms":10,"estimated_reclaim_ms":0,"estimated_ready_ms":30},"udid":"ABCD"}\n',
+      '{"device":"iPhone 17 Pro","environment":{},"expires_at_ms":61000,"lease":"lse_9f2c","os":"26.5","platform":"ios","state":"leased","timing":{"estimated_boot_ms":20,"estimated_provision_ms":10,"estimated_reclaim_ms":0,"estimated_ready_ms":30},"udid":"ABCD"}\n',
     );
     expect(connection.closed).toBe(true);
 
@@ -651,6 +665,173 @@ describe("CLI boundary", () => {
       payload: { leaseId: "lse_9f2c", ttlMs: 60_000 },
       type: "lease.renew",
     });
+  });
+
+  it("prints shell export lines instead of the JSON grant under --export-env", async () => {
+    const output = outputCapture();
+    const connection = new StubConnection();
+    connection.response("lease.request", {
+      ...detachedGrant,
+      // A device root is a user-configurable path, so it can hold a space or an
+      // apostrophe; both have to survive `eval "$(...)"` byte for byte.
+      environment: {
+        SIMLOCK_IOS_DEVICE_SET: "/Users/o'brien/My Sims/devices/ios",
+        ANDROID_ADB_SERVER_PORT: "5038",
+      },
+    });
+
+    await expect(
+      runCli(
+        ["lease", "--platform", "ios", "--device", "iPhone 17 Pro", "--detach", "--export-env"],
+        output.environmentWith({ connect: async () => connection }),
+      ),
+    ).resolves.toBe(0);
+    expect(output.stdout).toBe(
+      "export ANDROID_ADB_SERVER_PORT='5038'\n" +
+        "export SIMLOCK_IOS_DEVICE_SET='/Users/o'\\''brien/My Sims/devices/ios'\n",
+    );
+  });
+
+  it("prints nothing and succeeds when --export-env has no environment to export", async () => {
+    const output = outputCapture();
+    const connection = new StubConnection();
+    connection.response("lease.request", detachedGrant);
+
+    await expect(
+      runCli(
+        ["lease", "--platform", "ios", "--device", "iPhone 17 Pro", "--detach", "--export-env"],
+        output.environmentWith({ connect: async () => connection }),
+      ),
+    ).resolves.toBe(0);
+    expect(output.stdout).toBe("");
+  });
+
+  it("keeps holding the lease after printing export lines in held mode", async () => {
+    const output = outputCapture();
+    const signals = new EventEmitter();
+    const connection = new StubConnection();
+    connection.response("lease.request", {
+      ...detachedGrant,
+      environment: { SIMLOCK_IOS_DEVICE_SET: "/devices/ios" },
+      lease: { id: "lse_held_env", mode: "held", ttlDeadline: 61_000 },
+    });
+    connection.response("lease.release", { leaseId: "lse_held_env" });
+    const run = runCli(
+      ["lease", "--platform", "ios", "--device", "iPhone 17 Pro", "--export-env"],
+      output.environmentWith({ connect: async () => connection, signals }),
+    );
+
+    await vi.waitFor(() => expect(output.stdout).not.toBe(""));
+    expect(output.stdout).toBe("export SIMLOCK_IOS_DEVICE_SET='/devices/ios'\n");
+    signals.emit("SIGTERM");
+
+    await expect(run).resolves.toBe(0);
+    expect(connection.calls).toContainEqual({
+      payload: { leaseId: "lse_held_env" },
+      type: "lease.release",
+    });
+  });
+
+  it.each([
+    ["simctl", ["install", "booted", "./MyApp.app"]],
+    ["adb", ["shell", "input", "tap", "100", "200"]],
+  ])("asks the daemon to scope a %s passthrough and runs it locally", async (tool, args) => {
+    const output = outputCapture();
+    const connection = new StubConnection();
+    connection.response("driver.passthrough", {
+      args: ["-P", "5038", ...args],
+      command: "/sdk/adb",
+      env: { ANDROID_ADB_SERVER_PORT: "5038" },
+    });
+    const runPassthrough = vi.fn(async () => 0);
+
+    await expect(
+      runCli(
+        [tool, ...args],
+        output.environmentWith({ connect: async () => connection, runPassthrough }),
+      ),
+    ).resolves.toBe(0);
+    expect(connection.calls).toContainEqual({
+      payload: { args, tool },
+      type: "driver.passthrough",
+    });
+    expect(runPassthrough).toHaveBeenCalledWith({
+      args: ["-P", "5038", ...args],
+      command: "/sdk/adb",
+      env: { ANDROID_ADB_SERVER_PORT: "5038" },
+    });
+    expect(output.stdout).toBe("");
+  });
+
+  it("propagates the passthrough's own exit code rather than reporting success", async () => {
+    const output = outputCapture();
+    const connection = new StubConnection();
+    connection.response("driver.passthrough", { args: ["devices"], command: "adb", env: {} });
+
+    await expect(
+      runCli(
+        ["adb", "devices"],
+        output.environmentWith({
+          connect: async () => connection,
+          runPassthrough: async () => 42,
+        }),
+      ),
+    ).resolves.toBe(42);
+  });
+
+  it("renders a driver's refusal as a USAGE error, not as a daemon failure", async () => {
+    const output = outputCapture();
+    const connection = new StubConnection();
+    connection.response(
+      "driver.passthrough",
+      new DaemonClientError(
+        "PASSTHROUGH_REFUSED",
+        "Refusing `simlock simctl delete`: use `simlock release` or `simlock cleanup` instead.",
+      ),
+    );
+    const runPassthrough = vi.fn(async () => 0);
+
+    await expect(
+      runCli(
+        ["simctl", "delete", "ABCD"],
+        output.environmentWith({ connect: async () => connection, runPassthrough }),
+      ),
+    ).resolves.toBe(2);
+    expect(runPassthrough).not.toHaveBeenCalled();
+    expect(JSON.parse(output.stderr)).toEqual({
+      error: {
+        code: "USAGE",
+        message: expect.stringContaining("simlock release"),
+      },
+    });
+  });
+
+  it("passes a passthrough's own --help through to the tool rather than intercepting it", async () => {
+    const output = outputCapture();
+    const connection = new StubConnection();
+    connection.response("driver.passthrough", { args: ["--help"], command: "adb", env: {} });
+
+    await expect(
+      runCli(
+        ["adb", "--help"],
+        output.environmentWith({
+          connect: async () => connection,
+          runPassthrough: async () => 0,
+        }),
+      ),
+    ).resolves.toBe(0);
+    expect(connection.calls).toContainEqual({
+      payload: { args: ["--help"], tool: "adb" },
+      type: "driver.passthrough",
+    });
+  });
+
+  it("lists both tool passthroughs in root help", async () => {
+    const output = outputCapture();
+
+    await expect(runCli([], output.environment)).resolves.toBe(0);
+    expect(output.stdout).toContain("simctl <args...>");
+    expect(output.stdout).toContain("adb <args...>");
   });
 
   it("keeps status JSON stable", async () => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,6 +23,8 @@ import {
   parseRawDeviceUnhealthy,
   parseRawLeaseGrant,
   parseRawLeaseLost,
+  parseRawPassthroughCommand,
+  type RawPassthroughCommand,
 } from "../daemon-client/contracts.js";
 import { DaemonClientError, type DaemonConnection } from "../daemon-client/protocol.js";
 
@@ -33,6 +35,8 @@ const USAGE = `Usage: simlock <command> [options]
 Commands:
   lease, release, status, list, catalog, cleanup, doctor, nuke, events,
   daemon, config
+  simctl <args...>            Run xcrun simctl against Simlock's iOS device set
+  adb <args...>               Run adb against Simlock's adb server
   mcp                         Start the stdio MCP server
 Run 'simlock <command> --help' for command usage.`;
 
@@ -43,6 +47,13 @@ Run 'simlock <command> --help' for command usage.`;
  * its own lease.
  */
 const LEASE_LOST_EXIT_CODE = 14;
+
+/**
+ * The daemon's answer when a driver refuses to proxy a verb. It is a usage mistake, not a
+ * daemon fault, so the CLI re-raises it as one and the caller sees the `USAGE` / exit 2
+ * contract `docs/CLI.md` documents for a refused passthrough.
+ */
+const PASSTHROUGH_REFUSED_CODE = "PASSTHROUGH_REFUSED";
 
 const DAEMON_ERROR_EXIT_CODES: Readonly<Record<string, number>> = {
   BAD_FRAME: 2,
@@ -101,6 +112,12 @@ export interface CliEnvironment {
   readonly stderr: Output;
   readonly stdout: Output;
   readonly confirm?: (question: string) => Promise<boolean>;
+  /**
+   * Runs a daemon-resolved passthrough command and resolves with its exit code. A hook
+   * rather than a direct spawn so the `simctl` / `adb` wrappers are testable without a
+   * child process, the same way every other external effect here is injected.
+   */
+  readonly runPassthrough?: (command: RawPassthroughCommand) => Promise<number>;
   readonly writeConfigFile: (contents: Record<string, unknown>) => Promise<void>;
 }
 
@@ -153,6 +170,7 @@ function defaultCliEnvironment(env: NodeJS.ProcessEnv = process.env): CliEnviron
     stderr: process.stderr,
     stdout: process.stdout,
     confirm: confirmTerminal,
+    runPassthrough: spawnPassthrough,
     writeConfigFile: async (contents) => {
       await filesystem.mkdirp(dataDirectory);
       await filesystem.writeFileAtomic(configPath, `${JSON.stringify(contents, null, 2)}\n`);
@@ -196,6 +214,11 @@ export async function runCli(
         return await runDaemon(argv.slice(1), environment);
       case "config":
         return await runConfig(argv.slice(1), environment);
+      case "simctl":
+      case "adb":
+        // Every argument after the tool name is the tool's, verbatim -- including `--help`,
+        // which belongs to `simctl`/`adb` and not to Simlock. `simlock --help` lists these.
+        return await runPassthrough(argv[0], argv.slice(1), environment);
       case "mcp":
         return await runMcp(argv.slice(1), environment);
       default:
@@ -224,6 +247,31 @@ function cliErrorCode(error: unknown): string {
   if (error instanceof UsageError) return "USAGE";
   if (error instanceof DaemonClientError) return error.code;
   return "INTERNAL";
+}
+
+/**
+ * Asks the daemon which command reaches Simlock's devices for this tool, then runs it here.
+ * The split is architecture rule 8 in one function: the daemon owns the scoping (it is the
+ * process that knows which root and which adb port), and the CLI owns the terminal, so an
+ * interactive `adb shell` gets a tty and its exit code travels back to the caller's shell.
+ */
+async function runPassthrough(
+  tool: string,
+  args: readonly string[],
+  environment: CliEnvironment,
+): Promise<number> {
+  const run = environment.runPassthrough;
+  if (run === undefined) throw new Error("Tool passthrough is unavailable");
+  let response: unknown;
+  try {
+    response = await requestOnce(environment, "driver.passthrough", { args, tool });
+  } catch (error: unknown) {
+    if (error instanceof DaemonClientError && error.code === PASSTHROUGH_REFUSED_CODE) {
+      throw new UsageError(error.message);
+    }
+    throw error;
+  }
+  return run(parseRawPassthroughCommand(response));
 }
 
 async function runMcp(argv: readonly string[], environment: CliEnvironment): Promise<number> {
@@ -274,6 +322,7 @@ async function runLease(argv: readonly string[], environment: CliEnvironment): P
     "bind-pid": { type: "string" },
     detach: { type: "boolean" },
     device: { type: "string" },
+    "export-env": { type: "boolean" },
     help: { type: "boolean", short: "h" },
     "no-wait": { type: "boolean" },
     os: { type: "string" },
@@ -284,7 +333,7 @@ async function runLease(argv: readonly string[], environment: CliEnvironment): P
     environment.stdout.write(
       "Usage: simlock lease --platform <ios|android> --device <model> [--os <version>]\n" +
         "                     [--agent-id <id>] [--timeout <duration>] [--no-wait] [--detach]\n" +
-        "                     [--allow-download] [--bind-pid <pid>]\n",
+        "                     [--allow-download] [--export-env] [--bind-pid <pid>]\n",
     );
     return 0;
   }
@@ -362,7 +411,13 @@ async function runLease(argv: readonly string[], environment: CliEnvironment): P
       ...(timeoutMs === undefined ? {} : { timeoutMs }),
     });
     const result = leaseResult(response);
-    environment.stdout.write(`${JSON.stringify(result)}\n`);
+    // Held mode still holds after this line, whichever shape it took: `--export-env` only
+    // changes what stdout carries, never how long the lease lives.
+    environment.stdout.write(
+      values["export-env"] === true
+        ? exportEnvLines(result.environment)
+        : `${JSON.stringify(result)}\n`,
+    );
     if (detached || termination === undefined) return 0;
     await Promise.race([termination.settled, leaseLostSignal]);
     if (leaseLost) {
@@ -698,13 +753,32 @@ function commandArgs(
   }
 }
 
-function leaseResult(value: unknown): Record<string, unknown> & { readonly lease: string } {
+/**
+ * Shell `export` lines for `eval "$(simlock lease ... --export-env)"`. Single quotes because
+ * they are the only shell quoting that takes every byte literally, and `'\''` is the one way
+ * to get a literal quote back inside them -- a device-set path is a user-configurable path
+ * and may hold a space or an apostrophe. Sorted so repeated runs produce identical output.
+ */
+function exportEnvLines(environment: Readonly<Record<string, string>>): string {
+  return Object.entries(environment)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `export ${key}='${value.replaceAll("'", "'\\''")}'\n`)
+    .join("");
+}
+
+function leaseResult(value: unknown): Record<string, unknown> & {
+  readonly environment: Readonly<Record<string, string>>;
+  readonly lease: string;
+} {
   const grant = parseRawLeaseGrant(value);
   return {
     // Optional: undefined only for a device leased straight out of a pre-address `state.json`
     // without ever rebooting under this daemon -- see `DeviceRecord.address` in domain.ts.
     ...(grant.device.address === undefined ? {} : { address: grant.device.address }),
     device: grant.device.spec.model,
+    // Always present, `{}` at the least: an agent that reads it unconditionally should
+    // never have to distinguish "no scoping needed" from "an older daemon said nothing".
+    environment: grant.environment,
     expires_at_ms: grant.lease.ttlDeadline,
     lease: grant.lease.id,
     os: grant.device.spec.osVersion,
@@ -979,6 +1053,31 @@ function waitForTermination(
   });
   return { dispose: () => detach(), settled };
 }
+/**
+ * Inherited stdio, so a passthrough behaves exactly as the bare tool would: `adb shell`
+ * stays interactive, `simctl io ... screenshot` writes where it was told to, and nothing
+ * is buffered through this process. The scoped environment is layered over the CLI's own
+ * rather than replacing it -- it carries only the scoping keys, and a tool spawned without
+ * `PATH` or `ANDROID_HOME` would not find the SDK the daemon just pointed it at.
+ */
+async function spawnPassthrough(command: RawPassthroughCommand): Promise<number> {
+  const { spawn } = await import("node:child_process");
+  const { constants } = await import("node:os");
+  const child = spawn(command.command, [...command.args], {
+    env: { ...process.env, ...command.env },
+    stdio: "inherit",
+  });
+  return new Promise<number>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code, signal) => {
+      // A child killed by a signal has no exit code; report it the way a shell does, so a
+      // passthrough interrupted with ^C is distinguishable from one that simply failed.
+      if (code !== null) resolve(code);
+      else resolve(signal === null ? 1 : 128 + (constants.signals[signal] ?? 0));
+    });
+  });
+}
+
 async function confirmTerminal(question: string): Promise<boolean> {
   if (!process.stdin.isTTY) return false;
   const { createInterface } = await import("node:readline/promises");

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -27,6 +27,7 @@ import {
   type RawPassthroughCommand,
 } from "../daemon-client/contracts.js";
 import { DaemonClientError, type DaemonConnection } from "../daemon-client/protocol.js";
+import { spawnPassthrough } from "./passthrough.js";
 
 export { DaemonClientError, type DaemonConnection } from "../daemon-client/protocol.js";
 
@@ -54,6 +55,14 @@ const LEASE_LOST_EXIT_CODE = 14;
  * contract `docs/CLI.md` documents for a refused passthrough.
  */
 const PASSTHROUGH_REFUSED_CODE = "PASSTHROUGH_REFUSED";
+
+/**
+ * A key that is safe to the left of `=` in a shell `export`. Anything else is a command
+ * waiting for `eval` to run it, and escaping the value alone defends the half an attacker
+ * does not need. Not reachable through the shipped drivers (their keys are literals), but
+ * `SIMLOCK_DRIVERS_MODULE` and the wire both accept whatever a driver returns.
+ */
+const SHELL_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 const DAEMON_ERROR_EXIT_CODES: Readonly<Record<string, number>> = {
   BAD_FRAME: 2,
@@ -216,6 +225,11 @@ export async function runCli(
         return await runConfig(argv.slice(1), environment);
       case "simctl":
       case "adb":
+        // Named here rather than discovered from the drivers on purpose: these are
+        // user-facing command names published in `docs/CLI.md`, and the CLI never builds a
+        // simctl or adb argument -- it forwards the name and spawns whatever the daemon
+        // hands back, so which flags scope the tool and which verbs it refuses still live
+        // entirely in the driver (architecture rule 2 is about knowledge, not about names).
         // Every argument after the tool name is the tool's, verbatim -- including `--help`,
         // which belongs to `simctl`/`adb` and not to Simlock. `simlock --help` lists these.
         return await runPassthrough(argv[0], argv.slice(1), environment);
@@ -413,11 +427,8 @@ async function runLease(argv: readonly string[], environment: CliEnvironment): P
     const result = leaseResult(response);
     // Held mode still holds after this line, whichever shape it took: `--export-env` only
     // changes what stdout carries, never how long the lease lives.
-    environment.stdout.write(
-      values["export-env"] === true
-        ? exportEnvLines(result.environment)
-        : `${JSON.stringify(result)}\n`,
-    );
+    if (values["export-env"] === true) writeExportEnv(environment, result);
+    else environment.stdout.write(`${JSON.stringify(result)}\n`);
     if (detached || termination === undefined) return 0;
     await Promise.race([termination.settled, leaseLostSignal]);
     if (leaseLost) {
@@ -754,15 +765,42 @@ function commandArgs(
 }
 
 /**
+ * Writes the export lines, and -- when there are none -- one line to stderr saying so.
+ * Silence would be worse than it looks: the lease is committed and TTL-bound either way,
+ * and a caller that was told neither its id nor that anything was missing can neither
+ * renew nor release it, and has no scoping to reach the device with. stdout stays clean so
+ * `eval "$(...)"` is unaffected. An older daemon, which sends no `environment` at all, is
+ * the case that actually produces this.
+ */
+function writeExportEnv(environment: CliEnvironment, result: ReturnType<typeof leaseResult>): void {
+  environment.stdout.write(exportEnvLines(result.environment));
+  if (Object.keys(result.environment).length > 0) return;
+  environment.stderr.write(
+    `simlock: lease ${result.lease} carries no environment, so there is nothing to export and the device may be unreachable from a bare simctl or adb. Release it with \`simlock release ${result.lease}\`.\n`,
+  );
+}
+
+/**
  * Shell `export` lines for `eval "$(simlock lease ... --export-env)"`. Single quotes because
  * they are the only shell quoting that takes every byte literally, and `'\''` is the one way
  * to get a literal quote back inside them -- a device-set path is a user-configurable path
  * and may hold a space or an apostrophe. Sorted so repeated runs produce identical output.
+ *
+ * A key that is not a shell identifier fails the command rather than being skipped: the
+ * driver that produced it is broken, and dropping it silently would leave the holder with
+ * a lease it cannot reach and no idea why.
  */
 function exportEnvLines(environment: Readonly<Record<string, string>>): string {
   return Object.entries(environment)
     .sort(([left], [right]) => left.localeCompare(right))
-    .map(([key, value]) => `export ${key}='${value.replaceAll("'", "'\\''")}'\n`)
+    .map(([key, value]) => {
+      if (!SHELL_IDENTIFIER.test(key)) {
+        throw new Error(
+          `Refusing to export ${JSON.stringify(key)}: a lease environment key must be a shell identifier, and this one would change what \`eval\` runs.`,
+        );
+      }
+      return `export ${key}='${value.replaceAll("'", "'\\''")}'\n`;
+    })
     .join("");
 }
 
@@ -1052,30 +1090,6 @@ function waitForTermination(
         : undefined;
   });
   return { dispose: () => detach(), settled };
-}
-/**
- * Inherited stdio, so a passthrough behaves exactly as the bare tool would: `adb shell`
- * stays interactive, `simctl io ... screenshot` writes where it was told to, and nothing
- * is buffered through this process. The scoped environment is layered over the CLI's own
- * rather than replacing it -- it carries only the scoping keys, and a tool spawned without
- * `PATH` or `ANDROID_HOME` would not find the SDK the daemon just pointed it at.
- */
-async function spawnPassthrough(command: RawPassthroughCommand): Promise<number> {
-  const { spawn } = await import("node:child_process");
-  const { constants } = await import("node:os");
-  const child = spawn(command.command, [...command.args], {
-    env: { ...process.env, ...command.env },
-    stdio: "inherit",
-  });
-  return new Promise<number>((resolve, reject) => {
-    child.once("error", reject);
-    child.once("close", (code, signal) => {
-      // A child killed by a signal has no exit code; report it the way a shell does, so a
-      // passthrough interrupted with ^C is distinguishable from one that simply failed.
-      if (code !== null) resolve(code);
-      else resolve(signal === null ? 1 : 128 + (constants.signals[signal] ?? 0));
-    });
-  });
 }
 
 async function confirmTerminal(question: string): Promise<boolean> {

--- a/src/cli/passthrough.test.ts
+++ b/src/cli/passthrough.test.ts
@@ -1,0 +1,51 @@
+import { constants } from "node:os";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { spawnPassthrough } from "./passthrough.js";
+
+/** Runs the script in a child of this process's own node, the way a real tool would run. */
+function nodeCommand(script: string, env: Readonly<Record<string, string>> = {}) {
+  return { args: ["-e", script], command: process.execPath, env };
+}
+
+describe("spawnPassthrough", () => {
+  const originalPort = process.env.ANDROID_ADB_SERVER_PORT;
+
+  afterEach(() => {
+    if (originalPort === undefined) delete process.env.ANDROID_ADB_SERVER_PORT;
+    else process.env.ANDROID_ADB_SERVER_PORT = originalPort;
+  });
+
+  it("propagates the tool's own exit code", async () => {
+    await expect(spawnPassthrough(nodeCommand("process.exit(42)"))).resolves.toBe(42);
+  });
+
+  it("reports a signalled tool the way a shell does rather than as a plain failure", async () => {
+    // ^C on an interactive `simlock adb shell` has to be distinguishable from the tool
+    // exiting 1 on its own; a fixed code would collapse the two.
+    await expect(
+      spawnPassthrough(nodeCommand("process.kill(process.pid, 'SIGTERM')")),
+    ).resolves.toBe(128 + (constants.signals.SIGTERM ?? 0));
+  });
+
+  it("lets the daemon's scoping win over a stale value already in the environment", async () => {
+    // The merge order is the whole guarantee: a caller who exported this variable for an
+    // earlier lease would otherwise aim the command at whichever server that names.
+    process.env.ANDROID_ADB_SERVER_PORT = "5037";
+
+    await expect(
+      spawnPassthrough(
+        nodeCommand("process.exit(process.env.ANDROID_ADB_SERVER_PORT === '5038' ? 7 : 8)", {
+          ANDROID_ADB_SERVER_PORT: "5038",
+        }),
+      ),
+    ).resolves.toBe(7);
+  });
+
+  it("keeps the caller's own environment, which the tool needs to find its SDK", async () => {
+    await expect(
+      spawnPassthrough(nodeCommand("process.exit(process.env.PATH ? 0 : 9)")),
+    ).resolves.toBe(0);
+  });
+});

--- a/src/cli/passthrough.ts
+++ b/src/cli/passthrough.ts
@@ -1,0 +1,31 @@
+import type { RawPassthroughCommand } from "../daemon-client/contracts.js";
+
+/**
+ * Runs a daemon-resolved `simlock simctl` / `simlock adb` command in this process's own
+ * terminal.
+ *
+ * Inherited stdio, so a passthrough behaves exactly as the bare tool would: `adb shell`
+ * stays interactive, `simctl io ... screenshot` writes where it was told to, and nothing
+ * is buffered through this process. The scoped environment is layered over the CLI's own
+ * rather than replacing it -- it carries only the scoping keys, and a tool spawned without
+ * `PATH` or `ANDROID_HOME` would not find the SDK the daemon just pointed it at. The
+ * daemon's keys win the merge: a caller with a stale `ANDROID_ADB_SERVER_PORT` already
+ * exported would otherwise aim the command at whichever server that names.
+ */
+export async function spawnPassthrough(command: RawPassthroughCommand): Promise<number> {
+  const { spawn } = await import("node:child_process");
+  const { constants } = await import("node:os");
+  const child = spawn(command.command, [...command.args], {
+    env: { ...process.env, ...command.env },
+    stdio: "inherit",
+  });
+  return new Promise<number>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code, signal) => {
+      // A child killed by a signal has no exit code; report it the way a shell does, so a
+      // passthrough interrupted with ^C is distinguishable from one that simply failed.
+      if (code !== null) resolve(code);
+      else resolve(signal === null ? 1 : 128 + (constants.signals[signal] ?? 0));
+    });
+  });
+}

--- a/src/core/driver-catalog.test.ts
+++ b/src/core/driver-catalog.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import { FakeClock } from "../ports/index.js";
+import { PassthroughRefusedError } from "./driver.js";
 import { FakeDriver } from "./fake-driver.js";
-import { DriverCatalog, NoDriverError } from "./driver-catalog.js";
+import { DriverCatalog, NoDriverError, UnknownPassthroughToolError } from "./driver-catalog.js";
 
 describe("DriverCatalog", () => {
   it("resolves a request through its registered driver", async () => {
@@ -77,5 +78,51 @@ describe("DriverCatalog", () => {
 
     await expect(catalog.listCatalog()).resolves.toEqual([]);
     await expect(catalog.listCatalog("android")).resolves.toEqual([]);
+  });
+
+  it("routes a passthrough to the driver that claims its tool name", () => {
+    const clock = new FakeClock();
+    const ios = new FakeDriver({
+      clock,
+      passthrough: (args) => ({ args: ["--set", "/root", ...args], command: "xcrun", env: {} }),
+      passthroughTool: "simctl",
+      platform: "ios",
+    });
+    const android = new FakeDriver({
+      clock,
+      passthrough: () => ({ args: [], command: "adb", env: {} }),
+      passthroughTool: "adb",
+      platform: "android",
+    });
+    const catalog = new DriverCatalog([ios, android]);
+
+    expect(catalog.passthrough("simctl", ["list", "devices"])).toEqual({
+      args: ["--set", "/root", "list", "devices"],
+      command: "xcrun",
+      env: {},
+    });
+  });
+
+  it("lets a driver's refusal out untouched rather than translating it here", () => {
+    const clock = new FakeClock();
+    const driver = new FakeDriver({
+      clock,
+      passthrough: () => {
+        throw new PassthroughRefusedError("simctl", "Refusing `simlock simctl delete`");
+      },
+      passthroughTool: "simctl",
+      platform: "ios",
+    });
+
+    expect(() => new DriverCatalog([driver]).passthrough("simctl", ["delete", "ABCD"])).toThrow(
+      PassthroughRefusedError,
+    );
+  });
+
+  it("refuses a tool no registered driver answers to", () => {
+    const clock = new FakeClock();
+    const catalog = new DriverCatalog([new FakeDriver({ clock, platform: "ios" })]);
+
+    expect(() => catalog.passthrough("adb", ["devices"])).toThrow(UnknownPassthroughToolError);
   });
 });

--- a/src/core/driver-catalog.ts
+++ b/src/core/driver-catalog.ts
@@ -1,11 +1,19 @@
 import type { DeviceSpec, Platform } from "./domain.js";
-import type { DeviceRequest, Driver, DriverCatalogEntry } from "./driver.js";
+import type { DeviceRequest, Driver, DriverCatalogEntry, PassthroughCommand } from "./driver.js";
 
 /** Thrown when no installed driver can serve the requested platform. */
 export class NoDriverError extends Error {
   constructor(readonly platform: Platform) {
     super(`No driver registered for platform: ${platform}`);
     this.name = "NoDriverError";
+  }
+}
+
+/** Thrown when no registered driver answers to the requested `simlock <tool>` wrapper. */
+export class UnknownPassthroughToolError extends Error {
+  constructor(readonly tool: string) {
+    super(`No driver provides a ${tool} passthrough`);
+    this.name = "UnknownPassthroughToolError";
   }
 }
 
@@ -26,6 +34,21 @@ export class DriverCatalog {
     const driver = this.#drivers.get(platform);
     if (driver === undefined) throw new NoDriverError(platform);
     return driver;
+  }
+
+  /**
+   * Routes `simlock <tool> <args>` to whichever driver claims that tool name. Routing is
+   * all this does: which flag scopes the tool, which verbs it refuses, and what its
+   * environment must carry are decided inside the driver, so a third driver can add a
+   * wrapper without a line changing here (architecture rules 2 and 3).
+   */
+  passthrough(tool: string, args: readonly string[]): PassthroughCommand {
+    for (const driver of this.#drivers.values()) {
+      if (driver.passthroughTool === tool && driver.passthrough !== undefined) {
+        return driver.passthrough(args);
+      }
+    }
+    throw new UnknownPassthroughToolError(tool);
   }
 
   async resolveSpec(

--- a/src/core/driver.ts
+++ b/src/core/driver.ts
@@ -223,6 +223,13 @@ interface DriverRefusal<Event extends DriverRejectionEvent> {
    * open. `doctor` reports it as the failing reason.
    */
   readonly reason: DriverRejectionReason;
+  /**
+   * The `simlock <tool>` wrapper this driver would have answered to, when it has one.
+   * Carried because a passthrough that finds no driver is otherwise indistinguishable
+   * from a host with no SDK, and safety rule 9 promises Simlock reports *why*. The core
+   * only compares it to the requested tool name; the name itself is the driver's.
+   */
+  readonly passthroughTool?: string;
   /** One line, for `doctor` output and the startup log. */
   readonly summary: string;
 }

--- a/src/core/driver.ts
+++ b/src/core/driver.ts
@@ -141,6 +141,46 @@ export interface Driver {
    * path and never lets a failure here abort the rest of one.
    */
   dispose?(): Promise<void>;
+  /**
+   * The `simlock <tool>` name this driver answers to (`simctl`, `adb`), when it wraps a
+   * platform tool at all. Spelled `| undefined` rather than left plain optional so a
+   * driver that decides at construction time whether it has one can still say so.
+   */
+  readonly passthroughTool?: string | undefined;
+  /**
+   * Scoped command for `simlock <tool> <args>`, or `PassthroughRefusedError` for a verb
+   * this driver will not proxy. Both halves are the driver's business: only it knows
+   * which flag points its tool at the root it owns, and only it knows which verbs would
+   * change a device's lifecycle behind the registry's back (ADR 0001, decision 7).
+   */
+  passthrough?(args: readonly string[]): PassthroughCommand;
+}
+
+/**
+ * A ready-to-run invocation of a platform tool, already scoped to the driver's root. The
+ * frontend that runs it merges `env` over its own environment rather than replacing it --
+ * these are only the scoping keys, and a tool spawned without `PATH` would not be found.
+ */
+export interface PassthroughCommand {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly env: Readonly<Record<string, string>>;
+}
+
+/**
+ * A passthrough verb a driver refuses to proxy. The wrappers exist to inject scoping
+ * flags, and injecting them into `simctl delete` would hand back exactly the capability
+ * the containment root exists to remove -- so the refusal, and the message naming what to
+ * run instead, live with the driver that knows which verbs those are.
+ */
+export class PassthroughRefusedError extends Error {
+  constructor(
+    readonly tool: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "PassthroughRefusedError";
+  }
 }
 
 /** The events a driver may refuse to start with; each pairs with its own payload below. */

--- a/src/core/fake-driver.ts
+++ b/src/core/fake-driver.ts
@@ -8,6 +8,8 @@ import {
   type DriverEstimate,
   type DriverReality,
   type ObservedRunState,
+  type PassthroughCommand,
+  PassthroughRefusedError,
   RuntimeMissingError,
   UnknownModelError,
 } from "./driver.js";
@@ -45,6 +47,17 @@ export interface FakeDriverOptions {
   readonly latencyMs?: Partial<Record<FakeDriverOperation, number>>;
   /** What a grant for this driver's devices should carry; empty unless a test says otherwise. */
   readonly leaseEnvironment?: Readonly<Record<string, string>>;
+  /**
+   * The `simlock <tool>` name this fake claims, when a test needs one. Absent by default so
+   * two fakes in one catalog do not both answer to the same tool.
+   */
+  readonly passthroughTool?: string;
+  /**
+   * Builds the scoped command for that tool. Throw `PassthroughRefusedError` from here to
+   * model a driver's own refusal rules; omit it and every argument list is refused, which
+   * is what a driver claiming a tool it cannot build a command for would mean.
+   */
+  readonly passthrough?: (args: readonly string[]) => PassthroughCommand;
   readonly platform: Platform;
   readonly reclaimResult?: "ready" | "shutdown";
   readonly reclaimStrategy?: "erase" | "snapshot" | "wipe";
@@ -71,6 +84,8 @@ export class FakeDriver implements Driver {
   readonly #knownModels: Set<string> | undefined;
   readonly #latencyMs: FakeDriverOptions["latencyMs"];
   readonly #leaseEnvironment: Readonly<Record<string, string>>;
+  readonly passthroughTool: string | undefined;
+  readonly #passthrough: ((args: readonly string[]) => PassthroughCommand) | undefined;
   #nextDeviceNumber = 1;
   readonly #pendingMakeReady: (() => void)[] = [];
   readonly #reclaimResult: "ready" | "shutdown";
@@ -89,6 +104,8 @@ export class FakeDriver implements Driver {
       options.knownModels === undefined ? undefined : new Set(options.knownModels);
     this.#latencyMs = options.latencyMs;
     this.#leaseEnvironment = options.leaseEnvironment ?? {};
+    this.passthroughTool = options.passthroughTool;
+    this.#passthrough = options.passthrough;
     this.platform = options.platform;
     this.deviceRoot = options.deviceRoot ?? `/fake/${options.platform}`;
     this.#reclaimResult = options.reclaimResult ?? "ready";
@@ -224,6 +241,16 @@ export class FakeDriver implements Driver {
 
   leaseEnvironment(): Readonly<Record<string, string>> {
     return this.#leaseEnvironment;
+  }
+
+  passthrough(args: readonly string[]): PassthroughCommand {
+    if (this.#passthrough === undefined) {
+      throw new PassthroughRefusedError(
+        this.passthroughTool ?? "",
+        "Fake driver builds no passthrough command",
+      );
+    }
+    return this.#passthrough(args);
   }
 
   failOn(operation: FakeDriverOperation, callNumber: number, error: Error): void {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -22,9 +22,12 @@ export {
   type DriverRejection,
   type ObservedDevice,
   type ObservedRunState,
+  type PassthroughCommand,
+  PassthroughRefusedError,
   RuntimeMissingError,
   UnknownModelError,
 } from "./driver.js";
+export { UnknownPassthroughToolError } from "./driver-catalog.js";
 // fallow-ignore-next-line unused-type -- wire-visible rejection vocabulary for Simlock's own adb server.
 export type { AdbServerRejectionReason, DriverRejectionReason } from "./driver.js";
 export { Doctor } from "./doctor.js";

--- a/src/core/lease-acquisition-coordinator.test.ts
+++ b/src/core/lease-acquisition-coordinator.test.ts
@@ -166,6 +166,43 @@ describe("LeaseAcquisitionCoordinator", () => {
     expect(granted.lease.requesterId).toBe("agent");
   });
 
+  it.each([["provisioned"], ["ready"]] as const)(
+    "hands the owning driver's lease environment to a %s device's grant",
+    async (path) => {
+      const clock = new FakeClock(1_000);
+      const driver = new FakeDriver({
+        availableOsVersions: ["26.5"],
+        clock,
+        leaseEnvironment: { SIMLOCK_IOS_DEVICE_SET: "/home/agent/.simlock/devices/ios" },
+        platform: "ios",
+      });
+      const harness = await createHarness({ drivers: [driver] });
+      // Both acquisition paths funnel through the same construction site; asserting only
+      // the fresh-provision one would leave a warm-pool grant free to carry nothing.
+      if (path === "ready") await seedReady(harness);
+
+      const granted = await harness.coordinator.request(request, {
+        mode: "held",
+        requesterId: "agent",
+      });
+
+      expect(granted.environment).toEqual({
+        SIMLOCK_IOS_DEVICE_SET: "/home/agent/.simlock/devices/ios",
+      });
+    },
+  );
+
+  it("grants a device from a driver contributing nothing an empty environment", async () => {
+    const harness = await createHarness();
+
+    const granted = await harness.coordinator.request(request, {
+      mode: "held",
+      requesterId: "agent",
+    });
+
+    expect(granted.environment).toEqual({});
+  });
+
   it("rejects missing drivers and unresolved specs without leaving pending demand", async () => {
     const empty = await createHarness({ drivers: [] });
     await expect(

--- a/src/core/lease-acquisition-coordinator.ts
+++ b/src/core/lease-acquisition-coordinator.ts
@@ -349,13 +349,23 @@ export class LeaseAcquisitionCoordinator implements AcquisitionMaintenance {
     });
   }
 
+  /**
+   * The one place a `LeaseGrant` is built, which is why the lease environment is read
+   * here: every acquisition path -- ready device, fresh provision, boot, eviction -- funnels
+   * through it, so there is no second construction site to keep in step.
+   */
   async #grant(waiter: AcquisitionWaiter, deviceId: string): Promise<void> {
     const { device, lease } = await this.options.leases.grant({
       deviceId,
       mode: waiter.options.mode,
       requesterId: waiter.options.requesterId,
     });
-    this.options.queue.resolve(waiter, { device, lease, timing: waiter.timing });
+    this.options.queue.resolve(waiter, {
+      device,
+      environment: this.options.drivers.get(device.spec.platform).leaseEnvironment(),
+      lease,
+      timing: waiter.timing,
+    });
   }
 
   async #evictRunning(

--- a/src/core/lease-engine.ts
+++ b/src/core/lease-engine.ts
@@ -9,7 +9,7 @@ import type { Proposal } from "./cleanup/types.js";
 import { DeviceOperationClaims } from "./device-operation-claims.js";
 import { DeviceProvisioner } from "./device-provisioner.js";
 import type { LeaseRecord, Platform } from "./domain.js";
-import type { DeviceRequest, Driver } from "./driver.js";
+import type { DeviceRequest, Driver, PassthroughCommand } from "./driver.js";
 import { DriverCatalog, type PlatformCatalog } from "./driver-catalog.js";
 import {
   LeaseAcquisitionCoordinator,
@@ -271,6 +271,12 @@ export class LeaseEngine {
   // fallow-ignore-next-line unused-class-member -- called through CatalogReader by DaemonServer.
   async listCatalog(platform?: Platform): Promise<readonly PlatformCatalog[]> {
     return this.#drivers.listCatalog(platform);
+  }
+
+  /** Scoped command for a `simlock <tool>` wrapper, built by whichever driver claims it. */
+  // fallow-ignore-next-line unused-class-member -- called through PassthroughResolver by DaemonServer.
+  passthrough(tool: string, args: readonly string[]): PassthroughCommand {
+    return this.#drivers.passthrough(tool, args);
   }
 
   // fallow-ignore-next-line unused-class-member -- reached through the QueueControl port by DaemonServer.

--- a/src/core/lease-ports.ts
+++ b/src/core/lease-ports.ts
@@ -1,6 +1,6 @@
 import type { CapacityPlatform, RunningCapacity } from "./capacity/index.js";
 import type { LeaseRecord, Platform } from "./domain.js";
-import type { DeviceRequest } from "./driver.js";
+import type { DeviceRequest, PassthroughCommand } from "./driver.js";
 import type { PlatformCatalog } from "./driver-catalog.js";
 import type { LeaseGrant, LeaseRequestOptions } from "./wait-queue.js";
 
@@ -38,6 +38,15 @@ export interface LeaseExpirer {
 /** Read-only device catalog used by the `simlock catalog` command and MCP tool. */
 export interface CatalogReader {
   listCatalog(platform?: Platform): Promise<readonly PlatformCatalog[]>;
+}
+
+/**
+ * Resolves `simlock <tool> <args>` into the scoped command its owning driver builds, for
+ * the daemon request handler. Separate from `CatalogReader` because it answers about
+ * tooling rather than about devices, and nothing on the lease path needs it.
+ */
+export interface PassthroughResolver {
+  passthrough(tool: string, args: readonly string[]): PassthroughCommand;
 }
 
 /** Operator reset capability used by the nuke command facade. */

--- a/src/core/wait-queue.test.ts
+++ b/src/core/wait-queue.test.ts
@@ -27,6 +27,7 @@ function createQueue(onTimeout?: (waiter: import("./wait-queue.js").Waiter) => v
 function grant(): LeaseGrant {
   return {
     device: {} as LeaseGrant["device"],
+    environment: {},
     lease: {} as LeaseGrant["lease"],
     timing: {
       estimatedBootMs: 0,

--- a/src/core/wait-queue.ts
+++ b/src/core/wait-queue.ts
@@ -27,6 +27,12 @@ export interface LeaseTiming {
 
 export interface LeaseGrant {
   readonly device: DeviceRecord;
+  /**
+   * What the holder needs in its environment to reach this device at all -- the owning
+   * driver's own answer, forwarded verbatim. Empty is a legitimate answer; the core never
+   * reads a key here (architecture rule 2).
+   */
+  readonly environment: Readonly<Record<string, string>>;
   readonly lease: LeaseRecord;
   readonly timing: LeaseTiming;
 }

--- a/src/daemon-client/contracts.test.ts
+++ b/src/daemon-client/contracts.test.ts
@@ -6,6 +6,7 @@ import {
   parseRawDeviceUnhealthy,
   parseRawLeaseGrant,
   parseRawLeaseHeartbeatAck,
+  parseRawPassthroughCommand,
 } from "./contracts.js";
 
 const leaseGrant = {
@@ -13,6 +14,7 @@ const leaseGrant = {
     driverDeviceId: "ABCD",
     spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
   },
+  environment: { SIMLOCK_IOS_DEVICE_SET: "/home/agent/.simlock/devices/ios" },
   lease: { id: "lse_9f2c", mode: "held", ttlDeadline: 61_000 },
   timing: {
     estimatedBootMs: 20,
@@ -41,6 +43,57 @@ describe("parseRawLeaseGrant", () => {
     [null],
   ])("rejects malformed daemon payloads", (value) => {
     expect(() => parseRawLeaseGrant(value)).toThrow("Daemon returned an invalid lease grant");
+  });
+
+  it("reads a grant from a daemon too old to send an environment as having none", () => {
+    const { environment: _omitted, ...withoutEnvironment } = leaseGrant;
+
+    expect(parseRawLeaseGrant(withoutEnvironment).environment).toEqual({});
+  });
+
+  it.each([["not-an-object"], [42], [null], [["SIMLOCK_IOS_DEVICE_SET"]]])(
+    "reads a malformed environment as having none rather than failing the grant: %s",
+    (environment) => {
+      expect(parseRawLeaseGrant({ ...leaseGrant, environment }).environment).toEqual({});
+    },
+  );
+
+  it("keeps the string entries of an environment carrying non-string values", () => {
+    const environment = { ANDROID_ADB_SERVER_PORT: "5038", broken: 5038 };
+
+    expect(parseRawLeaseGrant({ ...leaseGrant, environment }).environment).toEqual({
+      ANDROID_ADB_SERVER_PORT: "5038",
+    });
+  });
+});
+
+describe("parseRawPassthroughCommand", () => {
+  it("parses the command a driver resolved for a passthrough", () => {
+    const command = {
+      args: ["-P", "5038", "shell", "getprop"],
+      command: "/sdk/platform-tools/adb",
+      env: { ANDROID_ADB_SERVER_PORT: "5038" },
+    };
+
+    expect(parseRawPassthroughCommand(command)).toEqual(command);
+  });
+
+  it("defaults a missing environment to none rather than failing", () => {
+    expect(parseRawPassthroughCommand({ args: ["list", "devices"], command: "xcrun" }).env).toEqual(
+      {},
+    );
+  });
+
+  it.each([
+    [{ args: [], command: "" }],
+    [{ args: ["shell", 42], command: "adb" }],
+    [{ args: "shell", command: "adb" }],
+    [{ command: "adb" }],
+    [null],
+  ])("rejects a command that could not be spawned as given", (value) => {
+    expect(() => parseRawPassthroughCommand(value)).toThrow(
+      "Daemon returned an invalid passthrough command",
+    );
   });
 });
 

--- a/src/daemon-client/contracts.ts
+++ b/src/daemon-client/contracts.ts
@@ -13,6 +13,11 @@ export interface RawLeaseGrant {
       readonly platform: "android" | "ios";
     };
   };
+  /**
+   * Scoping variables the holder needs to reach this device -- the device-set path on iOS,
+   * the adb server port on Android. Always present after parsing, `{}` at the least.
+   */
+  readonly environment: Readonly<Record<string, string>>;
   readonly lease: {
     readonly id: string;
     readonly mode: "detached" | "held";
@@ -60,6 +65,7 @@ export function parseRawLeaseGrant(value: unknown): RawLeaseGrant {
       driverDeviceId: device.driverDeviceId,
       spec: { model: spec.model, osVersion: spec.osVersion, platform: spec.platform },
     },
+    environment: parseStringRecord(grant.environment),
     lease: { id: lease.id, mode: lease.mode, ttlDeadline: lease.ttlDeadline },
     timing: {
       estimatedBootMs: timing.estimatedBootMs,
@@ -68,6 +74,45 @@ export function parseRawLeaseGrant(value: unknown): RawLeaseGrant {
       estimatedReadyMs: timing.estimatedReadyMs,
     },
   };
+}
+
+export interface RawPassthroughCommand {
+  readonly args: readonly string[];
+  readonly command: string;
+  readonly env: Readonly<Record<string, string>>;
+}
+
+/**
+ * Parses the `driver.passthrough` response. The command is spawned as-is, so the shape is
+ * checked before anything reaches a process: an argument list that is not entirely strings
+ * would otherwise stringify into whatever the tool made of it.
+ */
+export function parseRawPassthroughCommand(value: unknown): RawPassthroughCommand {
+  const payload = requireObject(value, "Daemon returned an invalid passthrough command");
+  if (
+    typeof payload.command !== "string" ||
+    payload.command === "" ||
+    !isStringArray(payload.args)
+  ) {
+    throw new Error("Daemon returned an invalid passthrough command");
+  }
+  return { args: [...payload.args], command: payload.command, env: parseStringRecord(payload.env) };
+}
+
+/**
+ * Lenient on purpose, and the one place that leniency is the right call: a daemon older
+ * than this CLI sends no `environment` with its grants at all, and a grant is still worth
+ * having without one. Refusing it would break the mixed pair over a field the client can
+ * do without, so a missing, non-object, or partly non-string value degrades to what it
+ * can carry rather than failing the whole response.
+ */
+function parseStringRecord(value: unknown): Readonly<Record<string, string>> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
 }
 
 /** Parses the lease-lost push notification body pushed to the lease's holding connection. */

--- a/src/daemon/main.test.ts
+++ b/src/daemon/main.test.ts
@@ -285,6 +285,9 @@ describe("discoverDrivers", () => {
     // `simlock events --json` publishes, so renaming `root` has to fail here.
     expect(rejections[0]).toEqual({
       event: "driver.root-rejected",
+      // The wrapper this platform would have answered to, so `simlock simctl` can say why
+      // it is missing instead of reading as "this host has no Xcode".
+      passthroughTool: "simctl",
       payload: { platform: "ios", reason: "wrong-instance", root: IOS_ROOT },
       platform: "ios",
       reason: "wrong-instance",

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -179,6 +179,7 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
     }),
     leases: leaseEngine,
     logger: logger.child("server"),
+    passthrough: leaseEngine,
     queue: leaseEngine,
     reaper,
     nuke,

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -20,9 +20,10 @@ import {
 import {
   AdbServerUnavailableError,
   AndroidDriver,
+  ANDROID_PASSTHROUGH_TOOL,
   SdkMissingError,
 } from "../drivers/android/index.js";
-import { IosSimctlDriver } from "../drivers/ios/index.js";
+import { IOS_PASSTHROUGH_TOOL, IosSimctlDriver } from "../drivers/ios/index.js";
 import {
   CryptoIdGenerator,
   JsonLinesLogger,
@@ -306,7 +307,7 @@ async function discoverIosDriver(
       root: error.path,
       summary: error.message,
     });
-    return { rejection: rootRejection(error) };
+    return { rejection: rootRejection(error, IOS_PASSTHROUGH_TOOL) };
   }
 }
 
@@ -350,7 +351,7 @@ async function discoverAndroidDriver(
         root: error.path,
         summary: error.message,
       });
-      return { rejection: rootRejection(error) };
+      return { rejection: rootRejection(error, ANDROID_PASSTHROUGH_TOOL) };
     }
     if (error instanceof AdbServerUnavailableError) {
       logger.error("Skipped Android driver: adb server unavailable", {
@@ -368,6 +369,7 @@ async function discoverAndroidDriver(
 function adbServerRejection(error: AdbServerUnavailableError): DriverRejection {
   return {
     event: "driver.adb-server-rejected",
+    passthroughTool: ANDROID_PASSTHROUGH_TOOL,
     payload: { port: error.port, reason: error.reason },
     platform: "android",
     reason: error.reason,
@@ -375,9 +377,15 @@ function adbServerRejection(error: AdbServerUnavailableError): DriverRejection {
   };
 }
 
-function rootRejection(error: OwnedRootError): DriverRejection {
+/**
+ * The tool name is passed in rather than derived from `error.platform`: which wrapper a
+ * platform answers to is the driver module's business, and this file is the composition
+ * root that already knows both driver classes (architecture rule 2).
+ */
+function rootRejection(error: OwnedRootError, passthroughTool: string): DriverRejection {
   return {
     event: "driver.root-rejected",
+    passthroughTool,
     payload: { platform: error.platform, reason: error.reason, root: error.path },
     platform: error.platform,
     reason: error.reason,

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -901,6 +901,58 @@ describe("DaemonServer driver rejections", () => {
     expect(response.error?.message).toBe("No driver registered for platform: android");
   });
 
+  it("names the refusal when a passthrough asks for the tool whose driver did not start", async () => {
+    const harness = await createHarness({
+      driverRejections: [
+        {
+          event: "driver.adb-server-rejected",
+          passthroughTool: "adb",
+          payload: { port: 5038, reason: "occupied" },
+          platform: "android",
+          reason: "occupied",
+          summary: "Refusing the Android driver: port 5038 is held by an adb server we do not own",
+        },
+      ],
+    });
+    const client = await createClient(harness.socketPath);
+    await hello(client);
+
+    const response = await client.request("driver.passthrough", {
+      args: ["devices"],
+      tool: "adb",
+    });
+
+    // Unexplained, "No driver provides a adb passthrough" reads as "this host has no
+    // Android SDK" and sends the operator off to install one, while the summary naming the
+    // port conflict sits unread in `driverRejections` (safety rule 9).
+    expect(response.error?.code).toBe("BAD_REQUEST");
+    expect(response.error?.message).toContain("port 5038 is held by an adb server we do not own");
+  });
+
+  it("leaves an unknown passthrough tool unexplained when no driver claimed it", async () => {
+    const harness = await createHarness({
+      driverRejections: [
+        {
+          event: "driver.root-rejected",
+          passthroughTool: "simctl",
+          payload: { platform: "ios", reason: "symlink", root: "/Devices" },
+          platform: "ios",
+          reason: "symlink",
+          summary: "Refusing the ios device root /Devices: it is a symlink",
+        },
+      ],
+    });
+    const client = await createClient(harness.socketPath);
+    await hello(client);
+
+    const response = await client.request("driver.passthrough", {
+      args: ["devices"],
+      tool: "adb",
+    });
+
+    expect(response.error?.message).toBe("No driver provides a adb passthrough");
+  });
+
   it("refuses at compile time to pair an event with another event's payload", () => {
     const rejection: DriverRejection = {
       event: "driver.adb-server-rejected",

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -11,6 +11,7 @@ import {
   CleanupReaper,
   FakeDriver,
   LeaseEngine,
+  PassthroughRefusedError,
   Registry,
 } from "../core/index.js";
 import {
@@ -342,6 +343,69 @@ describe("DaemonServer", () => {
       payload: { platforms: [] },
     });
     await expect(client.request("catalog.get", { platform: "foo" })).resolves.toMatchObject({
+      error: { code: "BAD_REQUEST" },
+      ok: false,
+    });
+  });
+
+  it("resolves a passthrough to its driver's command without running it here", async () => {
+    const clock = new FakeClock(1_000);
+    const driver = new FakeDriver({
+      availableOsVersions: ["26.5"],
+      clock,
+      passthrough: (args) => ({
+        args: ["simctl", "--set", "/root", ...args],
+        command: "xcrun",
+        env: {},
+      }),
+      passthroughTool: "simctl",
+      platform: "ios",
+    });
+    const harness = await createHarness({ clock, driver });
+    const client = await createClient(harness.socketPath);
+    await hello(client);
+
+    await expect(
+      client.request("driver.passthrough", { args: ["list", "devices"], tool: "simctl" }),
+    ).resolves.toMatchObject({
+      ok: true,
+      payload: { args: ["simctl", "--set", "/root", "list", "devices"], command: "xcrun" },
+    });
+  });
+
+  it("gives a refused verb its own code, so the CLI can render it as a usage error", async () => {
+    const clock = new FakeClock(1_000);
+    const driver = new FakeDriver({
+      availableOsVersions: ["26.5"],
+      clock,
+      passthrough: () => {
+        throw new PassthroughRefusedError("simctl", "Refusing it; use `simlock release` instead.");
+      },
+      passthroughTool: "simctl",
+      platform: "ios",
+    });
+    const harness = await createHarness({ clock, driver });
+    const client = await createClient(harness.socketPath);
+    await hello(client);
+
+    await expect(
+      client.request("driver.passthrough", { args: ["delete", "ABCD"], tool: "simctl" }),
+    ).resolves.toMatchObject({
+      error: { code: "PASSTHROUGH_REFUSED", message: expect.stringContaining("simlock release") },
+      ok: false,
+    });
+  });
+
+  it.each([
+    [{ args: ["devices"], tool: "adb" }],
+    [{ args: "list", tool: "simctl" }],
+    [{ args: ["list"] }],
+  ])("rejects a passthrough no driver can serve as given: %s", async (payload) => {
+    const harness = await createHarness();
+    const client = await createClient(harness.socketPath);
+    await hello(client);
+
+    await expect(client.request("driver.passthrough", payload)).resolves.toMatchObject({
       error: { code: "BAD_REQUEST" },
       ok: false,
     });
@@ -1296,6 +1360,7 @@ async function createHarness(
     }),
     leases: engine,
     ...(options.logger === undefined ? {} : { logger: options.logger }),
+    passthrough: engine,
     queue: engine,
     reaper,
     registry,

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -18,12 +18,15 @@ import {
   type DriverRejection,
   type LeaseHealthMonitor,
   type Nuke,
+  PassthroughRefusedError,
   UnknownLeaseError,
+  UnknownPassthroughToolError,
 } from "../core/index.js";
 import type {
   CapacityReader,
   CatalogReader,
   LeaseCommands,
+  PassthroughResolver,
   QueueControl,
 } from "../core/lease-ports.js";
 import type { Clock, IpcConnection, Logger, TimerHandle } from "../ports/index.js";
@@ -73,6 +76,8 @@ export interface DaemonServerOptions {
   readonly reaper: CleanupReaper;
   readonly healthMonitor?: LeaseHealthMonitor;
   readonly nuke?: Nuke;
+  /** Builds the scoped command behind `simlock simctl` / `simlock adb`; absent in tests that never use them. */
+  readonly passthrough?: PassthroughResolver;
   readonly registry: Registry;
   readonly version: string;
   /**
@@ -561,6 +566,18 @@ export class DaemonServer {
         connection.unsubscribeEvents?.();
         connection.unsubscribeEvents = undefined;
         return { subscribed: false };
+      case "driver.passthrough": {
+        const payload = objectPayload(frame.payload);
+        if (this.options.passthrough === undefined)
+          throw new Error("Tool passthrough is unavailable");
+        // Resolution only: the daemon never runs the command. Spawning it here would
+        // attach a user's interactive `adb shell` to the daemon's stdio, and the CLI is
+        // the process that actually has a terminal.
+        return this.options.passthrough.passthrough(
+          requiredString(payload, "tool"),
+          requiredStringArray(payload, "args"),
+        );
+      }
       case "config.get":
         return this.options.config;
       case "daemon.stop":
@@ -941,6 +958,14 @@ function requiredPlatform(payload: Record<string, unknown>): "ios" | "android" {
   return platform;
 }
 
+function requiredStringArray(payload: Record<string, unknown>, key: string): readonly string[] {
+  const value = payload[key];
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    throw new ProtocolError("BAD_REQUEST", `Missing required string array: ${key}`);
+  }
+  return value as readonly string[];
+}
+
 function optionalPlatform(payload: Record<string, unknown>): "ios" | "android" | undefined {
   if (payload.platform === undefined) {
     return undefined;
@@ -973,6 +998,16 @@ function errorCode(error: unknown): string {
   }
   if (error instanceof UnknownLeaseError) {
     return "UNKNOWN_LEASE";
+  }
+  // Its own code rather than BAD_REQUEST: the request was well formed, and the CLI turns
+  // this one into the `USAGE` line `docs/CLI.md` promises for a refused verb.
+  if (error instanceof PassthroughRefusedError) {
+    return "PASSTHROUGH_REFUSED";
+  }
+  // A tool no driver claims is the client naming something that does not exist here --
+  // `simlock adb` on a host with no Android SDK reaches exactly this.
+  if (error instanceof UnknownPassthroughToolError) {
+    return "BAD_REQUEST";
   }
   if (error instanceof StartupFailedError) {
     return "DAEMON_STARTUP_FAILED";

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -411,18 +411,26 @@ export class DaemonServer {
   /**
    * A `NO_DRIVER` for a platform whose driver refused to start says nothing on its own:
    * it reads identically to "this host has no Xcode". Safety rule 9 promises Simlock
-   * reports *why* a platform is missing, and the lease path is where a user meets that
-   * failure, so the refusal's own one-liner travels with the error.
+   * reports *why* a platform is missing, so the refusal's own one-liner travels with the
+   * error on both paths a user meets it: leasing, and the `simlock simctl` / `simlock adb`
+   * wrapper, whose bare "No driver provides a adb passthrough" reads as a missing SDK and
+   * sends the operator off to install one instead of at the port conflict that caused it.
    */
   #describeError(error: unknown): string {
     const message = errorMessage(error);
-    if (!(error instanceof NoDriverError)) {
-      return message;
-    }
-    const rejection = (this.options.driverRejections ?? []).find(
-      (candidate) => candidate.platform === error.platform,
-    );
+    const rejection = this.#rejectionFor(error);
     return rejection === undefined ? message : `${message} (${rejection.summary})`;
+  }
+
+  #rejectionFor(error: unknown): DriverRejection | undefined {
+    const rejections = this.options.driverRejections ?? [];
+    if (error instanceof NoDriverError) {
+      return rejections.find((candidate) => candidate.platform === error.platform);
+    }
+    if (error instanceof UnknownPassthroughToolError) {
+      return rejections.find((candidate) => candidate.passthroughTool === error.tool);
+    }
+    return undefined;
   }
 
   async #handleHello(connection: Connection, frame: RequestFrame): Promise<void> {

--- a/src/drivers/android/index.test.ts
+++ b/src/drivers/android/index.test.ts
@@ -4,7 +4,11 @@ import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 import type { Driver } from "../../core/driver.js";
-import { OWNED_ROOT_MARKER_FILE, OwnedRootError } from "../../core/index.js";
+import {
+  OWNED_ROOT_MARKER_FILE,
+  OwnedRootError,
+  PassthroughRefusedError,
+} from "../../core/index.js";
 import {
   FakeClock,
   FakeProcessSupervisor,
@@ -963,6 +967,50 @@ describe("AndroidDriver.create", () => {
     expect(runner.calls[0]?.options).toEqual({
       env: { ...scopedEnv, ANDROID_ADB_SERVER_PORT: "5199" },
     });
+  });
+
+  it("points an adb passthrough at Simlock's own server, which is the only one that sees it", async () => {
+    const filesystem = await androidFilesystem();
+    const driver = await createDriver(filesystem, new ScriptedProcessRunner([]));
+
+    expect(driver.passthrough(["shell", "input", "tap", "100", "200"])).toEqual({
+      args: ["-P", String(adbServerPort), "shell", "input", "tap", "100", "200"],
+      command: binaries.adb,
+      env: { ANDROID_ADB_SERVER_PORT: String(adbServerPort) },
+    });
+  });
+
+  it("refuses kill-server, which would detach every leased emulator at once", async () => {
+    const filesystem = await androidFilesystem();
+    const driver = await createDriver(filesystem, new ScriptedProcessRunner([]));
+
+    expect(() => driver.passthrough(["kill-server"])).toThrow(PassthroughRefusedError);
+    expect(() => driver.passthrough(["kill-server"])).toThrow(/simlock release/);
+  });
+
+  it("refuses an emu kill pair even behind the -s serial that targets a device", async () => {
+    const filesystem = await androidFilesystem();
+    const driver = await createDriver(filesystem, new ScriptedProcessRunner([]));
+
+    expect(() => driver.passthrough(["-s", "emulator-5586", "emu", "kill"])).toThrow(
+      PassthroughRefusedError,
+    );
+    expect(() => driver.passthrough(["-s", "emulator-5586", "emu", "kill"])).toThrow(
+      /simlock cleanup/,
+    );
+  });
+
+  it("proxies the emu subcommands that do not stop a device", async () => {
+    const filesystem = await androidFilesystem();
+    const driver = await createDriver(filesystem, new ScriptedProcessRunner([]));
+
+    expect(driver.passthrough(["emu", "avd", "name"]).args).toEqual([
+      "-P",
+      String(adbServerPort),
+      "emu",
+      "avd",
+      "name",
+    ]);
   });
 
   it("stops the adb server it adopted when the daemon disposes of it", async () => {

--- a/src/drivers/android/index.test.ts
+++ b/src/drivers/android/index.test.ts
@@ -988,6 +988,45 @@ describe("AndroidDriver.create", () => {
     expect(() => driver.passthrough(["kill-server"])).toThrow(/simlock release/);
   });
 
+  it("refuses kill-server behind a global flag, not only in first position", async () => {
+    const filesystem = await androidFilesystem();
+    const driver = await createDriver(filesystem, new ScriptedProcessRunner([]));
+
+    // Every other case passes it first, so an `args[0] === "kill-server"` rule would pass
+    // them all; this is the one that holds the documented "anywhere in the arguments".
+    expect(() => driver.passthrough(["-P", "1", "kill-server"])).toThrow(PassthroughRefusedError);
+  });
+
+  it.each([[["emu", "avd", "stop"]], [["-s", "emulator-5586", "emu", "avd", "stop"]]])(
+    "refuses an emu avd stop that would stop a device Simlock believes is running: %j",
+    async (args) => {
+      const filesystem = await androidFilesystem();
+      const driver = await createDriver(filesystem, new ScriptedProcessRunner([]));
+
+      expect(() => driver.passthrough(args)).toThrow(PassthroughRefusedError);
+      expect(() => driver.passthrough(args)).toThrow(/simlock release/);
+    },
+  );
+
+  it("refuses to delete the snapshot every later reclaim restores from", async () => {
+    const filesystem = await androidFilesystem();
+    const driver = await createDriver(filesystem, new ScriptedProcessRunner([]));
+
+    expect(() => driver.passthrough(["emu", "avd", "snapshot", "delete", "default_boot"])).toThrow(
+      PassthroughRefusedError,
+    );
+    expect(() => driver.passthrough(["emu", "avd", "snapshot", "delete", "default_boot"])).toThrow(
+      /full wipe/,
+    );
+  });
+
+  it("still proxies the snapshot operations that do not destroy the baseline", async () => {
+    const filesystem = await androidFilesystem();
+    const driver = await createDriver(filesystem, new ScriptedProcessRunner([]));
+
+    expect(driver.passthrough(["emu", "avd", "snapshot", "list"]).args).toContain("list");
+  });
+
   it("refuses an emu kill pair even behind the -s serial that targets a device", async () => {
     const filesystem = await androidFilesystem();
     const driver = await createDriver(filesystem, new ScriptedProcessRunner([]));

--- a/src/drivers/android/index.ts
+++ b/src/drivers/android/index.ts
@@ -12,6 +12,8 @@ import {
   type DriverReality,
   type ObservedDevice,
   type ObservedMark,
+  type PassthroughCommand,
+  PassthroughRefusedError,
   type ReclaimResult,
   RuntimeMissingError,
   UnknownModelError,
@@ -145,6 +147,17 @@ interface DeviceProfile {
   readonly name: string;
 }
 
+/**
+ * Verbs `simlock adb` will not proxy, both matched anywhere in the arguments rather than
+ * only in first position: `-s <serial> emu kill` is the same command with a target in
+ * front of it, and a positional scan is the only rule that catches both spellings without
+ * this module having to parse adb's own option grammar. `kill-server` would detach every
+ * leased emulator at once -- an agent's most reflexive troubleshooting step -- and
+ * `emu kill` stops a device the registry still believes is running (ADR 0001, decision 7).
+ */
+const REFUSED_ADB_VERB = "kill-server";
+const REFUSED_ADB_PAIR = ["emu", "kill"] as const;
+
 const allocationsByRunner = new WeakMap<ProcessRunner, PortAllocator>();
 
 export class AndroidDriver implements Driver {
@@ -249,6 +262,43 @@ export class AndroidDriver implements Driver {
     // `adb` reads this variable natively, so a lease holder needs nothing else to reach the
     // device: without it their `adb` talks to the shared server, which cannot see it.
     return { ANDROID_ADB_SERVER_PORT: String(this.#adbServerPort) };
+  }
+
+  readonly passthroughTool = "adb";
+
+  /**
+   * `adb -P <port> <args...>` against Simlock's own server, which is the only one that can
+   * see a Simlock emulator at all. `ANDROID_ADB_SERVER_PORT` rides along as well so any adb
+   * that re-execs itself stays on the same server; it says the same thing `-P` does, and
+   * saying it twice costs nothing.
+   */
+  passthrough(args: readonly string[]): PassthroughCommand {
+    this.#assertProxyable(args);
+    return {
+      args: ["-P", String(this.#adbServerPort), ...args],
+      command: this.#sdk.adb,
+      env: { ANDROID_ADB_SERVER_PORT: String(this.#adbServerPort) },
+    };
+  }
+
+  #assertProxyable(args: readonly string[]): void {
+    if (args.includes(REFUSED_ADB_VERB)) {
+      throw new PassthroughRefusedError(
+        this.passthroughTool,
+        `Refusing \`simlock adb ${REFUSED_ADB_VERB}\`: it would detach every leased emulator at once. Use \`simlock release\` to give a device back, or \`simlock cleanup\` to reclaim idle ones.`,
+      );
+    }
+    if (
+      args.some(
+        (argument, index) =>
+          argument === REFUSED_ADB_PAIR[0] && args[index + 1] === REFUSED_ADB_PAIR[1],
+      )
+    ) {
+      throw new PassthroughRefusedError(
+        this.passthroughTool,
+        "Refusing `simlock adb emu kill`: it stops a device Simlock still believes is running, which reports as drift on the next reconcile. Use `simlock release` (which reclaims the device for you) or `simlock cleanup` instead.",
+      );
+    }
   }
 
   /**

--- a/src/drivers/android/index.ts
+++ b/src/drivers/android/index.ts
@@ -148,17 +148,58 @@ interface DeviceProfile {
 }
 
 /**
- * Verbs `simlock adb` will not proxy, both matched anywhere in the arguments rather than
- * only in first position: `-s <serial> emu kill` is the same command with a target in
- * front of it, and a positional scan is the only rule that catches both spellings without
- * this module having to parse adb's own option grammar. `kill-server` would detach every
- * leased emulator at once -- an agent's most reflexive troubleshooting step -- and
- * `emu kill` stops a device the registry still believes is running (ADR 0001, decision 7).
+ * The `simlock <tool>` wrapper this driver answers to. Published as a constant because a
+ * driver that refused to start has no instance to ask, and `DriverRejection` carries the
+ * name so `simlock adb` can say why it is unavailable rather than reading as a missing SDK.
+ */
+export const ANDROID_PASSTHROUGH_TOOL = "adb";
+
+/** Every refusal ends the same way: the Simlock command that does it safely. */
+const RECLAIM_INSTEAD =
+  "Use `simlock release` (which reclaims the device for you) or `simlock cleanup` instead.";
+
+/**
+ * `kill-server` would detach every leased emulator at once -- an agent's most reflexive
+ * troubleshooting step. Matched anywhere in the arguments rather than in first position:
+ * `adb -P 1 kill-server` is the same command with a global in front of it, and a
+ * positional scan is the only rule that catches every spelling without this module having
+ * to parse adb's own option grammar.
  */
 const REFUSED_ADB_VERB = "kill-server";
-const REFUSED_ADB_PAIR = ["emu", "kill"] as const;
+
+/**
+ * Console commands `simlock adb` will not proxy, matched as a run of adjacent arguments
+ * anywhere in the list so that `-s <serial> emu kill` is caught along with `emu kill`.
+ * Every one of them reaches through Simlock's own adb server, which is the only server
+ * that can see these emulators at all -- a bare `adb` cannot, so what is refused here is
+ * genuinely a capability, and it is refused because it mutates a device behind the
+ * registry's back (ADR 0001, decision 7).
+ */
+const STOPS_A_RUNNING_DEVICE =
+  "it stops a device Simlock still believes is running, which reports as drift on the next reconcile.";
+
+const REFUSED_ADB_SEQUENCES: readonly {
+  readonly sequence: readonly string[];
+  readonly reason: string;
+}[] = [
+  { reason: STOPS_A_RUNNING_DEVICE, sequence: ["emu", "kill"] },
+  { reason: STOPS_A_RUNNING_DEVICE, sequence: ["emu", "avd", "stop"] },
+  {
+    // Not drift, which is why it needs saying: the emulator keeps running and nothing looks
+    // wrong. What is gone is the clean baseline `reclaimStrategy` restores from, so every
+    // later reclaim of this device silently degrades from a snapshot load to a full wipe.
+    reason:
+      "it destroys the clean-boot snapshot Simlock restores from, turning every later reclaim of this device into a full wipe.",
+    sequence: ["emu", "avd", "snapshot", "delete"],
+  },
+];
 
 const allocationsByRunner = new WeakMap<ProcessRunner, PortAllocator>();
+
+/** True when `sequence` appears as consecutive arguments starting anywhere in `args`. */
+function containsSequence(args: readonly string[], sequence: readonly string[]): boolean {
+  return args.some((_, index) => sequence.every((token, offset) => args[index + offset] === token));
+}
 
 export class AndroidDriver implements Driver {
   readonly platform = "android" as const;
@@ -264,7 +305,7 @@ export class AndroidDriver implements Driver {
     return { ANDROID_ADB_SERVER_PORT: String(this.#adbServerPort) };
   }
 
-  readonly passthroughTool = "adb";
+  readonly passthroughTool = ANDROID_PASSTHROUGH_TOOL;
 
   /**
    * `adb -P <port> <args...>` against Simlock's own server, which is the only one that can
@@ -288,15 +329,13 @@ export class AndroidDriver implements Driver {
         `Refusing \`simlock adb ${REFUSED_ADB_VERB}\`: it would detach every leased emulator at once. Use \`simlock release\` to give a device back, or \`simlock cleanup\` to reclaim idle ones.`,
       );
     }
-    if (
-      args.some(
-        (argument, index) =>
-          argument === REFUSED_ADB_PAIR[0] && args[index + 1] === REFUSED_ADB_PAIR[1],
-      )
-    ) {
+    const refused = REFUSED_ADB_SEQUENCES.find((candidate) =>
+      containsSequence(args, candidate.sequence),
+    );
+    if (refused !== undefined) {
       throw new PassthroughRefusedError(
         this.passthroughTool,
-        "Refusing `simlock adb emu kill`: it stops a device Simlock still believes is running, which reports as drift on the next reconcile. Use `simlock release` (which reclaims the device for you) or `simlock cleanup` instead.",
+        `Refusing \`simlock adb ${refused.sequence.join(" ")}\`: ${refused.reason} ${RECLAIM_INSTEAD}`,
       );
     }
   }

--- a/src/drivers/ios/index.test.ts
+++ b/src/drivers/ios/index.test.ts
@@ -9,6 +9,7 @@ import {
   DriverCrashError,
   OwnedRootError,
   OWNED_ROOT_MARKER_FILE,
+  PassthroughRefusedError,
   RuntimeMissingError,
   UnknownModelError,
 } from "../../core/index.js";
@@ -596,6 +597,41 @@ describe("IosSimctlDriver", () => {
     const driver = await createDriver(new ScriptedProcessRunner([]));
 
     expect(driver.leaseEnvironment()).toEqual({ SIMLOCK_IOS_DEVICE_SET: deviceRoot });
+  });
+
+  it("scopes a simctl passthrough to the device set the way its own calls are scoped", async () => {
+    const driver = await createDriver(new ScriptedProcessRunner([]));
+
+    expect(driver.passthrough(["install", "booted", "./MyApp.app"])).toEqual({
+      args: ["simctl", "--set", deviceRoot, "install", "booted", "./MyApp.app"],
+      command: "xcrun",
+      env: {},
+    });
+  });
+
+  it.each([["create"], ["erase"], ["delete"]])(
+    "refuses to proxy %s, naming the command that reclaims a device properly",
+    async (verb) => {
+      const driver = await createDriver(new ScriptedProcessRunner([]));
+
+      expect(() => driver.passthrough([verb, "ABCD"])).toThrow(PassthroughRefusedError);
+      expect(() => driver.passthrough([verb, "ABCD"])).toThrow(/simlock release/);
+      expect(() => driver.passthrough([verb, "ABCD"])).toThrow(/simlock cleanup/);
+    },
+  );
+
+  it("finds the refused verb past a leading flag rather than only in first position", async () => {
+    const driver = await createDriver(new ScriptedProcessRunner([]));
+
+    expect(() => driver.passthrough(["--verbose", "delete", "ABCD"])).toThrow(
+      PassthroughRefusedError,
+    );
+  });
+
+  it("proxies a refused word that is an argument rather than the subcommand", async () => {
+    const driver = await createDriver(new ScriptedProcessRunner([]));
+
+    expect(driver.passthrough(["spawn", "booted", "log", "erase"]).args).toContain("erase");
   });
 
   it.skipIf(process.env.SIMLOCK_LIVE_IOS !== "1")(

--- a/src/drivers/ios/index.test.ts
+++ b/src/drivers/ios/index.test.ts
@@ -634,6 +634,58 @@ describe("IosSimctlDriver", () => {
     expect(driver.passthrough(["spawn", "booted", "log", "erase"]).args).toContain("erase");
   });
 
+  it.each([
+    [["--profiles", "/tmp", "erase", "all"]],
+    [["--set", "/tmp", "delete", "all"]],
+    [["--set=/tmp", "create", "sim"]],
+  ])(
+    "refuses a caller-supplied scoping flag rather than reading its value as the subcommand: %j",
+    async (args) => {
+      const driver = await createDriver(new ScriptedProcessRunner([]));
+
+      // The bug this pins was not the flag itself: the flag's separated value was found as
+      // the subcommand, so the refused verb behind it was never seen, and the wrapper
+      // answered with `--set <simlockRoot>` prepended -- Simlock handing over the very path
+      // that contains every other agent's devices.
+      expect(() => driver.passthrough(args)).toThrow(PassthroughRefusedError);
+      expect(() => driver.passthrough(args)).toThrow(/supplies the device set itself/);
+    },
+  );
+
+  it("refuses to shut down every device in the set at once", async () => {
+    const driver = await createDriver(new ScriptedProcessRunner([]));
+
+    expect(() => driver.passthrough(["shutdown", "all"])).toThrow(PassthroughRefusedError);
+    expect(() => driver.passthrough(["shutdown", "all"])).toThrow(/simlock release/);
+  });
+
+  it("still proxies shutting a single device down by udid", async () => {
+    const driver = await createDriver(new ScriptedProcessRunner([]));
+
+    expect(driver.passthrough(["shutdown", "ABCD"]).args).toEqual([
+      "simctl",
+      "--set",
+      deviceRoot,
+      "shutdown",
+      "ABCD",
+    ]);
+  });
+
+  it("refuses to delete a runtime it cannot download back", async () => {
+    const driver = await createDriver(new ScriptedProcessRunner([]));
+
+    expect(() => driver.passthrough(["runtime", "delete", "26.5"])).toThrow(
+      PassthroughRefusedError,
+    );
+    expect(() => driver.passthrough(["runtime", "delete", "26.5"])).toThrow(/through Xcode/);
+  });
+
+  it("still proxies the runtime operations that only read", async () => {
+    const driver = await createDriver(new ScriptedProcessRunner([]));
+
+    expect(driver.passthrough(["runtime", "list"]).args).toContain("list");
+  });
+
   it.skipIf(process.env.SIMLOCK_LIVE_IOS !== "1")(
     "runs a provision-to-destroy smoke test against simctl",
     async () => {

--- a/src/drivers/ios/index.ts
+++ b/src/drivers/ios/index.ts
@@ -12,6 +12,8 @@ import {
   ensureOwnedRoot,
   type ObservedDevice,
   OwnedRootError,
+  type PassthroughCommand,
+  PassthroughRefusedError,
   type ObservedRunState,
   RuntimeMissingError,
   UnknownModelError,
@@ -40,6 +42,14 @@ const COLD_BOOT_ESTIMATE_MS = 60_000;
 // at either clean level, so this is the only reclaim number the driver has.
 const ERASE_ESTIMATE_MS = 34_000;
 const MARK_FILE_NAME = "simlock-mark.json";
+/**
+ * Verbs `simlock simctl` will not proxy. Every one of them changes a device's lifecycle,
+ * which the registry -- not `simctl` -- is the record of: a device created here has no
+ * registry entry and reads as an orphan, and one erased or deleted under a live lease
+ * reads as tampering on the next reconcile. Injecting `--set` for them would hand back
+ * exactly the capability the device set exists to take away (ADR 0001, decision 7).
+ */
+const REFUSED_SIMCTL_VERBS = new Set(["create", "erase", "delete"]);
 
 interface IosDriverData {
   readonly deviceTypeId: string;
@@ -129,7 +139,6 @@ export class IosSimctlDriver implements Driver {
     return new IosSimctlDriver(options, deviceRoot);
   }
 
-  // fallow-ignore-next-line unused-class-member -- Driver.deviceRoot contract; read by doctor --purge-orphans to say which root an orphan came from.
   get deviceRoot(): string {
     return this.#deviceRoot;
   }
@@ -301,9 +310,32 @@ export class IosSimctlDriver implements Driver {
    * custom set a UDID resolves to nothing without it. `docs/CLI.md` publishes the variable
    * name, and `simlock simctl` reads it back.
    */
-  // fallow-ignore-next-line unused-class-member -- Driver.leaseEnvironment contract; read by the lease path when it builds a grant.
   leaseEnvironment(): Readonly<Record<string, string>> {
     return { SIMLOCK_IOS_DEVICE_SET: this.#deviceRoot };
+  }
+
+  readonly passthroughTool = "simctl";
+
+  /**
+   * `xcrun simctl --set <root> <args...>`: the same insertion `#invokeSimctl` makes, for a
+   * command the caller runs itself. The refusal looks at the first argument that is not a
+   * flag, which is where a subcommand sits in every documented `simctl` invocation. That is
+   * an accident boundary and not a security one, exactly like the device set it guards
+   * (ADR 0001, "Not a security boundary"): someone who hand-writes a leading global flag
+   * that takes a value can slide a verb past it, and someone who wants to can simply run
+   * `xcrun simctl --set` themselves.
+   */
+  passthrough(args: readonly string[]): PassthroughCommand {
+    const verb = args.find((argument) => !argument.startsWith("-"));
+    if (verb !== undefined && REFUSED_SIMCTL_VERBS.has(verb)) {
+      throw new PassthroughRefusedError(
+        this.passthroughTool,
+        `Refusing \`simlock simctl ${verb}\`: it changes a device's lifecycle behind Simlock's registry, which would report the device as drifted on the next reconcile. Use \`simlock release\` (which reclaims the device for you) or \`simlock cleanup\` instead.`,
+      );
+    }
+    // No environment: on iOS the device set only ever reaches simctl on the command line
+    // (ADR 0001 records that every candidate variable was tried and ignored).
+    return { args: ["simctl", "--set", this.#deviceRoot, ...args], command: "xcrun", env: {} };
   }
 
   /** CoreSimulator lays a set out as `<set>/<UDID>`, so no subprocess can tell us more. */

--- a/src/drivers/ios/index.ts
+++ b/src/drivers/ios/index.ts
@@ -43,6 +43,14 @@ const COLD_BOOT_ESTIMATE_MS = 60_000;
 const ERASE_ESTIMATE_MS = 34_000;
 const MARK_FILE_NAME = "simlock-mark.json";
 /**
+ * The `simlock <tool>` wrapper this driver answers to. Published as a constant because a
+ * driver that refused to start has no instance to ask, and `DriverRejection` carries the
+ * name so `simlock simctl` can say why it is unavailable rather than reading as a missing
+ * SDK.
+ */
+export const IOS_PASSTHROUGH_TOOL = "simctl";
+
+/**
  * Verbs `simlock simctl` will not proxy. Every one of them changes a device's lifecycle,
  * which the registry -- not `simctl` -- is the record of: a device created here has no
  * registry entry and reads as an orphan, and one erased or deleted under a live lease
@@ -50,6 +58,29 @@ const MARK_FILE_NAME = "simlock-mark.json";
  * exactly the capability the device set exists to take away (ADR 0001, decision 7).
  */
 const REFUSED_SIMCTL_VERBS = new Set(["create", "erase", "delete"]);
+
+/**
+ * simctl's usage is `simctl [--set <path>] [--profiles <path>] <subcommand>`, so these are
+ * the only two globals whose value is a separate argv entry -- and a separated value is
+ * indistinguishable from a subcommand once it is in the array, which is how
+ * `--profiles /tmp erase all` used to read as the subcommand `/tmp` and slide past every
+ * refusal below. Refusing them is what makes "the first non-flag argument is the
+ * subcommand" true by construction rather than by pattern-matching. It is also right on
+ * its own terms: this wrapper exists to supply the device set, and a caller-supplied one
+ * would aim Simlock's own containment wherever it pointed.
+ */
+const CALLER_SUPPLIED_SCOPE_FLAGS = new Set(["set", "profiles"]);
+
+/**
+ * `shutdown all` is the iOS analogue of `adb kill-server`: it stops every device in the
+ * set, for every agent, and each affected lease then spends its recovery budget rebooting
+ * -- one that runs out ends as `lease_lost`. Shutting down a single device stays allowed.
+ */
+const SHUTDOWN_ALL_TARGET = "all";
+
+/** Every lifecycle refusal ends the same way: the Simlock command that does it safely. */
+const RECLAIM_INSTEAD =
+  "Use `simlock release` (which reclaims the device for you) or `simlock cleanup` instead.";
 
 interface IosDriverData {
   readonly deviceTypeId: string;
@@ -314,28 +345,74 @@ export class IosSimctlDriver implements Driver {
     return { SIMLOCK_IOS_DEVICE_SET: this.#deviceRoot };
   }
 
-  readonly passthroughTool = "simctl";
+  readonly passthroughTool = IOS_PASSTHROUGH_TOOL;
 
   /**
    * `xcrun simctl --set <root> <args...>`: the same insertion `#invokeSimctl` makes, for a
-   * command the caller runs itself. The refusal looks at the first argument that is not a
-   * flag, which is where a subcommand sits in every documented `simctl` invocation. That is
-   * an accident boundary and not a security one, exactly like the device set it guards
-   * (ADR 0001, "Not a security boundary"): someone who hand-writes a leading global flag
-   * that takes a value can slide a verb past it, and someone who wants to can simply run
-   * `xcrun simctl --set` themselves.
+   * command the caller runs itself. This is still an accident boundary and not a security
+   * one (ADR 0001, "Not a security boundary") -- someone who wants to can run
+   * `xcrun simctl --set` themselves -- but the wrapper must never be the thing that hands
+   * over the set path, so the two globals that could disguise a refused verb are refused
+   * before the verb is resolved at all.
    */
   passthrough(args: readonly string[]): PassthroughCommand {
-    const verb = args.find((argument) => !argument.startsWith("-"));
-    if (verb !== undefined && REFUSED_SIMCTL_VERBS.has(verb)) {
-      throw new PassthroughRefusedError(
-        this.passthroughTool,
-        `Refusing \`simlock simctl ${verb}\`: it changes a device's lifecycle behind Simlock's registry, which would report the device as drifted on the next reconcile. Use \`simlock release\` (which reclaims the device for you) or \`simlock cleanup\` instead.`,
-      );
-    }
+    this.#assertProxyable(args);
     // No environment: on iOS the device set only ever reaches simctl on the command line
     // (ADR 0001 records that every candidate variable was tried and ignored).
     return { args: ["simctl", "--set", this.#deviceRoot, ...args], command: "xcrun", env: {} };
+  }
+
+  #assertProxyable(args: readonly string[]): void {
+    const [verb, ...operands] = this.#subcommand(args);
+    if (verb === undefined) return;
+    if (REFUSED_SIMCTL_VERBS.has(verb)) {
+      this.#refuse(
+        verb,
+        `it changes a device's lifecycle behind Simlock's registry, which would report the device as drifted on the next reconcile. ${RECLAIM_INSTEAD}`,
+      );
+    }
+    if (verb === "shutdown" && operands.includes(SHUTDOWN_ALL_TARGET)) {
+      this.#refuse(
+        `shutdown ${SHUTDOWN_ALL_TARGET}`,
+        `it stops every device in Simlock's set at once -- every agent's, not just yours -- and each interrupted lease spends its recovery budget rebooting, so one that runs out ends as \`lease_lost\`. Shutting a single device down by udid is still allowed. ${RECLAIM_INSTEAD}`,
+      );
+    }
+    // A bare `simctl` reaches this too, so refusing it takes no capability away. The
+    // wrapper is advertised as the safe path, and being the convenient route to an
+    // unrecoverable multi-gigabyte deletion is not that.
+    if (verb === "runtime" && operands.find((operand) => !operand.startsWith("-")) === "delete") {
+      this.#refuse(
+        "runtime delete",
+        "it deletes a runtime shared with Xcode, and Simlock will not download one back (`--allow-download` cannot install iOS runtimes). Delete it through Xcode if that is really what you meant.",
+      );
+    }
+  }
+
+  #refuse(command: string, guidance: string): never {
+    throw new PassthroughRefusedError(
+      this.passthroughTool,
+      `Refusing \`simlock simctl ${command}\`: ${guidance}`,
+    );
+  }
+
+  /**
+   * The subcommand and its operands, refusing on the way anything that could be mistaken
+   * for a subcommand. A caller-supplied `--set`/`--profiles` (any spelling, `--set=<path>`
+   * included) is the only way a non-flag argument can precede the subcommand, so once
+   * those are gone the first non-flag argument *is* the subcommand.
+   */
+  #subcommand(args: readonly string[]): readonly string[] {
+    for (const [index, argument] of args.entries()) {
+      if (!argument.startsWith("-")) return args.slice(index);
+      const flag = /^-+([^=]*)/.exec(argument)?.[1];
+      if (flag !== undefined && CALLER_SUPPLIED_SCOPE_FLAGS.has(flag)) {
+        throw new PassthroughRefusedError(
+          this.passthroughTool,
+          `Refusing \`simlock simctl ${argument}\`: \`simlock simctl\` supplies the device set itself, and a caller-supplied \`--${flag}\` would point simctl somewhere Simlock does not manage. Drop the flag -- the command is already scoped -- or run \`xcrun simctl\` directly if you mean to leave Simlock's set.`,
+        );
+      }
+    }
+    return [];
   }
 
   /** CoreSimulator lays a set out as `<set>/<UDID>`, so no subprocess can tell us more. */

--- a/src/mcp/contracts.test.ts
+++ b/src/mcp/contracts.test.ts
@@ -33,6 +33,7 @@ describe("MCP contracts", () => {
       leaseSimulatorOutputSchema.parse({
         device: "iPhone 17 Pro",
         device_id: "ABCD",
+        environment: { SIMLOCK_IOS_DEVICE_SET: "/home/agent/.simlock/devices/ios" },
         expires_at_ms: 61_000,
         lease_id: "lse_9f2c",
         mode: "held",

--- a/src/mcp/contracts.ts
+++ b/src/mcp/contracts.ts
@@ -22,6 +22,9 @@ export const leaseSimulatorOutputSchema = z.object({
   address: nonEmptyString.optional(),
   device: nonEmptyString,
   device_id: nonEmptyString,
+  // Always present, `{}` at the least: containment means a bare `simctl`/`adb` cannot
+  // reach the granted device, so an agent needs this to use what it was just handed.
+  environment: z.record(z.string(), z.string()),
   expires_at_ms: finiteNumber,
   lease_id: nonEmptyString,
   mode: z.literal("held"),

--- a/src/mcp/session.test.ts
+++ b/src/mcp/session.test.ts
@@ -10,6 +10,7 @@ const rawGrant = {
     driverDeviceId: "ABCD",
     spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" as const },
   },
+  environment: { SIMLOCK_IOS_DEVICE_SET: "/home/agent/.simlock/devices/ios" },
   lease: { id: "lse_9f2c", mode: "held" as const, ttlDeadline: 61_000 },
   timing: {
     estimatedBootMs: 20,
@@ -31,6 +32,9 @@ describe("McpSession", () => {
     await expect(session.lease(input)).resolves.toEqual({
       device: "iPhone 17 Pro",
       device_id: "ABCD",
+      // The grant an agent gets over MCP has to say how to reach the device too: an MCP
+      // holder shells out to the same simctl/adb a CLI holder does.
+      environment: { SIMLOCK_IOS_DEVICE_SET: "/home/agent/.simlock/devices/ios" },
       expires_at_ms: 61_000,
       lease_id: "lse_9f2c",
       mode: "held",

--- a/src/mcp/session.ts
+++ b/src/mcp/session.ts
@@ -623,6 +623,7 @@ function leaseSimulatorOutput(grant: RawLeaseGrant): LeaseSimulatorOutput {
     address: grant.device.address,
     device: grant.device.spec.model,
     device_id: grant.device.driverDeviceId,
+    environment: grant.environment,
     expires_at_ms: grant.lease.ttlDeadline,
     lease_id: grant.lease.id,
     mode: "held",


### PR DESCRIPTION
Fourth of five stacked PRs implementing [ADR 0001](https://github.com/callstackincubator/simlock/blob/feat/owned-device-roots/docs/adr/0001-simlock-owned-device-roots.md). Based on #82.

1. [#80](https://github.com/callstackincubator/simlock/pull/80) owned device root validation and its ports
2. [#81](https://github.com/callstackincubator/simlock/pull/81) iOS: `simctl --set`, membership-based `listManaged`
3. [#82](https://github.com/callstackincubator/simlock/pull/82) Android: `ANDROID_AVD_HOME`, private supervised adb server
4. **lease environment and the `simctl` / `adb` passthroughs** ← this PR
5. doctor: `--purge-orphans`, legacy pre-root devices, docs status

## What this is

Containment cuts both ways, and PRs 2 and 3 only built the outward half. A simulator in Simlock's device set and an emulator on Simlock's adb server are unreachable with a bare `simctl` or `adb` — which is the point for everyone else, and a problem for the agent holding the lease. Until this lands, `simlock lease --json` returns a `udid` no documented workflow can address (ADR decision 7).

- **A grant carries an `environment`** the driver built and the core never reads — the device-set path on iOS, the adb server port on Android. Set at the single `LeaseGrant` construction site, forwarded verbatim, so a third driver contributes its own scoping without a core edit (architecture rule 2).
- **`--export-env`** prints it as shell exports for `eval`, quoted so a path with a space or an apostrophe survives the round trip. The e2e test asserts that through a real `/bin/sh`, not a string comparison.
- **`simlock simctl` and `simlock adb`** inject the scoping and pass every other argument through. Each driver owns the verbs its wrapper refuses, because handing those back would restore the exact capability this work removes.
- The client parses `environment` leniently, and only that field: an older daemon sends none, and a grant is still worth having without one.

## Review round (third commit)

An adversarial review found the most serious defect in the stack so far:

**`simlock simctl --profiles /tmp erase all` was proxied.** The subcommand was taken as the first argument not starting with `-`, and simctl's two global options put their value in a *separate* argv entry — so `/tmp` read as the subcommand, no refusal fired, and the daemon returned `xcrun simctl --set <simlockRoot> --profiles /tmp erase all`. **Simlock supplied the containment path itself**, erasing every simulator in the root including devices under another agent's live lease. The barrier was supposed to be knowing that path. A caller-supplied `--set`/`--profiles` is now refused outright, which makes "the first non-flag argument is the subcommand" true by construction.

Worth stating honestly: `simlock simctl list devices -j` prints `dataPath` for every device, so a *determined* user learns the root anyway, and the ADR says this is not a security boundary. What the refusal buys is the typo-and-reflex guard — and that was broken.

**The refusal list was a list of words, not a model of the rule.** It let through verbs worse than the ones it stopped: `simctl shutdown all` (the iOS analogue of `adb kill-server`, which Android refuses for exactly that reason — it stops every device Simlock believes is running, for every agent, burning each lease's recovery budget), `adb emu avd stop`, and `adb emu avd snapshot delete` (which destroys the baseline every later reclaim restores from, silently degrading reclaims from seconds to a full wipe). Bare tooling cannot reach any of those devices, so each was a returned capability. `simctl runtime delete` is not in that class but is now refused too — a wrapper offered as the safe path should not proxy something it cannot undo and Simlock will not re-download.

Also fixed: `--export-env` escaped values against every pathological input and did not escape keys at all, so a driver-supplied key could carry a command into the `eval` the flag exists for (confirmed by execution); and against an older daemon it exited 0 having printed nothing, leaving a lease committed, TTL-bound and unnameable.

## Not amended

ADR decision 7's `(delete, erase, create, emu kill)` is illustrative; the added refusals apply that decision rather than change it, so the record stands as written.

## Worth your judgement

**The passthrough requires no lease.** Any local process can `simlock adb shell …` against a device another agent holds. That may be intended operator convenience, but it makes the refusal list the only thing between one agent and another agent's device.

## Verification

`pnpm run check` green: typecheck, typecheck:e2e, lint, format, 927 unit tests, e2e 38 passed / 1 expected fail / 3 skipped (five new cases, including the real-`/bin/sh` export round trip). `fallow audit` clean across 34 changed files. The `slow-*` lanes gained passthrough and environment assertions but **cannot run here** — no macOS, no Xcode, no Android SDK.

One unrelated defect surfaced and was deliberately not absorbed: `daemon stop` does not exit while a detached lease is outstanding. It reproduces on `feat/owned-device-roots` with none of this stack applied; the new e2e test releases its lease with a comment pointing at it.

Refs #73, #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BuTqSL7fKJVRbFytNvZP7X

---
_Generated by [Claude Code](https://claude.ai/code/session_01BuTqSL7fKJVRbFytNvZP7X)_