### PR TITLE
fix(daemon): let the daemon exit while a detached lease is outstanding (6/6)

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -383,19 +383,27 @@ each rule *would* take (rule name, target, reason) without executing.
 
 Reconcile the daemon's state with reality (`simctl list`, `adb devices`,
 running emulator processes): report orphaned processes, registry entries
-whose device vanished, devices booted outside simlock, expired-but-held
-leases, devices stuck mid-transition, and orphans. `--fix` applies the safe
-corrections.
+whose device vanished, registry devices left behind in the pre-device-root
+locations, devices booted outside simlock, expired-but-held leases, devices
+stuck mid-transition, and orphans. `--fix` applies the safe corrections.
 
 An **orphan** is a device sitting inside a Simlock device root with no registry
 record — almost always a daemon that died between creating a device and writing
-it down. Because it is inside a root Simlock provably owns, it cannot be a
-device of yours, so it is safe to destroy; but `--fix` never touches it.
-Destroying orphans requires `--purge-orphans`, which asks for confirmation
-unless `--yes` is given, and refuses (exit 2, `USAGE`) when confirmation is
-declined or there is no terminal to ask at. Keeping it on its own flag means a
-`doctor --fix` already running unattended in CI does not start deleting things
-after an upgrade.
+it down. It is inside a root Simlock provably owns, so it is not a device of
+yours; `--fix` never touches it, and destroying orphans requires
+`--purge-orphans`, which asks for confirmation unless `--yes` is given, and
+refuses (exit 2, `USAGE`) when confirmation is declined or there is no terminal
+to ask at. Keeping it on its own flag means a `doctor --fix` already running
+unattended in CI does not start deleting things after an upgrade.
+
+Read that flag as destructive rather than tidy, because one case cannot be told
+apart from a leak: a device this very daemon is in the middle of provisioning
+has no registry record yet either, and that gap is exactly what produces
+orphans. An orphan has no record, so no lease guard and no operation claim can
+protect it. Purging while devices are being provisioned can therefore destroy
+one that a live request is waiting on. That is the risk the flag, the
+confirmation, and its absence from `--fix` exist to keep deliberate (see
+[ADR 0001](adr/0001-simlock-owned-device-roots.md), decision 6).
 
 Before the first device of a purge is destroyed, each root the purge is about
 to reach into is re-validated — ownership is proven at startup and then trusted
@@ -403,12 +411,19 @@ for the life of the daemon, which is fine for reporting and not fine for
 destroying (see [known-pitfalls.md](known-pitfalls.md)). A root that no longer
 proves ownership abandons the whole purge and leaves every finding standing. So
 does a device that could not be destroyed: it stays reported, and the rest of
-the run continues.
+the run continues. The registry is re-read at that same point: a device that
+finished provisioning and registered while the run was working is no longer an
+orphan by the time the list is acted on, and is left alone.
 
 Registry devices left behind in the *old* pre-device-root locations are
-reported the same way and are destroyed by `--fix`, since they are in the
+reported as `legacy-device` and are destroyed by `--fix`, since they are in the
 registry. They are not migrated: neither CoreSimulator nor the Android SDK
-supports relocating a device, so those are re-provisioned.
+supports relocating a device, so those are re-provisioned. Both AVD homes are
+searched on Android — the one `ANDROID_AVD_HOME` names now and the SDK's own
+`~/.android/avd` — because where an AVD lives today says nothing about where it
+was created. An Android AVD that an emulator is still running against is
+refused rather than deleted: it answers to your adb server, which Simlock does
+not drive, so stop it yourself (`adb emu kill`) and re-run `doctor --fix`.
 
 A root that fails ownership validation at startup — missing or foreign marker,
 symlink, wrong owner or permissions, or a `deviceRoot` that is not an absolute

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -40,6 +40,7 @@ in short: `subject.past-tense-fact`, emitted post-commit, facts not commands.
 | `device.recovered` | device id, lease id, attempts, duration | a crashed leased device was rebooted under its existing lease and passed readiness | LeaseHealthMonitor | implemented |
 | `device.recovery-failed` | device id, lease id, attempts, reason, error | recovery could not restore a leased device (absent from driver reality, provenance drift, or attempts exhausted) and its lease was released | LeaseHealthMonitor | implemented |
 | `device.orphan-purged` | driver device id, platform, device root | `simlock doctor --purge-orphans` destroyed a device that sat inside a validly-marked Simlock device root with no registry record — see [ADR 0001](adr/0001-simlock-owned-device-roots.md) | Doctor | implemented |
+| `device.legacy-destroyed` | device id, driver device id, platform, path (when the platform tooling reports one) | `simlock doctor --fix` destroyed a registry device that outlived the move to owned roots, through the pre-root location it still sat in — the only destruction Simlock performs outside an owned root, named apart from the `device.deleted` that follows it so it is attributable (safety rule 6) | Doctor | implemented |
 
 ## System
 

--- a/docs/adr/0001-simlock-owned-device-roots.md
+++ b/docs/adr/0001-simlock-owned-device-roots.md
@@ -388,6 +388,31 @@ live in the old locations become a typed `doctor` finding whose fix destroys
 them through their recorded old path — permitted under registry-only
 destruction, since they are in the registry. Users re-provision.
 
+**Correction (implementation, 2026-09-02).** There is no recorded old path.
+`DeviceRecord` carries a driver device id and no location, and adding one would
+not help: the records that need migrating were written before roots existed, by
+a version that had nothing to record. Each driver therefore *searches* the
+locations its platform could have used and matches by driver device id — iOS
+one unscoped `simctl list` over the default device set, Android a scan of both
+the AVD home `ANDROID_AVD_HOME` names now and the SDK's default `~/.android/avd`.
+Both, on Android, because the live environment says nothing about where an AVD
+was created: someone who made Simlock AVDs under the default home and later
+pointed the variable at another volume would otherwise have them looked for in
+the wrong place, reported as merely missing, and their records marked deleted —
+gigabytes stranded with nothing left to name them, produced by the migration
+path meant to prevent exactly that. A listing is not a claim: only entries a
+registry record names are ever destroyed, which is what keeps this within
+registry-only destruction.
+
+Destroying one still means reaching outside an owned root, so it is the one
+place that does, it emits `device.legacy-destroyed` to say so, and it is
+refused for a device the registry believes is leased. On Android it is also
+refused while an emulator is running against the AVD: those emulators answer to
+the user's own adb server, which Simlock does not drive, and refusing to stop a
+device while deleting its disk anyway is worse than either stopping it or
+leaving it alone. iOS shuts its pre-root simulators down first instead — there
+is one CoreSimulator service per user and Simlock is already talking to it.
+
 **Not a security boundary.** Restated because it will be misread otherwise: a
 user who deliberately passes `--set <path>` or raises
 `ADB_LOCAL_TRANSPORT_MAX_PORT` can still reach these devices. This ADR

--- a/docs/agent-rules/safety.md
+++ b/docs/agent-rules/safety.md
@@ -43,7 +43,8 @@ never enforce them only inside an individual rule or driver.
 4. **No implicit multi-GB downloads.** Missing runtimes / system images fail
    the request unless `--allow-download` was explicitly passed.
 5. **Destructive CLI commands confirm or require `--yes`**
-   (`release --all`, `nuke`). `cleanup` must always support `--dry-run`.
+   (`release --all`, `nuke`, `doctor --purge-orphans`). `cleanup` must always
+   support `--dry-run`.
 6. **Every destructive action is attributable.** Log/emit which rule or
    command caused it, on what target, and why (e.g. "idle 47m > T2=30m").
 7. **Reconcile before trusting state.** On daemon startup (and in `doctor`),

--- a/docs/known-pitfalls.md
+++ b/docs/known-pitfalls.md
@@ -144,9 +144,12 @@ a claim over devices that were never Simlock's.
 
 **Fix, and the deliberate half-measure in it:** destroying re-proves the root
 and reporting does not. `doctor --purge-orphans` calls `Driver.revalidateRoot()`
-— the same validation `create` was judged by, with the same arguments —
-immediately before its first destroy, and abandons the whole purge if any root
-refuses. Nothing else does, and that asymmetry is the point: a stale proof
+— the checks `create` was judged by, with the same arguments, minus the one
+thing a re-proof must never do: create. A root that is simply gone (an `rm -rf`,
+an unmounted volume under a configured `deviceRoot`) refuses here rather than
+being rebuilt empty under a device list describing what used to be in it. It
+runs immediately before the first destroy, and abandons the whole purge if any
+root refuses. Nothing else does, and that asymmetry is the point: a stale proof
 behind a *report* costs a confusing `doctor` run, while a stale proof behind a
 `destroy` costs the user their devices. Re-validating on every reconcile tick,
 or before every `listManaged`, would buy nothing for the case that matters and

--- a/e2e/daemon-lifecycle.test.ts
+++ b/e2e/daemon-lifecycle.test.ts
@@ -101,6 +101,35 @@ describe("daemon lifecycle & recovery", () => {
       expect(existsSync(env.logPath)).toBe(true);
     });
   });
+
+  it("stops while a detached lease is still outstanding", async () => {
+    const env = await withDaemon();
+    await env.driverScript.set({
+      ios: { knownModels: ["iPhone 16"], availableOsVersions: ["18.4"] },
+    });
+    const lease = await env.cli([
+      "lease",
+      "--platform",
+      "ios",
+      "--device",
+      "iPhone 16",
+      "--agent-id",
+      "outliving-agent",
+      "--detach",
+    ]);
+    expect(lease.code).toBe(0);
+
+    // A detached lease is deliberately left alone by shutdown -- its liveness is the TTL,
+    // not a connection -- and its armed TTL timer used to keep the process alive for the
+    // full fifteen minutes after `daemon stop` returned. Teardown's stray-process check is
+    // the assertion: it fails the test if the daemon that was told to stop is still there.
+    const stop = await env.cli(["daemon", "stop"]);
+    expect(stop.code).toBe(0);
+    await waitFor(() => !existsSync(env.socketPath), {
+      timeout: 10_000,
+      label: "daemon socket removed",
+    });
+  });
 });
 
 function countOccurrences(haystack: string, needle: string): number {

--- a/e2e/doctor-drift.test.ts
+++ b/e2e/doctor-drift.test.ts
@@ -231,7 +231,8 @@ describe("doctor and drift", () => {
     const purged = await env.cli(["doctor", "--purge-orphans", "--yes"]);
     expect(purged.code).toBe(0);
 
-    // Both findings go: destroying the device covers the process it was running.
+    // Both findings go, and only because the destroy was handed the process entry: that is
+    // what lets a driver stop the process before it unlinks the device underneath it.
     expect((purged.json as { findings: Finding[] }).findings).toEqual([]);
     const operations = (await env.driverLog.calls())
       .map((call) => call.operation)

--- a/e2e/lease-environment-passthrough.test.ts
+++ b/e2e/lease-environment-passthrough.test.ts
@@ -66,9 +66,9 @@ describe("reaching a leased device", () => {
       `${exported.stdout}printf %s "$SIMLOCK_IOS_DEVICE_SET"`,
     ]);
     expect(evaluated.stdout).toBe("/Users/o'brien/My Sims/devices/ios");
-    // Released rather than left to the TTL because an outstanding detached lease keeps the
-    // daemon from exiting on `daemon stop` -- a defect that predates this work (it
-    // reproduces on the branch this stack is based on) and is not this test's subject.
+    // Released rather than left to the TTL: this flow is about the grant, and leaving a
+    // lease outstanding would make it share a failure mode with the shutdown flow that
+    // covers that case deliberately (`daemon lifecycle & recovery`).
     const exportedGrant = JSON.parse((await env.cli(["status", "--json"])).stdout) as {
       readonly leases: readonly { readonly id: string }[];
     };

--- a/src/bus/index.test.ts
+++ b/src/bus/index.test.ts
@@ -137,6 +137,7 @@ describe("EventBus", () => {
       | "device.foreign-provenance-detected"
       | "device.stalled-transition-detected"
       | "device.orphan-purged"
+      | "device.legacy-destroyed"
       | "daemon.started"
       | "daemon.stopping"
       | "disk.pressure-detected"

--- a/src/bus/index.ts
+++ b/src/bus/index.ts
@@ -89,6 +89,14 @@ export interface EventMap {
     readonly platform: string;
     readonly deviceRoot: string;
   };
+  /** The one destruction outside an owned root, so it is named apart from `device.deleted`. */
+  "device.legacy-destroyed": {
+    readonly deviceId: string;
+    readonly driverDeviceId: string;
+    readonly platform: string;
+    /** Where the driver found it, when its tooling says; absent when it does not. */
+    readonly path?: string;
+  };
   "device.shutdown": { readonly deviceId: string; readonly initiator: string };
   "device.deleted": { readonly deviceId: string; readonly initiator: string };
   "daemon.started": { readonly version: string; readonly configSnapshot: unknown };

--- a/src/core/device-root.test.ts
+++ b/src/core/device-root.test.ts
@@ -11,7 +11,12 @@ import {
   NodeFilesystem,
 } from "../ports/index.js";
 import type { Platform } from "./domain.js";
-import { ensureOwnedRoot, OWNED_ROOT_MARKER_FILE, OwnedRootError } from "./index.js";
+import {
+  ensureOwnedRoot,
+  OWNED_ROOT_MARKER_FILE,
+  OwnedRootError,
+  validateOwnedRoot,
+} from "./index.js";
 
 const instanceId = "instance-a";
 const parent = "/home/agent/.simlock/devices";
@@ -60,6 +65,17 @@ function marker(overrides: Record<string, unknown> = {}): string {
     instanceId,
     platform: "ios",
     ...overrides,
+  });
+}
+
+/** The read-only re-proof, which takes the same arguments minus the ones only creating needs. */
+async function validate(filesystem: Filesystem, overrides: Overrides = {}): Promise<string> {
+  return validateOwnedRoot({
+    filesystem,
+    instanceId: overrides.instanceId ?? instanceId,
+    path: overrides.path ?? root,
+    platform: overrides.platform ?? "ios",
+    uid,
   });
 }
 
@@ -300,6 +316,44 @@ describe("ensureOwnedRoot", () => {
       path: root,
       platform: "ios",
     });
+  });
+});
+
+describe("validateOwnedRoot", () => {
+  it("accepts a root this instance still owns without writing anything to it", async () => {
+    const filesystem = createFilesystem();
+    await ensure(filesystem);
+    const before = await filesystem.readdir(root);
+
+    await expect(validate(filesystem)).resolves.toBe(root);
+    await expect(filesystem.readdir(root)).resolves.toEqual(before);
+  });
+
+  it("refuses a root that is not there rather than creating one", async () => {
+    const filesystem = createFilesystem();
+
+    // The whole point of a re-proof. `ensureOwnedRoot` reads "nothing is there" as a first
+    // start and builds a fresh, empty, validly-marked root -- correct at startup, and
+    // exactly wrong for a caller holding a device list that describes what used to be in
+    // it: an `rm -rf` or an unmounted volume would report success and let the purge run.
+    await expect(validate(filesystem)).rejects.toMatchObject({
+      reason: "missing-marker",
+      path: root,
+      platform: "ios",
+    });
+    await expect(filesystem.exists(root)).resolves.toBe(false);
+    await expect(filesystem.exists(parent)).resolves.toBe(false);
+  });
+
+  it("refuses a root swapped for a symlink or another instance's", async () => {
+    const symlinked = createFilesystem();
+    await ensure(symlinked);
+    symlinked.defineSymlink(root, "/Users/someone/Devices");
+    const foreign = createFilesystem();
+    await seedRoot(foreign, marker({ instanceId: "instance-b" }));
+
+    await expect(validate(symlinked)).rejects.toMatchObject({ reason: "symlink" });
+    await expect(validate(foreign)).rejects.toMatchObject({ reason: "wrong-instance" });
   });
 });
 

--- a/src/core/device-root.ts
+++ b/src/core/device-root.ts
@@ -44,10 +44,8 @@ export class OwnedRootError extends Error {
   }
 }
 
-export interface EnsureOwnedRootOptions {
+export interface ValidateOwnedRootOptions {
   readonly filesystem: Filesystem;
-  /** Names the staging directory a root is assembled in, so two racing daemons never share one. */
-  readonly idGenerator: IdGenerator;
   readonly instanceId: string;
   readonly path: string;
   readonly platform: Platform;
@@ -55,7 +53,14 @@ export interface EnsureOwnedRootOptions {
   readonly uid?: number;
 }
 
-type RootContext = Omit<EnsureOwnedRootOptions, "path"> & { readonly root: string };
+export interface EnsureOwnedRootOptions extends ValidateOwnedRootOptions {
+  /** Names the staging directory a root is assembled in, so two racing daemons never share one. */
+  readonly idGenerator: IdGenerator;
+}
+
+type RootContext = Omit<ValidateOwnedRootOptions, "path"> & { readonly root: string };
+
+type CreateContext = RootContext & { readonly idGenerator: IdGenerator };
 
 /**
  * Establishes that `path` is a device root this Simlock instance owns, creating it when
@@ -70,21 +75,7 @@ type RootContext = Omit<EnsureOwnedRootOptions, "path"> & { readonly root: strin
  * skips a single platform on this error and stops the whole daemon on any other.
  */
 export async function ensureOwnedRoot(options: EnsureOwnedRootOptions): Promise<string> {
-  if (!isAbsolute(options.path)) {
-    // `resolve` would make one up: a relative path lands wherever the process that
-    // launched the daemon happened to be standing, which for an auto-launched daemon is
-    // some agent's working directory rather than a place anyone chose to put tens of
-    // gigabytes of device data -- and in CP5 it is what `--purge-orphans` is aimed at.
-    // An empty path is not absolute either, so this covers it too.
-    throw refusal(
-      options.platform,
-      options.path,
-      "not-absolute",
-      "a device root has to be an absolute path, or it names a different directory to every process that reads the configuration",
-    );
-  }
-
-  const context: RootContext = { ...options, root: resolve(options.path) };
+  const context: CreateContext = { ...rootContext(options), idGenerator: options.idGenerator };
 
   if (await createRoot(context)) {
     // A root is never trusted on the strength of "we think we just made it": the checks
@@ -96,6 +87,42 @@ export async function ensureOwnedRoot(options: EnsureOwnedRootOptions): Promise<
 
   await validateExistingRoot(context);
   return context.root;
+}
+
+/**
+ * The same proof as `ensureOwnedRoot` with the creating half removed: it answers whether the
+ * root that is there right now still belongs to this instance, and never puts one there.
+ *
+ * This is what a re-proof has to be. `ensureOwnedRoot` treats "nothing is there" as the first
+ * start of a fresh root, which is correct at startup and exactly wrong afterwards: the failure
+ * that most obviously invalidates a device list already in hand -- an `rm -rf`, an unmounted
+ * volume under a `deviceRoot` pointed at external storage -- would silently build an empty
+ * root, report success, and let a purge proceed against a list describing a directory that is
+ * no longer there. A read-only check must also stay read-only: nothing here writes, `mkdirp`s
+ * a parent, or chmods anything.
+ */
+export async function validateOwnedRoot(options: ValidateOwnedRootOptions): Promise<string> {
+  const context = rootContext(options);
+  await validateExistingRoot(context);
+  return context.root;
+}
+
+function rootContext(options: ValidateOwnedRootOptions): RootContext {
+  if (!isAbsolute(options.path)) {
+    // `resolve` would make one up: a relative path lands wherever the process that
+    // launched the daemon happened to be standing, which for an auto-launched daemon is
+    // some agent's working directory rather than a place anyone chose to put tens of
+    // gigabytes of device data -- and it is what `--purge-orphans` is aimed at.
+    // An empty path is not absolute either, so this covers it too.
+    throw refusal(
+      options.platform,
+      options.path,
+      "not-absolute",
+      "a device root has to be an absolute path, or it names a different directory to every process that reads the configuration",
+    );
+  }
+
+  return { ...options, root: resolve(options.path) };
 }
 
 /**
@@ -115,7 +142,7 @@ export async function ensureOwnedRoot(options: EnsureOwnedRootOptions): Promise<
  * steps, and the alternatives (a Linux-only `renameat2`, or a lock file that becomes its
  * own stale-state problem) are worse.
  */
-async function createRoot(context: RootContext): Promise<boolean> {
+async function createRoot(context: CreateContext): Promise<boolean> {
   const { filesystem, root } = context;
 
   if ((await pathDetails(context, root, "it")) !== undefined) {
@@ -175,10 +202,16 @@ async function validateRootDirectory(context: RootContext): Promise<void> {
   const details = await pathDetails(context, root, "it");
 
   if (details === undefined) {
-    // The root existed a moment ago (that is why creation stood down, or the rename that
-    // published it succeeded) and is gone now. Creating it here would be the second
-    // attempt this function promises never to make.
-    throw rejected(context, "missing-marker", "it disappeared while it was being validated");
+    // Nothing is there. On the creating path the root existed a moment ago (that is why
+    // creation stood down, or the rename that published it succeeded) and has gone since;
+    // on the re-proof path it may have been removed or unmounted while the daemon held a
+    // device list from it. Either way validation never creates, and an absent root proves
+    // nothing about the devices something is about to act on.
+    throw rejected(
+      context,
+      "missing-marker",
+      "there is nothing at that path, and validation never creates a root",
+    );
   }
 
   if (details.kind === "symlink") {

--- a/src/core/doctor.test.ts
+++ b/src/core/doctor.test.ts
@@ -1496,9 +1496,219 @@ describe("Doctor with a platform it cannot observe", () => {
     expect(registry.snapshot.devices[0]?.state).toBe("leased");
   });
 
+  it("re-proves every root a purge reaches into, not only the first", async () => {
+    const clock = new FakeClock(10_000);
+    const eventBus = new EventBus(clock);
+    const registry = await loadRegistry(clock, eventBus);
+    const iosDriver = new FakeDriver({ clock, platform: "ios" });
+    iosDriver.setManagedReality({ devices: [observed("ios-orphan", "stopped")], processes: [] });
+    const androidDriver = new FakeDriver({ clock, platform: "android" });
+    androidDriver.setManagedReality({
+      devices: [observed("android-orphan", "stopped")],
+      processes: [],
+    });
+
+    await new Doctor({
+      clock,
+      config: config(),
+      drivers: [iosDriver, androidDriver],
+      eventBus,
+      registry,
+    }).reconcile({ purgeOrphans: true });
+
+    // Each root authorises destroying inside itself and nothing else, so a re-proof that
+    // stopped at the first platform would be destroying in the others on nobody's proof.
+    for (const driver of [iosDriver, androidDriver]) {
+      expect(driver.calls.map((call) => call.operation)).toEqual([
+        "listManaged",
+        "revalidateRoot",
+        "destroy",
+      ]);
+    }
+  });
+
+  it("purges an orphan through the process entry that carries its address", async () => {
+    const clock = new FakeClock(10_000);
+    const eventBus = new EventBus(clock);
+    const registry = await loadRegistry(clock, eventBus);
+    const driver = new FakeDriver({ clock, platform: "android" });
+    driver.setManagedReality({
+      // What a real driver reports: the device entry is reconnaissance and carries no usable
+      // address, while the process entry beside it is the emulator actually running.
+      devices: [{ address: "", deviceId: "orphan-1", driverData: {}, runState: "running" }],
+      processes: [{ address: "emulator-5586", deviceId: "orphan-1", driverData: {} }],
+    });
+
+    const report = await new Doctor({
+      clock,
+      config: config(),
+      drivers: [driver],
+      eventBus,
+      registry,
+    }).reconcile({ purgeOrphans: true });
+
+    // Destroying through the addressless entry is what let a driver skip the shutdown and
+    // unlink an AVD's files from under a live process -- after which nothing could attribute
+    // the survivor to anything ever again.
+    expect(driver.calls.find((call) => call.operation === "destroy")?.arguments[0]).toMatchObject({
+      address: "emulator-5586",
+    });
+    expect(report.findings).toEqual([]);
+  });
+
+  it("spares an orphan that acquired a registry record while the run was working", async () => {
+    const clock = new FakeClock(10_000);
+    const eventBus = new EventBus(clock);
+    const registry = await loadRegistry(clock, eventBus);
+    const driver = new FakeDriver({ clock, platform: "ios" });
+    driver.setManagedReality({ devices: [observed("racing", "stopped")], processes: [] });
+    // The re-proof is the last thing before the first destroy, so this stands in for a
+    // provision that committed while the run was busy listing and fixing.
+    vi.spyOn(driver, "revalidateRoot").mockImplementation(async () => {
+      await registry.registerDevice({
+        driverData: {},
+        driverDeviceId: "racing",
+        provisionDuration: 0,
+        spec: { model: "Phone", osVersion: "1", platform: "ios" },
+      });
+    });
+
+    const report = await new Doctor({
+      clock,
+      config: config(),
+      drivers: [driver],
+      eventBus,
+      registry,
+    }).reconcile({ purgeOrphans: true });
+
+    // What ADR 0001 accepts is that a device between `provision` and `registerDevice` cannot
+    // be told from a leak *at the instant of the destroy* -- not on a snapshot read minutes
+    // earlier, before every `listManaged`, every pre-root lookup and all of `--fix`.
+    expect(driver.calls.filter((call) => call.operation === "destroy")).toEqual([]);
+    expect(report.findings.map((finding) => finding.kind)).toEqual(["orphan-device"]);
+  });
+
+  it("looks outside the root once per driver, however many of its devices are missing", async () => {
+    const clock = new FakeClock(10_000);
+    const eventBus = new EventBus(clock);
+    const registry = await loadRegistry(clock, eventBus);
+    await readyDevice(registry, "stranded-1", "ios");
+    await readyDevice(registry, "stranded-2", "ios");
+    const driver = new FakeDriver({
+      clock,
+      legacyDevices: {
+        "stranded-1": { device: driverDevice("stranded-1") },
+        "stranded-2": { device: driverDevice("stranded-2") },
+      },
+      platform: "ios",
+    });
+    driver.setManagedReality({ devices: [], processes: [] });
+
+    const report = await new Doctor({
+      clock,
+      config: config(),
+      drivers: [driver],
+      eventBus,
+      registry,
+    }).reconcile();
+
+    // The lookup is a subprocess per call (iOS runs a full unscoped `simctl list`), it is
+    // the same answer every time, and it runs inside the converge that parks every request
+    // -- so one per driver, not one per device.
+    expect(driver.calls.filter((call) => call.operation === "listLegacy")).toHaveLength(1);
+    expect(report.findings.map((finding) => finding.kind)).toEqual([
+      "legacy-device",
+      "legacy-device",
+    ]);
+  });
+
+  it("says which device it destroyed outside the root, and where", async () => {
+    const { clock, driver, eventBus, registry } = await legacyDeviceSetup();
+
+    await new Doctor({ clock, config: config(), drivers: [driver], eventBus, registry }).reconcile({
+      fix: true,
+    });
+
+    // The only destruction Simlock performs outside an owned root. Without its own event the
+    // sole trace would be a `device.deleted` identical to a registry-only fix's, and safety
+    // rule 6 asks every destructive action to be attributable.
+    expect(eventBus.replay()).toContainEqual(
+      expect.objectContaining({
+        event: "device.legacy-destroyed",
+        payload: {
+          deviceId: registry.snapshot.devices[0]?.id,
+          driverDeviceId: "stranded",
+          path: "/Library/Devices/stranded",
+          platform: "ios",
+        },
+      }),
+    );
+  });
+
+  it("never destroys a legacy device whose record still says leased", async () => {
+    const clock = new FakeClock(10_000);
+    const eventBus = new EventBus(clock);
+    const filesystem = new MemoryFilesystem();
+    // A device recorded `leased` with no lease row -- the case `#fixForeignStateChange`
+    // already documents. There it costs a skipped transition; here the lease-table guard
+    // alone would let an unscoped delete through against a device someone may be holding.
+    await filesystem.writeFileAtomic(
+      "/state.json",
+      JSON.stringify({
+        devices: [
+          {
+            createdAt: 1,
+            driverData: {},
+            driverDeviceId: "stranded",
+            id: "dev_1",
+            spec: { model: "Phone", osVersion: "1", platform: "ios" },
+            state: "leased",
+          },
+        ],
+        leases: [],
+      }),
+    );
+    const registry = await Registry.load({
+      clock,
+      eventBus,
+      filesystem,
+      idGenerator: sequence(),
+      statePath: "/state.json",
+    });
+    const driver = new FakeDriver({
+      clock,
+      legacyDevices: { stranded: { device: driverDevice("stranded") } },
+      platform: "ios",
+    });
+    driver.setManagedReality({ devices: [], processes: [] });
+
+    await new Doctor({ clock, config: config(), drivers: [driver], eventBus, registry }).reconcile({
+      fix: true,
+    });
+
+    expect(driver.calls.filter((call) => call.operation === "destroyLegacy")).toEqual([]);
+    expect(registry.snapshot.devices[0]?.state).toBe("leased");
+  });
+
+  it("keeps the record of a legacy device whose destroy failed", async () => {
+    const { clock, driver, eventBus, registry } = await legacyDeviceSetup();
+    driver.failOn("destroyLegacy", 1, new Error("avdmanager delete failed"));
+
+    await new Doctor({ clock, config: config(), drivers: [driver], eventBus, registry }).reconcile({
+      fix: true,
+    });
+
+    // The order is load-bearing: marking the record first would strand the device, because
+    // the record is the only thing that names its old location at all.
+    expect(registry.snapshot.devices[0]?.state).toBe("ready");
+    expect(eventBus.replay().some((event) => event.event === "device.legacy-destroyed")).toBe(
+      false,
+    );
+  });
+
   it("reports a missing device as missing when the legacy lookup itself fails", async () => {
     const { clock, driver, eventBus, registry } = await legacyDeviceSetup();
-    driver.failOn("findLegacy", 1, new Error("simctl list failed"));
+    driver.failOn("listLegacy", 1, new Error("simctl list failed"));
 
     const report = await new Doctor({
       clock,

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -14,6 +14,7 @@ import type {
   DriverDevice,
   DriverRejection,
   DriverRejectionReason,
+  LegacyDevice,
   ObservedDevice,
   ObservedMark,
 } from "./driver.js";
@@ -168,6 +169,12 @@ export class Doctor {
       this.options.drivers.map((driver) => [driver.platform, driver]),
     );
     const findings: DoctorFinding[] = [];
+    // One pre-root listing per driver per run, and only once something is actually missing.
+    // The lookup is a subprocess per platform (an unscoped `simctl list`, a directory scan),
+    // and on the first start after roots ship every pre-existing device is missing by
+    // construction -- so a lookup per device meant N identical listings, serially, inside a
+    // converge that parks every request but `hello` and `status.get`.
+    const legacyDevices = new Map<Platform, Promise<ReadonlyMap<string, LegacyDevice>>>();
 
     for (const device of snapshot.devices) {
       if (observedPlatforms.has(device.spec.platform)) {
@@ -175,6 +182,7 @@ export class Doctor {
           device,
           registryDriftFindings(device, realDeviceKeys, observedDevices),
           driversByPlatform.get(device.spec.platform),
+          legacyDevices,
         );
         findings.push(...deviceFindings);
         if (deviceFindings.some((finding) => finding.kind === "foreign-state-change")) {
@@ -243,12 +251,37 @@ export class Doctor {
       return findings;
     }
 
+    // Re-read, deliberately, rather than reuse the snapshot this run opened with. That one
+    // was taken before every `listManaged`, every pre-root lookup and all of `--fix`'s work
+    // -- minutes, on a post-migration home. A device that finished provisioning and
+    // registered in between has a record now, and what the ADR accepts is that an orphan
+    // cannot be told from a leak *at the instant of the destroy*, not minutes earlier. The
+    // three registry-writing fixes re-read for the same reason.
+    const registered = new Set(
+      this.options.registry.snapshot.devices.map((device) =>
+        key(device.spec.platform, device.driverDeviceId),
+      ),
+    );
+    // The process finding for the same device carries the address its device finding does
+    // not: `listManaged` reports observed devices with no usable address (they are never
+    // granted), while the processes it reports beside them are what the driver actually saw
+    // running. Destroying through that entry is what lets a driver stop the process before
+    // it unlinks the files underneath it.
+    const processes = new Map(
+      findings
+        .filter((finding) => finding.kind === "orphan-process")
+        .map((finding) => [key(finding.platform, finding.device.deviceId), finding.device]),
+    );
+
     const purged = new Set<string>();
+    const stopped = new Set<string>();
     for (const orphan of orphans) {
+      const orphanKey = key(orphan.platform, orphan.device.deviceId);
       const driver = driversByPlatform.get(orphan.platform);
-      if (driver === undefined) continue;
+      if (driver === undefined || registered.has(orphanKey)) continue;
+      const runningProcess = processes.get(orphanKey);
       try {
-        await driver.destroy(orphan.device);
+        await driver.destroy(runningProcess ?? orphan.device);
       } catch (error: unknown) {
         this.#logger.error("Could not purge orphan device", {
           deviceId: orphan.device.deviceId,
@@ -257,7 +290,10 @@ export class Doctor {
         });
         continue;
       }
-      purged.add(key(orphan.platform, orphan.device.deviceId));
+      purged.add(orphanKey);
+      if (runningProcess !== undefined) {
+        stopped.add(orphanKey);
+      }
       this.options.eventBus.emit(
         "device.orphan-purged",
         {
@@ -269,16 +305,19 @@ export class Doctor {
       );
     }
 
-    // An `orphan-process` for a device that is now gone is gone with it: destroying the
-    // device covers the process it was running, so reporting both would ask the operator
-    // to deal with something that no longer exists.
-    return findings.filter(
-      (finding) =>
-        !(
-          (finding.kind === "orphan-device" || finding.kind === "orphan-process") &&
-          purged.has(key(finding.platform, finding.device.deviceId))
-        ),
-    );
+    // An `orphan-process` is dropped only when the destroy that covered it was handed that
+    // very process -- never on the reasoning that destroying a device must have stopped
+    // whatever was running it. A process still running after its device is gone is the one
+    // thing nothing can attribute to anything afterwards, so it has to stay in the report.
+    return findings.filter((finding) => {
+      if (finding.kind === "orphan-device") {
+        return !purged.has(key(finding.platform, finding.device.deviceId));
+      }
+      if (finding.kind === "orphan-process") {
+        return !stopped.has(key(finding.platform, finding.device.deviceId));
+      }
+      return true;
+    });
   }
 
   /**
@@ -333,23 +372,16 @@ export class Doctor {
     device: DeviceRecord,
     findings: readonly DoctorFinding[],
     driver: Driver | undefined,
+    cache: Map<Platform, Promise<ReadonlyMap<string, LegacyDevice>>>,
   ): Promise<readonly DoctorFinding[]> {
-    const findLegacy = driver?.findLegacy?.bind(driver);
-    if (findLegacy === undefined || !findings.some((f) => f.kind === "registry-device-missing")) {
+    if (
+      driver?.listLegacy === undefined ||
+      !findings.some((f) => f.kind === "registry-device-missing")
+    ) {
       return findings;
     }
 
-    let legacy;
-    try {
-      legacy = await findLegacy(device.driverDeviceId);
-    } catch (error: unknown) {
-      this.#logger.warn("Could not look for a pre-root copy of a missing device", {
-        deviceId: device.id,
-        platform: device.spec.platform,
-        reason: errorMessage(error),
-      });
-      return findings;
-    }
+    const legacy = (await this.#legacyDevices(driver, cache)).get(device.driverDeviceId);
     if (legacy === undefined) return findings;
 
     return findings.map((finding) =>
@@ -363,6 +395,43 @@ export class Doctor {
           }
         : finding,
     );
+  }
+
+  /** Memoised for the run: one listing per driver, however many of its devices are missing. */
+  #legacyDevices(
+    driver: Driver,
+    cache: Map<Platform, Promise<ReadonlyMap<string, LegacyDevice>>>,
+  ): Promise<ReadonlyMap<string, LegacyDevice>> {
+    const existing = cache.get(driver.platform);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const pending = this.#loadLegacyDevices(driver);
+    cache.set(driver.platform, pending);
+    return pending;
+  }
+
+  /**
+   * Keyed by driver device id, and empty when the lookup failed: "I could not look outside
+   * the root" is not "it is out there", and the finding that stands in that case is the one
+   * whose fix only writes to the registry. The first entry for an id wins -- two pre-root
+   * locations can hold the same name, and the destroy re-resolves which anyway.
+   */
+  async #loadLegacyDevices(driver: Driver): Promise<ReadonlyMap<string, LegacyDevice>> {
+    const byDriverDeviceId = new Map<string, LegacyDevice>();
+    try {
+      for (const legacy of (await driver.listLegacy?.()) ?? []) {
+        if (!byDriverDeviceId.has(legacy.device.deviceId)) {
+          byDriverDeviceId.set(legacy.device.deviceId, legacy);
+        }
+      }
+    } catch (error: unknown) {
+      this.#logger.warn("Could not look for pre-root copies of missing devices", {
+        platform: driver.platform,
+        reason: errorMessage(error),
+      });
+    }
+    return byDriverDeviceId;
   }
 
   #emitFindingEvents(findings: readonly DoctorFinding[]): void {
@@ -476,6 +545,15 @@ export class Doctor {
     if (snapshot.leases.some((lease) => lease.deviceId === finding.deviceId)) {
       return;
     }
+    // The device's own state as well as the lease table, because they can disagree: a record
+    // left `leased` with no lease reaches past the check above, exactly as
+    // `#fixForeignStateChange` documents. There the cost of missing it is a skipped
+    // transition; here it would be an unscoped delete against a device the registry still
+    // believes someone is holding (safety rule 2).
+    const device = snapshot.devices.find((candidate) => candidate.id === finding.deviceId);
+    if (device === undefined || device.state === "leased") {
+      return;
+    }
     try {
       await destroyLegacy(finding.device);
     } catch (error: unknown) {
@@ -486,6 +564,20 @@ export class Doctor {
       });
       return;
     }
+    // The one destruction Simlock performs outside an owned root, and the only trace of it
+    // otherwise would be a `device.deleted` indistinguishable from a registry-only fix
+    // (safety rule 6). `device.orphan-purged` exists for the *less* privileged of the two
+    // paths, so this one cannot be the unattributable one.
+    this.options.eventBus.emit(
+      "device.legacy-destroyed",
+      {
+        deviceId: finding.deviceId,
+        driverDeviceId: finding.device.deviceId,
+        platform: finding.platform,
+        ...(finding.path === undefined ? {} : { path: finding.path }),
+      },
+      "doctor",
+    );
     await this.#fixMissingDevice(finding.deviceId);
   }
 

--- a/src/core/driver.ts
+++ b/src/core/driver.ts
@@ -168,12 +168,19 @@ export interface Driver {
    */
   passthrough?(args: readonly string[]): PassthroughCommand;
   /**
-   * Looks for a registry device in the location this platform used before Simlock owned a
-   * root, and reports it without touching it. Optional: a driver with no pre-root history
-   * has nothing to find. The core only ever asks about a device the root itself no longer
-   * holds, so a "yes" here is what separates "stranded by the migration" from "gone".
+   * Everything this platform can see in the locations it used before Simlock owned a root,
+   * reported without touching any of it. Optional: a driver with no pre-root history has
+   * nothing to find.
+   *
+   * A whole listing rather than a per-device lookup, because the platform tools answer it
+   * that way: iOS pays a full unscoped `simctl list` per call, so a lookup per missing
+   * device meant N identical 30s-timeout listings, serially, inside the startup converge
+   * that parks every request -- and on the first start after roots ship *every* pre-existing
+   * device is missing by construction. Nothing here is a finding on its own: the core keeps
+   * only the entries a registry record names, which is what makes reaching outside the root
+   * registry-only destruction (safety rule 1) rather than a claim over the user's devices.
    */
-  findLegacy?(driverDeviceId: string): Promise<LegacyDevice | undefined>;
+  listLegacy?(): Promise<readonly LegacyDevice[]>;
   /**
    * Destroys such a device through the old, unscoped path it actually lives on. This is
    * the only Simlock call that reaches outside an owned root, and it is permitted because

--- a/src/core/fake-driver.ts
+++ b/src/core/fake-driver.ts
@@ -26,7 +26,7 @@ export type FakeDriverOperation =
   | "listCatalog"
   /** Recorded like every other call, so a test can pin that it precedes the first destroy. */
   | "revalidateRoot"
-  | "findLegacy"
+  | "listLegacy"
   | "destroyLegacy";
 
 export type DriverEstimateOperation = "provision" | "boot" | "reclaim";
@@ -65,9 +65,9 @@ export interface FakeDriverOptions {
   readonly passthrough?: (args: readonly string[]) => PassthroughCommand;
   readonly platform: Platform;
   /**
-   * What this driver claims to find outside its root for a given device id, keyed by
-   * `driverDeviceId`. Empty by default: a driver that has never had a pre-root life finds
-   * nothing, which is what keeps every other test's missing device simply missing.
+   * What this driver claims to find outside its root, keyed by `driverDeviceId`. Empty by
+   * default: a driver that has never had a pre-root life finds nothing, which is what keeps
+   * every other test's missing device simply missing.
    */
   readonly legacyDevices?: Readonly<Record<string, LegacyDevice>>;
   readonly reclaimResult?: "ready" | "shutdown";
@@ -138,9 +138,9 @@ export class FakeDriver implements Driver {
     await this.#beforeCall("revalidateRoot");
   }
 
-  async findLegacy(driverDeviceId: string): Promise<LegacyDevice | undefined> {
-    await this.#beforeCall("findLegacy", driverDeviceId);
-    return this.#legacyDevices.get(driverDeviceId);
+  async listLegacy(): Promise<readonly LegacyDevice[]> {
+    await this.#beforeCall("listLegacy");
+    return [...this.#legacyDevices.values()];
   }
 
   async destroyLegacy(device: DriverDevice): Promise<void> {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -32,8 +32,13 @@ export { UnknownPassthroughToolError } from "./driver-catalog.js";
 // fallow-ignore-next-line unused-type -- wire-visible rejection vocabulary for Simlock's own adb server.
 export type { AdbServerRejectionReason, DriverRejectionReason } from "./driver.js";
 export { Doctor } from "./doctor.js";
-export { ensureOwnedRoot, OWNED_ROOT_MARKER_FILE, OwnedRootError } from "./device-root.js";
-export type { EnsureOwnedRootOptions } from "./device-root.js";
+export {
+  ensureOwnedRoot,
+  OWNED_ROOT_MARKER_FILE,
+  OwnedRootError,
+  validateOwnedRoot,
+} from "./device-root.js";
+export type { EnsureOwnedRootOptions, ValidateOwnedRootOptions } from "./device-root.js";
 // fallow-ignore-next-line unused-type -- wire-visible rejection vocabulary, carried in the driver.root-rejected payload.
 export type { RootRejectionReason } from "./device-root.js";
 // fallow-ignore-next-line unused-type -- public shape of the on-disk ownership marker.

--- a/src/core/lease-engine.test.ts
+++ b/src/core/lease-engine.test.ts
@@ -1204,4 +1204,21 @@ describe("LeaseEngine startup reclaim backgrounding (#43)", () => {
     expect(driver.calls.filter((call) => call.operation === "reclaim")).toHaveLength(1);
     expect(driver.calls.filter((call) => call.operation === "shutdown")).toHaveLength(1);
   });
+
+  it("leaves no armed timer behind for a detached lease it is disposed with", async () => {
+    const harness = await createHarness({ lease: { detachedTtlMs: 900_000 } });
+    await harness.engine.request(request, { mode: "detached", requesterId: "detached-holder" });
+    expect(harness.clock.pendingTimerCount).toBeGreaterThan(0);
+
+    harness.engine.dispose();
+
+    // A real `setTimeout` holds the event loop open, so a timer surviving disposal is a
+    // daemon that has decided to stop and cannot: `daemon stop` used to hang for the
+    // fifteen minutes of an outstanding detached lease's TTL. Held leases hid it, because
+    // shutdown releases them and releasing cancels the timer.
+    expect(harness.clock.pendingTimerCount).toBe(0);
+    // The lease itself is untouched -- disposal cancels a timer, it does not expire a
+    // lease, which is what lets a detached lease survive the restart.
+    expect(harness.registry.snapshot.leases).toHaveLength(1);
+  });
 });

--- a/src/core/lease-engine.ts
+++ b/src/core/lease-engine.ts
@@ -262,9 +262,23 @@ export class LeaseEngine {
     await this.#releaseCoordinator.settleBackgroundReclaims();
   }
 
-  /** Cancels the quarantine coordinator's armed retry timers on daemon shutdown. */
+  /**
+   * Cancels every timer this engine armed, so the process can actually exit.
+   *
+   * The expiry timers matter as much as the quarantine ones and were missed: a lease's
+   * TTL is a `setTimeout` that outlives the decision to shut down, so a daemon with an
+   * outstanding *detached* lease kept running long after `daemon stop` -- up to the
+   * fifteen minutes of its own TTL. Held leases hid it, because releasing them on the way
+   * out cancels their timers; detached leases are deliberately left alone, since their
+   * liveness is the TTL rather than a connection.
+   *
+   * Cancelling expires nothing early and loses nothing: `ttlDeadline` is persisted with
+   * the lease, and `LeaseExpiryScheduler.restore` re-arms it on the next start, which is
+   * also what makes a detached lease survive a restart intact.
+   */
   dispose(): void {
     this.#quarantine.dispose();
+    this.#expiry.dispose();
   }
 
   /** Read-only device catalog; a platform without a registered driver is omitted. */

--- a/src/drivers/android/index.test.ts
+++ b/src/drivers/android/index.test.ts
@@ -1211,16 +1211,107 @@ describe("AndroidDriver pre-root devices", () => {
     });
   });
 
+  it("refuses to re-prove a root that has been removed since startup", async () => {
+    const filesystem = await androidFilesystem();
+    const driver = await createDriver(filesystem, new ScriptedProcessRunner([]));
+    await filesystem.rm(avdDirectory);
+
+    // The failure that most obviously invalidates a device list already in hand -- an
+    // `rm -rf`, an unmounted volume under a configured `deviceRoot`. Re-creating the root
+    // here would report success and let a purge run against a list of devices that are not
+    // there, so the re-proof refuses and creates nothing.
+    await expect(driver.revalidateRoot()).rejects.toMatchObject({
+      name: "OwnedRootError",
+      reason: "missing-marker",
+    });
+    await expect(filesystem.exists(avdDirectory)).resolves.toBe(false);
+  });
+
+  it("stops the emulator it finds running before deleting an AVD handed to it addressless", async () => {
+    const filesystem = await androidFilesystem({ config: "hw.ramSize=2048\n" });
+    const runner = new ScriptedProcessRunner([
+      processResult(binaries.adb, ["devices"], "List of devices attached\nemulator-5586\tdevice\n"),
+      processResult(
+        binaries.adb,
+        [
+          "-s",
+          "emulator-5586",
+          "shell",
+          `getprop ro.boot.qemu.avd_name; cat /data/local/tmp/simlock-mark.json 2>/dev/null || true`,
+        ],
+        "simlock_one\n",
+      ),
+      processResult(binaries.adb, ["-s", "emulator-5586", "emu", "kill"]),
+      processResult(binaries.adb, ["devices"], "List of devices attached\n"),
+      processResult(binaries.avdmanager, ["delete", "avd", "-n", "simlock_one"]),
+    ]);
+    const driver = await createDriver(filesystem, runner);
+
+    // Exactly what `doctor --purge-orphans` hands over: an observed device carries no port
+    // and no serial, because nothing addresses a device that is never granted. Deleting on
+    // that evidence alone unlinks the `.ini`, userdata and snapshots from under a live qemu
+    // process, and the AVD then being gone from the root, nothing could ever attribute the
+    // surviving emulator to it again.
+    await driver.destroy({
+      address: "",
+      deviceId: "simlock_one",
+      driverData: {
+        avdName: "simlock_one",
+        configHash: "recovered",
+        imageIdentity: "",
+        port: 0,
+        serial: "",
+      },
+    });
+
+    expect(runner.calls.map((call) => call.args)).toContainEqual([
+      "-s",
+      "emulator-5586",
+      "emu",
+      "kill",
+    ]);
+    expect(runner.calls.at(-1)?.args).toEqual(["delete", "avd", "-n", "simlock_one"]);
+  });
+
   it("finds an AVD stranded in the pre-root AVD home", async () => {
     const filesystem = await androidFilesystem();
     await filesystem.mkdirp(`${home}/.android/avd/simlock_old.avd`);
     const driver = await createDriver(filesystem, new ScriptedProcessRunner([]));
 
-    await expect(driver.findLegacy("simlock_old")).resolves.toMatchObject({
-      device: { deviceId: "simlock_old" },
-      path: `${home}/.android/avd/simlock_old.avd`,
+    await expect(driver.listLegacy()).resolves.toEqual([
+      {
+        device: expect.objectContaining({ deviceId: "simlock_old" }),
+        path: `${home}/.android/avd/simlock_old.avd`,
+      },
+    ]);
+  });
+
+  it("searches the SDK's default AVD home as well as the configured one", async () => {
+    const filesystem = await androidFilesystem();
+    await filesystem.mkdirp(`${home}/.android/avd/simlock_default_home.avd`);
+    await filesystem.mkdirp("/volumes/avds/simlock_configured_home.avd");
+    const driver = await createDriver(filesystem, new ScriptedProcessRunner([]), {
+      env: { ANDROID_AVD_HOME: "/volumes/avds", ANDROID_HOME: sdk },
     });
-    await expect(driver.findLegacy("simlock_never_existed")).resolves.toBeUndefined();
+
+    // `ANDROID_AVD_HOME` as it stands today says nothing about where an AVD was created
+    // before roots existed: someone who set it after Simlock had already made AVDs under
+    // `~/.android/avd` would otherwise have those reported as merely missing, their records
+    // marked deleted, and gigabytes stranded with nothing left to name them.
+    await expect(driver.listLegacy()).resolves.toEqual([
+      expect.objectContaining({ path: "/volumes/avds/simlock_configured_home.avd" }),
+      expect.objectContaining({ path: `${home}/.android/avd/simlock_default_home.avd` }),
+    ]);
+  });
+
+  it("never reports an AVD inside its own root as a pre-root device", async () => {
+    const filesystem = await androidFilesystem();
+    await filesystem.mkdirp(`${avdDirectory}/simlock_current.avd`);
+    const driver = await createDriver(filesystem, new ScriptedProcessRunner([]), {
+      env: { ANDROID_AVD_HOME: avdDirectory, ANDROID_HOME: sdk },
+    });
+
+    await expect(driver.listLegacy()).resolves.toEqual([]);
   });
 
   it("deletes a stranded AVD against the legacy AVD home, not Simlock's root", async () => {
@@ -1230,7 +1321,7 @@ describe("AndroidDriver pre-root devices", () => {
       processResult(binaries.avdmanager, ["delete", "avd", "-n", "simlock_old"]),
     ]);
     const driver = await createDriver(filesystem, runner);
-    const legacy = await driver.findLegacy("simlock_old");
+    const [legacy] = await driver.listLegacy();
 
     await driver.destroyLegacy(legacy!.device);
 
@@ -1241,6 +1332,20 @@ describe("AndroidDriver pre-root devices", () => {
       ANDROID_AVD_HOME: `${home}/.android/avd`,
       ANDROID_HOME: sdk,
     });
+  });
+
+  it("refuses to delete a stranded AVD an emulator is still running against", async () => {
+    const filesystem = await androidFilesystem();
+    await filesystem.mkdirp(`${home}/.android/avd/simlock_old.avd/hardware-qemu.ini.lock`);
+    const runner = new ScriptedProcessRunner([]);
+    const driver = await createDriver(filesystem, runner);
+    const [legacy] = await driver.listLegacy();
+
+    // Refusing to stop it on the user's adb server and unlinking its files anyway is
+    // strictly worse than either: `avdmanager delete avd` would take the `.ini`, the
+    // userdata images and the snapshots out from under a live qemu process.
+    await expect(driver.destroyLegacy(legacy!.device)).rejects.toThrow(/still holds its files/);
+    expect(runner.calls).toEqual([]);
   });
 });
 
@@ -1407,6 +1512,7 @@ async function createDriver(
   options: {
     readonly clock?: FakeClock;
     readonly driverConfig?: Readonly<Record<string, string | number | boolean>>;
+    readonly env?: Readonly<Record<string, string | undefined>>;
     readonly ids?: readonly string[];
     readonly readinessTimeoutMs?: number;
     readonly tcpProbe?: FakeTcpProbe;
@@ -1422,7 +1528,7 @@ async function createDriver(
   return AndroidDriver.create({
     clock: options.clock ?? new FakeClock(),
     driverConfig,
-    env: { ANDROID_HOME: sdk },
+    env: options.env ?? { ANDROID_HOME: sdk },
     filesystem,
     homeDirectory: home,
     hostAbi: "arm64-v8a",

--- a/src/drivers/android/index.ts
+++ b/src/drivers/android/index.ts
@@ -23,6 +23,8 @@ import {
   type EnsureOwnedRootOptions,
   type LegacyDevice,
   OwnedRootError,
+  validateOwnedRoot,
+  type ValidateOwnedRootOptions,
 } from "../../core/index.js";
 import type {
   Clock,
@@ -83,6 +85,13 @@ const SNAPSHOT_RECLAIM_ESTIMATE_MS = 6_000;
 // The slow branch is the one to quote: pricing the fast one would make every kept-warm reclaim
 // look stalled, while over-quoting only delays a finding.
 const WIPE_RECLAIM_ESTIMATE_MS = 32_000;
+// Lock files the emulator creates beside each AVD file it opens and removes when it exits.
+// `#isAvdRunning` reads them to tell a stopped pre-root AVD from one whose disk is live.
+const EMULATOR_LOCK_PATHS = [
+  "hardware-qemu.ini.lock",
+  "userdata-qemu.img.lock",
+  "multiinstance.lock",
+] as const;
 const CLEAN_BASELINE = "simlock_clean_baseline";
 const DURABLE_MARK_KEY = "simlock.mark";
 const ERASABLE_MARK_PATH = "/data/local/tmp/simlock-mark.json";
@@ -217,7 +226,7 @@ export class AndroidDriver implements Driver {
   readonly #filesystem: Filesystem;
   readonly #hostAbi: string;
   readonly #idGenerator: IdGenerator;
-  readonly #legacyAvdHome: string;
+  readonly #legacyAvdHomes: readonly string[];
   readonly #locks = new Map<string, Promise<void>>();
   readonly #onDiagnostic: ((diagnostic: AndroidDriverDiagnostic) => void) | undefined;
   readonly #portAllocator: PortAllocator;
@@ -225,14 +234,14 @@ export class AndroidDriver implements Driver {
   readonly #profiles = new Map<string, DeviceProfile>();
   readonly #readinessTimeoutMs: number;
   readonly #registrar: AdbRegistrar;
-  readonly #rootOptions: EnsureOwnedRootOptions;
+  readonly #rootOptions: ValidateOwnedRootOptions;
   readonly #sdk: AndroidSdkPaths;
 
   private constructor(
     options: AndroidDriverOptions,
     sdk: AndroidSdkPaths,
     deviceRoot: string,
-    rootOptions: EnsureOwnedRootOptions,
+    rootOptions: ValidateOwnedRootOptions,
     adbServer: AdbServerSupervisor,
     adbServerPort: number,
   ) {
@@ -250,12 +259,19 @@ export class AndroidDriver implements Driver {
     this.#registrar = new AdbRegistrar({ serverPort: adbServerPort, tcp: options.tcpProbe });
     this.#rootOptions = rootOptions;
     this.#sdk = sdk;
-    // Where an AVD Simlock made before it owned a root still sits: the AVD home the user
-    // had configured then, or the SDK's own default. Read only by `findLegacy` /
-    // `destroyLegacy` -- the fallback CP3 deleted from the driver proper, kept exactly here
-    // because a stranded device cannot be found anywhere else (ADR 0001, Migration).
-    this.#legacyAvdHome =
-      options.env.ANDROID_AVD_HOME ?? join(options.homeDirectory, ".android", "avd");
+    // Every AVD home an AVD Simlock made before it owned a root can still sit in: the one
+    // configured in this daemon's environment *and* the SDK's own default. Both, because
+    // `ANDROID_AVD_HOME` as it stands today says nothing about where an AVD was created
+    // before roots existed -- someone who made Simlock AVDs under `~/.android/avd` and later
+    // pointed the variable at their own volume would otherwise have those AVDs looked for in
+    // the wrong place, reported as merely missing, and their records marked deleted, leaving
+    // gigabytes with nothing left to name them (ADR 0001, Migration). The root itself is
+    // never one of them: an AVD there is not pre-root, it is simply gone, and it must never
+    // be answered through the unscoped path below. Read only by `listLegacy` /
+    // `destroyLegacy` -- the fallback CP3 deleted from the driver proper, kept exactly here.
+    this.#legacyAvdHomes = [
+      ...new Set([options.env.ANDROID_AVD_HOME, join(options.homeDirectory, ".android", "avd")]),
+    ].filter((home): home is string => home !== undefined && home !== "" && home !== deviceRoot);
     this.#portAllocator = portAllocatorFor(options.processRunner, sdk.adb);
   }
 
@@ -317,62 +333,97 @@ export class AndroidDriver implements Driver {
   }
 
   /**
-   * The same call `create` made, with the same arguments, because the proof *is* that call:
-   * a cheaper second check here would be a second validator, free to drift from the one
-   * every start is judged by. It is asked for immediately before Simlock destroys anything
-   * inside this root, since between then and startup the path can have become a symlink, or
-   * a `mv` can have left the user's own AVD home standing where this root was.
+   * The checks `create` made, minus the one thing a re-proof must never do: create. It is
+   * asked for immediately before Simlock destroys anything inside this root, since between
+   * then and startup the path can have become a symlink, or a `mv` can have left the user's
+   * own AVD home standing where this root was -- and a root that has simply gone (an
+   * `rm -rf`, an unmounted volume under a configured `deviceRoot`) refuses here rather than
+   * being rebuilt empty under a device list that describes what used to be in it.
    */
   async revalidateRoot(): Promise<void> {
-    await ensureOwnedRoot(this.#rootOptions);
+    await validateOwnedRoot(this.#rootOptions);
   }
 
   /**
-   * Looks for an AVD Simlock created before it owned a root, in the AVD home it would have
-   * used then. Reached only for a registry device this root no longer holds, and it only
-   * reads the filesystem. A legacy home that *is* the root means there is nothing pre-root
-   * about the device -- it is simply gone -- and must never be answered through the
-   * unscoped path below.
+   * Every AVD sitting in a pre-root AVD home, read straight off the filesystem and touched
+   * in no other way. Both homes are searched (see `#legacyAvdHomes`), and what comes back is
+   * candidates rather than findings: only the ones a registry record names ever reach a
+   * destroy, which is what keeps this registry-only destruction (safety rule 1) and not a
+   * claim over AVDs the user made themselves.
    */
-  async findLegacy(driverDeviceId: string): Promise<LegacyDevice | undefined> {
-    if (this.#legacyAvdHome === this.#deviceRoot) {
-      return undefined;
+  async listLegacy(): Promise<readonly LegacyDevice[]> {
+    const legacy: LegacyDevice[] = [];
+    for (const home of this.#legacyAvdHomes) {
+      for (const avdName of await this.#listAvdNames(home)) {
+        legacy.push({
+          device: legacyAndroidDevice(avdName),
+          path: join(home, `${avdName}.avd`),
+        });
+      }
     }
-    const path = join(this.#legacyAvdHome, `${driverDeviceId}.avd`);
-    if (!(await this.#filesystem.exists(path))) {
-      return undefined;
-    }
-
-    return {
-      device: {
-        address: driverDeviceId,
-        deviceId: driverDeviceId,
-        // A stranded AVD has no console port and no serial: it is not running on Simlock's
-        // server, and it is not this driver's business to look for it on anyone else's.
-        driverData: {
-          avdName: driverDeviceId,
-          configHash: "",
-          port: 0,
-          serial: "",
-        } satisfies AndroidDriverData,
-      },
-      path,
-    };
+    return legacy;
   }
 
   /**
    * Deletes a pre-root AVD through the AVD home it actually lives in. Permitted despite
    * sitting outside this driver's root because the registry names it: registry-only
-   * destruction (safety rule 1) is satisfied by the record, not by the root. The
-   * environment points at the legacy home and deliberately not at Simlock's adb server --
-   * an AVD that is somehow still running is running on the user's, and stopping devices on
-   * a server Simlock does not own is not something this may do.
+   * destruction (safety rule 1) is satisfied by the record, not by the root. The environment
+   * points at that home and deliberately not at Simlock's adb server -- a pre-root emulator
+   * answers to the user's own server, which Simlock does not own and will not drive.
+   *
+   * Which is why a running one is refused outright instead. Not driving the user's server
+   * and deleting the AVD's files anyway is the worst of both: `avdmanager delete avd`
+   * unlinks the `.ini`, the userdata images and the snapshots from under a live qemu
+   * process. Refusing costs a person one `adb emu kill` and a re-run of `doctor --fix`;
+   * the alternative costs them a corrupted device they cannot report. iOS shuts its
+   * pre-root simulators down instead, and that asymmetry is deliberate -- there is one
+   * CoreSimulator service per user and Simlock is already talking to it, so stopping a
+   * simulator there uses no privilege the scoped path does not already have.
    */
   async destroyLegacy(device: DriverDevice): Promise<void> {
     const { avdName } = this.#dataFor(device);
+    const home = await this.#legacyHomeOf(avdName);
+    // Gone between the listing and the fix. Nothing to delete, and nothing wrong: the
+    // caller's next step -- recording the device missing -- is the right one either way.
+    if (home === undefined) return;
+
+    if (await this.#isAvdRunning(join(home, `${avdName}.avd`))) {
+      throw new DriverCrashError(
+        `Refusing to delete the pre-root AVD ${avdName} in ${home}: an emulator still holds its files (a \`.lock\` beside them says so). Stop it with \`adb emu kill\` on the machine's own adb server -- or, if nothing is running, remove the stale locks -- then run \`simlock doctor --fix\` again.`,
+      );
+    }
+
     await this.#runOrThrow(this.#sdk.avdmanager, ["delete", "avd", "-n", avdName], {
-      env: { ...this.#baseEnv, ANDROID_AVD_HOME: this.#legacyAvdHome },
+      env: { ...this.#baseEnv, ANDROID_AVD_HOME: home },
     });
+  }
+
+  /** The pre-root home that holds this AVD, or `undefined` when none of them does. */
+  async #legacyHomeOf(avdName: string): Promise<string | undefined> {
+    for (const home of this.#legacyAvdHomes) {
+      if (await this.#filesystem.exists(join(home, `${avdName}.avd`))) {
+        return home;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * True while an emulator holds the AVD's files open. The emulator locks each file it
+   * opens by creating `<file>.lock` beside it and removes them when it exits, so this
+   * answers the question without contacting an adb server -- the only one that could see a
+   * pre-root emulator is the user's, and asking it would both start one on their behalf
+   * (`adb devices` launches a server) and mean reaching for a device on a server Simlock
+   * does not own. A lock left behind by a crashed emulator refuses the delete too; that is
+   * the error worth making, and the refusal says what to remove.
+   */
+  async #isAvdRunning(avdPath: string): Promise<boolean> {
+    for (const lock of EMULATOR_LOCK_PATHS) {
+      if (await this.#filesystem.exists(join(avdPath, lock))) {
+        return true;
+      }
+    }
+    return false;
   }
 
   leaseEnvironment(): Readonly<Record<string, string>> {
@@ -674,16 +725,67 @@ export class AndroidDriver implements Driver {
     });
   }
 
+  /**
+   * Stops whatever is running the AVD, then deletes it -- in that order, always.
+   *
+   * The address on `device` is not trusted to be there. An observed device carries none
+   * (`observedAndroidDevice` reports `port: 0`, `serial: ""`, because nothing addresses a
+   * device that is never granted), and `doctor --purge-orphans` destroys exactly those. On
+   * that evidence alone this used to skip the shutdown and go straight to `avdmanager delete
+   * avd`, unlinking the `.ini`, `config.ini`, userdata and snapshots from under a live qemu
+   * process -- and the AVD then being gone from the root, the surviving emulator could never
+   * be attributed to it again: invisible to Simlock forever, unreportable and unkillable,
+   * the permanent leak ADR 0001 exists to eliminate. So an address that is missing is looked
+   * up among the emulators actually running before anything is unlinked, and a device that
+   * will not stop fails the destroy rather than losing the AVD out from under it.
+   */
   async destroy(device: DriverDevice): Promise<void> {
     const data = this.#dataFor(device);
     await this.#withDeviceLock(data.avdName, async () => {
-      if (data.port > 0) {
-        await this.#shutdown(data, this.#stateFor(data));
+      const running = data.port > 0 ? data : await this.#runningEmulator(data.avdName);
+      if (running !== undefined) {
+        await this.#shutdown(running, this.#stateFor(running));
+        await this.#awaitEmulatorStopped(data.avdName, this.#clock.now());
       }
       await this.#runOrThrow(this.#sdk.avdmanager, ["delete", "avd", "-n", data.avdName]);
       this.#devices.delete(data.avdName);
-      this.#portAllocator.release(data.port);
+      this.#portAllocator.release(running?.port ?? data.port);
     });
+  }
+
+  /**
+   * The live console address of an AVD in this root, or `undefined` when nothing is running
+   * it. Membership in the root is checked first and the attribution is the same one
+   * `listManaged` makes: ownership is proven from where the AVD lives, never from which
+   * emulator happens to answer to a name (safety rule 8).
+   */
+  async #runningEmulator(avdName: string): Promise<AndroidDriverData | undefined> {
+    const avdNamesInRoot = new Set(await this.#listAvdNames());
+    if (!avdNamesInRoot.has(avdName)) {
+      return undefined;
+    }
+    const { settledSerials } = await this.#scanAdbSerials();
+    const { processes } = await this.#resolveRunningAvds(settledSerials, avdNamesInRoot);
+    const running = processes.find((candidate) => candidate.deviceId === avdName);
+    return running === undefined ? undefined : this.#dataFor(running);
+  }
+
+  /**
+   * Waits for a stopped emulator's transport to disappear. `emu kill` returns when the
+   * emulator acknowledges it, not when the process is gone, and an emulator this driver
+   * never spawned leaves no `ProcessHandle` to wait on -- so the transport going away is the
+   * only evidence available that the AVD's files have been released. Timing out throws:
+   * leaving an orphan reported is recoverable, deleting its disk while it runs is not.
+   */
+  async #awaitEmulatorStopped(avdName: string, startedAt: number): Promise<void> {
+    while ((await this.#runningEmulator(avdName)) !== undefined) {
+      if (this.#clock.now() - startedAt >= this.#readinessTimeoutMs) {
+        throw new DriverCrashError(
+          `Android emulator for ${avdName} is still attached after emu kill; refusing to delete an AVD a process is running against`,
+        );
+      }
+      await this.#delay(PORT_POLL_INTERVAL_MS);
+    }
   }
 
   async listManaged(): Promise<DriverReality> {
@@ -716,14 +818,16 @@ export class AndroidDriver implements Driver {
   }
 
   /**
-   * Every AVD in the root, whatever it is called. The name is a cosmetic label with no
+   * Every AVD in a directory, whatever it is called. The name is a cosmetic label with no
    * authority: what makes these AVDs Simlock's is that they sit inside a root Simlock
-   * created empty and marked, which nothing else can put an AVD into (safety rule 8).
+   * created empty and marked, which nothing else can put an AVD into (safety rule 8) --
+   * which is also why `listLegacy`, the one caller that passes a directory that is *not*
+   * the root, produces candidates for the registry to confirm rather than owned devices.
    */
-  async #listAvdNames(): Promise<string[]> {
+  async #listAvdNames(directory: string = this.#deviceRoot): Promise<string[]> {
     const avdNames: string[] = [];
-    if (await this.#filesystem.exists(this.#deviceRoot)) {
-      for (const entry of await this.#filesystem.readdir(this.#deviceRoot)) {
+    if (await this.#filesystem.exists(directory)) {
+      for (const entry of await this.#filesystem.readdir(directory)) {
         const match = /^(.+)\.avd$/.exec(entry);
         if (match?.[1] === undefined) continue;
         avdNames.push(match[1]);
@@ -1503,13 +1607,33 @@ function serialFor(port: number): string {
   return `emulator-${port}`;
 }
 
+/**
+ * A pre-root AVD as a `DriverDevice`: named, and carrying no console port and no serial. It
+ * is not on Simlock's adb server, and finding it on the user's is not this driver's business
+ * -- which is why `destroyLegacy` refuses a running one rather than reaching for it.
+ */
+function legacyAndroidDevice(avdName: string): DriverDevice {
+  return {
+    address: avdName,
+    deviceId: avdName,
+    driverData: {
+      avdName,
+      configHash: "",
+      port: 0,
+      serial: "",
+    } satisfies AndroidDriverData,
+  };
+}
+
 function observedAndroidDevice(
   avdName: string,
   runningByAvdName: ReadonlySet<string>,
   unattributableTransitionalSerial: boolean,
 ): ObservedDevice {
   return {
-    // Reconnaissance only: an observed device is never granted, so it carries no usable address.
+    // Reconnaissance only: an observed device is never granted, so it carries no usable
+    // address. Anything that acts on one has to resolve the address itself -- see `destroy`,
+    // which is handed exactly these by `doctor --purge-orphans`.
     address: "",
     deviceId: avdName,
     driverData: {

--- a/src/drivers/ios/index.test.ts
+++ b/src/drivers/ios/index.test.ts
@@ -62,7 +62,7 @@ const legacyUdid = "00000000-0000-0000-0000-0000000000ff";
 
 /**
  * The complete argv of every call the pre-root path is allowed to make without `--set`,
- * spelled out rather than pattern-matched: `findLegacy` / `destroyLegacy` deliberately
+ * spelled out rather than pattern-matched: `listLegacy` / `destroyLegacy` deliberately
  * address the machine's default set (ADR 0001, Migration), and every *other* call must
  * still fail the invariant below if its scoping ever goes missing.
  */
@@ -632,6 +632,24 @@ describe("IosSimctlDriver", () => {
     expect(failure).toMatchObject({ platform: "ios", reason: "symlink" });
   });
 
+  it("refuses to re-prove a device set that has been removed since startup", async () => {
+    const filesystem = new MemoryFilesystem();
+    const driver = await createDriver(new ScriptedProcessRunner([]), new FakeClock(), filesystem);
+    await filesystem.rm(deviceRoot);
+
+    const failure = await driver
+      .revalidateRoot()
+      .then(() => undefined)
+      .catch((error: unknown) => error);
+
+    // Re-creating it here would report success and let a purge run against a device list
+    // describing a directory that is no longer there -- and a re-proof that writes to the
+    // filesystem is not the read-only check three shipped documents describe.
+    expect(failure).toBeInstanceOf(OwnedRootError);
+    expect(failure).toMatchObject({ platform: "ios", reason: "missing-marker" });
+    await expect(filesystem.exists(deviceRoot)).resolves.toBe(false);
+  });
+
   it("finds a pre-root device in the machine's default set, without --set", async () => {
     const runner = new ScriptedProcessRunner([
       {
@@ -656,13 +674,15 @@ describe("IosSimctlDriver", () => {
     ]);
     const driver = await createDriver(runner);
 
-    await expect(driver.findLegacy(legacyUdid)).resolves.toMatchObject({
-      device: { deviceId: legacyUdid },
-      path: `/Library/Devices/${legacyUdid}`,
-    });
+    await expect(driver.listLegacy()).resolves.toEqual([
+      {
+        device: expect.objectContaining({ deviceId: legacyUdid }),
+        path: `/Library/Devices/${legacyUdid}`,
+      },
+    ]);
   });
 
-  it("reports no pre-root device when the default set does not hold the udid", async () => {
+  it("reports nothing pre-root when the default set is empty", async () => {
     const runner = new ScriptedProcessRunner([
       {
         match: { args: ["simctl", "list", "-j", "devices"], command: "xcrun" },
@@ -671,7 +691,7 @@ describe("IosSimctlDriver", () => {
     ]);
     const driver = await createDriver(runner);
 
-    await expect(driver.findLegacy(legacyUdid)).resolves.toBeUndefined();
+    await expect(driver.listLegacy()).resolves.toEqual([]);
   });
 
   it("destroys a pre-root device through the unscoped path it actually lives on", async () => {

--- a/src/drivers/ios/index.ts
+++ b/src/drivers/ios/index.ts
@@ -19,6 +19,8 @@ import {
   type ObservedRunState,
   RuntimeMissingError,
   UnknownModelError,
+  validateOwnedRoot,
+  type ValidateOwnedRootOptions,
 } from "../../core/index.js";
 import type { ObservedMark } from "../../core/driver.js";
 import type { DeviceSpec } from "../../core/index.js";
@@ -142,12 +144,12 @@ export class IosSimctlDriver implements Driver {
   readonly #processRunner: ProcessRunner;
   readonly #resolvedSpecs = new Map<string, ResolvedIosSpec>();
   readonly #deviceRoot: string;
-  readonly #rootOptions: EnsureOwnedRootOptions;
+  readonly #rootOptions: ValidateOwnedRootOptions;
 
   private constructor(
     options: IosSimctlDriverOptions,
     deviceRoot: string,
-    rootOptions: EnsureOwnedRootOptions,
+    rootOptions: ValidateOwnedRootOptions,
   ) {
     this.#clock = options.clock;
     this.#filesystem = options.filesystem;
@@ -184,14 +186,15 @@ export class IosSimctlDriver implements Driver {
   }
 
   /**
-   * The same call `create` made, with the same arguments, because the proof *is* that call:
-   * a cheaper second check here would be a second validator, free to drift from the one
-   * every start is judged by. It is asked for immediately before Simlock destroys anything
-   * inside this set, since between then and startup the path can have become a symlink, or
-   * a `mv` can have left the user's own device set standing where this one was.
+   * The checks `create` made, minus the one thing a re-proof must never do: create. It is
+   * asked for immediately before Simlock destroys anything inside this set, since between
+   * then and startup the path can have become a symlink, or a `mv` can have left the user's
+   * own device set standing where this one was -- and a set that has simply gone (an
+   * `rm -rf`, an unmounted volume) refuses here rather than being rebuilt empty under a
+   * device list that describes what used to be in it.
    */
   async revalidateRoot(): Promise<void> {
-    await ensureOwnedRoot(this.#rootOptions);
+    await validateOwnedRoot(this.#rootOptions);
   }
 
   async resolveSpec(
@@ -310,20 +313,17 @@ export class IosSimctlDriver implements Driver {
   }
 
   /**
-   * Looks for a UDID in the machine's default device set -- where every simulator Simlock
-   * created before it owned one still lives. Reached only for a registry device the root no
-   * longer holds, and it reads: `simctl list` is the one unscoped call that mutates nothing.
+   * The machine's default device set, where every simulator Simlock created before it owned
+   * one still lives. One listing per reconcile, not one per missing device: `simctl list` is
+   * a subprocess with a 30s timeout and its answer is the same for every UDID asked about.
+   * It reads and nothing more -- `list` is the one unscoped call that mutates nothing -- and
+   * the entries are candidates, never findings: only the ones a registry record names ever
+   * reach a destroy.
    */
-  async findLegacy(driverDeviceId: string): Promise<LegacyDevice | undefined> {
+  async listLegacy(): Promise<readonly LegacyDevice[]> {
     const result = await this.#legacySimctl(["list", "-j", "devices"], COMMAND_TIMEOUT_MS);
-    const found = parseManagedDevices(JSON.parse(result.stdout) as unknown).find(
-      (device) => device.udid === driverDeviceId,
-    );
-    if (found === undefined) {
-      return undefined;
-    }
 
-    return {
+    return parseManagedDevices(JSON.parse(result.stdout) as unknown).map((found) => ({
       device: {
         address: found.udid,
         deviceId: found.udid,
@@ -338,7 +338,7 @@ export class IosSimctlDriver implements Driver {
       // container's parent is the device directory -- and where the *old* set is is exactly
       // what this driver no longer knows any other way (ADR 0001, consequences).
       ...(found.dataPath === undefined ? {} : { path: dirname(found.dataPath) }),
-    };
+    }));
   }
 
   /**
@@ -346,6 +346,12 @@ export class IosSimctlDriver implements Driver {
    * despite living outside this driver's root because the registry names it: registry-only
    * destruction (safety rule 1) is satisfied by the record, not by the root. `doctor --fix`
    * is the only caller, and it checks the lease guard before asking.
+   *
+   * It stops the device first, where Android's `destroyLegacy` refuses a running one
+   * outright, and the asymmetry is deliberate: there is one CoreSimulator service per user
+   * and Simlock is already talking to it, so shutting a simulator down here uses no
+   * privilege the scoped path does not already have. Android's pre-root emulators answer to
+   * the user's own adb server instead, which Simlock does not own and will not drive.
    */
   async destroyLegacy(device: DriverDevice): Promise<void> {
     const { udid } = iosDriverData(device);
@@ -643,7 +649,7 @@ export class IosSimctlDriver implements Driver {
 
   /**
    * Deliberately unscoped, and the only thing in Simlock that is: the pre-root devices
-   * `findLegacy` / `destroyLegacy` deal with are in the machine's default set, which is
+   * `listLegacy` / `destroyLegacy` deal with are in the machine's default set, which is
    * where a `--set` would stop reaching them. Only those two may call it, and only for a
    * UDID a registry record names -- registry-only destruction (safety rule 1) is satisfied
    * by that record, not by the root.
@@ -737,7 +743,7 @@ function configuredDeviceRoot(options: IosSimctlDriverOptions): string {
 }
 
 interface ParsedManagedDevice {
-  /** Only `findLegacy` reads this; a scoped listing already knows where its devices are. */
+  /** Only `listLegacy` reads this; a scoped listing already knows where its devices are. */
   readonly dataPath?: string;
   readonly name: string;
   readonly runState: ObservedRunState;


### PR DESCRIPTION
Sixth and last of the stacked PRs. Based on #84. **This one is not part of ADR 0001** — it fixes a pre-existing defect the device-roots work surfaced.

1. [#80](https://github.com/callstackincubator/simlock/pull/80) owned device root validation and its ports
2. [#81](https://github.com/callstackincubator/simlock/pull/81) iOS device set scoping
3. [#82](https://github.com/callstackincubator/simlock/pull/82) Android AVD home and private adb server
4. [#83](https://github.com/callstackincubator/simlock/pull/83) lease environment and scoped wrappers
5. [#84](https://github.com/callstackincubator/simlock/pull/84) doctor: purge orphans, legacy devices, docs status
6. **daemon stop with an outstanding detached lease** ← this PR

## The defect

`simlock daemon stop` returns promptly and the process stays alive. The operator is left with a stopped daemon still holding its socket, and whatever restarts it finds the address in use.

`LeaseEngine.dispose` — the hook `DaemonServer#stop` invokes — cancelled the quarantine coordinator's timers and not the expiry scheduler's:

```ts
/** Cancels the quarantine coordinator's armed retry timers on daemon shutdown. */
dispose(): void {
  this.#quarantine.dispose();
}
```

A lease's TTL is a real `setTimeout`, so an outstanding lease kept Node's event loop alive for as long as its deadline had left — fifteen minutes by default for a detached one. `LeaseExpiryScheduler.dispose()` existed and was never called from production code.

**Held leases hid it**: shutdown releases them, and releasing cancels the timer. Detached leases are deliberately left alone, since their liveness is the TTL rather than a connection, so they were the only ones left armed — which is why nothing in the suite tripped over it until a new e2e flow in #83 left one behind.

## Why the fix is safe

Cancelling expires nothing early and loses nothing: `ttlDeadline` is persisted with the lease and re-armed by `LeaseExpiryScheduler.restore` on the next start. That is the same mechanism that lets a detached lease outlive a restart in the first place, which is the property that had to be preserved — the fix must not become "release everything on shutdown".

## Pre-existing, not introduced here

It reproduces on `feat/owned-device-roots` — the ADR-only branch, with none of this stack applied — using a two-line test that leases `--detach` and does not release. I kept it out of #83 rather than widening that checkpoint to absorb an unrelated shutdown defect.

## Verification

The unit test fails against the old code: removing `this.#expiry.dispose()` gives `expected 1 to be +0`, an armed timer surviving disposal. Coverage is in three places:

- a unit test asserting no timer survives disposal **and** that the lease itself is untouched, since cancelling a timer must not expire a lease;
- an e2e case in `daemon lifecycle & recovery` that leases detached, stops the daemon, and lets teardown's stray-process check be the assertion — the check that caught this by accident;
- the workaround comment in #83's e2e test now points at that flow instead of claiming the defect is unfixed.

`pnpm run check` green: typecheck, typecheck:e2e, lint, format, 950 unit tests, e2e 41 passed / 1 expected fail / 3 skipped. `fallow audit` clean across 4 changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BuTqSL7fKJVRbFytNvZP7X

---
_Generated by [Claude Code](https://claude.ai/code/session_01BuTqSL7fKJVRbFytNvZP7X)_