### PR TITLE
feat(ios): opt-in slim simulators (closes #87)

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -79,7 +79,7 @@ and booting, then — in held mode — keeps running to hold the lease.
 ```
 simlock lease --platform <ios|android> --device <model> [--os <version>]
               [--agent-id <id>] [--timeout <duration>] [--no-wait] [--detach]
-              [--allow-download] [--bind-pid <pid>]
+              [--allow-download] [--full] [--bind-pid <pid>]
 ```
 
 - `--platform`, `--device` — required. `--os` defaults to the newest runtime
@@ -109,7 +109,15 @@ simlock lease --platform <ios|android> --device <model> [--os <version>]
   see [EVENTS.md](EVENTS.md#components). The requester's own progress stream
   (below) does not yet reflect an in-flight download — see
   [known-pitfalls.md](known-pitfalls.md).
-- `--detach` — detached mode: print the lease result and exit; the lease is
+- `--full` — opt this lease out of iOS slim mode (see
+  [CONFIGURATION.md](CONFIGURATION.md) for what slim mode disables). Only
+  meaningful when `ios.slim.enabled` is on; ignored otherwise, and ignored
+  for Android. A `--full` request never matches, and never shares a pool key
+  with, a slim device, so it can wait for a fresh device to provision or
+  force a re-provision of one already running, even while slim devices sit
+  idle in the warm pool.
+- `--detach` — detached mode: print the lease result (the same JSON shape as
+  held mode's grant line, below, including `slim`) and exit; the lease is
   TTL-bound and must be renewed with `simlock lease renew`.
 - `--bind-pid <pid>` — held mode only: watch this pid for death instead of
   the CLI's actual parent. For a holder spawned from a short-lived subshell,
@@ -124,8 +132,14 @@ error message names the existing lease id to release first.
 As soon as the device is ready, one JSON line is printed on stdout:
 
 ```json
-{"lease":"lse_9f2c","platform":"ios","device":"iPhone 17 Pro","os":"26.5","udid":"ABCD-...","state":"leased"}
+{"lease":"lse_9f2c","platform":"ios","device":"iPhone 17 Pro","os":"26.5","udid":"ABCD-...","state":"leased","slim":true}
 ```
+
+`slim` is `true` when the granted device had its feature set reduced (iOS
+slim mode applied and this request did not pass `--full`) and `false`
+otherwise — always `false` for Android. It lets an agent explain a
+feature-loss failure (missing push notification, Spotlight result, StoreKit
+sheet, universal link, or system picker) instead of misreading it as a bug.
 
 then the process stays alive holding the lease. **Kill the process to
 release** — or let it die on its own: held mode watches its parent (the pid
@@ -317,6 +331,15 @@ responds the same way it does for a release-time purge failure — the device
 enters `quarantined` (see [#21](https://github.com/callstackincubator/simlock/issues/21))
 rather than being re-driven, since it may be mid-erase. As with every other
 `--fix` correction, a leased device is never touched.
+
+When `ios.slim.enabled` is on, `doctor` also reports a `driver-advisory`
+finding (code `slim-runtime-unsupported`) for each installed iOS runtime
+older than 18.5 — the version floor `launchctl disable` overrides need to
+survive a reboot (see [CONFIGURATION.md](CONFIGURATION.md)). Slim mode
+silently does nothing on those runtimes otherwise; this finding is what
+makes that visible. It is advisory only — there is no `--fix` for it, since
+the fix is either upgrading the runtime or narrowing `ios.slim` to the
+runtimes that support it.
 
 ## `simlock nuke [--delete-devices] [--yes]`
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -50,13 +50,21 @@ See [CLI.md](CLI.md#simlock-config-get-keyset-key-value) for the
 `simlock config` command itself.
 
 Slim mode is opt-in and iOS-only: it disables simulator daemon categories
-(e.g. logging, diagnostics) that most agent workloads never touch, trading
-some simulator functionality for a leaner runtime footprint. It requires
-iOS 18.5 or newer, since the underlying daemon controls are not available
-on older runtimes. Turning it on costs an extra boot per device -- the
-daemons are disabled between a first boot and a second, slower one -- which
-is why `ios.slim.bootTimeoutMs` defaults higher than the normal boot
-timeout, especially on slower CI runners.
+that most agent workloads never touch, trading some simulator functionality
+for a leaner runtime footprint. The categories are widgets, Siri/Apple
+Intelligence, Spotlight/search, iCloud, App Store, mail/calendar (PIM),
+Safari/web, Family Sharing, Health, Photos, bundled apps (News/Weather/Maps/
+Tips/games), messaging, connectivity, telemetry, and a miscellaneous group
+(`widgets`, `siri`, `search`, `icloud`, `store`, `pim`, `web`, `family`,
+`health`, `photos`, `apps`, `messaging`, `connectivity`, `telemetry`,
+`other` -- the valid `ios.slim.categories` strings, defined in
+`src/drivers/ios/slim-labels.ts`). Measured on one simulator: ~258 -> ~70
+processes, ~4.0 GB -> ~0.9 GB. It requires iOS 18.5 or newer, since the
+underlying daemon controls are not available on older runtimes. Turning it
+on costs an extra boot per device -- the daemons are disabled between a
+first boot and a second, slower one -- which is why
+`ios.slim.bootTimeoutMs` defaults higher than the normal boot timeout,
+especially on slower CI runners.
 
 ## Capacity strategies
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -30,6 +30,9 @@ a warning. Inspect the effective, merged configuration at any time with
 | `health.maxConcurrentRecoveries`  | Cap on simultaneous recovery reboots, so a machine wake (every device reads `stopped` at once) cannot start a boot storm.                                                                                                   | `1`                                                               |
 | `stalledTransition.thresholdMultiplier` | Factor applied to a driver's own `provision + boot` (for `provisioning`) or `reclaim` (for `reclaiming`) estimate to get the stall threshold for `simlock doctor`'s `stalled-transition` finding. | `3`                                                               |
 | `stalledTransition.minimumThresholdMs` | Floor under the multiplied estimate, for a driver whose estimate is near zero.                                                                                                                                | `1 minute`                                                        |
+| `ios.slim.enabled`                | Master switch for slim mode: disables iOS simulator daemon categories to cut RAM and CPU overhead per device.                                                                                                                | `false`                                                          |
+| `ios.slim.categories`             | Which daemon categories to disable when slim mode is on. Omitted means every category the driver knows.                                                                                                                      | every known category                                             |
+| `ios.slim.bootTimeoutMs`          | Boot deadline used while slim mode is on, in place of the normal boot timeout.                                                                                                                                                | `10 minutes`                                                     |
 
 All limit values must be positive integers; all durations and byte sizes
 must be non-negative numbers (milliseconds and bytes, respectively).
@@ -41,8 +44,19 @@ must be non-negative numbers (milliseconds and bytes, respectively).
 `stalledTransition.minimumThresholdMs` must be a non-negative number.
 `http.enabled` is a boolean, `http.host` a string, and `http.port` an
 integer in `1`-`65535`.
+`ios.slim.enabled` is a boolean, `ios.slim.categories` an array of
+non-empty strings, and `ios.slim.bootTimeoutMs` a positive number.
 See [CLI.md](CLI.md#simlock-config-get-keyset-key-value) for the
 `simlock config` command itself.
+
+Slim mode is opt-in and iOS-only: it disables simulator daemon categories
+(e.g. logging, diagnostics) that most agent workloads never touch, trading
+some simulator functionality for a leaner runtime footprint. It requires
+iOS 18.5 or newer, since the underlying daemon controls are not available
+on older runtimes. Turning it on costs an extra boot per device -- the
+daemons are disabled between a first boot and a second, slower one -- which
+is why `ios.slim.bootTimeoutMs` defaults higher than the normal boot
+timeout, especially on slower CI runners.
 
 ## Capacity strategies
 

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -39,6 +39,18 @@ in short: `subject.past-tense-fact`, emitted post-commit, facts not commands.
 | `device.crash-detected` | device id, lease id, platform, observed | a leased device was observed `stopped` for `health.stableObservations` consecutive ticks | LeaseHealthMonitor | implemented |
 | `device.recovered` | device id, lease id, attempts, duration | a crashed leased device was rebooted under its existing lease and passed readiness | LeaseHealthMonitor | implemented |
 | `device.recovery-failed` | device id, lease id, attempts, reason, error | recovery could not restore a leased device (absent from driver reality, provenance drift, or attempts exhausted) and its lease was released | LeaseHealthMonitor | implemented |
+| `device.slimmed` | device id, address, platform (ios), categories, label count, duration, signature, unknown labels | *after* the post-slim reboot's `bootstatus` succeeded -- i.e. once the `launchctl disable` overrides applied via `simctl spawn` are actually in force on the simulator | driver-diagnostics | implemented |
+
+`device.slimmed` reports a fact committed to the *simulator's own launchd database*, not to the
+Simlock registry (ADR #87, "opt-in slim iOS simulators") -- so events rule 3 ("emit post-commit
+only") is satisfied by waiting for that commit to become observable, not by waiting on a registry
+write: the driver applies the `launchctl disable` overrides, reboots the device, and only fires
+`onSlimmed` once the second `bootstatus` has passed, proving the overrides survived the reboot and
+are actually in force. The registry's own `device.ready` for that same boot is a separate,
+later event, emitted through the normal readiness path once the driver call returns. A *skipped*
+slim -- the runtime is older than iOS 18.5, its runtime id didn't parse, or the disable pass itself
+failed -- is deliberately not an event: it isn't a fact worth putting in front of every event-bus
+consumer, just operator diagnostics, so it's a `warn` log line (`daemon.driver-discovery`) instead.
 
 ## Components
 

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -42,7 +42,7 @@ in short: `subject.past-tense-fact`, emitted post-commit, facts not commands.
 | `device.slimmed` | device id, address, platform (ios), categories, label count, duration, signature, unknown labels | *after* the post-slim reboot's `bootstatus` succeeded -- i.e. once the `launchctl disable` overrides applied via `simctl spawn` are actually in force on the simulator | driver-diagnostics | implemented |
 
 `device.slimmed` reports a fact committed to the *simulator's own launchd database*, not to the
-Simlock registry (ADR #87, "opt-in slim iOS simulators") -- so events rule 3 ("emit post-commit
+Simlock registry (ADR 0002, `docs/adr/0002-opt-in-slim-ios-simulators.md`) -- so events rule 3 ("emit post-commit
 only") is satisfied by waiting for that commit to become observable, not by waiting on a registry
 write: the driver applies the `launchctl disable` overrides, reboots the device, and only fires
 `onSlimmed` once the second `bootstatus` has passed, proving the overrides survived the reboot and

--- a/docs/HTTP-API.md
+++ b/docs/HTTP-API.md
@@ -85,13 +85,21 @@ Role: `agent`. Enqueues a device request.
   "ttlMs": 900000,
   "timeoutMs": 300000,
   "noWait": false,
-  "allowDownload": false
+  "allowDownload": false,
+  "full": false
 }
 ```
 
 `platform` and `device` are required; `os` defaults to the newest installed
 runtime; `ttlMs` defaults to `lease.detachedTtlMs`; `timeoutMs` (optional) is
 enforced daemon-side so a vanished client can't hold a queue slot forever.
+`full` (optional, default `false`) opts this request out of iOS slim mode —
+platform-neutral in shape, but only the iOS driver acts on it (as "do not
+slim"); Android ignores it. A `full: true` request never matches, and never
+shares a pool key with, a slim device, so it can wait for a fresh device to
+provision or force a re-provision of one already running, even while slim
+devices sit idle in the warm pool. See [CONFIGURATION.md](CONFIGURATION.md)
+for what slim mode disables.
 An `Idempotency-Key` header (at most 200 characters) makes a replay of the
 same key, from the same requester, return the original request resource
 instead of double-queueing — held in memory with a TTL, so a replay after a
@@ -156,7 +164,7 @@ already reached a terminal state — the body names the lease id if it was
     "udid": "ABCD-...", "deviceId": "dev_1a2b",
     "createdAt": "2026-09-01T09:14:07Z",
     "expiresAt": "2026-09-01T09:29:07Z", "ttlMs": 900000,
-    "dataPlane": null
+    "dataPlane": null, "slim": true
 } }
 ```
 
@@ -164,6 +172,13 @@ already reached a terminal state — the body names the lease id if it was
 leased device remotely (the data plane) is a separate, not-yet-implemented
 concern — see [Not implemented](#not-implemented) below. It is in the schema
 now so its arrival is additive rather than a breaking shape change.
+
+`slim` is `true` when the granted device had its feature set reduced (iOS
+slim mode applied and the request did not carry `full: true`), `false`
+otherwise — always `false` for Android. It lets a client explain a
+feature-loss failure (missing push notification, Spotlight result,
+StoreKit sheet, universal link, or system picker) instead of misreading it
+as a bug.
 
 ### `GET /v1/leases/{id}`
 

--- a/docs/adr/0001-simlock-owned-device-roots.md
+++ b/docs/adr/0001-simlock-owned-device-roots.md
@@ -1,0 +1,344 @@
+# 0001. Simlock-owned device roots
+
+- **Status:** Accepted — not yet implemented
+- **Date:** 2026-09-02
+- **Issue:** [#73](https://github.com/callstackincubator/simlock/issues/73),
+  part of [#70](https://github.com/callstackincubator/simlock/issues/70)
+- **Supersedes:** nothing
+
+## Context
+
+Simlock decides whether it may destroy a device by asking the registry. Two
+things are wrong with that as the *only* answer.
+
+**Ownership is currently inferred from names.** `Driver.listManaged()` answers
+"what is mine" with a prefix match: `device.name.startsWith("simlock-")` on
+iOS, `avdName.startsWith("simlock_")` on Android. A user who runs
+`avdmanager create avd -n simlock_x` gets adopted silently — `docs/doctor`
+already carries a comment admitting this. #73 states the rule plainly: *do not
+infer ownership from simulator names.*
+
+**There is a window where a device Simlock created is invisible to Simlock.**
+`DeviceProvisioner#provision` calls `driver.provision(spec)` and only then
+`registry.registerDevice(...)`. If the registry write fails — or the daemon
+dies — the simulator exists on disk with no registry record. Under
+"registry-only destruction" Simlock may never touch it again. Every such crash
+leaks multiple gigabytes, permanently and silently.
+
+Both problems are the same problem: the registry is being asked two different
+questions, and it can only really answer one of them.
+
+> **The registry is the authoritative device *state*. It cannot be the
+> authoritative device *inventory*.**
+
+A containment root can answer the inventory question structurally. #73
+proposes exactly that for iOS. This ADR adopts it for both platforms, because
+the mechanisms differ enough that deciding them separately would produce two
+incompatible ownership models in one product.
+
+### What the platforms actually support
+
+Verified against Xcode's `simctl` and `adb` 37.0.1 (Darwin arm64) before
+deciding, because the two platforms are *not* symmetric and the asymmetry
+drives the design.
+
+**iOS — containment is inherent.** `xcrun simctl --set <path>` scopes every
+subcommand. A device in a custom set is absent from the default `simctl list`,
+and — the part that matters — it is not addressable at all without the flag:
+
+```
+$ xcrun simctl boot   <udid>   → Invalid device or device pair
+$ xcrun simctl erase  <udid>   → Invalid device
+$ xcrun simctl delete <udid>   → Invalid device
+```
+
+CoreSimulator resolves a UDID *within* a set, not globally. Knowing the UDID
+buys nothing without the path. No environment variable redirects the default
+set (`SIMULATOR_DEVICE_SET_PATH`, `CORESIMULATOR_DEVICE_SET_PATH`,
+`SIMCTL_DEVICE_SET_PATH`, `DEVICE_SET_PATH` were all tried and ignored), and
+the set is not registered anywhere globally, so nothing discovers it by
+accident. Runtimes remain global: a fresh set lists the same runtimes as the
+default one, so there is no duplication cost.
+
+**Android — containment must be constructed.** There is no `--set`.
+`ANDROID_AVD_HOME` relocates AVD definitions, which hides them from Android
+Studio's Device Manager and from a bare `avdmanager list avd` — but a *running*
+emulator is just `emulator-5554` on the machine-wide adb server, visible to
+anyone and killable with `adb emu kill`. Two further mechanisms close that gap:
+
+- `ADB_LOCAL_TRANSPORT_MAX_PORT` bounds which emulator ports an adb server
+  will ever discover (default 5585 — console ports 5554–5584, 16 emulators).
+  Measured, with a fake emulator listening at each port:
+
+  | adb server | ceiling | sees `emulator-5556` | sees `emulator-5600` |
+  |---|---|---|---|
+  | `:5040` | 5555 | no | no |
+  | `:5038` | 5585 (default) | yes | **no** |
+  | `:5039` | 5683 | yes | **yes** |
+
+- `ADB_USB=0`, `ADB_MDNS=0`, and `ADB_REJECT_KILL_SERVER=1` make a private adb
+  server safe to run alongside the user's. From adb's own `client/main.cpp`,
+  USB and mDNS initialisation are skipped entirely rather than filtered:
+
+  ```c
+  if (!getenv("ADB_USB") || strcmp(getenv("ADB_USB"), "0") != 0) {
+      if (is_libusb_enabled()) { libusb::usb_init(); } else { usb_init(); }
+  } else {
+      adb_notify_device_scan_complete();
+  }
+  ```
+
+  Confirmed via `adb server-status`: `usb_backend: USB_DISABLED`,
+  `mdns_backend: MDNS_DISABLED`, emulators still visible.
+  `ADB_REJECT_KILL_SERVER=1` makes `adb kill-server` return
+  `error: kill-server rejected by remote server`, so an agent's troubleshooting
+  reflex cannot detach every leased device at once.
+
+Unix-domain sockets are **not** available for the adb server on macOS
+(`unix:`, `localfilesystem:`, and `localabstract:` all fail), so the private
+server must be a TCP port.
+
+Neither mechanism is a security boundary. Anyone who knows the path can pass
+`--set`; anyone can raise `ADB_LOCAL_TRANSPORT_MAX_PORT`. They are *accident*
+boundaries, and that is the claim this ADR makes.
+
+## Decision
+
+### 1. Every driver owns a device root under `SIMLOCK_HOME`
+
+```
+~/.simlock/                                   # SIMLOCK_HOME
+├── config.json
+├── state.json                                # registry: device state + leases
+├── instance.json                             # { instanceId } — written once, never regenerated
+├── adb-server.json                           # { pid, port, startedAt } — daemon runtime state
+├── daemon.sock
+├── daemon.log
+└── devices/
+    ├── ios/                                  # drivers.ios.deviceRoot → simctl --set
+    │   ├── .simlock-owned.json               # ownership marker
+    │   └── <UDID>/                           # CoreSimulator's own layout
+    │       ├── device.plist
+    │       ├── simlock-mark.json             # durable provenance mark
+    │       └── data/
+    │           └── simlock-mark.json         # erasable provenance mark
+    └── android/                              # drivers.android.deviceRoot → ANDROID_AVD_HOME
+        ├── .simlock-owned.json               # ownership marker
+        ├── simlock_<n>.ini                   # AVD pointer file
+        └── simlock_<n>.avd/
+            ├── config.ini                    # carries the durable mark key
+            ├── simlock-clean-baseline.json
+            └── snapshots/
+```
+
+Roots hold **device instances only**. Runtimes and system images stay in their
+SDK locations: a custom device set already sees every global runtime, and
+relocating Android system images would duplicate gigabytes per Simlock home
+while fighting `sdkmanager`.
+
+Paths default to `${SIMLOCK_HOME}/devices/<platform>` and are overridable per
+platform. Deriving from `SIMLOCK_HOME` gives per-home device isolation for
+free, which is one of #73's completion conditions; the override exists because
+device data is tens of gigabytes and home directories are not always the right
+volume.
+
+### 2. Ownership is proven by a per-root marker
+
+```ts
+interface OwnedRootMarker {
+  schemaVersion: 1;
+  owner: "simlock";
+  instanceId: string;
+  platform: Platform;
+}
+```
+
+One marker per root, identical schema across platforms, because roots are
+independently configurable and therefore must be independently validated.
+
+Validation is pure filesystem logic — canonicalise the path, refuse a
+symlinked root or marker, check owner and permissions, require `instanceId` to
+match this instance — so it lives **once** in the platform-agnostic core.
+Each driver supplies only its own path. Duplicating these checks per driver
+would duplicate exactly the code least tolerable to get wrong.
+
+Roots are created at daemon start, atomically with their marker, and **only**
+for a root Simlock itself creates empty. An existing root with a valid,
+matching marker is used. An existing unmarked root — empty or not — is
+refused. Simlock never adopts and never marks a pre-existing root; "empty
+right now" is not proof of "empty when marked". Failing at startup rather than
+lazily means validation failures surface at boot, not in the middle of a lease
+request.
+
+`instanceId` is a UUID written to `${SIMLOCK_HOME}/instance.json` on first
+start and never regenerated. It deliberately does **not** live in
+`state.json`: a corrupt registry is precisely the situation in which you would
+rebuild, and losing the instance id would strand every device in the root
+behind a `wrong-instance` error.
+
+### 3. iOS is scoped with `--set`
+
+Every `simctl` invocation carries `--set <deviceRoot>`. The driver funnels all
+of them through one private method, so this is a single insertion point rather
+than a per-call-site change. Device-set membership replaces the `simlock-`
+prefix as the answer to `listManaged()`.
+
+### 4. Android is scoped with an AVD home *and* a private adb server
+
+Emulator and `avdmanager` invocations carry:
+
+```
+ANDROID_AVD_HOME=<deviceRoot>
+ANDROID_ADB_SERVER_PORT=<adbServerPort>
+```
+
+Simlock starts and supervises its own adb server:
+
+```sh
+ADB_USB=0 ADB_MDNS=0 ADB_REJECT_KILL_SERVER=1 \
+ADB_LOCAL_TRANSPORT_MAX_PORT=5683 adb -P <adbServerPort> start-server
+```
+
+Console ports move to **5586–5682**, above the default 5585 discovery ceiling,
+so the user's adb server and Android Studio cannot see, drive, or kill a
+Simlock emulator. This also repairs two existing defects: the current range
+starts at 5554 and so competes with the user's own emulators, and it extends
+to 5682 while the port allocator derives occupancy from `adb devices` — which
+cannot report anything above the ceiling, so high ports read as free even when
+occupied, and a device that lands on one never becomes visible to the
+readiness probe.
+
+If the configured port is occupied, the Android driver **fails closed** with a
+typed finding. Silently attaching to whichever server is already listening
+could attach to Android Studio's and would erase the guarantee without
+producing a single error.
+
+`adb-server.json` records the server's pid because `ADB_REJECT_KILL_SERVER=1`
+means the only way to stop it is by pid; a daemon that crashed must find and
+reap its own leftover server on restart. It is deliberately not in
+`state.json`, so process supervision does not depend on registry integrity.
+
+### 5. Containment replaces provenance *inference*, not the registry
+
+`listManaged()` stops matching names and starts reporting root membership.
+The `simlock-` / `simlock_` naming stays as a cosmetic label — it is useful in
+`adb devices` output and emulator window titles — but carries no authority.
+
+The durable/erasable provenance **marks** stay. They detect a device erased or
+deleted out from under a live lease, which containment makes rarer but not
+impossible, since a deliberate `--set` still reaches in.
+
+The registry stays, unchanged in role. A directory listing cannot report which
+of seven states a device is in, who holds it and until when, how long it has
+been idle, when its next quarantine retry is armed, or how many recovery
+attempts remain — and deriving any of that from device-set contents would put
+`simctl` and AVD knowledge inside the platform-agnostic core.
+
+### 6. Orphans are reported, never automatically destroyed
+
+A device inside a validly-marked root with no registry record is an orphan.
+`doctor` reports it (the `orphan-device` / `orphan-process` findings already
+exist and become trustworthy once membership replaces prefix matching).
+Destroying one requires an explicit `simlock doctor --purge-orphans`.
+
+Automatic reaping was considered and rejected. Every central safety filter —
+including the leased-device guard that enforces safety rule 2 — is written
+over registry records. An orphan has no record, so orphan proposals would
+bypass the entire safety net by construction, and `DeviceOperationClaims` is
+keyed by registry device id, so no claim can protect one either. Combined with
+the provision-then-register window, an automatic reaper firing mid-provision
+would delete a device being provisioned for a live request. Explicit opt-in
+keeps marker validation off every unattended destruction path.
+
+`--purge-orphans` is its own flag rather than part of `--fix`, so anyone
+already running `doctor --fix` unattended does not acquire a destructive
+behaviour on upgrade.
+
+### 7. A lease carries the environment needed to reach its device
+
+Containment cuts both ways: an agent holding a lease cannot reach its device
+with bare `simctl` or `adb` either. Drivers therefore return an opaque
+`environment: Record<string, string>` with the grant; the core passes it
+through without interpreting it; the CLI renders it as shell `export` lines
+and in `--json`. iOS contributes its device-set path, Android its adb server
+port.
+
+Simlock additionally exposes `simlock simctl` and `simlock adb` passthroughs
+that inject the scoping flags, refusing verbs that would mutate device
+lifecycle behind the registry's back (`delete`, `erase`, `create`,
+`emu kill`) and pointing at `simlock release` / `simlock cleanup` instead.
+Without that refusal the wrappers would hand back the exact capability this
+ADR exists to remove.
+
+## Consequences
+
+**Good.**
+
+- Ownership becomes structural. #73's "do not infer ownership from simulator
+  names" is satisfied by deleting code, not adding it.
+- The existing `orphan-device` / `orphan-process` findings become trustworthy,
+  and the permanent multi-gigabyte leak from a crash mid-provision becomes
+  recoverable.
+- No core changes. `Driver.listManaged()` is already the platform-agnostic
+  "what is mine" call and already feeds `DoctorFinding`; only its answer
+  changes, inside the driver modules. Adding a third driver still requires no
+  core edit.
+- Two Android port-allocation defects are fixed as a side effect.
+- The iOS driver stops *learning* its devices root by parsing `dataPath` out
+  of `simctl` output; it reads it from config.
+- A Simlock simulator no longer appears in Xcode, and a Simlock emulator no
+  longer appears in Android Studio, so accidental interference becomes very
+  unlikely.
+
+**Costs.**
+
+- Android gains a supervised child process. Its pid must be tracked, reaped on
+  shutdown, and adopted-or-killed after a crash — and `ADB_REJECT_KILL_SERVER`
+  means `adb kill-server` will not do it.
+- `SIMLOCK_HOME` grows from kilobytes to tens of gigabytes. It must live on a
+  local volume with room.
+- Startup gains a fail-closed path: a bad marker or an occupied adb port stops
+  the affected driver rather than degrading.
+- Agents must honour the lease environment, or use the wrappers.
+- Existing devices are stranded (see below).
+- Two Simlock instances on one machine now need distinct `adbServerPort`
+  values. `SIMLOCK_HOME` alone no longer fully isolates them, and the e2e
+  helper that runs a real Android driver under a temporary home must set it.
+
+**Migration.** Existing devices are not moved. CoreSimulator has no supported
+way to relocate a device between sets, and moving an AVD means rewriting
+absolute paths inside its `.ini` and config. Registry entries whose devices
+live in the old locations become a typed `doctor` finding whose fix destroys
+them through their recorded old path — permitted under registry-only
+destruction, since they are in the registry. Users re-provision.
+
+**Not a security boundary.** Restated because it will be misread otherwise: a
+user who deliberately passes `--set <path>` or raises
+`ADB_LOCAL_TRANSPORT_MAX_PORT` can still reach these devices. This ADR
+prevents accidents, not attacks. The provenance marks exist precisely because
+deliberate interference remains possible.
+
+## Alternatives considered
+
+**Keep registry-only ownership and accept the leak.** Rejected: it leaves #73
+unsatisfied and leaves prefix matching — which silently adopts a user's
+`simlock_`-named AVD — in place.
+
+**Drop the registry and derive everything from the roots.** Rejected. Only one
+of the registry's responsibilities is ownership; state, leases, idle timers,
+quarantine schedules, recovery budgets, capacity accounting, and the wait
+queue have no filesystem representation. Deriving them would move `simctl` and
+AVD knowledge into the core and make the filesystem a transactional store,
+which it is not.
+
+**iOS-only containment (#73 as written).** Rejected as a stopping point: it
+would leave two different ownership models in one product, and the Android
+half is where name-based adoption actually bites.
+
+**`ANDROID_AVD_HOME` alone, no private adb server.** Rejected once
+`ADB_USB=0` and `ADB_MDNS=0` were confirmed to remove the USB and network
+contention that was the main objection. Without the private server, running
+emulators stay globally visible and Android ownership could never be proven
+structurally.
+
+**Automatic orphan reaping.** Rejected — see decision 6.

--- a/docs/adr/0002-opt-in-slim-ios-simulators.md
+++ b/docs/adr/0002-opt-in-slim-ios-simulators.md
@@ -44,21 +44,24 @@ those, so slim cannot be the only mode.
 
 ```jsonc
 {
-  "drivers": {
-    "ios": {
-      "slim": {
-        "enabled": false,          // default
-        "categories": ["..."]      // optional; defaults to the full curated list
-      }
+  "ios": {
+    "slim": {
+      "enabled": false,          // default
+      "categories": ["..."],     // optional; defaults to every category the driver knows
+      "bootTimeoutMs": 600000    // boot deadline while slim is on (see 8)
     }
   }
 }
 ```
 
-`slim` is configuration of the iOS driver, not a field of `DeviceSpec`. Spec
-identity stays `{ platform, model, osVersion }`, so the warm pool, the
-acquisition planner, and the capacity policy are unchanged. The core never
-learns that slimming exists.
+`slim` is configuration of the iOS driver, threaded into the driver at
+construction. The core never learns which daemons exist or what
+"slim" means; it only learns two platform-neutral facts, described in 3
+and 6: whether a driver *may* reduce a device (`Driver.reducesFeatures`)
+and whether it *did* (`DriverDevice.featureProfile`).
+
+The default is **off** for the first release. It flips to on only once the
+label list has been exercised across several runtimes in the wild.
 
 The default is **off** for the first release. It flips to on only once the
 label list has been exercised across several runtimes in the wild.
@@ -84,23 +87,26 @@ directly would each have to re-derive those guarantees.
 
 ### 3. The pass is idempotent and self-describing
 
-`driverData` gains:
+The iOS driver's `driverData` gains two fields: `slimSignature`, a hash
+over the resolved categories *and* their labels, and `slimMarkToken`, the
+device's erasable provenance-mark token as read when slimming was applied.
+The second boot is skipped only when both match what is true now. A
+differing token is how an intervening `simctl erase` is detected; a
+differing signature means the categories or the shipped label list changed.
+Either way the pass re-runs. Existing registries without the fields are
+treated as "never slimmed"; no migration is needed.
 
-```ts
-{
-  slim?: {
-    applied: true;
-    labelSetHash: string;   // hash of the exact labels disabled
-    runtime: string;        // iOS version the labels were chosen for
-  }
-}
-```
+The marker is written only when every chunk of the disable pass actually
+ran. A chunk that failed to run leaves the marker unwritten so the whole
+set is retried on the next boot; a label the simulator itself rejected is
+recorded and does not block the marker, so a runtime with one renamed
+daemon converges in a single boot instead of re-applying forever.
 
-The second boot is skipped when the stored hash matches the hash of the
-labels the current config would produce *and* the device has not been erased
-since. A config change to `categories` changes the hash and forces a re-pass
-on the next `makeReady`. Existing registries without the field are treated as
-"never slimmed"; no migration is needed.
+Alongside the driver's private data, `DriverDevice` and `DeviceRecord`
+carry a platform-neutral `featureProfile: "full" | "reduced"`. It is set on
+every readiness transition, so a stale `"reduced"` can never outlive a boot
+that did not slim. This is what the lease response's `slim` flag (6) is
+derived from, without the core reading opaque driver data.
 
 ### 4. Runtimes older than iOS 18.5 are skipped with a warning
 
@@ -118,14 +124,25 @@ once; the user opted in.
 
 ### 6. A lease can ask for a full device
 
-`simlock acquire --full` (MCP `full: true`, HTTP `full: true`) requests a
+`simlock lease --full` (MCP `full: true`, HTTP `full: true`) requests a
 device without the slim pass. The lease response always carries
 `slim: true | false`, so an agent whose StoreKit test fails on a slim device
 sees a greppable reason rather than an inexplicable timeout.
 
-Full and slim devices under the same spec are kept apart by a pool key that
-includes the mode. A `--full` request never receives a slim device; it waits
-or triggers provisioning like any other pool miss.
+Full and slim devices are kept apart through spec identity. `DeviceSpec`
+gains an optional `full: true`, and `sameSpec` compares it (with `undefined`
+equal to `false`, so existing registries keep matching). The core stamps it
+in exactly one place, when `LeaseAcquisitionCoordinator` resolves a spec,
+and only when the resolving driver declares `reducesFeatures`, which the iOS
+driver does only while slim is enabled. A driver that never reduces
+anything, such as Android, therefore never sees its pool split. A `--full`
+request never receives a slim device; it waits or triggers provisioning like
+any other pool miss.
+
+Crash recovery is the one path that reboots a leased device. It calls
+`makeReady` with `purpose: "recover"`, and the iOS driver treats that as a
+plain boot with no slim pass and no second reboot. Safety rule 2's
+recovery exception grants a reboot and nothing more.
 
 ### 7. An unknown label is never a boot failure
 
@@ -137,9 +154,28 @@ worse than no slim pass.
 
 ### 8. The boot deadline accounts for the second boot
 
-`BootTimeoutError` thresholds are raised when slim is on. simslim uses a
-ten-minute deadline on CI runners; the driver adopts a comparable budget for
-the combined boot–slim–reboot sequence rather than for each boot separately.
+`ios.slim.bootTimeoutMs` (default ten minutes, matching simslim on CI
+runners) replaces the ordinary `bootstatus` deadline, but only for a boot
+that will actually slim: a `--full` device, a runtime below the floor, or a
+recovery boot keeps the normal deadline. `Driver.estimate` quotes the
+double-boot cost for the same boots so `doctor` does not read a slim boot
+as a stalled transition.
+
+### 9. The event is reported by the driver, after the reboot proves it
+
+`device.slimmed` is bridged from the driver's `onSlimmed` callback in the
+daemon, exactly like `component.install-*`, and fires only once the
+post-slim `bootstatus` has passed. The fact it reports is committed to the
+simulator's launchd database, not the registry, which is why the bridge
+does not wait on a registry write. A skipped or failed slim is a warning
+log line, not an event.
+
+### 10. Failure degrades to "not slimmed", never to a failed lease
+
+A failed disable pass, a shutdown that times out, or a hiccup in the slim
+reboot all return the device as-is with an honest `featureProfile`
+(conservatively `"reduced"` when the driver cannot tell), and the lease
+proceeds. Only a genuine inability to bring the device back up propagates.
 
 ## Consequences
 
@@ -172,7 +208,14 @@ the combined boot–slim–reboot sequence rather than for each boot separately.
   visible rather than fixing it.
 - **A maintained label list.** Apple's daemon set drifts; the list needs a
   refresh per iOS major. Decision 7 keeps drift from being a failure, but not
-  from being a slow leak of memory savings.
+  from being a slow leak of memory savings. Re-syncing the list changes the
+  signature and re-slims every device on its next boot, which is intended.
+- **No `launchctl enable` pass.** Narrowing `categories` re-applies the
+  narrower set but never re-enables what the wider set disabled. Devices
+  slimmed under the old list must be reclaimed before the change is trusted.
+- **Turning slim off strands `--full` devices.** Once `reducesFeatures` is
+  false no new spec carries `full: true`, so devices provisioned for a
+  `--full` request match nothing until the idle cleanup rules reap them.
 
 **Safety review.** Compatible with every invariant in
 `docs/agent-rules/safety.md`: registry-only targets, never a leased device,
@@ -181,11 +224,18 @@ attributable through `device.slimmed`.
 
 ## Alternatives considered
 
-**Make slim part of `DeviceSpec`.** Rejected. It would put a driver
-implementation detail into spec identity and split every pool, capacity
-estimate, and catalog entry in two for a property the core has no reason to
-know about. A pool key derived by the driver achieves the separation without
-leaking the concept.
+**Make the slim *configuration* part of `DeviceSpec`.** Rejected. It would
+put a driver implementation detail into spec identity and split every pool
+in two for a property the core has no reason to know about. Only the
+platform-neutral `full` opt-out is in spec identity, and only when a driver
+declares it can reduce anything, so a platform that never reduces is never
+fragmented.
+
+**Let the driver derive the pool key itself.** Rejected. Pool matching lives
+in the core, and a driver-owned key would need a new concept in the driver
+interface for one flag. Stamping `full` centrally, gated by
+`reducesFeatures`, keeps drivers unaware of request flags (architecture
+rule 3) with a two-line change.
 
 **Slim at provision time only, never on reboot.** Rejected. Overrides do not
 survive `erase`, so a provision-only pass would leave every reclaimed device

--- a/docs/adr/0002-opt-in-slim-ios-simulators.md
+++ b/docs/adr/0002-opt-in-slim-ios-simulators.md
@@ -1,0 +1,204 @@
+# 0002. Opt-in slim iOS simulators
+
+- **Status:** Accepted
+- **Date:** 2026-09-02
+- **Issue:** [#87](https://github.com/callstackincubator/simlock/issues/87)
+- **Supersedes:** nothing
+
+## Context
+
+Simlock exists to pack as many leased devices onto one machine as possible.
+A stock iOS simulator idles at roughly 4 GB physical footprint across about
+260 processes. On a 16 GB Mac that caps the fleet at four devices, and
+memory — not CPU or disk — is what ends the scaling curve.
+
+Almost none of that footprint serves a test run. It is Siri, Spotlight,
+iCloud, the App Store, Mail, Safari, Photos, News, Weather, Maps, Family
+Sharing, Health, Home, messaging, and telemetry daemons that launchd starts
+on every boot because a real phone would want them.
+
+[simslim](https://github.com/mobai-app/simslim) demonstrates the fix. It
+writes persistent `launchctl disable` entries for a curated list of launchd
+labels into the simulator's *own* launchd database, via
+`simctl spawn <udid> launchctl ...`, then reboots. Measured on one simulator:
+
+| | stock | slim |
+|---|---|---|
+| processes | 258 | 70 |
+| phys_footprint | 4.0 GB | 0.9 GB |
+
+Two properties of the mechanism drive this ADR:
+
+- **The overrides live inside the device's data partition.** Nothing on the
+  host changes. `simctl erase` wipes them along with everything else.
+- **Persistence needs iOS 18.5 or newer.** Older runtimes accept the
+  `launchctl disable` commands and then forget them at the next boot.
+
+The savings are not free. A slim device loses push notifications, Spotlight,
+StoreKit, universal links, and some system pickers. Some test suites need
+those, so slim cannot be the only mode.
+
+## Decision
+
+### 1. Slim mode is a driver-level, opt-in setting
+
+```jsonc
+{
+  "drivers": {
+    "ios": {
+      "slim": {
+        "enabled": false,          // default
+        "categories": ["..."]      // optional; defaults to the full curated list
+      }
+    }
+  }
+}
+```
+
+`slim` is configuration of the iOS driver, not a field of `DeviceSpec`. Spec
+identity stays `{ platform, model, osVersion }`, so the warm pool, the
+acquisition planner, and the capacity policy are unchanged. The core never
+learns that slimming exists.
+
+The default is **off** for the first release. It flips to on only once the
+label list has been exercised across several runtimes in the wild.
+
+### 2. Slimming happens inside `makeReady`, and nowhere else
+
+After `simctl boot` and `simctl bootstatus -b` succeed, and only when slim
+is enabled, the driver:
+
+1. applies the disable list through `simctl spawn <udid> launchctl disable`,
+2. shuts the device down,
+3. boots it again and waits for `bootstatus -b`,
+4. records what it did in `driverData` (see 3),
+5. emits `device.slimmed` after the registry commit.
+
+`makeReady` is the single choke point because it is the only operation that
+already holds the safety guarantees this needs: it runs on registry-owned
+devices, it never runs on a leased device (the crash-recovery exception in
+`ManagedDeviceLifecycle.recoverLeased` reboots an already-provisioned device
+and is precisely the case where re-slimming is correct), and it downloads
+nothing. Slimming from a cleanup rule, from `doctor`, or from the CLI
+directly would each have to re-derive those guarantees.
+
+### 3. The pass is idempotent and self-describing
+
+`driverData` gains:
+
+```ts
+{
+  slim?: {
+    applied: true;
+    labelSetHash: string;   // hash of the exact labels disabled
+    runtime: string;        // iOS version the labels were chosen for
+  }
+}
+```
+
+The second boot is skipped when the stored hash matches the hash of the
+labels the current config would produce *and* the device has not been erased
+since. A config change to `categories` changes the hash and forces a re-pass
+on the next `makeReady`. Existing registries without the field are treated as
+"never slimmed"; no migration is needed.
+
+### 4. Runtimes older than iOS 18.5 are skipped with a warning
+
+The overrides do not persist there, so a pass would cost a boot and buy
+nothing. The driver compares the runtime version numerically (not
+lexically — `26.0` is newer than `18.5`), skips the pass, logs a warning,
+and `doctor` reports the mismatch between config and runtime.
+
+### 5. The warm pool absorbs the cost
+
+Slimming doubles the boot work. Warm-pool provisioning and reclaim both run
+off the request path, so with a pool of at least one device per spec the
+lease-time cost stays at one boot. Cold acquisitions pay the second boot
+once; the user opted in.
+
+### 6. A lease can ask for a full device
+
+`simlock acquire --full` (MCP `full: true`, HTTP `full: true`) requests a
+device without the slim pass. The lease response always carries
+`slim: true | false`, so an agent whose StoreKit test fails on a slim device
+sees a greppable reason rather than an inexplicable timeout.
+
+Full and slim devices under the same spec are kept apart by a pool key that
+includes the mode. A `--full` request never receives a slim device; it waits
+or triggers provisioning like any other pool miss.
+
+### 7. An unknown label is never a boot failure
+
+Apple renames and retires daemons between runtimes. `launchctl disable` on
+a label that does not exist is logged and skipped; the pass continues and
+`makeReady` succeeds. The label list is versioned per iOS major so the
+mismatch stays small, but a slim pass that bricks provisioning is strictly
+worse than no slim pass.
+
+### 8. The boot deadline accounts for the second boot
+
+`BootTimeoutError` thresholds are raised when slim is on. simslim uses a
+ten-minute deadline on CI runners; the driver adopts a comparable budget for
+the combined boot–slim–reboot sequence rather than for each boot separately.
+
+## Consequences
+
+**Good.**
+
+- Roughly four times the iOS devices per machine. This is the core value of
+  the product, and no other backlog item moves the number.
+- No host modification. Every change lives inside the simulator's data
+  partition, and `erase` — which reclaim already performs — is the complete
+  undo.
+- No core change. The driver interface, registry schema, and safety filters
+  are untouched; `driverData` was already opaque to the core.
+- Fully compatible with [0001](0001-simlock-owned-device-roots.md): `simctl
+  spawn` is just another `simctl` call and takes `--set` like the rest.
+
+**Costs.**
+
+- **Every lease cycle costs two boots.** `IosDriver.reclaim` always runs
+  `simctl erase`, which wipes the overrides, so every reclaimed device is
+  re-slimmed. Accepted because reclaim runs off the critical path. A
+  non-erasing `standard` clean would remove the cost and is left for a later
+  ADR.
+- **Feature loss is real and silent at the API level.** Push, Spotlight,
+  StoreKit, universal links, and some pickers stop working. Mitigated by
+  `--full`, the `slim` flag in the lease response, and a documented list in
+  `known-pitfalls.md`.
+- **Pool fragmentation.** Mixing modes under one spec means a `--full`
+  request may wait behind slim devices or force provisioning.
+- **Runtimes older than 18.5 gain nothing.** The version gate makes this
+  visible rather than fixing it.
+- **A maintained label list.** Apple's daemon set drifts; the list needs a
+  refresh per iOS major. Decision 7 keeps drift from being a failure, but not
+  from being a slow leak of memory savings.
+
+**Safety review.** Compatible with every invariant in
+`docs/agent-rules/safety.md`: registry-only targets, never a leased device,
+no downloads, destruction only through the existing `erase` path, every pass
+attributable through `device.slimmed`.
+
+## Alternatives considered
+
+**Make slim part of `DeviceSpec`.** Rejected. It would put a driver
+implementation detail into spec identity and split every pool, capacity
+estimate, and catalog entry in two for a property the core has no reason to
+know about. A pool key derived by the driver achieves the separation without
+leaking the concept.
+
+**Slim at provision time only, never on reboot.** Rejected. Overrides do not
+survive `erase`, so a provision-only pass would leave every reclaimed device
+stock again. `makeReady` is the only hook that runs after every erase.
+
+**Avoid the double boot by skipping `erase` on reclaim.** Deferred, not
+rejected. It changes the reclaim contract for every consumer and deserves
+its own ADR once slim mode has shipped and the real cost is measured.
+
+**Default on.** Rejected for the first release. Feature loss is silent for
+callers who have not read the docs, and the label list has not yet been
+exercised across runtimes. Revisit once both are true.
+
+**Trim via `simctl` device-type overrides or a custom runtime.** Rejected.
+No supported mechanism exists; simslim's approach is the only one that
+survives reboots on stock runtimes.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,24 @@
+# Architecture decision records
+
+One file per decision that shapes the system and would be expensive to
+reverse. An ADR explains *why* a choice was made, so a later reader (human or
+agent) can tell a deliberate constraint from an accident.
+
+Naming: `NNNN-kebab-case-title.md`, numbered in the order decisions are
+accepted. Numbers are never reused, and an ADR is never edited to say
+something different — a decision that changes gets a new ADR that supersedes
+the old one, and the old one's Status is updated to point at it.
+
+Status values:
+
+- **Proposed** — under discussion, not binding.
+- **Accepted** — binding. Code that contradicts it is a bug.
+- **Accepted — not yet implemented** — binding as a target. The docs describe
+  the decided end state; the code has not caught up. Anyone implementing
+  toward it should treat the documentation as the specification.
+- **Superseded by NNNN** — no longer binding; read the replacement.
+
+| ADR | Title | Status |
+|---|---|---|
+| [0001](0001-simlock-owned-device-roots.md) | Simlock-owned device roots | Accepted — not yet implemented |
+| [0002](0002-opt-in-slim-ios-simulators.md) | Opt-in slim iOS simulators | Accepted |

--- a/docs/known-pitfalls.md
+++ b/docs/known-pitfalls.md
@@ -203,7 +203,23 @@ the now-narrower set on its next boot — but the `launchctl disable` overrides
 already written for the *removed* category are never undone. They live in the
 simulator's own launchd database and only disappear on `simctl erase`. The
 device keeps reporting `slim: true` and keeps missing that category's
-functionality, with no error surfaced anywhere. Workaround: after narrowing
-the category list, reclaim (or destroy) every device already running under
-the old, wider set before relying on the change — a plain reboot is not
-enough.
+functionality, with no error surfaced anywhere. The real consequence is
+stronger than the flag alone suggests: the device ends up slimmer than *any*
+configuration ever asked for — it carries both the newly-narrower disable set
+it just re-applied *and* the leftover overrides from the wider set it was
+slimmed under before, a combination no `ios.slim.categories` value on its own
+would ever produce. Workaround: after narrowing the category list, reclaim
+(or destroy) every device already running under the old, wider set before
+relying on the change — a plain reboot is not enough.
+
+**Turning `ios.slim.enabled` off leaves orphaned `--full` devices sitting in
+the pool.** `full` only earns its own pool key while the driver might
+otherwise hand back a reduced device (`Driver.reducesFeatures`); once slim
+mode is off, no newly resolved spec ever carries `full: true` again. A device
+that was provisioned for a `--full` request while slim mode was on keeps
+`full: true` on its spec in the registry, so it can no longer match anything
+a resolver produces — it becomes unmatchable by any new request. This is not
+a permanent orphan: the idle-shutdown and idle-destroy cleanup rules reap it
+on the same timers as any other idle device, since neither rule cares what a
+device's spec matches. Until those timers fire, though, it occupies a pool
+slot doing nothing.

--- a/docs/known-pitfalls.md
+++ b/docs/known-pitfalls.md
@@ -194,3 +194,16 @@ match on model/os alone would otherwise be instant. Depending on capacity,
 that means either queueing for a fresh device to provision or forcing a
 re-provision of a device already running. This is inherent to keeping pool
 matching from fragmenting on driver-level settings, not a bug to fix.
+
+**Narrowing `ios.slim.categories` does not re-enable anything on existing
+devices.** There is no `launchctl enable` pass anywhere in the driver. When an
+operator removes a category from `ios.slim.categories`, the signature that
+gates re-applying the disable pass changes, so an existing device re-applies
+the now-narrower set on its next boot — but the `launchctl disable` overrides
+already written for the *removed* category are never undone. They live in the
+simulator's own launchd database and only disappear on `simctl erase`. The
+device keeps reporting `slim: true` and keeps missing that category's
+functionality, with no error surfaced anywhere. Workaround: after narrowing
+the category list, reclaim (or destroy) every device already running under
+the old, wider set before relying on the change — a plain reboot is not
+enough.

--- a/docs/known-pitfalls.md
+++ b/docs/known-pitfalls.md
@@ -187,13 +187,25 @@ every lease response carries a `slim` flag so a caller can tell a
 feature-loss failure apart from an actual bug instead of guessing.
 
 **Mixing slim and full devices under one spec can make `--full` wait or
-re-provision.** `full` is part of the pool key (ADR "serve from a separate
-pool key"), not part of `DeviceSpec` itself, so a `--full` request never
-matches a slim device sitting warm in the pool — even when one is idle and a
+re-provision.** `full` is part of spec identity (`DeviceSpec.full`, compared by `sameSpec`,
+see [ADR 0002](adr/0002-opt-in-slim-ios-simulators.md)), so a `--full`
+request never matches a slim device sitting warm in the pool — even when one is idle and a
 match on model/os alone would otherwise be instant. Depending on capacity,
 that means either queueing for a fresh device to provision or forcing a
 re-provision of a device already running. This is inherent to keeping pool
 matching from fragmenting on driver-level settings, not a bug to fix.
+
+**`launchctl disable` accepts labels that do not exist.** Verified on iOS
+26.4 and 27.0 simulators: disabling `system/com.apple.does.not.exist` exits
+0 and writes the entry to the override database like any other. So the
+per-label `simlock-slim-failed` channel (and the `unknownLabels` field of
+`device.slimmed`) reports labels the shell-safety filter rejected or a
+`launchctl` that crashed, never a daemon Apple has renamed or removed. Drift
+in the label list is invisible at apply time; the only signal is a slim
+device that is not as slim as expected. Re-sync `slim-labels.ts` against
+upstream simslim per iOS major. Newer runtimes also print a deprecation
+warning asking for `user/foreground/<label>` instead of `system/<label>`;
+the `system/` form still takes effect and is what simslim uses.
 
 **Narrowing `ios.slim.categories` does not re-enable anything on existing
 devices.** There is no `launchctl enable` pass anywhere in the driver. When an

--- a/docs/known-pitfalls.md
+++ b/docs/known-pitfalls.md
@@ -146,3 +146,51 @@ real protocol machinery, not a small addition, so it was deliberately not
 built in stage 4. `component.install-started`'s payload already carries
 enough (`platform`, `componentId`) that a future pass wiring this through
 would mostly be plumbing, not new information to invent.
+
+## iOS slim mode: accepted costs and feature loss (#87)
+
+`ios.slim` (opt-in, default off) has the iOS driver disable ~170 launchd
+daemons across simulator daemon categories to cut RAM/CPU footprint (see
+[CONFIGURATION.md](CONFIGURATION.md)). It carries four trade-offs worth
+knowing before turning it on.
+
+**Every reclaim pays two boots, indefinitely.** `IosSimctlDriver.reclaim`
+always runs `simctl erase`, which wipes the simulator's data partition —
+including the launchd overrides slimming wrote there. So a reclaimed device
+is never still slim: the next `makeReady` re-applies the full disable pass
+and reboots twice (once to boot the freshly erased device, once more for the
+overrides to take effect) rather than skipping straight to the idempotence
+check. Accepted because both reclaim and warm-pool provisioning run off the
+lease-granting critical path — the requester waiting on a device only pays
+for this when nothing pre-provisioned was available. A non-erasing
+`standard` clean level, if one is added later, would let a reclaimed device
+stay slim and remove this cost; no such level exists today.
+
+**Runtimes older than iOS 18.5 silently get nothing.** `launchctl disable`
+overrides only persist across a reboot on iOS 18.5+; older runtimes accept
+the commands and drop them on the post-slim reboot, so slimming would cost a
+second boot for no effect. `planSlimBoot` (`src/drivers/ios/index.ts`) gates
+on this and skips the apply pass entirely rather than paying that cost —
+silently, from the requester's point of view: the lease still grants, just
+with `slim: false`. `simlock doctor`'s `driver-advisory` /
+`slim-runtime-unsupported` finding is what makes an unsupported runtime
+visible to an operator instead of it only ever showing up as an unexpectedly
+non-slim lease.
+
+**Slim devices lose features that depend on the disabled daemons.** Expect
+push notifications, Spotlight/on-device search, StoreKit/App Store sheets,
+universal links, Siri/Apple Intelligence, iCloud sync, and some system
+pickers to not work on a slim device — the categories that back them are
+exactly the ones slimming disables. Mitigations: `simlock lease --full` (MCP
+`full: true`, HTTP `full: true`) opts a single lease out of slimming, and
+every lease response carries a `slim` flag so a caller can tell a
+feature-loss failure apart from an actual bug instead of guessing.
+
+**Mixing slim and full devices under one spec can make `--full` wait or
+re-provision.** `full` is part of the pool key (ADR "serve from a separate
+pool key"), not part of `DeviceSpec` itself, so a `--full` request never
+matches a slim device sitting warm in the pool — even when one is idle and a
+match on model/os alone would otherwise be instant. Depending on capacity,
+that means either queueing for a fresh device to provision or forcing a
+re-provision of a device already running. This is inherent to keeping pool
+matching from fragmenting on driver-level settings, not a bug to fix.

--- a/docs/known-pitfalls.md
+++ b/docs/known-pitfalls.md
@@ -195,6 +195,17 @@ that means either queueing for a fresh device to provision or forcing a
 re-provision of a device already running. This is inherent to keeping pool
 matching from fragmenting on driver-level settings, not a bug to fix.
 
+**A cold slim lease outlives a default MCP request timeout.** Measured on
+one machine: a `--full` cold lease took ~28s, a cold slim lease ~160s (two
+real boots plus the disable pass). The MCP SDK's default per-request timeout
+is 60s, so an MCP client that does not reset its timeout on progress
+notifications gets `MCP error -32001: Request timed out` on the slim lease
+even though the daemon completes it. Simlock relays boot progress as MCP
+progress notifications precisely so clients can pass
+`resetTimeoutOnProgress: true` (or a longer timeout) on `lease_simulator`;
+`e2e/slow-ios-slim.test.ts` shows the call shape. The warm pool hides this
+for every lease after the first.
+
 **`launchctl disable` accepts labels that do not exist.** Verified on iOS
 26.4 and 27.0 simulators: disabling `system/com.apple.does.not.exist` exits
 0 and writes the entry to the override database like any other. So the

--- a/e2e/fake-driver/fake-driver.ts
+++ b/e2e/fake-driver/fake-driver.ts
@@ -116,9 +116,16 @@ export class OutOfProcessFakeDriver implements Driver {
     return { address: defaultAddress(deviceId), deviceId, driverData: { fakeDeviceId: deviceId } };
   }
 
-  /** Re-reads the script's `address` on every boot -- see `FakeDriverPlatformScript.address`. */
-  async makeReady(device: DriverDevice): Promise<DriverDevice> {
-    const script = await this.#beforeCall("makeReady", [device]);
+  /**
+   * Re-reads the script's `address` on every boot -- see `FakeDriverPlatformScript.address`.
+   * `options.purpose` is logged alongside the call but otherwise ignored -- this fake never
+   * applies any configuration a `"recover"` boot would need to skip.
+   */
+  async makeReady(
+    device: DriverDevice,
+    options?: { readonly purpose: "prepare" | "recover" },
+  ): Promise<DriverDevice> {
+    const script = await this.#beforeCall("makeReady", [device, options]);
     this.#devices.set(device.deviceId, "ready");
     return {
       address: script.address ?? defaultAddress(device.deviceId),

--- a/e2e/slow-ios-slim.test.ts
+++ b/e2e/slow-ios-slim.test.ts
@@ -1,0 +1,514 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+import { SLIM_CATEGORIES, labelsFor } from "../src/drivers/ios/slim-labels.js";
+import { waitFor, waitForDeviceState, withDaemon } from "./helpers/index.js";
+import type { TestEnv } from "./helpers/env.js";
+
+const execFileAsync = promisify(execFile);
+
+interface SimctlDevice {
+  readonly udid: string;
+  readonly name: string;
+  readonly state: string;
+}
+
+interface LeaseGrant {
+  readonly lease: string;
+  readonly udid: string;
+  readonly slim: boolean;
+  readonly device: string;
+  readonly os: string;
+}
+
+interface DoctorReport {
+  readonly findings: readonly {
+    readonly kind: string;
+    readonly code?: string;
+    readonly platform?: string;
+    readonly deviceId?: string;
+  }[];
+}
+
+interface CatalogPlatform {
+  readonly platform: string;
+  readonly models: readonly string[];
+  readonly runtimes: readonly string[];
+}
+
+async function simctlDevices(): Promise<SimctlDevice[]> {
+  const { stdout } = await execFileAsync("xcrun", ["simctl", "list", "devices", "-j"]);
+  const parsed = JSON.parse(stdout) as { devices: Record<string, SimctlDevice[]> };
+  return Object.values(parsed.devices).flat();
+}
+
+async function deleteStraySimlockSimulators(): Promise<void> {
+  const devices = await simctlDevices();
+  for (const device of devices) {
+    if (device.name.startsWith("simlock-")) {
+      await execFileAsync("xcrun", ["simctl", "delete", device.udid]).catch(() => undefined);
+    }
+  }
+}
+
+/**
+ * Parses `xcrun simctl spawn <udid> launchctl print-disabled system`, which prints lines like
+ * `		"com.apple.foo" => disabled` / `=> enabled` (verified live on this machine, iOS 26.4.1).
+ * Returns only the labels currently disabled.
+ */
+async function printDisabled(udid: string): Promise<Set<string>> {
+  const { stdout } = await execFileAsync("xcrun", [
+    "simctl",
+    "spawn",
+    udid,
+    "launchctl",
+    "print-disabled",
+    "system",
+  ]);
+  const disabled = new Set<string>();
+  const pattern = /"([^"]+)"\s*=>\s*disabled/g;
+  for (const match of stdout.matchAll(pattern)) {
+    const label = match[1];
+    if (label !== undefined) disabled.add(label);
+  }
+  return disabled;
+}
+
+/**
+ * Count of launchd jobs the simulator's own launchd is managing, via `launchctl list` run
+ * *inside* the simulator through `simctl spawn` (not `ps` on the host, which would count host
+ * processes across every booted simulator indiscriminately). One line per job plus a header
+ * line; good enough as a relative, before/after comparison -- this test never asserts an
+ * absolute count, only that a slim device's count is materially lower than a full device's.
+ */
+async function processCount(udid: string): Promise<number> {
+  const { stdout } = await execFileAsync("xcrun", ["simctl", "spawn", udid, "launchctl", "list"]);
+  return stdout.split("\n").filter((line) => line.trim() !== "").length;
+}
+
+async function catalogModelAndOs(env: TestEnv): Promise<{ model: string; os: string }> {
+  const catalog = await env.cli(["catalog", "--json", "--platform", "ios"]);
+  expect(catalog.code, `catalog failed: ${catalog.stderr}`).toBe(0);
+  const platforms = (catalog.json as { platforms: CatalogPlatform[] }).platforms;
+  const iosCatalog = platforms.find((platform) => platform.platform === "ios");
+  expect(iosCatalog, "simlock catalog reported no iOS platform").toBeDefined();
+  const model = iosCatalog?.models[0];
+  const os = iosCatalog?.runtimes[0];
+  expect(model, "simlock catalog reported no iOS models").toBeDefined();
+  expect(os, "simlock catalog reported no iOS runtimes").toBeDefined();
+  return { model: model as string, os: os as string };
+}
+
+async function leaseDetached(
+  env: TestEnv,
+  model: string,
+  os: string,
+  agentId: string,
+  extraArgs: readonly string[] = [],
+): Promise<LeaseGrant> {
+  const lease = await env.cli(
+    [
+      "lease",
+      "--platform",
+      "ios",
+      "--device",
+      model,
+      "--os",
+      os,
+      "--agent-id",
+      agentId,
+      "--detach",
+      ...extraArgs,
+    ],
+    { timeout: 600_000 },
+  );
+  expect(lease.code, `lease failed: ${lease.stderr}`).toBe(0);
+  return lease.json as LeaseGrant;
+}
+
+const ALL_LABELS = new Set(labelsFor(SLIM_CATEGORIES));
+const ALL_CATEGORY_NAMES = new Set(SLIM_CATEGORIES.map((category) => category.name));
+
+// This lane needs the real simctl toolchain and real launchd behaviour inside the simulator,
+// hence darwin-only. Never installs a runtime itself (no --allow-download).
+describe.skipIf(process.platform !== "darwin")(
+  "iOS slim mode (real simctl)",
+  { tags: ["slow", "ios"] },
+  () => {
+    it(
+      "scenario 1: slim off (default) is byte-for-byte today's behaviour",
+      { timeout: 300_000 },
+      async () => {
+        const env = await withDaemon({ driver: "real" });
+        try {
+          const { model, os } = await catalogModelAndOs(env);
+          const grant = await leaseDetached(env, model, os, "slim-off-default");
+
+          expect(grant.slim, "grant.slim must be false when ios.slim is not configured").toBe(
+            false,
+          );
+
+          const disabled = await printDisabled(grant.udid);
+          const overlap = [...ALL_LABELS].filter((label) => disabled.has(label));
+          expect(
+            overlap,
+            `expected none of the slim label set disabled on a non-slim device, found: ${overlap.join(", ")}`,
+          ).toEqual([]);
+
+          const recorded = await env.events("1h");
+          const slimmedEvents = recorded.filter((event) => event.event === "device.slimmed");
+          expect(slimmedEvents, "no device.slimmed event expected with slim off").toEqual([]);
+
+          const doctorReport = (await env.cli(["doctor"])).json as DoctorReport;
+          const advisories = doctorReport.findings.filter(
+            (finding) => finding.kind === "driver-advisory",
+          );
+          expect(advisories, "no driver-advisory finding expected with slim off").toEqual([]);
+
+          await env.cli(["nuke", "--delete-devices", "--yes"], { timeout: 180_000 });
+        } finally {
+          await deleteStraySimlockSimulators();
+        }
+      },
+    );
+
+    it(
+      "scenario 2/3/4/7: cold slim lease, idempotence across a reclaim, --full opt-out, and doctor advisory absence",
+      { timeout: 900_000 },
+      async () => {
+        const env = await withDaemon({
+          driver: "real",
+          configOverrides: { ios: { slim: { enabled: true } } },
+        });
+        try {
+          const { model, os } = await catalogModelAndOs(env);
+
+          // --- scenario 4 half A + baseline process count: a --full lease is untouched. ---
+          const fullStart = Date.now();
+          const fullGrant = await leaseDetached(env, model, os, "slim-full-opt-out", ["--full"]);
+          const fullDurationMs = Date.now() - fullStart;
+          expect(fullGrant.slim, "a --full lease must never be slim").toBe(false);
+          const fullDisabled = await printDisabled(fullGrant.udid);
+          const fullOverlap = [...ALL_LABELS].filter((label) => fullDisabled.has(label));
+          expect(
+            fullOverlap,
+            `--full device must have none of the slim labels disabled, found: ${fullOverlap.join(", ")}`,
+          ).toEqual([]);
+          const fullProcessCount = await processCount(fullGrant.udid);
+
+          const doctorAfterFull = (await env.cli(["doctor"])).json as DoctorReport;
+          const driftForFull = doctorAfterFull.findings.filter(
+            (finding) => finding.kind !== "driver-advisory" && finding.deviceId !== undefined,
+          );
+          expect(
+            driftForFull.filter((finding) => finding.deviceId === fullGrant.udid),
+            "doctor must report no drift for the --full device",
+          ).toEqual([]);
+
+          // --- scenario 2: a cold, non-full lease produces a slim device. ---
+          const eventsBeforeSlim = await env.events("1h");
+          const slimmedBefore = eventsBeforeSlim.filter(
+            (event) => event.event === "device.slimmed",
+          ).length;
+
+          const slimStart = Date.now();
+          const slimGrant = await leaseDetached(env, model, os, "slim-cold");
+          const slimDurationMs = Date.now() - slimStart;
+
+          expect(slimGrant.slim, "a plain lease under ios.slim.enabled must be slim").toBe(true);
+          expect(slimGrant.udid).not.toBe(fullGrant.udid);
+
+          const slimDisabled = await printDisabled(slimGrant.udid);
+          const missing = [...ALL_LABELS].filter((label) => !slimDisabled.has(label));
+          expect(
+            missing.length,
+            `expected every slim label disabled on a slim device, missing ${missing.length} of ${ALL_LABELS.size}: ${missing.slice(0, 10).join(", ")}${missing.length > 10 ? "..." : ""}`,
+          ).toBe(0);
+
+          const boot = await simctlDevices();
+          expect(boot.find((device) => device.udid === slimGrant.udid)?.state).toBe("Booted");
+
+          const slimProcessCount = await processCount(slimGrant.udid);
+          const reduction = 1 - slimProcessCount / fullProcessCount;
+          expect(
+            reduction,
+            `expected the slim device's launchctl job count (${String(slimProcessCount)}) to be ` +
+              `at least 30% lower than the full device's (${String(fullProcessCount)}), got a ` +
+              `${(reduction * 100).toFixed(1)}% reduction`,
+          ).toBeGreaterThanOrEqual(0.3);
+
+          const eventsAfterSlim = await env.expectEvents(["device.slimmed"], { since: "1h" });
+          const slimmedEvents = eventsAfterSlim.filter((event) => event.event === "device.slimmed");
+          expect(slimmedEvents.length).toBe(slimmedBefore + 1);
+          const slimmedFact = slimmedEvents.at(-1)?.payload as {
+            deviceId: string;
+            platform?: string;
+            categories: readonly string[];
+            labelCount: number;
+            unknownLabels: readonly string[];
+          };
+          expect(slimmedFact.categories.length, "expected every category resolved").toBe(
+            SLIM_CATEGORIES.length,
+          );
+          expect(new Set(slimmedFact.categories)).toEqual(ALL_CATEGORY_NAMES);
+          expect(slimmedFact.labelCount).toBe(ALL_LABELS.size);
+          // Reported, not asserted empty -- known-pitfalls.md documents that Apple drift can
+          // legitimately produce rejected labels here; this is evidence for the report, not a
+          // pass/fail condition.
+          // eslint-disable-next-line no-console
+          console.log(
+            `[slim e2e] scenario 2 unknownLabels (${slimmedFact.unknownLabels.length}): ` +
+              JSON.stringify(slimmedFact.unknownLabels),
+          );
+
+          console.log(
+            `[slim e2e] lease duration: full=${String(fullDurationMs)}ms slim(cold)=${String(slimDurationMs)}ms; ` +
+              `process count: full=${String(fullProcessCount)} slim=${String(slimProcessCount)} ` +
+              `(${(reduction * 100).toFixed(1)}% reduction)`,
+          );
+
+          // --- scenario 7: doctor advisory is absent (both installed runtimes are >= 18.5). ---
+          const doctorAfterSlim = (await env.cli(["doctor"])).json as DoctorReport;
+          const advisories = doctorAfterSlim.findings.filter(
+            (finding) => finding.kind === "driver-advisory",
+          );
+          expect(
+            advisories,
+            "expected no slim-runtime-unsupported advisory: both installed runtimes on this " +
+              "machine (26.4.1, 27.0) are >= 18.5",
+          ).toEqual([]);
+
+          // --- scenario 3: release, then re-lease the same spec. Per docs/known-pitfalls.md
+          // ("Every reclaim pays two boots, indefinitely"), IosSimctlDriver.reclaim always runs
+          // `simctl erase`, wiping the launchctl overrides -- so the documented behaviour is
+          // that the warm-pooled device comes back stock and pays a SECOND device.slimmed, not
+          // that it's skipped. We assert that documented behaviour here.
+          const releaseResult = await env.cli(["release", slimGrant.lease]);
+          expect(releaseResult.code).toBe(0);
+          await waitForDeviceState(env, slimGrant.udid, "ready", { timeout: 120_000 });
+
+          const relet = await leaseDetached(env, model, os, "slim-cold");
+          expect(relet.udid, "expected the warm-pooled device to be reused").toBe(slimGrant.udid);
+          expect(relet.slim, "re-leased device must still report slim: true").toBe(true);
+
+          const eventsAfterRelease = await env.expectEvents(["device.slimmed", "device.slimmed"], {
+            since: "1h",
+          });
+          const slimmedAfterRelease = eventsAfterRelease.filter(
+            (event) => event.event === "device.slimmed",
+          );
+          expect(
+            slimmedAfterRelease.length,
+            "expected a SECOND device.slimmed for this udid after release+re-lease, per the " +
+              "documented erase-on-reclaim cost (docs/known-pitfalls.md)",
+          ).toBe(slimmedBefore + 2);
+
+          await env.cli(["nuke", "--delete-devices", "--yes"], { timeout: 180_000 });
+        } finally {
+          await deleteStraySimlockSimulators();
+        }
+      },
+    );
+
+    it(
+      "scenario 5/6: a categories subset disables only its own labels, and an unknown category is not fatal",
+      { timeout: 900_000 },
+      async () => {
+        const siriLabels = new Set(
+          labelsFor(SLIM_CATEGORIES.filter((category) => category.name === "siri")),
+        );
+        const telemetryLabels = new Set(
+          labelsFor(SLIM_CATEGORIES.filter((category) => category.name === "telemetry")),
+        );
+        const photosLabels = new Set(
+          labelsFor(SLIM_CATEGORIES.filter((category) => category.name === "photos")),
+        );
+
+        const env = await withDaemon({
+          driver: "real",
+          configOverrides: {
+            ios: { slim: { enabled: true, categories: ["siri", "telemetry"] } },
+          },
+        });
+        try {
+          const { model, os } = await catalogModelAndOs(env);
+
+          // --- scenario 5 ---
+          const grant = await leaseDetached(env, model, os, "slim-subset");
+          expect(grant.slim).toBe(true);
+          const disabled = await printDisabled(grant.udid);
+
+          const missingSiri = [...siriLabels].filter((label) => !disabled.has(label));
+          const missingTelemetry = [...telemetryLabels].filter((label) => !disabled.has(label));
+          expect(missingSiri, "expected every siri label disabled").toEqual([]);
+          expect(missingTelemetry, "expected every telemetry label disabled").toEqual([]);
+
+          const leakedPhotos = [...photosLabels].filter((label) => disabled.has(label));
+          expect(
+            leakedPhotos,
+            `expected no photos-category label disabled, found: ${leakedPhotos.join(", ")}`,
+          ).toEqual([]);
+
+          const recorded = await env.expectEvents(["device.slimmed"], { since: "1h" });
+          const fact = recorded.find((event) => event.event === "device.slimmed")?.payload as {
+            categories: readonly string[];
+          };
+          expect(fact.categories).toEqual(["siri", "telemetry"]);
+
+          await env.cli(["nuke", "--delete-devices", "--yes"], { timeout: 180_000 });
+
+          // --- scenario 6: an unknown category alongside a known one is not fatal. ---
+          await env.withConfig(
+            { ios: { slim: { enabled: true, categories: ["siri", "no-such-category"] } } },
+            async () => {
+              const grant2 = await leaseDetached(env, model, os, "slim-unknown-category");
+              expect(grant2.slim, "lease must still succeed and be slim").toBe(true);
+              const disabled2 = await printDisabled(grant2.udid);
+              const missingSiri2 = [...siriLabels].filter((label) => !disabled2.has(label));
+              expect(missingSiri2, "expected every siri label disabled").toEqual([]);
+
+              await env.cli(["nuke", "--delete-devices", "--yes"], { timeout: 180_000 });
+            },
+          );
+        } finally {
+          await deleteStraySimlockSimulators();
+        }
+      },
+    );
+
+    it(
+      "scenario 8: a health-monitor recovery boot does not re-slim",
+      { timeout: 600_000 },
+      async () => {
+        const env = await withDaemon({
+          driver: "real",
+          configOverrides: {
+            ios: { slim: { enabled: true } },
+            health: { probeIntervalMs: 2_000, recoveryBackoffMs: 1_000, stableObservations: 1 },
+          },
+        });
+        try {
+          const { model, os } = await catalogModelAndOs(env);
+          const grant = await leaseDetached(env, model, os, "slim-recovery", []);
+          expect(grant.slim).toBe(true);
+          const disabledBefore = await printDisabled(grant.udid);
+          expect([...ALL_LABELS].filter((label) => !disabledBefore.has(label)).length).toBe(0);
+
+          const eventsBefore = await env.events("1h");
+          const slimmedBefore = eventsBefore.filter(
+            (event) => event.event === "device.slimmed",
+          ).length;
+
+          // Pull the device out from under simlock, exactly as leased-device-crash-recovery.test.ts
+          // does with the fake driver -- here with the real simctl toolchain.
+          await execFileAsync("xcrun", ["simctl", "shutdown", grant.udid]);
+
+          await env.expectEvents(["device.crash-detected", "device.recovered"], {
+            since: "1h",
+            timeout: 180_000,
+          });
+
+          const booted = await simctlDevices();
+          expect(booted.find((device) => device.udid === grant.udid)?.state).toBe("Booted");
+
+          const disabledAfter = await printDisabled(grant.udid);
+          const missingAfter = [...ALL_LABELS].filter((label) => !disabledAfter.has(label));
+          expect(missingAfter, "expected the device to still be fully slim after recovery").toEqual(
+            [],
+          );
+
+          const eventsAfter = await env.events("1h");
+          const slimmedAfter = eventsAfter.filter(
+            (event) => event.event === "device.slimmed",
+          ).length;
+          expect(
+            slimmedAfter,
+            "recovery must not fire a new device.slimmed (recover purpose never slims)",
+          ).toBe(slimmedBefore);
+
+          await env.cli(["release", grant.lease]).catch(() => undefined);
+          await env.cli(["nuke", "--delete-devices", "--yes"], { timeout: 180_000 });
+        } finally {
+          await deleteStraySimlockSimulators();
+        }
+      },
+    );
+
+    it("scenario 9: MCP carries the slim flag both ways", { timeout: 600_000 }, async () => {
+      const env = await withDaemon({
+        driver: "real",
+        configOverrides: { ios: { slim: { enabled: true } } },
+      });
+      try {
+        const { model, os } = await catalogModelAndOs(env);
+        const mcp = await env.mcpClient({ env: { SIMLOCK_AGENT_ID: "slim-mcp" } });
+        try {
+          // The SDK's default request timeout is 60s; a cold slim lease takes ~160s on this
+          // machine (two real boots). Simlock relays boot progress as MCP progress
+          // notifications, so a client that resets its timeout on progress survives it --
+          // which is what a real agent's client must do too (see docs/known-pitfalls.md).
+          const leaseCallOptions = { resetTimeoutOnProgress: true, timeout: 600_000 };
+          const fullResult = await mcp.client.callTool(
+            {
+              name: "lease_simulator",
+              arguments: { platform: "ios", device: model, os, full: true },
+            },
+            undefined,
+            leaseCallOptions,
+          );
+          const fullLeased = fullResult.structuredContent as {
+            lease_id: string;
+            slim: boolean;
+          };
+          expect(fullLeased.slim, "MCP full:true lease must report slim:false").toBe(false);
+
+          await mcp.client.callTool({
+            name: "release_simulator",
+            arguments: { lease_id: fullLeased.lease_id },
+          });
+
+          const slimResult = await mcp.client.callTool(
+            {
+              name: "lease_simulator",
+              arguments: { platform: "ios", device: model, os },
+            },
+            undefined,
+            leaseCallOptions,
+          );
+          const slimLeased = slimResult.structuredContent as {
+            lease_id: string;
+            slim: boolean;
+          };
+          expect(
+            slimLeased.slim,
+            "MCP plain lease under ios.slim.enabled must report slim:true",
+          ).toBe(true);
+
+          await mcp.client.callTool({
+            name: "release_simulator",
+            arguments: { lease_id: slimLeased.lease_id },
+          });
+        } finally {
+          await mcp.close();
+        }
+
+        await env.cli(["nuke", "--delete-devices", "--yes"], { timeout: 180_000 });
+      } finally {
+        await deleteStraySimlockSimulators();
+      }
+
+      // HTTP is skipped here: it needs a real reserved port plus its own auth-token setup
+      // (see http-api.test.ts) on top of another real cold iOS lease, which -- given MCP
+      // already exercises the same `grant.slim` plumbing through a second transport -- was
+      // judged not worth a third real boot cycle in this already-expensive slow lane.
+    });
+
+    it("no simlock- simulator remains after this file's flows", { timeout: 60_000 }, async () => {
+      await waitFor(
+        async () => !(await simctlDevices()).some((device) => device.name.startsWith("simlock-")),
+        { timeout: 30_000, label: "no simlock- simulator left behind" },
+      );
+    });
+  },
+);

--- a/src/bus/index.test.ts
+++ b/src/bus/index.test.ts
@@ -133,6 +133,7 @@ describe("EventBus", () => {
       | "device.quarantine-stranded"
       | "device.shutdown"
       | "device.deleted"
+      | "device.slimmed"
       | "component.install-started"
       | "component.installed"
       | "component.install-failed"

--- a/src/bus/index.ts
+++ b/src/bus/index.ts
@@ -87,6 +87,16 @@ export interface EventMap {
   };
   "device.shutdown": { readonly deviceId: string; readonly initiator: string };
   "device.deleted": { readonly deviceId: string; readonly initiator: string };
+  "device.slimmed": {
+    readonly deviceId: string;
+    readonly address: string;
+    readonly platform: "ios";
+    readonly categories: readonly string[];
+    readonly labelCount: number;
+    readonly durationMs: number;
+    readonly signature: string;
+    readonly unknownLabels: readonly string[];
+  };
   "component.install-started": {
     readonly platform: string;
     readonly componentId: string;

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -1163,6 +1163,7 @@ function testConfig(): Config {
     stalledTransition: { thresholdMultiplier: 3, minimumThresholdMs: 60_000 },
     downloads: { policy: "on-request", acceptAndroidLicenses: false, timeoutMs: 1_200_000 },
     http: { enabled: false, host: "127.0.0.1", port: 4700 },
+    ios: { slim: { enabled: false, bootTimeoutMs: 600_000 } },
     idle: { deleteAfterMs: 60_000, shutdownAfterMs: 10_000 },
     lease: { detachedTtlMs: 60_000, heldTtlBackstopMs: 60_000, heartbeatIntervalMs: 15_000 },
     capacity: {

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -838,6 +838,77 @@ describe("CLI boundary", () => {
     );
   });
 
+  it("passes every doctor finding through to stdout as JSON, driver-advisory included", async () => {
+    const output = outputCapture();
+    const connection = new StubConnection();
+    connection.response("doctor.run", {
+      findings: [
+        { deviceId: "dev_1", kind: "registry-device-missing", platform: "ios" },
+        {
+          code: "slim-runtime-unsupported",
+          kind: "driver-advisory",
+          message: "iOS 18.4 is below the 18.5 persistent-override floor",
+          platform: "ios",
+        },
+      ],
+    });
+
+    await expect(
+      runCli(["doctor"], output.environmentWith({ connect: async () => connection })),
+    ).resolves.toBe(0);
+    expect(connection.calls).toContainEqual({ payload: { fix: false }, type: "doctor.run" });
+    expect(JSON.parse(output.stdout)).toEqual({
+      findings: [
+        { deviceId: "dev_1", kind: "registry-device-missing", platform: "ios" },
+        {
+          code: "slim-runtime-unsupported",
+          kind: "driver-advisory",
+          message: "iOS 18.4 is below the 18.5 persistent-override floor",
+          platform: "ios",
+        },
+      ],
+    });
+  });
+
+  it("surfaces a driver-advisory finding as a plain warning line on stderr, distinct from drift", async () => {
+    const output = outputCapture();
+    const connection = new StubConnection();
+    connection.response("doctor.run", {
+      findings: [
+        { deviceId: "dev_1", kind: "registry-device-missing", platform: "ios" },
+        {
+          code: "slim-runtime-unsupported",
+          kind: "driver-advisory",
+          message: "iOS 18.4 is below the 18.5 persistent-override floor",
+          platform: "ios",
+        },
+      ],
+    });
+
+    await expect(
+      runCli(["doctor", "--fix"], output.environmentWith({ connect: async () => connection })),
+    ).resolves.toBe(0);
+    expect(connection.calls).toContainEqual({ payload: { fix: true }, type: "doctor.run" });
+    expect(output.stderr).toBe(
+      "Warning [ios] slim-runtime-unsupported: iOS 18.4 is below the 18.5 persistent-override floor\n",
+    );
+    // Only the advisory gets a warning line -- the drift finding is not echoed to stderr.
+    expect(output.stderr).not.toContain("registry-device-missing");
+  });
+
+  it("writes nothing to stderr when doctor reports no driver-advisory findings", async () => {
+    const output = outputCapture();
+    const connection = new StubConnection();
+    connection.response("doctor.run", {
+      findings: [{ deviceId: "dev_1", kind: "registry-device-missing", platform: "ios" }],
+    });
+
+    await expect(
+      runCli(["doctor"], output.environmentWith({ connect: async () => connection })),
+    ).resolves.toBe(0);
+    expect(output.stderr).toBe("");
+  });
+
   it("releases and exits when the watched parent process dies, via the same path as a signal", async () => {
     const output = outputCapture();
     const signals = new EventEmitter();

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -280,6 +280,73 @@ describe("CLI boundary", () => {
     await expect.poll(() => harness.registry.snapshot.leases).toHaveLength(0);
   });
 
+  it("sends full: true in the lease.request payload for --full and reports slim in the result", async () => {
+    const output = outputCapture();
+    const signals = new EventEmitter();
+    const connection = new StubConnection();
+    connection.response("lease.request", {
+      device: {
+        driverDeviceId: "ABCD",
+        featureProfile: "full",
+        spec: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+        state: "leased",
+      },
+      lease: { id: "lse_full", mode: "held", ttlDeadline: 61_000 },
+      timing: {
+        estimatedBootMs: 0,
+        estimatedProvisionMs: 0,
+        estimatedReclaimMs: 0,
+        estimatedReadyMs: 0,
+      },
+    });
+    const run = runCli(
+      ["lease", "--platform", "ios", "--device", "iPhone 16", "--full"],
+      output.environmentWith({ connect: async () => connection, signals }),
+    );
+
+    await vi.waitFor(() => expect(output.stdout).not.toBe(""));
+    signals.emit("SIGTERM");
+    await expect(run).resolves.toBe(0);
+
+    const leaseCall = connection.calls.find((call) => call.type === "lease.request");
+    expect(leaseCall?.payload).toMatchObject({ request: { full: true } });
+    expect(JSON.parse(output.stdout)).toMatchObject({ slim: false });
+  });
+
+  it("omits full from the lease.request payload without --full", async () => {
+    const output = outputCapture();
+    const signals = new EventEmitter();
+    const connection = new StubConnection();
+    connection.response("lease.request", {
+      device: {
+        driverDeviceId: "ABCD",
+        spec: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+        state: "leased",
+      },
+      lease: { id: "lse_default", mode: "held", ttlDeadline: 61_000 },
+      timing: {
+        estimatedBootMs: 0,
+        estimatedProvisionMs: 0,
+        estimatedReclaimMs: 0,
+        estimatedReadyMs: 0,
+      },
+    });
+    const run = runCli(
+      ["lease", "--platform", "ios", "--device", "iPhone 16"],
+      output.environmentWith({ connect: async () => connection, signals }),
+    );
+
+    await vi.waitFor(() => expect(output.stdout).not.toBe(""));
+    signals.emit("SIGTERM");
+    await expect(run).resolves.toBe(0);
+
+    const leaseCall = connection.calls.find((call) => call.type === "lease.request");
+    const requestPayload = (leaseCall?.payload as { request: Record<string, unknown> } | undefined)
+      ?.request;
+    expect(requestPayload).not.toHaveProperty("full");
+    expect(JSON.parse(output.stdout)).toMatchObject({ slim: false });
+  });
+
   it("reports a post-signal release failure as a structured stderr line, not prose", async () => {
     const output = outputCapture();
     const signals = new EventEmitter();
@@ -638,7 +705,7 @@ describe("CLI boundary", () => {
       ),
     ).resolves.toBe(0);
     expect(detached.stdout).toBe(
-      '{"device":"iPhone 17 Pro","expires_at_ms":61000,"lease":"lse_9f2c","os":"26.5","platform":"ios","state":"leased","timing":{"estimated_boot_ms":20,"estimated_provision_ms":10,"estimated_reclaim_ms":0,"estimated_ready_ms":30},"udid":"ABCD"}\n',
+      '{"device":"iPhone 17 Pro","expires_at_ms":61000,"lease":"lse_9f2c","os":"26.5","platform":"ios","slim":false,"state":"leased","timing":{"estimated_boot_ms":20,"estimated_provision_ms":10,"estimated_reclaim_ms":0,"estimated_ready_ms":30},"udid":"ABCD"}\n',
     );
     expect(connection.closed).toBe(true);
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -559,11 +559,32 @@ async function runDoctor(argv: readonly string[], environment: CliEnvironment): 
     environment.stdout.write("Usage: simlock doctor [--fix]\n");
     return 0;
   }
-  writeResult(
-    environment,
-    await requestOnce(environment, "doctor.run", { fix: values.fix ?? false }),
-  );
+  const response = await requestOnce(environment, "doctor.run", { fix: values.fix ?? false });
+  writeDriverAdvisoryWarnings(environment, response);
+  writeResult(environment, response);
   return 0;
+}
+
+/**
+ * `driver-advisory` findings (`src/core/doctor.ts`) are configuration-level information, not
+ * drift -- `--fix` never acts on them (see `Doctor#applySafeFixes`). Surfaced as plain warning
+ * lines on stderr, distinct from every drift-finding kind, so a human running `doctor`
+ * interactively notices them without having to parse the JSON report; stdout keeps carrying
+ * every finding kind unmodified via `writeResult`, matching the JSON-passthrough convention
+ * `list`/`cleanup`/`nuke` already use, so a scripted consumer of stdout sees no behavior change.
+ */
+function writeDriverAdvisoryWarnings(environment: CliEnvironment, response: unknown): void {
+  if (typeof response !== "object" || response === null) return;
+  const findings = (response as Record<string, unknown>).findings;
+  if (!Array.isArray(findings)) return;
+  for (const finding of findings) {
+    if (typeof finding !== "object" || finding === null) continue;
+    const record = finding as Record<string, unknown>;
+    if (record.kind !== "driver-advisory") continue;
+    environment.stderr.write(
+      `Warning [${String(record.platform)}] ${String(record.code)}: ${String(record.message)}\n`,
+    );
+  }
 }
 
 async function runNuke(argv: readonly string[], environment: CliEnvironment): Promise<number> {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -313,6 +313,7 @@ async function runLease(argv: readonly string[], environment: CliEnvironment): P
     "bind-pid": { type: "string" },
     detach: { type: "boolean" },
     device: { type: "string" },
+    full: { type: "boolean" },
     help: { type: "boolean", short: "h" },
     "no-wait": { type: "boolean" },
     os: { type: "string" },
@@ -323,7 +324,7 @@ async function runLease(argv: readonly string[], environment: CliEnvironment): P
     environment.stdout.write(
       "Usage: simlock lease --platform <ios|android> --device <model> [--os <version>]\n" +
         "                     [--agent-id <id>] [--timeout <duration>] [--no-wait] [--detach]\n" +
-        "                     [--allow-download] [--bind-pid <pid>]\n",
+        "                     [--allow-download] [--full] [--bind-pid <pid>]\n",
     );
     return 0;
   }
@@ -397,6 +398,7 @@ async function runLease(argv: readonly string[], environment: CliEnvironment): P
         model: values.device,
         ...(typeof values.os === "string" ? { osVersion: values.os } : {}),
         platform: values.platform,
+        ...(values.full === true ? { full: true } : {}),
       },
       ...(timeoutMs === undefined ? {} : { timeoutMs }),
     });
@@ -842,6 +844,7 @@ function leaseResult(value: unknown): Record<string, unknown> & { readonly lease
     lease: grant.lease.id,
     os: grant.device.spec.osVersion,
     platform: grant.device.spec.platform,
+    slim: grant.slim,
     state: "leased",
     timing: {
       estimated_boot_ms: grant.timing.estimatedBootMs,

--- a/src/core/acquisition-planner.test.ts
+++ b/src/core/acquisition-planner.test.ts
@@ -23,6 +23,7 @@ const config: Config = {
   stalledTransition: { thresholdMultiplier: 3, minimumThresholdMs: 60_000 },
   downloads: { policy: "on-request", acceptAndroidLicenses: false, timeoutMs: 1_200_000 },
   http: { enabled: false, host: "127.0.0.1", port: 4700 },
+  ios: { slim: { enabled: false, bootTimeoutMs: 600_000 } },
   idle: { deleteAfterMs: 60_000, shutdownAfterMs: 10_000 },
   warmPool: {
     quarantine: {

--- a/src/core/cleanup/idle-destroy.test.ts
+++ b/src/core/cleanup/idle-destroy.test.ts
@@ -19,6 +19,7 @@ const config: Config = {
   stalledTransition: { thresholdMultiplier: 3, minimumThresholdMs: 60_000 },
   downloads: { policy: "on-request", acceptAndroidLicenses: false, timeoutMs: 1_200_000 },
   http: { enabled: false, host: "127.0.0.1", port: 4700 },
+  ios: { slim: { enabled: false, bootTimeoutMs: 600_000 } },
   idle: { deleteAfterMs: 30_000, shutdownAfterMs: 10_000 },
   warmPool: {
     quarantine: {

--- a/src/core/cleanup/idle-shutdown.test.ts
+++ b/src/core/cleanup/idle-shutdown.test.ts
@@ -17,6 +17,7 @@ const config: Config = {
   stalledTransition: { thresholdMultiplier: 3, minimumThresholdMs: 60_000 },
   downloads: { policy: "on-request", acceptAndroidLicenses: false, timeoutMs: 1_200_000 },
   http: { enabled: false, host: "127.0.0.1", port: 4700 },
+  ios: { slim: { enabled: false, bootTimeoutMs: 600_000 } },
   idle: { deleteAfterMs: 30_000, shutdownAfterMs: 10_000 },
   warmPool: {
     quarantine: {

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -83,6 +83,7 @@ describe("loadConfig", () => {
         },
       },
       stalledTransition: { thresholdMultiplier: 3, minimumThresholdMs: 60_000 },
+      ios: { slim: { enabled: false, bootTimeoutMs: 600_000 } },
     });
     expect(Object.isFrozen(config)).toBe(true);
     expect(Object.isFrozen(resourceOptions(config).limits)).toBe(true);
@@ -492,6 +493,94 @@ describe("loadConfig", () => {
     await expect(
       loadConfig({ configPath, filesystem, systemStats: createStats() }),
     ).rejects.toThrow(path);
+  });
+
+  it("defaults ios.slim to disabled with no categories and a slim boot timeout", async () => {
+    const config = await loadConfig({
+      configPath,
+      filesystem: new MemoryFilesystem(),
+      systemStats: createStats(),
+    });
+
+    expect(config.ios.slim).toEqual({ enabled: false, bootTimeoutMs: 600_000 });
+    expect(config.ios.slim.categories).toBeUndefined();
+    expect("categories" in config.ios.slim).toBe(false);
+  });
+
+  it("applies a file-level ios.slim override, including an explicit category list", async () => {
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp("/home/agent/.simlock");
+    await filesystem.writeFileAtomic(
+      configPath,
+      JSON.stringify({
+        ios: {
+          slim: { enabled: true, categories: ["logging", "diagnostics"], bootTimeoutMs: 900_000 },
+        },
+      }),
+    );
+
+    const config = await loadConfig({ configPath, filesystem, systemStats: createStats() });
+    expect(config.ios.slim).toEqual({
+      enabled: true,
+      categories: ["logging", "diagnostics"],
+      bootTimeoutMs: 900_000,
+    });
+  });
+
+  it("rejects a non-boolean ios.slim.enabled", async () => {
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp("/home/agent/.simlock");
+    await filesystem.writeFileAtomic(
+      configPath,
+      JSON.stringify({ ios: { slim: { enabled: "yes" } } }),
+    );
+
+    await expect(
+      loadConfig({ configPath, filesystem, systemStats: createStats() }),
+    ).rejects.toThrow("ios.slim.enabled");
+  });
+
+  it.each([
+    [{ ios: { slim: { bootTimeoutMs: 0 } } }, "ios.slim.bootTimeoutMs"],
+    [{ ios: { slim: { bootTimeoutMs: -1 } } }, "ios.slim.bootTimeoutMs"],
+    [{ ios: { slim: { bootTimeoutMs: "600000" } } }, "ios.slim.bootTimeoutMs"],
+  ])("rejects a non-positive or malformed ios.slim.bootTimeoutMs", async (contents, path) => {
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp("/home/agent/.simlock");
+    await filesystem.writeFileAtomic(configPath, JSON.stringify(contents));
+
+    await expect(
+      loadConfig({ configPath, filesystem, systemStats: createStats() }),
+    ).rejects.toThrow(path);
+  });
+
+  it.each([
+    [{ ios: { slim: { categories: "logging" } } }],
+    [{ ios: { slim: { categories: [1, 2] } } }],
+    [{ ios: { slim: { categories: [""] } } }],
+  ])("rejects a malformed ios.slim.categories", async (contents) => {
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp("/home/agent/.simlock");
+    await filesystem.writeFileAtomic(configPath, JSON.stringify(contents));
+
+    await expect(
+      loadConfig({ configPath, filesystem, systemStats: createStats() }),
+    ).rejects.toThrow("ios.slim.categories");
+  });
+
+  it("warns about an unknown key nested under ios.slim without rejecting the file", async () => {
+    const filesystem = new MemoryFilesystem();
+    const warn = vi.fn();
+    await filesystem.mkdirp("/home/agent/.simlock");
+    await filesystem.writeFileAtomic(
+      configPath,
+      JSON.stringify({ ios: { slim: { turboMode: true } } }),
+    );
+
+    await expect(
+      loadConfig({ configPath, filesystem, systemStats: createStats(), warn }),
+    ).resolves.toBeDefined();
+    expect(warn).toHaveBeenCalledWith('Unknown config key: "ios.slim.turboMode"');
   });
 
   it("applies a file-level stalledTransition override", async () => {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -22,6 +22,7 @@ import {
   positiveInteger,
   positiveNumber,
   requireObject,
+  stringArray,
   stringUnion,
   stringValue,
   type Validator,
@@ -81,6 +82,16 @@ export interface Config {
     readonly maxRecoveryAttempts: number;
     readonly recoveryBackoffMs: number;
     readonly maxConcurrentRecoveries: number;
+  };
+  readonly ios: {
+    readonly slim: {
+      /** Opt-in; default false. */
+      readonly enabled: boolean;
+      /** Which daemon categories to disable. Undefined means "every category the driver knows". */
+      readonly categories?: readonly string[];
+      /** Boot deadline used while slim mode is on (slim adds a second boot; CI runners are slow). */
+      readonly bootTimeoutMs: number;
+    };
   };
   readonly stalledTransition: {
     /**
@@ -289,6 +300,12 @@ function defaultConfig(systemStats: SystemStats, strategy: CapacityStrategyName)
       recoveryBackoffMs: 5_000,
       maxConcurrentRecoveries: 1,
     },
+    ios: {
+      slim: {
+        enabled: false,
+        bootTimeoutMs: 600_000,
+      },
+    },
     stalledTransition: {
       thresholdMultiplier: 3,
       minimumThresholdMs: 60_000,
@@ -386,6 +403,13 @@ function configValidators(strategy: CapacityStrategyName): Record<string, Valida
       maxRecoveryAttempts: positiveInteger,
       recoveryBackoffMs: positiveNumber,
       maxConcurrentRecoveries: positiveInteger,
+    }),
+    ios: objectValidator({
+      slim: objectValidator({
+        enabled: booleanValue,
+        categories: stringArray,
+        bootTimeoutMs: positiveNumber,
+      }),
     }),
     stalledTransition: objectValidator({
       thresholdMultiplier: numberAtLeast(1),

--- a/src/core/doctor.test.ts
+++ b/src/core/doctor.test.ts
@@ -1313,5 +1313,6 @@ function config(stalledTransitionOverrides: Partial<Config["stalledTransition"]>
     },
     downloads: { policy: "on-request", acceptAndroidLicenses: false, timeoutMs: 1_200_000 },
     http: { enabled: false, host: "127.0.0.1", port: 4700 },
+    ios: { slim: { enabled: false, bootTimeoutMs: 600_000 } },
   };
 }

--- a/src/core/doctor.test.ts
+++ b/src/core/doctor.test.ts
@@ -1231,6 +1231,167 @@ describe("Doctor", () => {
     expect(firstForeignStateSeq).toBeGreaterThan(lastCommitSeq);
     expect(events.at(-1)?.event).toBe("doctor.reconciled");
   });
+
+  describe("driver advisories", () => {
+    it("collects driver-advisory findings from a driver that implements advisories()", async () => {
+      const clock = new FakeClock(10_000);
+      const eventBus = new EventBus(clock);
+      const registry = await Registry.load({
+        clock,
+        eventBus,
+        filesystem: new MemoryFilesystem(),
+        idGenerator: sequence(),
+        statePath: "/state.json",
+      });
+      const driver = withAdvisories(new FakeDriver({ clock, platform: "ios" }), [
+        { code: "slim-runtime-unsupported", message: "iOS 17.0 predates the 18.5 floor" },
+      ]);
+
+      const report = await new Doctor({
+        clock,
+        config: config(),
+        drivers: [driver],
+        eventBus,
+        registry,
+      }).reconcile();
+
+      expect(report.findings).toEqual([
+        {
+          code: "slim-runtime-unsupported",
+          kind: "driver-advisory",
+          message: "iOS 17.0 predates the 18.5 floor",
+          platform: "ios",
+        },
+      ]);
+    });
+
+    it("contributes nothing from a driver that has no advisories() method", async () => {
+      const clock = new FakeClock(10_000);
+      const eventBus = new EventBus(clock);
+      const registry = await Registry.load({
+        clock,
+        eventBus,
+        filesystem: new MemoryFilesystem(),
+        idGenerator: sequence(),
+        statePath: "/state.json",
+      });
+      const driver = new FakeDriver({ clock, platform: "ios" });
+
+      const report = await new Doctor({
+        clock,
+        config: config(),
+        drivers: [driver],
+        eventBus,
+        registry,
+      }).reconcile();
+
+      expect(report.findings.filter((finding) => finding.kind === "driver-advisory")).toEqual([]);
+    });
+
+    it("tolerates a rejecting advisories() without failing the rest of reconcile", async () => {
+      const clock = new FakeClock(10_000);
+      const eventBus = new EventBus(clock);
+      const registry = await Registry.load({
+        clock,
+        eventBus,
+        filesystem: new MemoryFilesystem(),
+        idGenerator: sequence(),
+        statePath: "/state.json",
+      });
+      const registered = await registry.registerDevice({
+        driverData: { fakeDeviceId: "missing" },
+        driverDeviceId: "missing",
+        provisionDuration: 0,
+        spec: { model: "Phone", osVersion: "1", platform: "ios" },
+      });
+      await registry.transitionDevice(registered.id, "ready", {
+        event: "device.ready",
+        payload: { bootDuration: 0, deviceId: registered.id },
+      });
+      const driver = Object.assign(new FakeDriver({ clock, platform: "ios" }), {
+        advisories: () => Promise.reject(new Error("advisories boom")),
+      });
+
+      const report = await new Doctor({
+        clock,
+        config: config(),
+        drivers: [driver],
+        eventBus,
+        registry,
+      }).reconcile();
+
+      expect(report.findings.filter((finding) => finding.kind === "driver-advisory")).toEqual([]);
+      // The rest of reconcile still ran: the missing device is still reported.
+      expect(report.findings.map((finding) => finding.kind)).toContain("registry-device-missing");
+    });
+
+    it("--fix never acts on a driver-advisory finding", async () => {
+      const clock = new FakeClock(10_000);
+      const eventBus = new EventBus(clock);
+      const registry = await Registry.load({
+        clock,
+        eventBus,
+        filesystem: new MemoryFilesystem(),
+        idGenerator: sequence(),
+        statePath: "/state.json",
+      });
+      const driver = withAdvisories(new FakeDriver({ clock, platform: "ios" }), [
+        { code: "slim-runtime-unsupported", message: "detail" },
+      ]);
+
+      const report = await new Doctor({
+        clock,
+        config: config(),
+        drivers: [driver],
+        eventBus,
+        registry,
+      }).reconcile({ fix: true });
+
+      expect(report.findings).toEqual([
+        {
+          code: "slim-runtime-unsupported",
+          kind: "driver-advisory",
+          message: "detail",
+          platform: "ios",
+        },
+      ]);
+      // Nothing in `--fix` touched the driver beyond the reconcile-time reads: no
+      // provision/makeReady/reclaim/shutdown/destroy call was made for the advisory.
+      expect(driver.calls.map((call) => call.operation)).toEqual(["listManaged"]);
+    });
+
+    it("excludes driver-advisory findings from the doctor.reconciled event's driftFindings", async () => {
+      const clock = new FakeClock(10_000);
+      const eventBus = new EventBus(clock);
+      const registry = await Registry.load({
+        clock,
+        eventBus,
+        filesystem: new MemoryFilesystem(),
+        idGenerator: sequence(),
+        statePath: "/state.json",
+      });
+      const driver = withAdvisories(new FakeDriver({ clock, platform: "ios" }), [
+        { code: "slim-runtime-unsupported", message: "detail" },
+      ]);
+
+      await new Doctor({
+        clock,
+        config: config(),
+        drivers: [driver],
+        eventBus,
+        registry,
+      }).reconcile();
+
+      const reconciled = eventBus.replay().find((event) => event.event === "doctor.reconciled");
+      expect(reconciled).toBeDefined();
+      const payload = reconciled!.payload as {
+        readonly driftFindings: readonly { readonly kind: string }[];
+      };
+      expect(payload.driftFindings.some((finding) => finding.kind === "driver-advisory")).toBe(
+        false,
+      );
+    });
+  });
 });
 
 async function readyDevice(
@@ -1270,6 +1431,16 @@ async function shutdownDevice(
 function sequence() {
   let next = 1;
   return { generate: () => `${next++}` };
+}
+
+/** Attaches a fixed `advisories()` result to a `FakeDriver` instance -- `FakeDriver` itself
+ * never implements the optional method, so tests that need a driver reporting advisories add it
+ * ad hoc rather than growing the fake's own surface for a single test file's needs. */
+function withAdvisories(
+  driver: FakeDriver,
+  advisories: readonly { readonly code: string; readonly message: string }[],
+): FakeDriver {
+  return Object.assign(driver, { advisories: () => Promise.resolve(advisories) });
 }
 
 function config(stalledTransitionOverrides: Partial<Config["stalledTransition"]> = {}): Config {

--- a/src/core/doctor.test.ts
+++ b/src/core/doctor.test.ts
@@ -500,6 +500,52 @@ describe("Doctor", () => {
     ]);
   });
 
+  it("does not report foreign-state-change for a device this daemon holds an operation claim on", async () => {
+    const clock = new FakeClock(10_000);
+    const eventBus = new EventBus(clock);
+    const registry = await Registry.load({
+      clock,
+      eventBus,
+      filesystem: new MemoryFilesystem(),
+      idGenerator: sequence(),
+      statePath: "/state.json",
+    });
+    // A lease-path boot from `shutdown` runs `makeReady` while the committed record still
+    // says `shutdown` -- observed reality goes `running` before that boot's own transition
+    // commits. Claiming the device is what tells doctor this is in-flight work, not drift.
+    const iosDevice = await shutdownDevice(registry, "simlock-ios-1", "ios");
+
+    const iosDriver = new FakeDriver({ clock, platform: "ios" });
+    iosDriver.setManagedReality({
+      devices: [
+        {
+          address: "simlock-ios-1-address",
+          deviceId: "simlock-ios-1",
+          driverData: {},
+          runState: "running",
+        },
+      ],
+      processes: [],
+    });
+
+    const claims = new DeviceOperationClaims();
+    const claim = claims.tryClaim(iosDevice.id, "boot");
+    expect(claim).toBeDefined();
+
+    const report = await new Doctor({
+      claims,
+      clock,
+      config: config(),
+      drivers: [iosDriver],
+      eventBus,
+      registry,
+    }).reconcile();
+
+    expect(report.findings.filter((finding) => finding.kind === "foreign-state-change")).toEqual(
+      [],
+    );
+  });
+
   it("reports foreign-state-change for a device shut down outside Simlock, on both platforms", async () => {
     const clock = new FakeClock(10_000);
     const eventBus = new EventBus(clock);

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -43,6 +43,20 @@ export type DoctorFinding =
       readonly enteredAt: number;
       readonly ageMs: number;
       readonly thresholdMs: number;
+    }
+  | {
+      /**
+       * Configuration-level information from a single driver's `advisories()`, not drift:
+       * nothing here describes a divergence between the registry and observed reality, so
+       * `--fix` never acts on it (see `#applySafeFixes`) and it is excluded from the
+       * `doctor.reconciled` event's `driftFindings` payload (see the comment at that emit
+       * call) -- it stays in `DoctorReport.findings` (what `doctor.run` returns to a caller)
+       * only.
+       */
+      readonly kind: "driver-advisory";
+      readonly platform: Platform;
+      readonly code: string;
+      readonly message: string;
     };
 
 /**
@@ -137,14 +151,57 @@ export class Doctor {
     }
     findings.push(...orphanFindings(realities, registryDeviceKeys));
     findings.push(...expiredLeaseFindings(snapshot.leases, this.options.clock.now()));
+    findings.push(...(await this.#collectAdvisories()));
 
     const report = { findings };
     if (fix) {
       await this.#applySafeFixes(findings);
     }
     this.#emitFindingEvents(findings);
-    this.options.eventBus.emit("doctor.reconciled", { driftFindings: findings }, "doctor");
+    this.options.eventBus.emit(
+      "doctor.reconciled",
+      {
+        // `driftFindings` is a stable payload contract (events rule 6: additive changes only)
+        // that has always meant "things `--fix` might correct" -- every finding kind so far.
+        // A `driver-advisory` is neither drift nor ever actionable by `--fix` (see
+        // `#applySafeFixes`), so folding it into this field would silently redefine what an
+        // existing consumer is entitled to assume about every entry in it. It stays available
+        // through `DoctorReport.findings` (what `doctor.run` returns to a caller) but is
+        // filtered out of the event payload.
+        driftFindings: findings.filter((finding) => finding.kind !== "driver-advisory"),
+      },
+      "doctor",
+    );
     return report;
+  }
+
+  /**
+   * `advisories()` is optional, read-only, best-effort diagnostic information a single driver
+   * reports about its own configuration -- unlike `listManaged` (whose failure today aborts the
+   * whole reconcile via the unhandled rejection in the `Promise.all` above; widening that
+   * tolerance is out of scope here), a driver with no `advisories()` or one that rejects simply
+   * contributes nothing rather than failing every other driver's findings along with it.
+   */
+  async #collectAdvisories(): Promise<DoctorFinding[]> {
+    const perDriver = await Promise.all(
+      this.options.drivers.map(async (driver): Promise<DoctorFinding[]> => {
+        if (driver.advisories === undefined) {
+          return [];
+        }
+        try {
+          const advisories = await driver.advisories();
+          return advisories.map((advisory) => ({
+            code: advisory.code,
+            kind: "driver-advisory" as const,
+            message: advisory.message,
+            platform: driver.platform,
+          }));
+        } catch {
+          return [];
+        }
+      }),
+    );
+    return perDriver.flat();
   }
 
   #emitFindingEvents(findings: readonly DoctorFinding[]): void {
@@ -186,29 +243,39 @@ export class Doctor {
 
   async #applySafeFixes(findings: readonly DoctorFinding[]): Promise<void> {
     for (const finding of findings) {
-      switch (finding.kind) {
-        case "registry-device-missing":
-          await this.#fixMissingDevice(finding.deviceId);
-          break;
-        case "orphan-device":
-        case "orphan-process":
-          // Registry-only destruction: unregistered reality is report-only.
-          break;
-        case "expired-live-lease":
-          if (this.options.leaseExpirer !== undefined) {
-            await this.options.leaseExpirer.expire(finding.leaseId);
-          }
-          break;
-        case "foreign-state-change":
-          await this.#fixForeignStateChange(finding);
-          break;
-        case "foreign-provenance-change":
-          // Report-only: re-marking destroys the evidence, and the device may be leased.
-          break;
-        case "stalled-transition":
-          await this.#fixStalledTransition(finding);
-          break;
-      }
+      await this.#applySafeFix(finding);
+    }
+  }
+
+  /** One finding's `--fix` action, split out of `#applySafeFixes` so the per-kind dispatch
+   * (already at the edge of this file's complexity budget with `driver-advisory` added) doesn't
+   * also have to carry the loop. */
+  async #applySafeFix(finding: DoctorFinding): Promise<void> {
+    switch (finding.kind) {
+      case "registry-device-missing":
+        await this.#fixMissingDevice(finding.deviceId);
+        break;
+      case "orphan-device":
+      case "orphan-process":
+        // Registry-only destruction: unregistered reality is report-only.
+        break;
+      case "expired-live-lease":
+        if (this.options.leaseExpirer !== undefined) {
+          await this.options.leaseExpirer.expire(finding.leaseId);
+        }
+        break;
+      case "foreign-state-change":
+        await this.#fixForeignStateChange(finding);
+        break;
+      case "foreign-provenance-change":
+        // Report-only: re-marking destroys the evidence, and the device may be leased.
+        break;
+      case "stalled-transition":
+        await this.#fixStalledTransition(finding);
+        break;
+      case "driver-advisory":
+        // Information, not drift: `--fix` never acts on a driver advisory.
+        break;
     }
   }
 

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -127,7 +127,12 @@ export class Doctor {
     const findings: DoctorFinding[] = [];
 
     for (const device of snapshot.devices) {
-      const deviceFindings = registryDriftFindings(device, realDeviceKeys, observedDevices);
+      const deviceFindings = registryDriftFindings(
+        device,
+        realDeviceKeys,
+        observedDevices,
+        this.options.claims,
+      );
       findings.push(...deviceFindings);
       if (deviceFindings.some((finding) => finding.kind === "foreign-state-change")) {
         await this.options.registry.markForeignStateDetected(device.id, this.options.clock.now());
@@ -350,26 +355,64 @@ function registryDriftFindings(
   device: DeviceRecord,
   realDeviceKeys: ReadonlySet<string>,
   observedDevices: ReadonlyMap<string, ObservedDevice>,
+  claims?: Pick<DeviceOperationClaims, "isClaimed">,
 ): DoctorFinding[] {
   const findings: DoctorFinding[] = [];
   const deviceKey = key(device.spec.platform, device.driverDeviceId);
 
-  if (device.state !== "deleted" && !realDeviceKeys.has(deviceKey)) {
-    findings.push({
-      deviceId: device.id,
-      kind: "registry-device-missing",
-      platform: device.spec.platform,
-    });
+  const missing = missingDeviceFinding(device, deviceKey, realDeviceKeys);
+  if (missing !== undefined) {
+    findings.push(missing);
   }
 
   // `expected === undefined` means the registry is mid-transition (provisioning,
   // reclaiming, deleted). Simlock is acting on the device itself in those states,
   // including erasing it, so neither run state nor marks are compared.
+  //
+  // A device this daemon holds an operation claim on is excluded the same way, the same
+  // live-versus-orphaned test `stalledTransitionFinding` already applies (see its comment). A
+  // lease-path boot from `shutdown` runs `makeReady` while the committed record still says
+  // `shutdown` -- observed reality goes `running` before the transition that would update
+  // `expectedRunState` ever commits. Without this guard a concurrent `doctor --fix` reads that
+  // as foreign drift, "fixes" the record to `ready`, and the boot's own transition commit
+  // afterwards finds the record changed underneath it and silently drops its
+  // `address`/`driverData`/`featureProfile`, dropping the waiter. The claim is held for the
+  // whole boot, so it exactly brackets the window this needs to cover -- unlike
+  // `stalledTransitionFinding`, this applies regardless of `device.state`, since the record can
+  // be `shutdown`, `ready`, or `leased` while a claimed operation is in flight against it.
   const expected = expectedRunState(device.state);
   const observed = observedDevices.get(deviceKey);
-  if (expected === undefined || observed === undefined) {
-    return findings;
+  const claimed = claims?.isClaimed(device.id) === true;
+  if (expected !== undefined && observed !== undefined && !claimed) {
+    findings.push(...liveDriftFindings(device, expected, observed));
   }
+
+  return findings;
+}
+
+function missingDeviceFinding(
+  device: DeviceRecord,
+  deviceKey: string,
+  realDeviceKeys: ReadonlySet<string>,
+): DoctorFinding | undefined {
+  if (device.state === "deleted" || realDeviceKeys.has(deviceKey)) {
+    return undefined;
+  }
+  return { deviceId: device.id, kind: "registry-device-missing", platform: device.spec.platform };
+}
+
+/**
+ * Run-state and provenance drift for a device whose registry state expects a definite run
+ * state and that has an observed-reality match. Split out of `registryDriftFindings` so the
+ * mid-transition/claim guard there is one flat condition rather than threading through this
+ * logic's own branches.
+ */
+function liveDriftFindings(
+  device: DeviceRecord,
+  expected: "running" | "stopped",
+  observed: ObservedDevice,
+): DoctorFinding[] {
+  const findings: DoctorFinding[] = [];
 
   if (observed.runState !== "transitioning" && observed.runState !== expected) {
     findings.push({

--- a/src/core/domain.test.ts
+++ b/src/core/domain.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { type DeviceRecord, IllegalTransition, transition, transitionEnteredAt } from "./index.js";
+import { type DeviceSpec, sameSpec } from "./domain.js";
 
 const baseDevice: Omit<DeviceRecord, "state"> = {
   createdAt: 1_000,
@@ -66,5 +67,34 @@ describe("transitionEnteredAt", () => {
     for (const state of ["ready", "leased", "quarantined", "shutdown", "deleted"] as const) {
       expect(transitionEnteredAt({ ...baseDevice, state })).toBeUndefined();
     }
+  });
+});
+
+describe("sameSpec", () => {
+  const spec: DeviceSpec = { model: "iPhone 16", osVersion: "26.5", platform: "ios" };
+
+  it("matches two identical plain specs", () => {
+    expect(sameSpec(spec, { ...spec })).toBe(true);
+  });
+
+  it("treats undefined and false full as the same value", () => {
+    expect(sameSpec(spec, { ...spec, full: false })).toBe(true);
+    expect(sameSpec({ ...spec, full: false }, spec)).toBe(true);
+  });
+
+  it("fragments a --full spec from a slim (non-full) spec", () => {
+    expect(sameSpec({ ...spec, full: true }, spec)).toBe(false);
+    expect(sameSpec(spec, { ...spec, full: true })).toBe(false);
+    expect(sameSpec({ ...spec, full: true }, { ...spec, full: false })).toBe(false);
+  });
+
+  it("matches two full specs", () => {
+    expect(sameSpec({ ...spec, full: true }, { ...spec, full: true })).toBe(true);
+  });
+
+  it("still compares platform, model, and osVersion", () => {
+    expect(sameSpec(spec, { ...spec, model: "iPhone 15" })).toBe(false);
+    expect(sameSpec(spec, { ...spec, osVersion: "26.4" })).toBe(false);
+    expect(sameSpec(spec, { ...spec, platform: "android" })).toBe(false);
   });
 });

--- a/src/core/domain.ts
+++ b/src/core/domain.ts
@@ -4,14 +4,27 @@ export interface DeviceSpec {
   readonly platform: Platform;
   readonly model: string;
   readonly osVersion: string;
+  /**
+   * Set when this spec was resolved from a `--full` request (see `DeviceRequest.full`): a
+   * device with no driver-side resource reduction. Part of spec identity (`sameSpec`) so a
+   * `--full` request never matches, and never shares a pool key with, a slim device -- the
+   * ADR's "serve from a separate pool key". Never `false`; omitted for every request that did
+   * not ask for it, so specs stay byte-identical to before this field existed.
+   */
+  readonly full?: boolean;
 }
 
-/** Spec identity as every selection path means it: same platform, model, and OS version. */
+/**
+ * Spec identity as every selection path means it: same platform, model, OS version, and
+ * `full`-ness. `undefined` and `false` compare equal for `full` so registries written before
+ * this field existed keep matching.
+ */
 export function sameSpec(left: DeviceSpec, right: DeviceSpec): boolean {
   return (
     left.platform === right.platform &&
     left.model === right.model &&
-    left.osVersion === right.osVersion
+    left.osVersion === right.osVersion &&
+    (left.full ?? false) === (right.full ?? false)
   );
 }
 
@@ -51,6 +64,13 @@ export interface DeviceRecord {
    * ever guesses at a value it wasn't told.
    */
   readonly address?: string;
+  /**
+   * Mirrors `DriverDevice.featureProfile` (see `driver.ts`), current as of this device's last
+   * `ready` transition. Undefined for a device still `provisioning` (never made ready yet)
+   * and for any driver that does not reduce anything -- today's behaviour, and every non-iOS
+   * driver.
+   */
+  readonly featureProfile?: "full" | "reduced";
 }
 
 export interface LeaseRecord {
@@ -96,6 +116,7 @@ export class IllegalTransition extends Error {
 export interface DeviceTransitionUpdate {
   readonly address?: string;
   readonly driverData?: unknown;
+  readonly featureProfile?: "full" | "reduced";
 }
 
 export function transition(

--- a/src/core/driver.ts
+++ b/src/core/driver.ts
@@ -5,6 +5,13 @@ export interface DeviceRequest {
   readonly platform: Platform;
   readonly model: string;
   readonly osVersion?: string;
+  /**
+   * Platform-neutral request for a device with no driver-side resource reduction -- the
+   * iOS driver happens to implement this as "do not slim"; other drivers ignore it. Never
+   * read by the core beyond stamping it onto the resolved spec (see `DeviceSpec.full` and
+   * the comment where `LeaseAcquisitionCoordinator` does that stamping).
+   */
+  readonly full?: boolean;
 }
 
 export interface DriverDevice {
@@ -18,6 +25,14 @@ export interface DriverDevice {
    * across a boot -- see `Driver.makeReady`.
    */
   readonly address: string;
+  /**
+   * What the driver actually produced for this device, as of its last `makeReady` --
+   * platform-neutral so the core can report feature loss without reading a driver's opaque
+   * `driverData`. `"reduced"` means the driver cut the device's feature set (the iOS driver's
+   * slim mode); `"full"` means it did not. `undefined` means the driver does not reduce
+   * anything at all -- today's behaviour, and every non-iOS driver.
+   */
+  readonly featureProfile?: "full" | "reduced";
 }
 
 /**

--- a/src/core/driver.ts
+++ b/src/core/driver.ts
@@ -1,5 +1,5 @@
 import type { Filesystem } from "../ports/index.js";
-import type { DeviceSpec, Platform } from "./domain.js";
+import type { DeviceSpec, DeviceTransitionUpdate, Platform } from "./domain.js";
 
 export interface DeviceRequest {
   readonly platform: Platform;
@@ -33,6 +33,32 @@ export interface DriverDevice {
    * anything at all -- today's behaviour, and every non-iOS driver.
    */
   readonly featureProfile?: "full" | "reduced";
+}
+
+/**
+ * Builds a `DeviceTransitionUpdate` from a driver's freshly re-read device, always including
+ * `featureProfile` -- even when the driver returned `undefined`. `transition`'s
+ * `{...record, ...update}` spread only clears a stale value when the update object *has* the
+ * key; omitting it (as a conditional spread like `...(fp === undefined ? {} : { featureProfile:
+ * fp })` does) would let a previous `"reduced"` survive a re-boot where slimming wasn't applied
+ * this time, reporting `slim: true` on a device that is actually full-fat.
+ * `DeviceTransitionUpdate["featureProfile"]` itself can't say "present but undefined" under
+ * `exactOptionalPropertyTypes`, so the object is built with the wider type and cast at the
+ * boundary -- the explicit `undefined` here is a deliberate runtime value, not a type-checking
+ * gap. Shared by every readiness path that commits a driver's post-`makeReady` result
+ * (`ManagedDeviceLifecycle`, `WarmPoolCoordinator`) so they can't drift on this.
+ */
+export function readyTransitionUpdate(readyDevice: DriverDevice): DeviceTransitionUpdate {
+  const update: {
+    readonly address: string;
+    readonly driverData: unknown;
+    readonly featureProfile: "full" | "reduced" | undefined;
+  } = {
+    address: readyDevice.address,
+    driverData: readyDevice.driverData,
+    featureProfile: readyDevice.featureProfile,
+  };
+  return update as DeviceTransitionUpdate;
 }
 
 /**

--- a/src/core/driver.ts
+++ b/src/core/driver.ts
@@ -112,6 +112,19 @@ export interface DriverCatalogEntry {
   readonly defaultRuntime: string | undefined;
 }
 
+/**
+ * A configuration-level problem only the owning driver can see -- reported by `doctor`
+ * alongside its own drift findings (`src/core/doctor.ts`'s `driver-advisory` finding kind).
+ * Unlike drift, this is never something `--fix` acts on: it describes a standing condition of
+ * the driver's own configuration (e.g. a feature silently doing nothing given the installed
+ * runtimes), not a divergence between the registry and reality.
+ */
+export interface DriverAdvisory {
+  /** Short kebab-case identifier the driver owns; the core never interprets it. */
+  readonly code: string;
+  readonly message: string;
+}
+
 export interface Driver {
   readonly platform: Platform;
   resolveSpec(
@@ -146,6 +159,13 @@ export interface Driver {
   /** Read-only: must never trigger a runtime / system-image download. */
   listCatalog(): Promise<DriverCatalogEntry>;
   estimate(estimate: DriverEstimate, spec: DeviceSpec): number;
+  /**
+   * Configuration-level problems only this driver can see -- reported by `doctor` alongside its
+   * drift findings. Read-only and side-effect free (same contract as `listCatalog`): it must
+   * never trigger a download, boot, or mutate anything. Optional: a driver with nothing to
+   * advise omits it.
+   */
+  advisories?(): Promise<readonly DriverAdvisory[]>;
 }
 
 export class RuntimeMissingError extends Error {

--- a/src/core/driver.ts
+++ b/src/core/driver.ts
@@ -127,6 +127,15 @@ export interface DriverAdvisory {
 
 export interface Driver {
   readonly platform: Platform;
+  /**
+   * True when this driver may hand back devices with a reduced feature set (the iOS driver's
+   * slim mode, when actually enabled), so a caller's `full` request is meaningful and must not
+   * share a pool key with a normal one. Optional; a driver that never reduces anything -- the
+   * default, and every non-iOS driver -- omits it, equivalent to `false`. Read once per spec
+   * resolution by `LeaseAcquisitionCoordinator`, which is the only place `DeviceSpec.full` gets
+   * stamped onto a resolved spec.
+   */
+  readonly reducesFeatures?: boolean;
   resolveSpec(
     request: DeviceRequest,
     options: {
@@ -147,7 +156,21 @@ export interface Driver {
    * boot, so a device coming back from `shutdown` (or a driver restart) can land on a different
    * one. `deviceId` and the registry-relevant parts of `driverData` do not change.
    */
-  makeReady(device: DriverDevice): Promise<DriverDevice>;
+  makeReady(
+    device: DriverDevice,
+    options?: {
+      /**
+       * What this readiness call is for. `"prepare"` (the default) may do work that changes
+       * the device's configuration -- a fresh boot, a driver's own opt-in configuration pass
+       * (the iOS driver's slim apply). `"recover"` is the one caller (`ManagedDeviceLifecycle.
+       * recoverLeased`, safety rule 2's narrow crash-recovery exception) that reboots a device
+       * that is still `leased`: it must do the minimum needed to get that device running again
+       * and must never change its configuration, so a driver treats `"recover"` as "boot only,
+       * do not apply anything new".
+       */
+      readonly purpose: "prepare" | "recover";
+    },
+  ): Promise<DriverDevice>;
   reclaim(
     device: DriverDevice,
     options: { readonly clean: "standard" | "full" },

--- a/src/core/fake-driver.ts
+++ b/src/core/fake-driver.ts
@@ -51,6 +51,13 @@ export interface FakeDriverOptions {
   readonly platform: Platform;
   readonly reclaimResult?: "ready" | "shutdown";
   readonly reclaimStrategy?: "erase" | "snapshot" | "wipe";
+  /**
+   * `Driver.reducesFeatures` passthrough -- undefined by default (this fake, like every real
+   * driver except iOS with slim mode on, does not reduce anything), settable by a test that
+   * needs to exercise `LeaseAcquisitionCoordinator`'s `full`-stamping decision without a real
+   * iOS driver.
+   */
+  readonly reducesFeatures?: boolean;
 }
 
 export class FakeDriverUnknownDeviceError extends Error {
@@ -62,6 +69,7 @@ export class FakeDriverUnknownDeviceError extends Error {
 
 export class FakeDriver implements Driver {
   readonly platform: Platform;
+  readonly reducesFeatures?: boolean;
   readonly #availableOsVersions: Set<string>;
   readonly #callCounts = new Map<FakeDriverOperation, number>();
   readonly #calls: FakeDriverCall[] = [];
@@ -92,6 +100,9 @@ export class FakeDriver implements Driver {
       options.knownModels === undefined ? undefined : new Set(options.knownModels);
     this.#latencyMs = options.latencyMs;
     this.platform = options.platform;
+    if (options.reducesFeatures !== undefined) {
+      this.reducesFeatures = options.reducesFeatures;
+    }
     this.#reclaimResult = options.reclaimResult ?? "ready";
     this.#reclaimStrategy = options.reclaimStrategy ?? "wipe";
   }
@@ -136,9 +147,17 @@ export class FakeDriver implements Driver {
     return { address: addressFor(deviceId, 0), deviceId, driverData: { fakeDeviceId: deviceId } };
   }
 
-  /** Each boot re-reads a fresh address, same as the real drivers -- never the caller's. */
-  async makeReady(device: DriverDevice): Promise<DriverDevice> {
-    await this.#beforeCall("makeReady", device);
+  /**
+   * Each boot re-reads a fresh address, same as the real drivers -- never the caller's.
+   * `options.purpose` is recorded on the call log (`calls`) so a test can assert a caller (e.g.
+   * `ManagedDeviceLifecycle.recoverLeased`) requested `"recover"`, but this fake never reduces
+   * anything regardless of purpose -- there is no configuration-changing behaviour to gate.
+   */
+  async makeReady(
+    device: DriverDevice,
+    options?: { readonly purpose: "prepare" | "recover" },
+  ): Promise<DriverDevice> {
+    await this.#beforeCall("makeReady", device, options);
     this.#requireDevice(device);
 
     if (this.#hangMakeReady) {

--- a/src/core/fake-driver.ts
+++ b/src/core/fake-driver.ts
@@ -39,6 +39,13 @@ export interface FakeDriverOptions {
    * `estimateMs.reclaim`, so a test that does not care about the split says nothing.
    */
   readonly fullCleanReclaimEstimateMs?: number;
+  /**
+   * The `DriverDevice.featureProfile` `makeReady` reports for every boot -- undefined by
+   * default (this fake, like every real driver except iOS, does not reduce anything), settable
+   * by a test that needs to exercise the core's `featureProfile` persistence without a real
+   * iOS driver.
+   */
+  readonly featureProfile?: "full" | "reduced";
   readonly knownModels?: readonly string[];
   readonly latencyMs?: Partial<Record<FakeDriverOperation, number>>;
   readonly platform: Platform;
@@ -60,6 +67,7 @@ export class FakeDriver implements Driver {
   readonly #calls: FakeDriverCall[] = [];
   readonly #clock: Clock;
   readonly #estimateMs: FakeDriverOptions["estimateMs"];
+  readonly #featureProfile: "full" | "reduced" | undefined;
   readonly #fullCleanReclaimEstimateMs: number | undefined;
   readonly #failures = new Map<string, Error>();
   #hangMakeReady = false;
@@ -78,6 +86,7 @@ export class FakeDriver implements Driver {
     this.#availableOsVersions = new Set(options.availableOsVersions ?? ["latest"]);
     this.#clock = options.clock;
     this.#estimateMs = options.estimateMs;
+    this.#featureProfile = options.featureProfile;
     this.#fullCleanReclaimEstimateMs = options.fullCleanReclaimEstimateMs;
     this.#knownModels =
       options.knownModels === undefined ? undefined : new Set(options.knownModels);
@@ -145,6 +154,7 @@ export class FakeDriver implements Driver {
       address: addressFor(device.deviceId, bootCount),
       deviceId: device.deviceId,
       driverData: device.driverData,
+      ...(this.#featureProfile === undefined ? {} : { featureProfile: this.#featureProfile }),
     };
   }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -22,6 +22,7 @@ export {
   type DeviceRequest,
   DiskSpaceGuard,
   type Driver,
+  type DriverAdvisory,
   type DriverCatalogEntry,
   DriverCrashError,
   type DriverDevice,

--- a/src/core/lease-acquisition-coordinator.test.ts
+++ b/src/core/lease-acquisition-coordinator.test.ts
@@ -29,6 +29,7 @@ function config(maxDevices = 1): Config {
     downloads: { acceptAndroidLicenses: false, policy: "on-request", timeoutMs: 1_200_000 },
     eventBuffer: { capacity: 100 },
     http: { enabled: false, host: "127.0.0.1", port: 4700 },
+    ios: { slim: { enabled: false, bootTimeoutMs: 600_000 } },
     health: {
       enabled: true,
       maxConcurrentRecoveries: 1,

--- a/src/core/lease-acquisition-coordinator.test.ts
+++ b/src/core/lease-acquisition-coordinator.test.ts
@@ -444,4 +444,38 @@ describe("LeaseAcquisitionCoordinator", () => {
       harness.coordinator.request(request, { mode: "held", requesterId: "reopened" }),
     ).resolves.toMatchObject({ lease: { requesterId: "reopened" } });
   });
+
+  it("stamps full: true onto the resolved spec centrally for a --full request", async () => {
+    const harness = await createHarness();
+    const granted = await harness.coordinator.request(
+      { ...request, full: true },
+      { mode: "held", requesterId: "agent" },
+    );
+
+    expect(granted.device.spec).toMatchObject({ full: true });
+  });
+
+  it("never stamps full: false onto a spec for a plain request", async () => {
+    const harness = await createHarness();
+    const granted = await harness.coordinator.request(request, {
+      mode: "held",
+      requesterId: "agent",
+    });
+
+    expect(granted.device.spec).not.toHaveProperty("full");
+  });
+
+  it("keeps a --full request from matching a warm slim device of the same spec", async () => {
+    const harness = await createHarness({ maxDevices: 2 });
+    await seedReady(harness, request);
+
+    const granted = await harness.coordinator.request(
+      { ...request, full: true },
+      { mode: "held", requesterId: "agent" },
+    );
+
+    // A fresh device was provisioned rather than the warm slim one being handed out.
+    expect(granted.device.spec).toMatchObject({ full: true });
+    expect(harness.driver.calls.filter((call) => call.operation === "provision")).toHaveLength(2);
+  });
 });

--- a/src/core/lease-acquisition-coordinator.test.ts
+++ b/src/core/lease-acquisition-coordinator.test.ts
@@ -445,8 +445,17 @@ describe("LeaseAcquisitionCoordinator", () => {
     ).resolves.toMatchObject({ lease: { requesterId: "reopened" } });
   });
 
-  it("stamps full: true onto the resolved spec centrally for a --full request", async () => {
-    const harness = await createHarness();
+  it("stamps full: true onto the resolved spec centrally for a --full request against a driver that reduces features", async () => {
+    const harness = await createHarness({
+      drivers: [
+        new FakeDriver({
+          availableOsVersions: ["26.5"],
+          clock: new FakeClock(1_000),
+          platform: "ios",
+          reducesFeatures: true,
+        }),
+      ],
+    });
     const granted = await harness.coordinator.request(
       { ...request, full: true },
       { mode: "held", requesterId: "agent" },
@@ -465,8 +474,18 @@ describe("LeaseAcquisitionCoordinator", () => {
     expect(granted.device.spec).not.toHaveProperty("full");
   });
 
-  it("keeps a --full request from matching a warm slim device of the same spec", async () => {
-    const harness = await createHarness({ maxDevices: 2 });
+  it("keeps a --full request from matching a warm slim device of the same spec, against a driver that reduces features", async () => {
+    const harness = await createHarness({
+      drivers: [
+        new FakeDriver({
+          availableOsVersions: ["26.5"],
+          clock: new FakeClock(1_000),
+          platform: "ios",
+          reducesFeatures: true,
+        }),
+      ],
+      maxDevices: 2,
+    });
     await seedReady(harness, request);
 
     const granted = await harness.coordinator.request(
@@ -477,5 +496,17 @@ describe("LeaseAcquisitionCoordinator", () => {
     // A fresh device was provisioned rather than the warm slim one being handed out.
     expect(granted.device.spec).toMatchObject({ full: true });
     expect(harness.driver.calls.filter((call) => call.operation === "provision")).toHaveLength(2);
+  });
+
+  it("never stamps full: true onto a spec when the resolving driver does not reduce features, so a --full request produces a spec identical to a normal one", async () => {
+    const harness = await createHarness();
+
+    const fullRequest = await harness.coordinator.request(
+      { ...request, full: true },
+      { mode: "held", requesterId: "agent-full" },
+    );
+
+    expect(fullRequest.device.spec).not.toHaveProperty("full");
+    expect(fullRequest.device.spec).toEqual(request);
   });
 });

--- a/src/core/lease-acquisition-coordinator.ts
+++ b/src/core/lease-acquisition-coordinator.ts
@@ -227,8 +227,17 @@ export class LeaseAcquisitionCoordinator implements AcquisitionMaintenance {
       // matches and provisions on -- so `full` is stamped on centrally here, rather than any
       // driver having to know about the flag (architecture rule 3: drivers stay unaware of
       // core-only request flags). Never stamped `false`; omitted when the request did not ask
-      // for it, so specs stay byte-identical to every request that predates this flag.
-      waiter.spec = request.full === true ? { ...resolved, full: true } : resolved;
+      // for it, so specs stay byte-identical to every request that predates this flag. Also
+      // omitted when the resolving driver doesn't declare `reducesFeatures` (finding #6, issue
+      // #87 review): a `full` request only means something -- and only earns its own pool key,
+      // never shared with a normal request's (`sameSpec`) -- against a driver that might
+      // otherwise hand back a reduced device. Stamping it regardless would fragment a platform
+      // like Android, which never reduces anything, into two identical pools for no behavioural
+      // difference.
+      waiter.spec =
+        request.full === true && driver.reducesFeatures === true
+          ? { ...resolved, full: true }
+          : resolved;
     } catch (error: unknown) {
       await this.options.decisions.run(async () => {
         this.#reject(waiter, asError(error), "unresolvable-spec");

--- a/src/core/lease-acquisition-coordinator.ts
+++ b/src/core/lease-acquisition-coordinator.ts
@@ -215,7 +215,7 @@ export class LeaseAcquisitionCoordinator implements AcquisitionMaintenance {
       return;
     }
     try {
-      waiter.spec = await driver.resolveSpec(request, {
+      const resolved = await driver.resolveSpec(request, {
         allowDownload: options.allowDownload ?? false,
         // The waiter is the one place that knows which requester triggered this resolution;
         // threaded through so a component install a driver ends up doing on this request's
@@ -223,6 +223,12 @@ export class LeaseAcquisitionCoordinator implements AcquisitionMaintenance {
         // to it.
         requesterId: options.requesterId,
       });
+      // This is the single place a driver's `resolveSpec` result becomes the spec the core
+      // matches and provisions on -- so `full` is stamped on centrally here, rather than any
+      // driver having to know about the flag (architecture rule 3: drivers stay unaware of
+      // core-only request flags). Never stamped `false`; omitted when the request did not ask
+      // for it, so specs stay byte-identical to every request that predates this flag.
+      waiter.spec = request.full === true ? { ...resolved, full: true } : resolved;
     } catch (error: unknown) {
       await this.options.decisions.run(async () => {
         this.#reject(waiter, asError(error), "unresolvable-spec");

--- a/src/core/lease-engine.test.ts
+++ b/src/core/lease-engine.test.ts
@@ -26,6 +26,7 @@ function config(overrides: Partial<Config["lease"]> = {}): Config {
     downloads: { acceptAndroidLicenses: false, policy: "on-request", timeoutMs: 1_200_000 },
     eventBuffer: { capacity: 100 },
     http: { enabled: false, host: "127.0.0.1", port: 4700 },
+    ios: { slim: { enabled: false, bootTimeoutMs: 600_000 } },
     health: {
       enabled: true,
       maxConcurrentRecoveries: 1,

--- a/src/core/lease-health-monitor.test.ts
+++ b/src/core/lease-health-monitor.test.ts
@@ -53,6 +53,7 @@ function config(overrides: Partial<Config["health"]> = {}): Config {
     stalledTransition: { thresholdMultiplier: 3, minimumThresholdMs: 60_000 },
     downloads: { policy: "on-request", acceptAndroidLicenses: false, timeoutMs: 1_200_000 },
     http: { enabled: false, host: "127.0.0.1", port: 4700 },
+    ios: { slim: { enabled: false, bootTimeoutMs: 600_000 } },
   };
 }
 

--- a/src/core/managed-device-lifecycle.test.ts
+++ b/src/core/managed-device-lifecycle.test.ts
@@ -336,4 +336,77 @@ describe("ManagedDeviceLifecycle", () => {
       expect(retried).toMatchObject({ id: ready.id, state: "leased" });
     });
   });
+
+  it("persists a driver's featureProfile alongside address and driverData on boot (#makeReady path)", async () => {
+    const clock = new FakeClock(1_000);
+    const eventBus = new EventBus(clock);
+    const driver = new FakeDriver({ clock, featureProfile: "reduced", platform: "ios" });
+    let nextId = 0;
+    const registry = await Registry.load({
+      clock,
+      eventBus,
+      filesystem: new MemoryFilesystem(),
+      idGenerator: { generate: () => `${nextId++}` },
+      statePath,
+    });
+    const lifecycle = new ManagedDeviceLifecycle(
+      new DriverCatalog([driver]),
+      registry,
+      new SerializedDecision(),
+      new DeviceOperationClaims(),
+      clock,
+    );
+    const driverDevice = await driver.provision({
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
+    });
+    const device = await registry.registerDevice({
+      driverData: driverDevice.driverData,
+      driverDeviceId: driverDevice.deviceId,
+      provisionDuration: 0,
+      spec: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+    });
+
+    const ready = await lifecycle.readyProvisioned(device);
+
+    expect(ready).toMatchObject({ featureProfile: "reduced" });
+  });
+
+  it("persists a driver's featureProfile via the bootForLease handoff path (#makeReadyForLease)", async () => {
+    const clock = new FakeClock(1_000);
+    const eventBus = new EventBus(clock);
+    const driver = new FakeDriver({ clock, featureProfile: "reduced", platform: "ios" });
+    let nextId = 0;
+    const registry = await Registry.load({
+      clock,
+      eventBus,
+      filesystem: new MemoryFilesystem(),
+      idGenerator: { generate: () => `${nextId++}` },
+      statePath,
+    });
+    const claims = new DeviceOperationClaims();
+    const lifecycle = new ManagedDeviceLifecycle(
+      new DriverCatalog([driver]),
+      registry,
+      new SerializedDecision(),
+      claims,
+      clock,
+    );
+    const driverDevice = await driver.provision({
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
+    });
+    const device = await registry.registerDevice({
+      driverData: driverDevice.driverData,
+      driverDeviceId: driverDevice.deviceId,
+      provisionDuration: 0,
+      spec: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+    });
+
+    const handoff = await lifecycle.readyProvisionedForLease(device);
+
+    expect(handoff?.device).toMatchObject({ featureProfile: "reduced" });
+  });
 });

--- a/src/core/managed-device-lifecycle.test.ts
+++ b/src/core/managed-device-lifecycle.test.ts
@@ -432,4 +432,171 @@ describe("ManagedDeviceLifecycle", () => {
 
     expect(handoff?.device).toMatchObject({ featureProfile: "reduced" });
   });
+
+  it("boot clears a stale featureProfile when the driver now reports undefined (#makeReady, shutdown path)", async () => {
+    // Regression for the HIGH finding: a conditional spread that omitted `featureProfile`
+    // entirely whenever the driver returned `undefined` left a previously-stored "reduced" on
+    // the record, so a device slim mode no longer applies to kept reporting `slim: true`.
+    const harness = await createHarness();
+    const ready = await harness.registry.transitionDevice(
+      harness.device.id,
+      "ready",
+      { event: "device.ready", payload: { bootDuration: 0, deviceId: harness.device.id } },
+      {
+        address: harness.device.driverDeviceId,
+        driverData: harness.device.driverData,
+        featureProfile: "reduced",
+      },
+    );
+    expect(ready.featureProfile).toBe("reduced");
+    await harness.driver.shutdown({
+      address: ready.address ?? "",
+      deviceId: ready.driverDeviceId,
+      driverData: ready.driverData,
+    });
+    const shutdown = await harness.registry.transitionDevice(ready.id, "shutdown", {
+      event: "device.shutdown",
+      payload: { deviceId: ready.id, initiator: "test" },
+    });
+    expect(shutdown.featureProfile).toBe("reduced");
+
+    // `harness.driver` (a plain `FakeDriver` with no `featureProfile` option) reports `undefined`
+    // on this boot -- the driver-side equivalent of slim mode having been switched off.
+    const booted = await harness.lifecycle.boot(shutdown);
+
+    expect(booted?.featureProfile).toBeUndefined();
+  });
+
+  it("bootForLease clears a stale featureProfile when the driver now reports undefined (#makeReadyForLease, shutdown path)", async () => {
+    const harness = await createHarness();
+    const ready = await harness.registry.transitionDevice(
+      harness.device.id,
+      "ready",
+      { event: "device.ready", payload: { bootDuration: 0, deviceId: harness.device.id } },
+      {
+        address: harness.device.driverDeviceId,
+        driverData: harness.device.driverData,
+        featureProfile: "reduced",
+      },
+    );
+    await harness.driver.shutdown({
+      address: ready.address ?? "",
+      deviceId: ready.driverDeviceId,
+      driverData: ready.driverData,
+    });
+    const shutdown = await harness.registry.transitionDevice(ready.id, "shutdown", {
+      event: "device.shutdown",
+      payload: { deviceId: ready.id, initiator: "test" },
+    });
+    const claim = harness.claims.tryClaim(shutdown.id, "boot");
+    if (claim === undefined) throw new Error("expected boot claim");
+
+    const handoff = await harness.lifecycle.bootForLease(shutdown, claim);
+
+    expect(handoff?.device.featureProfile).toBeUndefined();
+  });
+
+  it("readyProvisioned clears a stale featureProfile when the driver now reports undefined (#makeReady, provisioning path)", async () => {
+    // A device can't naturally re-enter "provisioning" once it leaves, so the persisted state is
+    // seeded directly (as a restarted daemon would load it from disk) to exercise the same
+    // provisioning-branch code path the "shutdown" tests above cover for the other branch.
+    const clock = new FakeClock(1_000);
+    const eventBus = new EventBus(clock);
+    const driver = new FakeDriver({ clock, platform: "ios" });
+    const driverDevice = await driver.provision({
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
+    });
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp("/home/agent/.simlock");
+    await filesystem.writeFileAtomic(
+      statePath,
+      JSON.stringify({
+        devices: [
+          {
+            createdAt: 0,
+            driverData: driverDevice.driverData,
+            driverDeviceId: driverDevice.deviceId,
+            featureProfile: "reduced",
+            id: "dev_stale",
+            spec: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+            state: "provisioning",
+          },
+        ],
+        leases: [],
+      }),
+    );
+    const registry = await Registry.load({
+      clock,
+      eventBus,
+      filesystem,
+      idGenerator: { generate: () => "unused" },
+      statePath,
+    });
+    const lifecycle = new ManagedDeviceLifecycle(
+      new DriverCatalog([driver]),
+      registry,
+      new SerializedDecision(),
+      new DeviceOperationClaims(),
+      clock,
+    );
+    const device = registry.snapshot.devices[0];
+    if (device === undefined) throw new Error("expected seeded device");
+    expect(device.featureProfile).toBe("reduced");
+
+    const readyDevice = await lifecycle.readyProvisioned(device);
+
+    expect(readyDevice?.featureProfile).toBeUndefined();
+  });
+
+  it("readyProvisionedForLease clears a stale featureProfile when the driver now reports undefined (#makeReadyForLease, provisioning path)", async () => {
+    const clock = new FakeClock(1_000);
+    const eventBus = new EventBus(clock);
+    const driver = new FakeDriver({ clock, platform: "ios" });
+    const driverDevice = await driver.provision({
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
+    });
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp("/home/agent/.simlock");
+    await filesystem.writeFileAtomic(
+      statePath,
+      JSON.stringify({
+        devices: [
+          {
+            createdAt: 0,
+            driverData: driverDevice.driverData,
+            driverDeviceId: driverDevice.deviceId,
+            featureProfile: "reduced",
+            id: "dev_stale_2",
+            spec: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+            state: "provisioning",
+          },
+        ],
+        leases: [],
+      }),
+    );
+    const registry = await Registry.load({
+      clock,
+      eventBus,
+      filesystem,
+      idGenerator: { generate: () => "unused" },
+      statePath,
+    });
+    const lifecycle = new ManagedDeviceLifecycle(
+      new DriverCatalog([driver]),
+      registry,
+      new SerializedDecision(),
+      new DeviceOperationClaims(),
+      clock,
+    );
+    const device = registry.snapshot.devices[0];
+    if (device === undefined) throw new Error("expected seeded device");
+
+    const handoff = await lifecycle.readyProvisionedForLease(device);
+
+    expect(handoff?.device.featureProfile).toBeUndefined();
+  });
 });

--- a/src/core/managed-device-lifecycle.test.ts
+++ b/src/core/managed-device-lifecycle.test.ts
@@ -335,6 +335,29 @@ describe("ManagedDeviceLifecycle", () => {
       const retried = await harness.lifecycle.recoverLeased(ready, lease.id);
       expect(retried).toMatchObject({ id: ready.id, state: "leased" });
     });
+
+    it("requests makeReady with purpose 'recover', never the default (finding #1, issue #87 review)", async () => {
+      // Safety rule 2's crash-recovery exception may only reboot an already-provisioned,
+      // still-leased device -- never apply any configuration change a normal "prepare" boot
+      // might (the iOS driver's slim pass). `recoverLeased` must always ask for that narrower
+      // contract explicitly; see `IosSimctlDriver.makeReady`'s dedicated coverage for what a
+      // real driver does with it.
+      const harness = await createHarness();
+      const ready = await readyDevice(harness);
+      const lease = await harness.registry.createLease({
+        deviceId: ready.id,
+        mode: "held",
+        requesterId: "agent",
+        ttlDeadline: 10_000,
+      });
+
+      await harness.lifecycle.recoverLeased(ready, lease.id);
+
+      const recoveryCall = harness.driver.calls.filter((call) => call.operation === "makeReady")[
+        harness.driver.calls.filter((call) => call.operation === "makeReady").length - 1
+      ];
+      expect(recoveryCall?.arguments[1]).toEqual({ purpose: "recover" });
+    });
   });
 
   it("persists a driver's featureProfile alongside address and driverData on boot (#makeReady path)", async () => {

--- a/src/core/managed-device-lifecycle.ts
+++ b/src/core/managed-device-lifecycle.ts
@@ -137,6 +137,13 @@ export class ManagedDeviceLifecycle {
    * device stays `leased` throughout: this performs no registry transition
    * and emits no event, deliberately -- the caller (a `LeaseHealthMonitor`)
    * owns deciding what happened and telling the holder.
+   *
+   * Calls `makeReady` with `{ purpose: "recover" }` (see `Driver.makeReady`), never the
+   * default: safety rule 2 permits this exception to reboot an already-provisioned device and
+   * nothing more, so a driver must not use this reboot to apply any configuration change (the
+   * iOS driver's slim pass) it would otherwise make on a normal `"prepare"` boot -- that would
+   * be a second, unannounced reboot and a configuration change under an active lease, which is
+   * exactly the broader privilege the rule says this exception does not grant.
    */
   // fallow-ignore-next-line unused-class-member -- called through LeaseHealthMonitor's lifecycle port.
   async recoverLeased(target: DeviceRecord, leaseId: string): Promise<DeviceRecord | undefined> {
@@ -153,7 +160,7 @@ export class ManagedDeviceLifecycle {
       // still using the address from its original grant.
       await this.catalog
         .get(claimed.device.spec.platform)
-        .makeReady(toDriverDevice(claimed.device));
+        .makeReady(toDriverDevice(claimed.device), { purpose: "recover" });
     } catch (error: unknown) {
       await this.#release(claimed);
       throw error;

--- a/src/core/managed-device-lifecycle.ts
+++ b/src/core/managed-device-lifecycle.ts
@@ -5,7 +5,7 @@ import {
   type DeviceOperationClaim,
 } from "./device-operation-claims.js";
 import type { DeviceRecord, DeviceState, DeviceTransitionUpdate, LeaseRecord } from "./domain.js";
-import type { DriverDevice } from "./driver.js";
+import { readyTransitionUpdate, type DriverDevice } from "./driver.js";
 import { DriverCatalog } from "./driver-catalog.js";
 import { SerializedDecision } from "./serialized-decision.js";
 
@@ -242,11 +242,7 @@ export class ManagedDeviceLifecycle {
         event: "device.ready",
         payload: { bootDuration: this.clock.now() - startedAt, deviceId: claimed.device.id },
       },
-      {
-        address: ready.address,
-        driverData: ready.driverData,
-        ...(ready.featureProfile === undefined ? {} : { featureProfile: ready.featureProfile }),
-      },
+      readyTransitionUpdate(ready),
     );
   }
 
@@ -277,11 +273,7 @@ export class ManagedDeviceLifecycle {
           event: "device.ready",
           payload: { bootDuration: this.clock.now() - startedAt, deviceId: claimed.device.id },
         },
-        {
-          address: ready.address,
-          driverData: ready.driverData,
-          ...(ready.featureProfile === undefined ? {} : { featureProfile: ready.featureProfile }),
-        },
+        readyTransitionUpdate(ready),
       );
       if (device === undefined) {
         await this.#release(claimed);

--- a/src/core/managed-device-lifecycle.ts
+++ b/src/core/managed-device-lifecycle.ts
@@ -67,7 +67,6 @@ export class ManagedDeviceLifecycle {
     return this.#makeReady(target, "shutdown", claim);
   }
 
-  // fallow-ignore-next-line unused-class-member -- no production caller: superseded by readyProvisionedForLease, still covered by its own tests.
   async readyProvisioned(target: DeviceRecord): Promise<DeviceRecord | undefined> {
     return this.#makeReady(target, "provisioning");
   }
@@ -82,7 +81,6 @@ export class ManagedDeviceLifecycle {
   }
 
   /** Makes a provisioned device ready while retaining its claim for lease handoff. */
-  // fallow-ignore-next-line unused-class-member -- reached through DeviceProvisioner's lifecycle port.
   async readyProvisionedForLease(target: DeviceRecord): Promise<ReadyDeviceHandoff | undefined> {
     return this.#makeReadyForLease(target, "provisioning");
   }
@@ -237,7 +235,11 @@ export class ManagedDeviceLifecycle {
         event: "device.ready",
         payload: { bootDuration: this.clock.now() - startedAt, deviceId: claimed.device.id },
       },
-      { address: ready.address, driverData: ready.driverData },
+      {
+        address: ready.address,
+        driverData: ready.driverData,
+        ...(ready.featureProfile === undefined ? {} : { featureProfile: ready.featureProfile }),
+      },
     );
   }
 
@@ -268,7 +270,11 @@ export class ManagedDeviceLifecycle {
           event: "device.ready",
           payload: { bootDuration: this.clock.now() - startedAt, deviceId: claimed.device.id },
         },
-        { address: ready.address, driverData: ready.driverData },
+        {
+          address: ready.address,
+          driverData: ready.driverData,
+          ...(ready.featureProfile === undefined ? {} : { featureProfile: ready.featureProfile }),
+        },
       );
       if (device === undefined) {
         await this.#release(claimed);

--- a/src/core/nuke.test.ts
+++ b/src/core/nuke.test.ts
@@ -158,6 +158,7 @@ function config(): Config {
     stalledTransition: { thresholdMultiplier: 3, minimumThresholdMs: 60_000 },
     downloads: { policy: "on-request", acceptAndroidLicenses: false, timeoutMs: 1_200_000 },
     http: { enabled: false, host: "127.0.0.1", port: 4700 },
+    ios: { slim: { enabled: false, bootTimeoutMs: 600_000 } },
     idle: { deleteAfterMs: 10, shutdownAfterMs: 5 },
     lease: { detachedTtlMs: 60_000, heldTtlBackstopMs: 60_000, heartbeatIntervalMs: 15_000 },
     capacity: {

--- a/src/core/reaper.test.ts
+++ b/src/core/reaper.test.ts
@@ -57,6 +57,7 @@ function config(): Config {
     stalledTransition: { thresholdMultiplier: 3, minimumThresholdMs: 60_000 },
     downloads: { policy: "on-request", acceptAndroidLicenses: false, timeoutMs: 1_200_000 },
     http: { enabled: false, host: "127.0.0.1", port: 4700 },
+    ios: { slim: { enabled: false, bootTimeoutMs: 600_000 } },
     idle: { deleteAfterMs: 30_000, shutdownAfterMs: 10_000 },
     lease: { detachedTtlMs: 100, heldTtlBackstopMs: 100, heartbeatIntervalMs: 25 },
     capacity: {

--- a/src/core/registry.test.ts
+++ b/src/core/registry.test.ts
@@ -632,6 +632,101 @@ describe("Registry", () => {
     ).rejects.toThrow("Invalid device record in registry state");
   });
 
+  it("survives a save/reload round-trip with featureProfile set", async () => {
+    const clock = new FakeClock(1_000);
+    const filesystem = new MemoryFilesystem();
+    const options = {
+      clock,
+      eventBus: new EventBus(clock),
+      filesystem,
+      idGenerator: { generate: () => "test" },
+      statePath,
+    };
+    const registry = await Registry.load(options);
+    const device = await registry.registerDevice({
+      driverData: {},
+      driverDeviceId: "driver_test",
+      provisionDuration: 0,
+      spec,
+    });
+    await registry.transitionDevice(
+      device.id,
+      "ready",
+      { event: "device.ready", payload: { bootDuration: 5, deviceId: device.id } },
+      { featureProfile: "reduced" },
+    );
+
+    const reloaded = await Registry.load(options);
+
+    expect(reloaded.snapshot).toEqual(registry.snapshot);
+    expect(reloaded.snapshot.devices[0]).toMatchObject({ featureProfile: "reduced" });
+  });
+
+  it("leaves featureProfile absent when the persisted record never set it", async () => {
+    const clock = new FakeClock(1_000);
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp("/home/agent/.simlock");
+    await filesystem.writeFileAtomic(
+      statePath,
+      JSON.stringify({
+        devices: [
+          {
+            createdAt: 500,
+            driverData: {},
+            driverDeviceId: "driver_no_profile",
+            id: "dev_no_profile",
+            spec,
+            state: "ready",
+          },
+        ],
+        leases: [],
+      }),
+    );
+
+    const registry = await Registry.load({
+      clock,
+      eventBus: new EventBus(clock),
+      filesystem,
+      idGenerator: { generate: () => "new" },
+      statePath,
+    });
+
+    expect(registry.snapshot.devices[0]).not.toHaveProperty("featureProfile");
+  });
+
+  it("drops a garbage featureProfile rather than failing the whole registry load", async () => {
+    const clock = new FakeClock(1_000);
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp("/home/agent/.simlock");
+    await filesystem.writeFileAtomic(
+      statePath,
+      JSON.stringify({
+        devices: [
+          {
+            createdAt: 500,
+            driverData: {},
+            driverDeviceId: "driver_garbage",
+            featureProfile: "not-a-real-profile",
+            id: "dev_garbage",
+            spec,
+            state: "ready",
+          },
+        ],
+        leases: [],
+      }),
+    );
+
+    const registry = await Registry.load({
+      clock,
+      eventBus: new EventBus(clock),
+      filesystem,
+      idGenerator: { generate: () => "new" },
+      statePath,
+    });
+
+    expect(registry.snapshot.devices[0]).not.toHaveProperty("featureProfile");
+  });
+
   it("clears recovery markers as part of the same commit that ends a lease", async () => {
     const clock = new FakeClock(1_000);
     const suffixes = ["device", "lease"];

--- a/src/core/registry.ts
+++ b/src/core/registry.ts
@@ -560,6 +560,7 @@ const deviceRecordKeys = [
   "quarantineAttempts",
   "quarantineNextRetryAt",
   "address",
+  "featureProfile",
 ] as const;
 const leaseRecordKeys = [
   "id",
@@ -639,7 +640,7 @@ function parseDevice(value: unknown): DeviceRecord {
     throw new RegistryLoadError("Invalid device record in registry state");
   }
 
-  const { address, createdAt, driverData, driverDeviceId, id, spec, state } = value;
+  const { address, createdAt, driverData, driverDeviceId, featureProfile, id, spec, state } = value;
   if (
     typeof id !== "string" ||
     typeof driverDeviceId !== "string" ||
@@ -658,6 +659,7 @@ function parseDevice(value: unknown): DeviceRecord {
   return {
     ...parseOptionalDeviceNumbers(value),
     ...(address === undefined ? {} : { address }),
+    ...(isFeatureProfile(featureProfile) ? { featureProfile } : {}),
     createdAt,
     driverData,
     driverDeviceId,
@@ -665,6 +667,15 @@ function parseDevice(value: unknown): DeviceRecord {
     spec,
     state: state === "warm" ? "reclaiming" : state,
   };
+}
+
+/**
+ * Unlike `address`, a garbage `featureProfile` is dropped rather than failing the whole record --
+ * it is a derived, re-derivable-on-next-boot hint (see `domain.ts`), not load-bearing identity, so
+ * a corrupt value should not stop the registry (and every other device in it) from loading.
+ */
+function isFeatureProfile(value: unknown): value is "full" | "reduced" {
+  return value === "full" || value === "reduced";
 }
 
 function parseLease(value: unknown): LeaseRecord {

--- a/src/core/validation.ts
+++ b/src/core/validation.ts
@@ -112,6 +112,17 @@ export function integerInRange(minimum: number, maximum: number): Validator {
   };
 }
 
+export function stringArray(value: unknown, path: string): readonly string[] {
+  if (
+    !Array.isArray(value) ||
+    !value.every((item) => typeof item === "string" && item.length > 0)
+  ) {
+    throw invalidValue(path, "an array of strings");
+  }
+
+  return value as readonly string[];
+}
+
 export function stringUnion<Value extends string>(
   allowed: readonly Value[],
   describe: (allowed: readonly Value[]) => string = (values) =>

--- a/src/core/warm-pool-coordinator.test.ts
+++ b/src/core/warm-pool-coordinator.test.ts
@@ -28,6 +28,7 @@ const config: Config = {
   stalledTransition: { thresholdMultiplier: 3, minimumThresholdMs: 60_000 },
   downloads: { policy: "on-request", acceptAndroidLicenses: false, timeoutMs: 1_200_000 },
   http: { enabled: false, host: "127.0.0.1", port: 4700 },
+  ios: { slim: { enabled: false, bootTimeoutMs: 600_000 } },
   idle: { deleteAfterMs: 60_000, shutdownAfterMs: 10_000 },
   warmPool: {
     quarantine: {

--- a/src/core/warm-pool-coordinator.test.ts
+++ b/src/core/warm-pool-coordinator.test.ts
@@ -4,7 +4,7 @@ import { EventBus } from "../bus/index.js";
 import { FakeClock, FakeSystemStats } from "../ports/index.js";
 import { CapacityCoordinator, createCapacityStrategy } from "./capacity/index.js";
 import type { Config } from "./config.js";
-import type { DeviceRecord, DeviceSpec, LeaseRecord } from "./domain.js";
+import type { DeviceRecord, DeviceSpec, DeviceTransitionUpdate, LeaseRecord } from "./domain.js";
 import { FakeDriver } from "./fake-driver.js";
 import { DriverCatalog } from "./driver-catalog.js";
 import type { QuarantinePurgeFailure } from "./quarantine-coordinator.js";
@@ -55,6 +55,7 @@ const config: Config = {
 
 class TestRegistry {
   #devices: DeviceRecord[];
+  lastUpdate: DeviceTransitionUpdate | undefined;
 
   constructor(
     devices: readonly DeviceRecord[],
@@ -82,11 +83,13 @@ class TestRegistry {
         readonly strategy: "erase" | "snapshot" | "wipe";
       };
     },
+    update?: DeviceTransitionUpdate,
   ): Promise<DeviceRecord> {
     const index = this.#devices.findIndex((device) => device.id === deviceId);
     const current = this.#devices[index];
     if (index === -1 || current === undefined) throw new Error("missing device");
-    const updated = { ...current, state: to } as DeviceRecord;
+    this.lastUpdate = update;
+    const updated = { ...current, ...update, state: to } as DeviceRecord;
     this.#devices[index] = updated;
     this.eventBus.emit("device.reclaimed", event.payload, "test-registry");
     return updated;
@@ -238,6 +241,41 @@ describe("WarmPoolCoordinator", () => {
 
     expect(harness.registry.snapshot.devices[0]?.state).toBe("ready");
     expect(harness.driver.calls.map((call) => call.operation)).toContain("makeReady");
+  });
+
+  it("stores the driver's featureProfile when a warm re-boot slims the device", async () => {
+    const clock = new FakeClock(1_000);
+    const driver = new FakeDriver({
+      clock,
+      featureProfile: "reduced",
+      platform: "ios",
+      reclaimResult: "shutdown",
+    });
+    const harness = await createHarness({ driver });
+
+    await harness.coordinator.reclaim(released(harness.reclaiming));
+
+    expect(harness.registry.snapshot.devices[0]?.state).toBe("ready");
+    expect(harness.registry.lastUpdate).toMatchObject({ featureProfile: "reduced" });
+    expect(harness.registry.snapshot.devices[0]).toMatchObject({ featureProfile: "reduced" });
+  });
+
+  it("clears a stale featureProfile when a warm re-boot's makeReady reports no reduction", async () => {
+    const clock = new FakeClock(1_000);
+    const driver = new FakeDriver({ clock, platform: "ios", reclaimResult: "shutdown" });
+    const staleReclaiming = {
+      ...device("reclaiming", "reclaiming", (await driver.provision(spec)).deviceId, spec),
+      featureProfile: "reduced" as const,
+    };
+    const harness = await createHarness({ devices: [staleReclaiming], driver });
+
+    await harness.coordinator.reclaim(released(staleReclaiming));
+
+    // The update object carries the key with an explicit `undefined` value so the registry's
+    // spread actually clears the stale "reduced" rather than leaving it in place (see the
+    // comment in WarmPoolCoordinator#reclaim).
+    expect(harness.registry.lastUpdate).toHaveProperty("featureProfile", undefined);
+    expect(harness.registry.snapshot.devices[0]?.featureProfile).toBeUndefined();
   });
 
   it("hands a release-time purge failure to quarantine instead of readiness-checking the device back in", async () => {

--- a/src/core/warm-pool-coordinator.ts
+++ b/src/core/warm-pool-coordinator.ts
@@ -99,10 +99,7 @@ export class WarmPoolCoordinator {
         },
         disposition.readyDevice === undefined
           ? undefined
-          : {
-              address: disposition.readyDevice.address,
-              driverData: disposition.readyDevice.driverData,
-            },
+          : readyTransitionUpdate(disposition.readyDevice),
       );
     });
     this.options.notifyAvailability();
@@ -210,6 +207,29 @@ export class WarmPoolCoordinator {
 
 function capacityDevices(devices: readonly DeviceRecord[]): readonly CapacityDevice[] {
   return devices.map((device) => ({ platform: device.spec.platform, state: device.state }));
+}
+
+/**
+ * Always includes `featureProfile`, even when the driver returned `undefined` -- `transition`'s
+ * `{...record, ...update}` spread only clears a stale value when the update object *has* the
+ * key; omitting it here (as the conditional-spread pattern elsewhere does) would let a previous
+ * "reduced" survive a re-boot where slimming wasn't applied this time, reporting `slim: true` on
+ * a device that is actually full-fat. `DeviceTransitionUpdate["featureProfile"]` itself can't say
+ * "present but undefined" under `exactOptionalPropertyTypes`, so the object is built with the
+ * wider type and cast at the boundary -- the explicit `undefined` here is a deliberate runtime
+ * value, not a type-checking gap.
+ */
+function readyTransitionUpdate(readyDevice: DriverDevice): DeviceTransitionUpdate {
+  const update: {
+    readonly address: string;
+    readonly driverData: unknown;
+    readonly featureProfile: "full" | "reduced" | undefined;
+  } = {
+    address: readyDevice.address,
+    driverData: readyDevice.driverData,
+    featureProfile: readyDevice.featureProfile,
+  };
+  return update as DeviceTransitionUpdate;
 }
 
 /**

--- a/src/core/warm-pool-coordinator.ts
+++ b/src/core/warm-pool-coordinator.ts
@@ -9,7 +9,7 @@ import {
   type Platform,
   sameSpec,
 } from "./domain.js";
-import type { Driver, DriverDevice } from "./driver.js";
+import { readyTransitionUpdate, type Driver, type DriverDevice } from "./driver.js";
 import type { QuarantinePurgeFailure } from "./quarantine-coordinator.js";
 import type { ReleasedLease } from "./registry.js";
 import type { SerializedDecision } from "./serialized-decision.js";
@@ -207,29 +207,6 @@ export class WarmPoolCoordinator {
 
 function capacityDevices(devices: readonly DeviceRecord[]): readonly CapacityDevice[] {
   return devices.map((device) => ({ platform: device.spec.platform, state: device.state }));
-}
-
-/**
- * Always includes `featureProfile`, even when the driver returned `undefined` -- `transition`'s
- * `{...record, ...update}` spread only clears a stale value when the update object *has* the
- * key; omitting it here (as the conditional-spread pattern elsewhere does) would let a previous
- * "reduced" survive a re-boot where slimming wasn't applied this time, reporting `slim: true` on
- * a device that is actually full-fat. `DeviceTransitionUpdate["featureProfile"]` itself can't say
- * "present but undefined" under `exactOptionalPropertyTypes`, so the object is built with the
- * wider type and cast at the boundary -- the explicit `undefined` here is a deliberate runtime
- * value, not a type-checking gap.
- */
-function readyTransitionUpdate(readyDevice: DriverDevice): DeviceTransitionUpdate {
-  const update: {
-    readonly address: string;
-    readonly driverData: unknown;
-    readonly featureProfile: "full" | "reduced" | undefined;
-  } = {
-    address: readyDevice.address,
-    driverData: readyDevice.driverData,
-    featureProfile: readyDevice.featureProfile,
-  };
-  return update as DeviceTransitionUpdate;
 }
 
 /**

--- a/src/daemon-client/contracts.test.ts
+++ b/src/daemon-client/contracts.test.ts
@@ -24,7 +24,27 @@ const leaseGrant = {
 
 describe("parseRawLeaseGrant", () => {
   it("parses the lease fields shared by daemon frontends", () => {
-    expect(parseRawLeaseGrant(leaseGrant)).toEqual(leaseGrant);
+    expect(parseRawLeaseGrant(leaseGrant)).toEqual({ ...leaseGrant, slim: false });
+  });
+
+  it("defaults slim to false when an older daemon never sends featureProfile", () => {
+    expect(parseRawLeaseGrant(leaseGrant).slim).toBe(false);
+  });
+
+  it("reports slim: true when the device's featureProfile is reduced", () => {
+    const grant = {
+      ...leaseGrant,
+      device: { ...leaseGrant.device, featureProfile: "reduced" },
+    };
+    expect(parseRawLeaseGrant(grant).slim).toBe(true);
+  });
+
+  it("reports slim: false when the device's featureProfile is full", () => {
+    const grant = {
+      ...leaseGrant,
+      device: { ...leaseGrant.device, featureProfile: "full" },
+    };
+    expect(parseRawLeaseGrant(grant).slim).toBe(false);
   });
 
   it.each([
@@ -38,6 +58,7 @@ describe("parseRawLeaseGrant", () => {
     [{ ...leaseGrant, lease: { ...leaseGrant.lease, mode: "forever" } }],
     [{ ...leaseGrant, lease: { id: "lse_9f2c", mode: "held" } }],
     [{ ...leaseGrant, timing: { ...leaseGrant.timing, estimatedReadyMs: "30" } }],
+    [{ ...leaseGrant, device: { ...leaseGrant.device, featureProfile: "half" } }],
     [null],
   ])("rejects malformed daemon payloads", (value) => {
     expect(() => parseRawLeaseGrant(value)).toThrow("Daemon returned an invalid lease grant");

--- a/src/daemon-client/contracts.ts
+++ b/src/daemon-client/contracts.ts
@@ -13,6 +13,12 @@ export interface RawLeaseGrant {
       readonly platform: "android" | "ios";
     };
   };
+  /**
+   * Whether the granted device had its feature set reduced (`DeviceRecord.featureProfile ===
+   * "reduced"`), so agents can explain feature-loss failures. Defaults to `false` when an
+   * older daemon never sends `featureProfile` at all -- absence is never treated as an error.
+   */
+  readonly slim: boolean;
   readonly lease: {
     readonly id: string;
     readonly mode: "detached" | "held";
@@ -41,6 +47,9 @@ export function parseRawLeaseGrant(value: unknown): RawLeaseGrant {
   if (
     typeof device.driverDeviceId !== "string" ||
     (device.address !== undefined && typeof device.address !== "string") ||
+    (device.featureProfile !== undefined &&
+      device.featureProfile !== "full" &&
+      device.featureProfile !== "reduced") ||
     typeof spec.model !== "string" ||
     typeof spec.osVersion !== "string" ||
     (spec.platform !== "ios" && spec.platform !== "android") ||
@@ -60,6 +69,9 @@ export function parseRawLeaseGrant(value: unknown): RawLeaseGrant {
       driverDeviceId: device.driverDeviceId,
       spec: { model: spec.model, osVersion: spec.osVersion, platform: spec.platform },
     },
+    // Absent on an older daemon that never sends `featureProfile` -- default to `false` rather
+    // than throwing, so an old daemon paired with a new client keeps working.
+    slim: device.featureProfile === "reduced",
     lease: { id: lease.id, mode: lease.mode, ttlDeadline: lease.ttlDeadline },
     timing: {
       estimatedBootMs: timing.estimatedBootMs,

--- a/src/daemon/main.test.ts
+++ b/src/daemon/main.test.ts
@@ -19,6 +19,7 @@ import {
   bridgeAndroidDriverDiagnostic,
   discoverDrivers,
   emitComponentInstallDiagnostic,
+  emitSlimDiagnostic,
   startDaemon,
   wireComponentInstallLogging,
   type StartDaemonOptions,
@@ -268,6 +269,43 @@ describe("component install diagnostic bridging", () => {
   });
 });
 
+describe("slim diagnostic bridging", () => {
+  it("emits device.slimmed with the driver-diagnostics module for a SlimmedFact", () => {
+    const clock = new FakeClock(1_000);
+    const eventBus = new EventBus(clock);
+    const seen: unknown[] = [];
+    eventBus.subscribeAll((envelope) => seen.push(envelope));
+    const bridge = emitSlimDiagnostic(eventBus);
+
+    bridge({
+      address: "simlock-ios-1-address",
+      categories: ["siri", "spotlight"],
+      deviceId: "simlock-ios-1",
+      durationMs: 12_000,
+      labelCount: 170,
+      signature: "sig-abc123",
+      unknownLabels: ["com.apple.unknown-daemon"],
+    });
+
+    expect(seen).toEqual([
+      expect.objectContaining({
+        event: "device.slimmed",
+        module: "driver-diagnostics",
+        payload: {
+          address: "simlock-ios-1-address",
+          categories: ["siri", "spotlight"],
+          deviceId: "simlock-ios-1",
+          durationMs: 12_000,
+          labelCount: 170,
+          platform: "ios",
+          signature: "sig-abc123",
+          unknownLabels: ["com.apple.unknown-daemon"],
+        },
+      }),
+    ]);
+  });
+});
+
 describe("wireComponentInstallLogging", () => {
   it('writes a durable structured log line under logger.child("components") when component.installed fires', () => {
     const clock = new FakeClock(1_000);
@@ -339,6 +377,45 @@ describe("wireComponentInstallLogging", () => {
     );
 
     expect(sink.records).toEqual([]);
+  });
+
+  it('writes a durable structured log line under logger.child("slim") when device.slimmed fires', () => {
+    const clock = new FakeClock(1_000);
+    const sink = new MemoryLogSink();
+    const logger = new JsonLinesLogger({ clock, level: "debug", sink });
+    const eventBus = new EventBus(clock);
+
+    wireComponentInstallLogging(eventBus, logger);
+    eventBus.emit(
+      "device.slimmed",
+      {
+        address: "simlock-ios-1-address",
+        categories: ["siri", "spotlight"],
+        deviceId: "simlock-ios-1",
+        durationMs: 12_000,
+        labelCount: 170,
+        platform: "ios",
+        signature: "sig-abc123",
+        unknownLabels: [],
+      },
+      "driver-diagnostics",
+    );
+
+    expect(sink.records).toContainEqual(
+      expect.objectContaining({
+        level: "info",
+        message: "Device slimmed",
+        module: "daemon.slim",
+        fields: {
+          categories: ["siri", "spotlight"],
+          deviceId: "simlock-ios-1",
+          durationMs: 12_000,
+          labelCount: 170,
+          signature: "sig-abc123",
+          unknownLabels: [],
+        },
+      }),
+    );
   });
 });
 

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -282,7 +282,7 @@ export interface DriverDiscoveryContext {
   readonly processRunner: ProcessRunner;
   /**
    * The iOS driver's opt-in slim mode (`ios.slim` in config). Never threaded into the Android
-   * driver -- slim is iOS-only (ADR #87, "out of scope: Android equivalent"). Omitted or
+   * driver -- slim is iOS-only (ADR 0002, out of scope: Android equivalent). Omitted or
    * undefined leaves the driver's own default (today's full-fat behaviour) untouched.
    */
   readonly slim?: {

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -20,7 +20,7 @@ import {
   type AndroidDriverDiagnostic,
 } from "../drivers/android/index.js";
 import type { ComponentInstallDiagnostic } from "../drivers/diagnostics.js";
-import { IosSimctlDriver } from "../drivers/ios/index.js";
+import { IosSimctlDriver, type SlimmedFact } from "../drivers/ios/index.js";
 import { createHttpApp } from "../http/app.js";
 import { HttpGateway } from "../http/server.js";
 import { TokenStore } from "../http/token-store.js";
@@ -115,6 +115,7 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
       idGenerator,
       logger,
       processRunner,
+      slim: config.ios.slim,
     }));
   const leaseEngine = new LeaseEngine({
     clock,
@@ -279,6 +280,16 @@ export interface DriverDiscoveryContext {
   readonly idGenerator: IdGenerator;
   readonly logger: Logger;
   readonly processRunner: ProcessRunner;
+  /**
+   * The iOS driver's opt-in slim mode (`ios.slim` in config). Never threaded into the Android
+   * driver -- slim is iOS-only (ADR #87, "out of scope: Android equivalent"). Omitted or
+   * undefined leaves the driver's own default (today's full-fat behaviour) untouched.
+   */
+  readonly slim?: {
+    readonly enabled: boolean;
+    readonly categories?: readonly string[];
+    readonly bootTimeoutMs: number;
+  };
 }
 
 export async function discoverDrivers(options: DriverDiscoveryContext): Promise<Driver[]> {
@@ -302,7 +313,16 @@ export async function discoverDrivers(options: DriverDiscoveryContext): Promise<
         filesystem: options.filesystem,
         idGenerator: options.idGenerator,
         onDiagnostic: emitComponentInstallDiagnostic(options.eventBus, "ios"),
+        onSlimmed: emitSlimDiagnostic(options.eventBus),
+        onSlimSkipped: (fact) => {
+          logger.warn("Skipped iOS device slim", {
+            deviceId: fact.deviceId,
+            detail: fact.detail,
+            reason: fact.reason,
+          });
+        },
         processRunner: options.processRunner,
+        ...(options.slim === undefined ? {} : { slim: options.slim }),
       }),
     );
     logger.info("Discovered driver", { platform: "ios" });
@@ -429,6 +449,33 @@ export function emitComponentInstallDiagnostic(
   };
 }
 
+/**
+ * Turns the iOS driver's `SlimmedFact` into the matching `device.slimmed` bus event. Mirrors
+ * `emitComponentInstallDiagnostic`: the driver never depends on the event bus directly
+ * (architecture rule 5) -- this is the one place, at driver construction, that bridges the
+ * driver's `onSlimmed` callback to a post-commit fact for observers (`simlock events`, and the
+ * durable-log subscription in `startDaemon`). A *skipped* slim is deliberately not bridged here
+ * -- see `onSlimSkipped` in `discoverDrivers`, which logs it instead (see `docs/EVENTS.md`).
+ */
+export function emitSlimDiagnostic(eventBus: Pick<EventBus, "emit">): (fact: SlimmedFact) => void {
+  return (fact) => {
+    eventBus.emit(
+      "device.slimmed",
+      {
+        deviceId: fact.deviceId,
+        address: fact.address,
+        platform: "ios",
+        categories: fact.categories,
+        labelCount: fact.labelCount,
+        durationMs: fact.durationMs,
+        signature: fact.signature,
+        unknownLabels: fact.unknownLabels,
+      },
+      "driver-diagnostics",
+    );
+  };
+}
+
 function isComponentInstallDiagnostic(diagnostic: {
   readonly kind: string;
 }): diagnostic is ComponentInstallDiagnostic {
@@ -457,10 +504,11 @@ export function bridgeAndroidDriverDiagnostic(
 }
 
 /**
- * Durable bookkeeping for component installs: the event ring buffer (`simlock events`) resets
- * on daemon restart, so a component simlock installed on an agent's behalf is only attributable
- * later through this log line -- see the `Logger` port ("Operational logging is a separate
- * concern from the event bus" in ARCHITECTURE.md).
+ * Durable bookkeeping for component installs (and iOS slims, below): the event ring buffer
+ * (`simlock events`) resets on daemon restart, so a component simlock installed -- or a device it
+ * slimmed -- on an agent's behalf is only attributable later through this log line -- see the
+ * `Logger` port ("Operational logging is a separate concern from the event bus" in
+ * ARCHITECTURE.md).
  */
 export function wireComponentInstallLogging(
   eventBus: Pick<EventBus, "subscribe">,
@@ -475,6 +523,18 @@ export function wireComponentInstallLogging(
       ...(envelope.payload.requesterId === undefined
         ? {}
         : { requesterId: envelope.payload.requesterId }),
+    });
+  });
+
+  const slimLogger = logger.child("slim");
+  eventBus.subscribe("device.slimmed", (envelope) => {
+    slimLogger.info("Device slimmed", {
+      categories: envelope.payload.categories,
+      deviceId: envelope.payload.deviceId,
+      durationMs: envelope.payload.durationMs,
+      labelCount: envelope.payload.labelCount,
+      signature: envelope.payload.signature,
+      unknownLabels: envelope.payload.unknownLabels,
     });
   });
 }

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -1495,6 +1495,7 @@ function testConfig(
       ...downloadsOverrides,
     },
     http: { enabled: false, host: "127.0.0.1", port: 4700 },
+    ios: { slim: { enabled: false, bootTimeoutMs: 600_000 } },
     idle: { deleteAfterMs: 60_000, shutdownAfterMs: 10_000 },
     lease: {
       detachedTtlMs: 60_000,

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -1238,6 +1238,44 @@ describe("DaemonServer download policy", () => {
   });
 });
 
+describe("DaemonServer full request flag", () => {
+  it("parses request.full: true into a spec stamped full: true", async () => {
+    const harness = await createHarness();
+    const client = await createClient(harness.socketPath);
+    await hello(client);
+
+    const grant = await client.request("lease.request", {
+      mode: "held",
+      requesterId: "agent-1",
+      request: { full: true, model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+    });
+
+    expect(grant.ok).toBe(true);
+    expect(
+      (grant.payload as { device: { spec: Record<string, unknown> } }).device.spec,
+    ).toMatchObject({ full: true });
+    await client.close();
+  });
+
+  it("omits full from the spec when the request does not ask for it", async () => {
+    const harness = await createHarness();
+    const client = await createClient(harness.socketPath);
+    await hello(client);
+
+    const grant = await client.request("lease.request", {
+      mode: "held",
+      requesterId: "agent-1",
+      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+    });
+
+    expect(grant.ok).toBe(true);
+    expect(
+      (grant.payload as { device: { spec: Record<string, unknown> } }).device.spec,
+    ).not.toHaveProperty("full");
+    await client.close();
+  });
+});
+
 describe("DaemonServer error code mapping", () => {
   it("maps InsufficientDiskSpaceError to INSUFFICIENT_DISK_SPACE", async () => {
     const clock = new FakeClock(1_000);

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -1240,7 +1240,10 @@ describe("DaemonServer download policy", () => {
 
 describe("DaemonServer full request flag", () => {
   it("parses request.full: true into a spec stamped full: true", async () => {
-    const harness = await createHarness();
+    // Stamping `full` is gated on the resolving driver declaring `reducesFeatures` -- without it
+    // there is nothing to opt out of, so the flag would (correctly) leave the spec untouched and
+    // this test would be asserting the wrong half of that contract.
+    const harness = await createHarness({ reducesFeatures: true });
     const client = await createClient(harness.socketPath);
     await hello(client);
 
@@ -1334,6 +1337,8 @@ async function createHarness(
     readonly downloads?: Partial<Config["downloads"]>;
     readonly driver?: FakeDriver;
     readonly logger?: Logger;
+    /** Passed to the default `FakeDriver`; makes a `--full` request meaningful (see `Driver.reducesFeatures`). */
+    readonly reducesFeatures?: boolean;
     readonly settle?: () => Promise<void>;
     readonly stateFilesystem?: MemoryFilesystem;
     readonly stopAuxiliary?: () => Promise<void>;
@@ -1363,6 +1368,9 @@ async function createHarness(
       ...(options.estimateMs === undefined ? {} : { estimateMs: options.estimateMs }),
       ...(options.latencyMs === undefined ? {} : { latencyMs: options.latencyMs }),
       platform: "ios",
+      ...(options.reducesFeatures === undefined
+        ? {}
+        : { reducesFeatures: options.reducesFeatures }),
     });
   const config = testConfig(options.lease, options.downloads);
   const engine = new LeaseEngine({

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -559,10 +559,12 @@ export class DaemonServer {
     const payload = objectPayload(value);
     const requestPayload = isObject(payload.request) ? payload.request : payload;
     const osVersion = optionalString(requestPayload, "osVersion", "os");
+    const full = optionalBoolean(requestPayload, "full") ?? false;
     const request: DeviceRequest = {
       model: requiredString(requestPayload, "model", "device"),
       platform: requiredPlatform(requestPayload),
       ...(osVersion === undefined ? {} : { osVersion }),
+      ...(full ? { full: true } : {}),
     };
     const mode = payload.mode === "detached" ? "detached" : "held";
     const requesterId = optionalString(payload, "requesterId") ?? this.options.defaultRequesterId;

--- a/src/drivers/ios/index.test.ts
+++ b/src/drivers/ios/index.test.ts
@@ -2451,6 +2451,7 @@ function createSlimDriver(
 /** Mirrors `#applySlimLabels`'s generated script -- keeps test expectations in sync by construction. */
 function slimScript(labels: readonly string[]): string {
   return (
+    `[ -n "$SIMULATOR_ROOT" ] && export DYLD_ROOT_PATH="$SIMULATOR_ROOT"; ` +
     `for l in ${labels.join(" ")}; do launchctl disable "system/$l" ` +
     `>/dev/null 2>&1 || echo "simlock-slim-failed $l"; done`
   );

--- a/src/drivers/ios/index.test.ts
+++ b/src/drivers/ios/index.test.ts
@@ -28,6 +28,7 @@ import {
   type SlimmedFact,
   type SlimSkippedFact,
 } from "./index.js";
+import { labelsFor, resolveSlimCategories } from "./slim-labels.js";
 
 const listFixture = readFileSync(new URL("./fixtures/simctl-list.json", import.meta.url), "utf8");
 const listDevicesFixture = readFileSync(
@@ -861,10 +862,12 @@ describe("IosSimctlDriver", () => {
         driverData,
       }),
     ).resolves.toEqual({
+      // No `featureProfile` here: slim mode isn't configured at all for this driver, and
+      // `DriverDevice.featureProfile`'s contract is that `undefined` means "this driver does
+      // not reduce anything" -- only true while slim mode is off (finding #7, issue #87 review).
       address: driverData.udid,
       deviceId: driverData.udid,
       driverData,
-      featureProfile: "full",
     });
     expect(runner.calls).toEqual([
       {
@@ -1281,10 +1284,11 @@ describe("IosSimctlDriver", () => {
           driverData,
         }),
       ).resolves.toEqual({
+        // No `featureProfile`: slim mode is off entirely, so `undefined` is the correct
+        // "does not reduce anything" report (finding #7, issue #87 review).
         address: driverData.udid,
         deviceId: driverData.udid,
         driverData,
-        featureProfile: "full",
       });
       expect(runner.calls.map((call) => call.args)).toEqual([
         ["simctl", "boot", driverData.udid],
@@ -1355,6 +1359,104 @@ describe("IosSimctlDriver", () => {
         signature: widgetsSignature,
         unknownLabels: [],
       });
+      expect(onSlimSkipped).not.toHaveBeenCalled();
+    });
+
+    it("downgrades a failed post-apply shutdown to a skip instead of failing the lease (finding #3, issue #87 review)", async () => {
+      // The apply itself succeeded and the device is still running from the first boot at the
+      // top of this test -- `#shutdown` failing here (a non-zero exit `simctl shutdown` doesn't
+      // recognize as "already shutdown") means nothing was actually rebooted, so the device is
+      // still a healthy, leaseable one. `makeReady`'s own contract ("a failed or skipped slim
+      // never fails the lease") must hold: this downgrades to the skip path, not a rejection.
+      const filesystem = new MemoryFilesystem();
+      await filesystem.mkdirp(dataPath);
+      const runner = new ScriptedProcessRunner([
+        { match: { command: "xcrun", args: ["simctl", "boot", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", slim18_5.udid, "-b"] } },
+        {
+          match: listDevicesInvocation,
+          result: { code: 0, stderr: "", stdout: deviceListResponse("Booted") },
+        },
+        {
+          match: {
+            args: ["simctl", "spawn", slim18_5.udid, "/bin/sh", "-c", slimScript(widgetsLabels)],
+            command: "xcrun",
+          },
+        },
+        {
+          match: { command: "xcrun", args: ["simctl", "shutdown", slim18_5.udid] },
+          result: { code: 1, stderr: "unexpected shutdown failure", stdout: "" },
+        },
+      ]);
+      const onSlimmed = vi.fn();
+      const onSlimSkipped = vi.fn();
+      const driver = createSlimDriver(runner, filesystem, slimOptions(), onSlimmed, onSlimSkipped);
+
+      const result = await driver.makeReady({
+        address: slim18_5.udid,
+        deviceId: slim18_5.udid,
+        driverData: slim18_5,
+      });
+
+      expect(result).toEqual({
+        address: slim18_5.udid,
+        deviceId: slim18_5.udid,
+        driverData: slim18_5,
+        featureProfile: "full",
+      });
+      // No second boot was ever attempted -- the shutdown that would have preceded it failed.
+      expect(runner.calls.map((call) => call.args)).toEqual([
+        ["simctl", "boot", slim18_5.udid],
+        ["simctl", "bootstatus", slim18_5.udid, "-b"],
+        ["simctl", "list", "-j", "devices"],
+        ["simctl", "spawn", slim18_5.udid, "/bin/sh", "-c", slimScript(widgetsLabels)],
+        ["simctl", "shutdown", slim18_5.udid],
+      ]);
+      expect(onSlimmed).not.toHaveBeenCalled();
+      expect(onSlimSkipped).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: slim18_5.udid, reason: "apply-failed" }),
+      );
+    });
+
+    it("still fails the lease when the shutdown succeeds but the second boot doesn't -- the device really is left shut down (finding #3, issue #87 review)", async () => {
+      // Unlike the shutdown-failure case above, the device here genuinely is no longer running
+      // once `#shutdown` succeeds -- returning it as "ready" from a skip path would be a lie.
+      // This must still raise like any other boot failure.
+      const filesystem = new MemoryFilesystem();
+      await filesystem.mkdirp(dataPath);
+      const runner = new ScriptedProcessRunner([
+        { match: { command: "xcrun", args: ["simctl", "boot", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", slim18_5.udid, "-b"] } },
+        {
+          match: listDevicesInvocation,
+          result: { code: 0, stderr: "", stdout: deviceListResponse("Booted") },
+        },
+        {
+          match: {
+            args: ["simctl", "spawn", slim18_5.udid, "/bin/sh", "-c", slimScript(widgetsLabels)],
+            command: "xcrun",
+          },
+        },
+        { match: { command: "xcrun", args: ["simctl", "shutdown", slim18_5.udid] } },
+        {
+          match: { command: "xcrun", args: ["simctl", "boot", slim18_5.udid] },
+          result: { code: 1, stderr: "current state: Shutting Down", stdout: "" },
+        },
+      ]);
+      const onSlimmed = vi.fn();
+      const onSlimSkipped = vi.fn();
+      const driver = createSlimDriver(runner, filesystem, slimOptions(), onSlimmed, onSlimSkipped);
+
+      await expect(
+        driver.makeReady({
+          address: slim18_5.udid,
+          deviceId: slim18_5.udid,
+          driverData: slim18_5,
+        }),
+      ).rejects.toEqual(
+        expect.objectContaining({ message: expect.stringContaining("Shutting Down") }),
+      );
+      expect(onSlimmed).not.toHaveBeenCalled();
       expect(onSlimSkipped).not.toHaveBeenCalled();
     });
 
@@ -1603,7 +1705,14 @@ describe("IosSimctlDriver", () => {
       expect(onSlimmed).toHaveBeenCalledTimes(1);
     });
 
-    it("reports a failed launchd label without failing the boot, and still marks slimmed", async () => {
+    it("reports a failed launchd label as a partial apply: reboots but never marks slimmed (finding #2, issue #87 review)", async () => {
+      // A single label the script itself reports as failed (`simlock-slim-failed`) is enough to
+      // make this a *partial* apply, even though the chunk that carried it ran successfully.
+      // Writing the idempotence marker here would permanently mark the device "slim" with a
+      // launchd label never actually disabled -- see the comment on `#applySlimAndReboot`'s
+      // `applyOutcome.failedLabels.length > 0` branch. The device still reboots (the labels that
+      // did apply are worth keeping), but `driverData` must come back unchanged so the next
+      // `makeReady` retries the whole label set.
       const filesystem = new MemoryFilesystem();
       await filesystem.mkdirp(dataPath);
       const runner = new ScriptedProcessRunner([
@@ -1629,7 +1738,8 @@ describe("IosSimctlDriver", () => {
         { match: { command: "xcrun", args: ["simctl", "bootstatus", slim18_5.udid, "-b"] } },
       ]);
       const onSlimmed = vi.fn();
-      const driver = createSlimDriver(runner, filesystem, slimOptions(), onSlimmed);
+      const onSlimSkipped = vi.fn();
+      const driver = createSlimDriver(runner, filesystem, slimOptions(), onSlimmed, onSlimSkipped);
 
       const result = await driver.makeReady({
         address: slim18_5.udid,
@@ -1637,9 +1747,126 @@ describe("IosSimctlDriver", () => {
         driverData: slim18_5,
       });
 
-      expect(result.driverData).toEqual({ ...slim18_5, slimSignature: widgetsSignature });
-      expect(onSlimmed).toHaveBeenCalledWith(
-        expect.objectContaining({ unknownLabels: ["com.apple.chronod"] }),
+      expect(result).toEqual({
+        address: slim18_5.udid,
+        deviceId: slim18_5.udid,
+        driverData: slim18_5,
+        featureProfile: "full",
+      });
+      expect(runner.calls.map((call) => call.args)).toEqual([
+        ["simctl", "boot", slim18_5.udid],
+        ["simctl", "bootstatus", slim18_5.udid, "-b"],
+        ["simctl", "list", "-j", "devices"],
+        ["simctl", "spawn", slim18_5.udid, "/bin/sh", "-c", slimScript(widgetsLabels)],
+        ["simctl", "shutdown", slim18_5.udid],
+        ["simctl", "boot", slim18_5.udid],
+        ["simctl", "bootstatus", slim18_5.udid, "-b"],
+      ]);
+      expect(onSlimmed).not.toHaveBeenCalled();
+      expect(onSlimSkipped).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: slim18_5.udid, reason: "apply-failed" }),
+      );
+    });
+
+    it("4 chunks, one times out: reboots, writes no marker, and a later boot re-applies (finding #2, issue #87 review)", async () => {
+      // The full, unfiltered label set (~170 labels, per the SLIM_CHUNK_SIZE=50 comment in
+      // index.ts) chunks into 4 `simctl spawn` calls. If the last one times out under load, the
+      // other 3 chunks still ran -- `#applySlimLabels` reports the whole apply as "applied"
+      // (`anyChunkSucceeded`), but with the timed-out chunk's labels folded into `failedLabels`.
+      // That must NOT be enough to write the idempotence marker: the device reboots (the labels
+      // that did apply are worth keeping), but comes back exactly as it went in, so the very
+      // next `makeReady` sees no stored `slimSignature` and re-applies the whole set again.
+      const allLabels = labelsFor(resolveSlimCategories(undefined).categories);
+      const chunkSize = 50;
+      const chunks = [
+        allLabels.slice(0, chunkSize),
+        allLabels.slice(chunkSize, chunkSize * 2),
+        allLabels.slice(chunkSize * 2, chunkSize * 3),
+        allLabels.slice(chunkSize * 3),
+      ].filter((labelChunk) => labelChunk.length > 0);
+      expect(chunks).toHaveLength(4);
+      const lastChunk = chunks[3];
+      if (lastChunk === undefined) {
+        throw new Error("expected a 4th chunk");
+      }
+
+      const filesystem = new MemoryFilesystem();
+      await filesystem.mkdirp(dataPath);
+      const clock = new FakeClock();
+      const runner = new ScriptedProcessRunner([
+        { match: { command: "xcrun", args: ["simctl", "boot", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", slim18_5.udid, "-b"] } },
+        {
+          match: listDevicesInvocation,
+          result: { code: 0, stderr: "", stdout: deviceListResponse("Booted") },
+        },
+        ...chunks.slice(0, 3).map((labelChunk) => ({
+          match: {
+            args: ["simctl", "spawn", slim18_5.udid, "/bin/sh", "-c", slimScript(labelChunk)],
+            command: "xcrun",
+          },
+        })),
+        {
+          hangs: true,
+          match: {
+            args: ["simctl", "spawn", slim18_5.udid, "/bin/sh", "-c", slimScript(lastChunk)],
+            command: "xcrun",
+          },
+        },
+        { match: { command: "xcrun", args: ["simctl", "shutdown", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "boot", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", slim18_5.udid, "-b"] } },
+      ]);
+      const onSlimmed = vi.fn();
+      const onSlimSkipped = vi.fn();
+      const driver = new IosSimctlDriver({
+        clock,
+        filesystem,
+        idGenerator: { generate: () => "device-1" },
+        onSlimSkipped,
+        onSlimmed,
+        processRunner: runner,
+        // No `categories` filter -- every category's labels, chunked the same way a real,
+        // unfiltered slim run would be.
+        slim: { bootTimeoutMs: 300_000, enabled: true },
+      });
+
+      const ready = driver.makeReady({
+        address: slim18_5.udid,
+        deviceId: slim18_5.udid,
+        driverData: slim18_5,
+      });
+
+      while (runner.calls.length < 7) {
+        await Promise.resolve();
+      }
+      clock.advance(60_000); // SLIM_CHUNK_TIMEOUT_MS
+
+      const result = await ready;
+
+      expect(result).toEqual({
+        address: slim18_5.udid,
+        deviceId: slim18_5.udid,
+        // Unchanged: no `slimSignature`/`slimMarkToken` written, so the next `makeReady` will
+        // find `#checkAlreadySlimmed` false and re-apply the whole set.
+        driverData: slim18_5,
+        featureProfile: "full",
+      });
+      expect(runner.calls.map((call) => call.args)).toEqual([
+        ["simctl", "boot", slim18_5.udid],
+        ["simctl", "bootstatus", slim18_5.udid, "-b"],
+        ["simctl", "list", "-j", "devices"],
+        ["simctl", "spawn", slim18_5.udid, "/bin/sh", "-c", slimScript(chunks[0] ?? [])],
+        ["simctl", "spawn", slim18_5.udid, "/bin/sh", "-c", slimScript(chunks[1] ?? [])],
+        ["simctl", "spawn", slim18_5.udid, "/bin/sh", "-c", slimScript(chunks[2] ?? [])],
+        ["simctl", "spawn", slim18_5.udid, "/bin/sh", "-c", slimScript(lastChunk)],
+        ["simctl", "shutdown", slim18_5.udid],
+        ["simctl", "boot", slim18_5.udid],
+        ["simctl", "bootstatus", slim18_5.udid, "-b"],
+      ]);
+      expect(onSlimmed).not.toHaveBeenCalled();
+      expect(onSlimSkipped).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: slim18_5.udid, reason: "apply-failed" }),
       );
     });
 
@@ -1723,6 +1950,51 @@ describe("IosSimctlDriver", () => {
       expect(onSlimSkipped).not.toHaveBeenCalled();
     });
 
+    it("a purpose: 'recover' boot never applies slim, even on a device that would otherwise qualify (finding #1, issue #87 review)", async () => {
+      // `slim18_5` (not `full`, an 18.5+ runtime) is exactly the shape of device
+      // "boots, applies the disable list, and reboots on a qualifying, not-yet-slimmed device"
+      // (above) slims -- the only difference here is `{ purpose: "recover" }`, standing in for
+      // `ManagedDeviceLifecycle.recoverLeased`'s call on a crashed, still-*leased* device. Safety
+      // rule 2's exception may only reboot; a slim pass here (a second, unannounced reboot plus
+      // a launchctl-disable pass) would be exactly the broader privilege the rule withholds. So
+      // this must produce a single ordinary boot: no `simctl list`, no `simctl spawn`, no second
+      // shutdown/boot, and no `device.slimmed` fact.
+      const filesystem = new MemoryFilesystem();
+      await filesystem.mkdirp(dataPath);
+      const runner = new ScriptedProcessRunner([
+        { match: { command: "xcrun", args: ["simctl", "boot", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", slim18_5.udid, "-b"] } },
+      ]);
+      const onSlimmed = vi.fn();
+      const onSlimSkipped = vi.fn();
+      const driver = createSlimDriver(runner, filesystem, slimOptions(), onSlimmed, onSlimSkipped);
+
+      const result = await driver.makeReady(
+        {
+          address: slim18_5.udid,
+          deviceId: slim18_5.udid,
+          driverData: slim18_5,
+        },
+        { purpose: "recover" },
+      );
+
+      expect(result).toEqual({
+        address: slim18_5.udid,
+        deviceId: slim18_5.udid,
+        driverData: slim18_5,
+        featureProfile: "full",
+      });
+      expect(runner.calls.map((call) => call.args)).toEqual([
+        ["simctl", "boot", slim18_5.udid],
+        ["simctl", "bootstatus", slim18_5.udid, "-b"],
+      ]);
+      // The ordinary, un-widened boot deadline -- not `slim.bootTimeoutMs` -- since this boot
+      // never considers applying anything.
+      expect(runner.calls[1]?.options).toEqual({ timeoutMs: 120_000 });
+      expect(onSlimmed).not.toHaveBeenCalled();
+      expect(onSlimSkipped).not.toHaveBeenCalled();
+    });
+
     it("loads driverData that predates the slim fields without throwing (backwards compatibility)", async () => {
       const runner = new ScriptedProcessRunner([
         { match: { command: "xcrun", args: ["simctl", "boot", driverData.udid] } },
@@ -1741,10 +2013,10 @@ describe("IosSimctlDriver", () => {
           driverData,
         }),
       ).resolves.toEqual({
+        // No `featureProfile`: slim mode is off here too.
         address: driverData.udid,
         deviceId: driverData.udid,
         driverData,
-        featureProfile: "full",
       });
     });
 
@@ -1808,6 +2080,18 @@ describe("IosSimctlDriver", () => {
       expect(driver.estimate({ operation: "boot" }, spec)).toBe(150_000);
     });
 
+    it("quotes the plain cold-boot cost for a full spec even when slim is on, since a full spec never slims (finding #4, issue #87 review)", () => {
+      const driver = new IosSimctlDriver({
+        clock: new FakeClock(),
+        filesystem: new MemoryFilesystem(),
+        idGenerator: { generate: () => "device-1" },
+        processRunner: new ScriptedProcessRunner([]),
+        slim: slimOptions(),
+      });
+
+      expect(driver.estimate({ operation: "boot" }, { ...spec, full: true })).toBe(60_000);
+    });
+
     describe("advisories()", () => {
       it("reports slim-runtime-unsupported when an installed runtime predates 18.5", async () => {
         const driver = createSlimDriver(
@@ -1844,6 +2128,41 @@ describe("IosSimctlDriver", () => {
         const driver = createDriver(scriptedListRunner());
 
         await expect(driver.advisories()).resolves.toEqual([]);
+      });
+
+      it("reports an installed runtime with an unparseable identifier as unsupported, even though its marketing version looks modern (finding #5, issue #87 review)", async () => {
+        // The marketing `version` string here ("26.5") would pass the persistent-slim floor if
+        // `advisories()` still parsed it directly -- but this fixture's `identifier` doesn't
+        // match `iosRuntimeVersionFromId`'s pattern, and `planSlimBoot` (the boot-time decision)
+        // only ever reads the identifier. `advisories()` must reuse that same call so the two
+        // can never disagree about whether this runtime actually gets slimmed.
+        const devicetypes = (JSON.parse(listFixture) as { devicetypes: unknown }).devicetypes;
+        const weirdIdentifierFixture = JSON.stringify({
+          devicetypes,
+          runtimes: [
+            {
+              identifier: "com.apple.CoreSimulator.SimRuntime.iOS-not-a-version",
+              isAvailable: true,
+              name: "iOS 26.5",
+              supportedDeviceTypes: [],
+              version: "26.5",
+            },
+          ],
+        });
+        const runner = new ScriptedProcessRunner([
+          {
+            match: listInvocation,
+            result: { code: 0, stderr: "", stdout: weirdIdentifierFixture },
+          },
+        ]);
+        const driver = createSlimDriver(runner, new MemoryFilesystem(), slimOptions());
+
+        await expect(driver.advisories()).resolves.toEqual([
+          {
+            code: "slim-runtime-unsupported",
+            message: expect.stringContaining("26.5"),
+          },
+        ]);
       });
 
       it("reports nothing when slim is configured but disabled", async () => {

--- a/src/drivers/ios/index.test.ts
+++ b/src/drivers/ios/index.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   BootTimeoutError,
@@ -20,7 +20,14 @@ import {
   type Filesystem,
 } from "../../ports/index.js";
 import type { ComponentInstallDiagnostic } from "../diagnostics.js";
-import { IosSimctlDriver } from "./index.js";
+import {
+  IosSimctlDriver,
+  iosRuntimeVersionFromId,
+  sanitizeSlimLabels,
+  supportsPersistentSlim,
+  type SlimmedFact,
+  type SlimSkippedFact,
+} from "./index.js";
 
 const listFixture = readFileSync(new URL("./fixtures/simctl-list.json", import.meta.url), "utf8");
 const listDevicesFixture = readFileSync(
@@ -768,6 +775,45 @@ describe("IosSimctlDriver", () => {
     ]);
   });
 
+  it("stamps full: true into driver data for a --full request, omitted otherwise", async () => {
+    const runner = new ScriptedProcessRunner([
+      {
+        match: listInvocation,
+        result: { code: 0, stderr: "", stdout: listFixture },
+      },
+      {
+        match: {
+          command: "xcrun",
+          args: [
+            "simctl",
+            "create",
+            "simlock-device-1",
+            driverData.deviceTypeId,
+            driverData.runtimeId,
+          ],
+        },
+        result: { code: 0, stderr: "", stdout: `${driverData.udid}\n` },
+      },
+      {
+        match: listDevicesInvocation,
+        result: { code: 0, stderr: "", stdout: deviceListResponse("Shutdown") },
+      },
+    ]);
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp(dataPath);
+    const driver = createDriver(runner, new FakeClock(), filesystem);
+    await driver.resolveSpec(
+      { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      { allowDownload: false },
+    );
+
+    await expect(driver.provision({ ...spec, full: true })).resolves.toEqual({
+      address: driverData.udid,
+      deviceId: driverData.udid,
+      driverData: { ...driverData, full: true },
+    });
+  });
+
   it("surfaces simctl failures with stderr", async () => {
     const runner = new ScriptedProcessRunner([
       {
@@ -814,7 +860,12 @@ describe("IosSimctlDriver", () => {
         deviceId: driverData.udid,
         driverData,
       }),
-    ).resolves.toEqual({ address: driverData.udid, deviceId: driverData.udid, driverData });
+    ).resolves.toEqual({
+      address: driverData.udid,
+      deviceId: driverData.udid,
+      driverData,
+      featureProfile: "full",
+    });
     expect(runner.calls).toEqual([
       {
         args: ["simctl", "boot", driverData.udid],
@@ -1163,6 +1214,600 @@ describe("IosSimctlDriver", () => {
     },
     150_000,
   );
+
+  describe("slim mode", () => {
+    const widgetsLabels = [
+      "com.apple.PosterBoard",
+      "com.apple.chronod",
+      "com.apple.liveactivitiesd",
+    ];
+    const widgetsSignature = "v1:1ea7bd351e05525c";
+    const searchSignature = "v1:7587bb9b67a41b64";
+    const slim18_5 = { ...driverData, runtimeId: "com.apple.CoreSimulator.SimRuntime.iOS-18-5" };
+    const slim18_4 = { ...driverData, runtimeId: "com.apple.CoreSimulator.SimRuntime.iOS-18-4" };
+    const slim17_5 = { ...driverData, runtimeId: "com.apple.CoreSimulator.SimRuntime.iOS-17-5" };
+    const slim26_0 = { ...driverData, runtimeId: "com.apple.CoreSimulator.SimRuntime.iOS-26-0" };
+    const slimGarbageRuntime = { ...driverData, runtimeId: "not-a-runtime-id" };
+
+    function slimOptions(bootTimeoutMs = 300_000) {
+      return { bootTimeoutMs, categories: ["widgets"], enabled: true } as const;
+    }
+
+    it("parses simctl runtime ids into [major, minor], including edge cases", () => {
+      expect(iosRuntimeVersionFromId("com.apple.CoreSimulator.SimRuntime.iOS-18-5")).toEqual([
+        18, 5,
+      ]);
+      expect(iosRuntimeVersionFromId("com.apple.CoreSimulator.SimRuntime.iOS-26-0")).toEqual([
+        26, 0,
+      ]);
+      expect(iosRuntimeVersionFromId("com.apple.CoreSimulator.SimRuntime.iOS-18")).toEqual([18, 0]);
+      expect(iosRuntimeVersionFromId("com.apple.CoreSimulator.SimRuntime.iOS-18-5-1")).toEqual([
+        18, 5,
+      ]);
+      expect(iosRuntimeVersionFromId("")).toBeUndefined();
+      expect(iosRuntimeVersionFromId("garbage")).toBeUndefined();
+    });
+
+    it("gates persistent slim on iOS 18.5+ without falling into string comparison", () => {
+      // A naive string/lexicographic compare would put "9.0" ahead of "18.5" -- the gate must
+      // compare the parsed integers instead.
+      expect(supportsPersistentSlim([18, 5])).toBe(true);
+      expect(supportsPersistentSlim([26, 0])).toBe(true);
+      expect(supportsPersistentSlim([9, 0])).toBe(false);
+      expect(supportsPersistentSlim([18, 4])).toBe(false);
+      expect(supportsPersistentSlim(undefined)).toBe(false);
+    });
+
+    it("filters a label that could break out of the generated shell script", () => {
+      expect(
+        sanitizeSlimLabels(["com.apple.good", "system; rm -rf /", 'com.apple."quoted"']),
+      ).toEqual({
+        rejected: ["system; rm -rf /", 'com.apple."quoted"'],
+        safe: ["com.apple.good"],
+      });
+    });
+
+    it("leaves the command sequence unchanged when the slim option is omitted (regression guard)", async () => {
+      const runner = new ScriptedProcessRunner([
+        { match: { command: "xcrun", args: ["simctl", "boot", driverData.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", driverData.udid, "-b"] } },
+      ]);
+      const onSlimmed = vi.fn();
+
+      await expect(
+        createDriver(runner).makeReady({
+          address: driverData.udid,
+          deviceId: driverData.udid,
+          driverData,
+        }),
+      ).resolves.toEqual({
+        address: driverData.udid,
+        deviceId: driverData.udid,
+        driverData,
+        featureProfile: "full",
+      });
+      expect(runner.calls.map((call) => call.args)).toEqual([
+        ["simctl", "boot", driverData.udid],
+        ["simctl", "bootstatus", driverData.udid, "-b"],
+      ]);
+      expect(onSlimmed).not.toHaveBeenCalled();
+    });
+
+    it("boots, applies the disable list, and reboots on a qualifying, not-yet-slimmed device", async () => {
+      const filesystem = new MemoryFilesystem();
+      await filesystem.mkdirp(dataPath);
+      const runner = new ScriptedProcessRunner([
+        { match: { command: "xcrun", args: ["simctl", "boot", slim18_5.udid] } },
+        {
+          match: { command: "xcrun", args: ["simctl", "bootstatus", slim18_5.udid, "-b"] },
+        },
+        {
+          match: listDevicesInvocation,
+          result: { code: 0, stderr: "", stdout: deviceListResponse("Booted") },
+        },
+        {
+          match: {
+            args: ["simctl", "spawn", slim18_5.udid, "/bin/sh", "-c", slimScript(widgetsLabels)],
+            command: "xcrun",
+          },
+        },
+        { match: { command: "xcrun", args: ["simctl", "shutdown", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "boot", slim18_5.udid] } },
+        {
+          match: { command: "xcrun", args: ["simctl", "bootstatus", slim18_5.udid, "-b"] },
+        },
+      ]);
+      const onSlimmed = vi.fn();
+      const onSlimSkipped = vi.fn();
+      const driver = createSlimDriver(runner, filesystem, slimOptions(), onSlimmed, onSlimSkipped);
+
+      const result = await driver.makeReady({
+        address: slim18_5.udid,
+        deviceId: slim18_5.udid,
+        driverData: slim18_5,
+      });
+
+      expect(result).toEqual({
+        address: slim18_5.udid,
+        deviceId: slim18_5.udid,
+        driverData: { ...slim18_5, slimSignature: widgetsSignature },
+        featureProfile: "reduced",
+      });
+      expect(runner.calls.map((call) => call.args)).toEqual([
+        ["simctl", "boot", slim18_5.udid],
+        ["simctl", "bootstatus", slim18_5.udid, "-b"],
+        ["simctl", "list", "-j", "devices"],
+        ["simctl", "spawn", slim18_5.udid, "/bin/sh", "-c", slimScript(widgetsLabels)],
+        ["simctl", "shutdown", slim18_5.udid],
+        ["simctl", "boot", slim18_5.udid],
+        ["simctl", "bootstatus", slim18_5.udid, "-b"],
+      ]);
+      // Both boots use the widened slim deadline, not the default 120s.
+      expect(runner.calls[1]?.options).toEqual({ timeoutMs: 300_000 });
+      expect(runner.calls[6]?.options).toEqual({ timeoutMs: 300_000 });
+      expect(onSlimmed).toHaveBeenCalledTimes(1);
+      expect(onSlimmed).toHaveBeenCalledWith({
+        address: slim18_5.udid,
+        categories: ["widgets"],
+        deviceId: slim18_5.udid,
+        durationMs: expect.any(Number),
+        labelCount: 3,
+        signature: widgetsSignature,
+        unknownLabels: [],
+      });
+      expect(onSlimSkipped).not.toHaveBeenCalled();
+    });
+
+    it("is idempotent: same signature and mark token skip the whole slim step (single boot)", async () => {
+      const filesystem = new MemoryFilesystem();
+      await filesystem.mkdirp(dataPath);
+      await filesystem.writeFileAtomic(erasableMarkPath, JSON.stringify({ token: "tok-1" }));
+      const slimmedData = {
+        ...slim18_5,
+        slimMarkToken: "tok-1",
+        slimSignature: widgetsSignature,
+      };
+      const runner = new ScriptedProcessRunner([
+        { match: { command: "xcrun", args: ["simctl", "boot", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", slim18_5.udid, "-b"] } },
+        {
+          match: listDevicesInvocation,
+          result: { code: 0, stderr: "", stdout: deviceListResponse("Booted") },
+        },
+      ]);
+      const onSlimmed = vi.fn();
+      const driver = createSlimDriver(runner, filesystem, slimOptions(), onSlimmed);
+
+      const result = await driver.makeReady({
+        address: slim18_5.udid,
+        deviceId: slim18_5.udid,
+        driverData: slimmedData,
+      });
+
+      expect(result).toEqual({
+        address: slim18_5.udid,
+        deviceId: slim18_5.udid,
+        driverData: slimmedData,
+        featureProfile: "reduced",
+      });
+      expect(runner.calls.map((call) => call.args)).toEqual([
+        ["simctl", "boot", slim18_5.udid],
+        ["simctl", "bootstatus", slim18_5.udid, "-b"],
+        ["simctl", "list", "-j", "devices"],
+      ]);
+      expect(onSlimmed).not.toHaveBeenCalled();
+    });
+
+    it("re-slims when the mark token differs (device was erased since it was last slimmed)", async () => {
+      const filesystem = new MemoryFilesystem();
+      await filesystem.mkdirp(dataPath);
+      await filesystem.writeFileAtomic(erasableMarkPath, JSON.stringify({ token: "tok-fresh" }));
+      const staleData = {
+        ...slim18_5,
+        slimMarkToken: "tok-stale",
+        slimSignature: widgetsSignature,
+      };
+      const runner = new ScriptedProcessRunner([
+        { match: { command: "xcrun", args: ["simctl", "boot", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", slim18_5.udid, "-b"] } },
+        {
+          match: listDevicesInvocation,
+          result: { code: 0, stderr: "", stdout: deviceListResponse("Booted") },
+        },
+        {
+          match: {
+            args: ["simctl", "spawn", slim18_5.udid, "/bin/sh", "-c", slimScript(widgetsLabels)],
+            command: "xcrun",
+          },
+        },
+        { match: { command: "xcrun", args: ["simctl", "shutdown", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "boot", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", slim18_5.udid, "-b"] } },
+      ]);
+      const onSlimmed = vi.fn();
+      const driver = createSlimDriver(runner, filesystem, slimOptions(), onSlimmed);
+
+      const result = await driver.makeReady({
+        address: slim18_5.udid,
+        deviceId: slim18_5.udid,
+        driverData: staleData,
+      });
+
+      expect(result.driverData).toEqual({
+        ...slim18_5,
+        slimMarkToken: "tok-fresh",
+        slimSignature: widgetsSignature,
+      });
+      expect(onSlimmed).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-slims when the stored signature came from a different category selection", async () => {
+      const filesystem = new MemoryFilesystem();
+      await filesystem.mkdirp(dataPath);
+      await filesystem.writeFileAtomic(erasableMarkPath, JSON.stringify({ token: "tok-1" }));
+      const driftedData = {
+        ...slim18_5,
+        slimMarkToken: "tok-1",
+        slimSignature: searchSignature,
+      };
+      const runner = new ScriptedProcessRunner([
+        { match: { command: "xcrun", args: ["simctl", "boot", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", slim18_5.udid, "-b"] } },
+        {
+          match: listDevicesInvocation,
+          result: { code: 0, stderr: "", stdout: deviceListResponse("Booted") },
+        },
+        {
+          match: {
+            args: ["simctl", "spawn", slim18_5.udid, "/bin/sh", "-c", slimScript(widgetsLabels)],
+            command: "xcrun",
+          },
+        },
+        { match: { command: "xcrun", args: ["simctl", "shutdown", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "boot", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", slim18_5.udid, "-b"] } },
+      ]);
+      const onSlimmed = vi.fn();
+      const driver = createSlimDriver(runner, filesystem, slimOptions(), onSlimmed);
+
+      await driver.makeReady({
+        address: slim18_5.udid,
+        deviceId: slim18_5.udid,
+        driverData: driftedData,
+      });
+
+      expect(onSlimmed).toHaveBeenCalledTimes(1);
+      expect(onSlimmed).toHaveBeenCalledWith(
+        expect.objectContaining({ signature: widgetsSignature }),
+      );
+    });
+
+    it("skips slim with reason runtime-too-old on iOS 18.4 (single boot, no spawns)", async () => {
+      const runner = new ScriptedProcessRunner([
+        { match: { command: "xcrun", args: ["simctl", "boot", slim18_4.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", slim18_4.udid, "-b"] } },
+      ]);
+      const onSlimSkipped = vi.fn();
+      const driver = createSlimDriver(
+        runner,
+        new MemoryFilesystem(),
+        slimOptions(),
+        undefined,
+        onSlimSkipped,
+      );
+
+      const result = await driver.makeReady({
+        address: slim18_4.udid,
+        deviceId: slim18_4.udid,
+        driverData: slim18_4,
+      });
+
+      expect(result).toEqual({
+        address: slim18_4.udid,
+        deviceId: slim18_4.udid,
+        driverData: slim18_4,
+        featureProfile: "full",
+      });
+      expect(runner.calls).toHaveLength(2);
+      expect(onSlimSkipped).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: slim18_4.udid, reason: "runtime-too-old" }),
+      );
+      // Off (or gate-failed) uses the ordinary 120s bootstatus deadline, not the slim one.
+      expect(runner.calls[1]?.options).toEqual({ timeoutMs: 120_000 });
+    });
+
+    it("skips slim with reason runtime-too-old on iOS 17.5", async () => {
+      const runner = new ScriptedProcessRunner([
+        { match: { command: "xcrun", args: ["simctl", "boot", slim17_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", slim17_5.udid, "-b"] } },
+      ]);
+      const onSlimSkipped = vi.fn();
+      const driver = createSlimDriver(
+        runner,
+        new MemoryFilesystem(),
+        slimOptions(),
+        undefined,
+        onSlimSkipped,
+      );
+
+      await driver.makeReady({
+        address: slim17_5.udid,
+        deviceId: slim17_5.udid,
+        driverData: slim17_5,
+      });
+
+      expect(onSlimSkipped).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: "runtime-too-old" }),
+      );
+    });
+
+    it("skips slim with reason unknown-runtime on an unparseable runtimeId", async () => {
+      const runner = new ScriptedProcessRunner([
+        { match: { command: "xcrun", args: ["simctl", "boot", slimGarbageRuntime.udid] } },
+        {
+          match: {
+            command: "xcrun",
+            args: ["simctl", "bootstatus", slimGarbageRuntime.udid, "-b"],
+          },
+        },
+      ]);
+      const onSlimSkipped = vi.fn();
+      const driver = createSlimDriver(
+        runner,
+        new MemoryFilesystem(),
+        slimOptions(),
+        undefined,
+        onSlimSkipped,
+      );
+
+      await driver.makeReady({
+        address: slimGarbageRuntime.udid,
+        deviceId: slimGarbageRuntime.udid,
+        driverData: slimGarbageRuntime,
+      });
+
+      expect(onSlimSkipped).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: "unknown-runtime" }),
+      );
+    });
+
+    it("slims iOS 26.0 (version comparison must not be string-lexicographic)", async () => {
+      const filesystem = new MemoryFilesystem();
+      await filesystem.mkdirp(dataPath);
+      const runner = new ScriptedProcessRunner([
+        { match: { command: "xcrun", args: ["simctl", "boot", slim26_0.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", slim26_0.udid, "-b"] } },
+        {
+          match: listDevicesInvocation,
+          result: { code: 0, stderr: "", stdout: deviceListResponse("Booted") },
+        },
+        {
+          match: {
+            args: ["simctl", "spawn", slim26_0.udid, "/bin/sh", "-c", slimScript(widgetsLabels)],
+            command: "xcrun",
+          },
+        },
+        { match: { command: "xcrun", args: ["simctl", "shutdown", slim26_0.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "boot", slim26_0.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", slim26_0.udid, "-b"] } },
+      ]);
+      const onSlimmed = vi.fn();
+      const driver = createSlimDriver(runner, filesystem, slimOptions(), onSlimmed);
+
+      await driver.makeReady({
+        address: slim26_0.udid,
+        deviceId: slim26_0.udid,
+        driverData: slim26_0,
+      });
+
+      expect(onSlimmed).toHaveBeenCalledTimes(1);
+    });
+
+    it("reports a failed launchd label without failing the boot, and still marks slimmed", async () => {
+      const filesystem = new MemoryFilesystem();
+      await filesystem.mkdirp(dataPath);
+      const runner = new ScriptedProcessRunner([
+        { match: { command: "xcrun", args: ["simctl", "boot", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", slim18_5.udid, "-b"] } },
+        {
+          match: listDevicesInvocation,
+          result: { code: 0, stderr: "", stdout: deviceListResponse("Booted") },
+        },
+        {
+          match: {
+            args: ["simctl", "spawn", slim18_5.udid, "/bin/sh", "-c", slimScript(widgetsLabels)],
+            command: "xcrun",
+          },
+          result: {
+            code: 0,
+            stderr: "",
+            stdout: "simlock-slim-failed com.apple.chronod\n",
+          },
+        },
+        { match: { command: "xcrun", args: ["simctl", "shutdown", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "boot", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", slim18_5.udid, "-b"] } },
+      ]);
+      const onSlimmed = vi.fn();
+      const driver = createSlimDriver(runner, filesystem, slimOptions(), onSlimmed);
+
+      const result = await driver.makeReady({
+        address: slim18_5.udid,
+        deviceId: slim18_5.udid,
+        driverData: slim18_5,
+      });
+
+      expect(result.driverData).toEqual({ ...slim18_5, slimSignature: widgetsSignature });
+      expect(onSlimmed).toHaveBeenCalledWith(
+        expect.objectContaining({ unknownLabels: ["com.apple.chronod"] }),
+      );
+    });
+
+    it("treats a total apply failure as a skip: single boot, no reboot, no marker, no event", async () => {
+      const filesystem = new MemoryFilesystem();
+      await filesystem.mkdirp(dataPath);
+      const runner = new ScriptedProcessRunner([
+        { match: { command: "xcrun", args: ["simctl", "boot", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", slim18_5.udid, "-b"] } },
+        {
+          match: listDevicesInvocation,
+          result: { code: 0, stderr: "", stdout: deviceListResponse("Booted") },
+        },
+        {
+          match: {
+            args: ["simctl", "spawn", slim18_5.udid, "/bin/sh", "-c", slimScript(widgetsLabels)],
+            command: "xcrun",
+          },
+          result: { code: 1, stderr: "boom", stdout: "" },
+        },
+      ]);
+      const onSlimmed = vi.fn();
+      const onSlimSkipped = vi.fn();
+      const driver = createSlimDriver(runner, filesystem, slimOptions(), onSlimmed, onSlimSkipped);
+
+      const result = await driver.makeReady({
+        address: slim18_5.udid,
+        deviceId: slim18_5.udid,
+        driverData: slim18_5,
+      });
+
+      expect(result).toEqual({
+        address: slim18_5.udid,
+        deviceId: slim18_5.udid,
+        driverData: slim18_5,
+        featureProfile: "full",
+      });
+      expect(runner.calls.map((call) => call.args)).toEqual([
+        ["simctl", "boot", slim18_5.udid],
+        ["simctl", "bootstatus", slim18_5.udid, "-b"],
+        ["simctl", "list", "-j", "devices"],
+        ["simctl", "spawn", slim18_5.udid, "/bin/sh", "-c", slimScript(widgetsLabels)],
+      ]);
+      expect(onSlimmed).not.toHaveBeenCalled();
+      expect(onSlimSkipped).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: slim18_5.udid, reason: "apply-failed" }),
+      );
+    });
+
+    it("never slims a device marked full:true, even when it otherwise qualifies", async () => {
+      const fullData = { ...slim18_5, full: true };
+      const runner = new ScriptedProcessRunner([
+        { match: { command: "xcrun", args: ["simctl", "boot", fullData.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", fullData.udid, "-b"] } },
+      ]);
+      const onSlimmed = vi.fn();
+      const onSlimSkipped = vi.fn();
+      const driver = createSlimDriver(
+        runner,
+        new MemoryFilesystem(),
+        slimOptions(),
+        onSlimmed,
+        onSlimSkipped,
+      );
+
+      const result = await driver.makeReady({
+        address: fullData.udid,
+        deviceId: fullData.udid,
+        driverData: fullData,
+      });
+
+      expect(result).toEqual({
+        address: fullData.udid,
+        deviceId: fullData.udid,
+        driverData: fullData,
+        featureProfile: "full",
+      });
+      expect(runner.calls).toHaveLength(2);
+      expect(runner.calls[1]?.options).toEqual({ timeoutMs: 120_000 });
+      expect(onSlimmed).not.toHaveBeenCalled();
+      expect(onSlimSkipped).not.toHaveBeenCalled();
+    });
+
+    it("loads driverData that predates the slim fields without throwing (backwards compatibility)", async () => {
+      const runner = new ScriptedProcessRunner([
+        { match: { command: "xcrun", args: ["simctl", "boot", driverData.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", driverData.udid, "-b"] } },
+      ]);
+
+      // `driverData` has no `full`/`slimSignature`/`slimMarkToken` -- exactly what a `state.json`
+      // registry written before slim mode shipped looks like. Slim is off here, so this is just
+      // proving `iosDriverData` doesn't choke on the missing fields (a slim-on equivalent is
+      // covered by "boots, applies the disable list..." above, which starts from data with no
+      // prior slim markers either).
+      await expect(
+        createDriver(runner).makeReady({
+          address: driverData.udid,
+          deviceId: driverData.udid,
+          driverData,
+        }),
+      ).resolves.toEqual({
+        address: driverData.udid,
+        deviceId: driverData.udid,
+        driverData,
+        featureProfile: "full",
+      });
+    });
+
+    it("times out the post-slim bootstatus using slim.bootTimeoutMs, not the default 120s", async () => {
+      const filesystem = new MemoryFilesystem();
+      await filesystem.mkdirp(dataPath);
+      const clock = new FakeClock();
+      const runner = new ScriptedProcessRunner([
+        { match: { command: "xcrun", args: ["simctl", "boot", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", slim18_5.udid, "-b"] } },
+        {
+          match: listDevicesInvocation,
+          result: { code: 0, stderr: "", stdout: deviceListResponse("Booted") },
+        },
+        {
+          match: {
+            args: ["simctl", "spawn", slim18_5.udid, "/bin/sh", "-c", slimScript(widgetsLabels)],
+            command: "xcrun",
+          },
+        },
+        { match: { command: "xcrun", args: ["simctl", "shutdown", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "boot", slim18_5.udid] } },
+        {
+          hangs: true,
+          match: { command: "xcrun", args: ["simctl", "bootstatus", slim18_5.udid, "-b"] },
+        },
+        { match: { command: "xcrun", args: ["simctl", "shutdown", slim18_5.udid] } },
+      ]);
+      const driver = new IosSimctlDriver({
+        clock,
+        filesystem,
+        idGenerator: { generate: () => "device-1" },
+        processRunner: runner,
+        slim: slimOptions(),
+      });
+
+      const ready = driver.makeReady({
+        address: slim18_5.udid,
+        deviceId: slim18_5.udid,
+        driverData: slim18_5,
+      });
+
+      while (runner.calls.length < 7) {
+        await Promise.resolve();
+      }
+      clock.advance(300_000);
+
+      await expect(ready).rejects.toBeInstanceOf(BootTimeoutError);
+      expect(runner.calls[6]?.options).toEqual({ timeoutMs: 300_000 });
+    });
+
+    it("estimates the boot cost with the slim reboot+apply budget when slim is on", () => {
+      const driver = new IosSimctlDriver({
+        clock: new FakeClock(),
+        filesystem: new MemoryFilesystem(),
+        idGenerator: { generate: () => "device-1" },
+        processRunner: new ScriptedProcessRunner([]),
+        slim: slimOptions(),
+      });
+
+      expect(driver.estimate({ operation: "boot" }, spec)).toBe(150_000);
+    });
+  });
 });
 
 function createDriver(
@@ -1204,6 +1849,36 @@ function createTokenDriver(
     },
     processRunner: runner,
   });
+}
+
+function createSlimDriver(
+  runner: ScriptedProcessRunner,
+  filesystem: Filesystem,
+  slim: {
+    readonly enabled: boolean;
+    readonly categories?: readonly string[];
+    readonly bootTimeoutMs: number;
+  },
+  onSlimmed?: (fact: SlimmedFact) => void,
+  onSlimSkipped?: (fact: SlimSkippedFact) => void,
+): IosSimctlDriver {
+  return new IosSimctlDriver({
+    clock: new FakeClock(),
+    filesystem,
+    idGenerator: { generate: () => "device-1" },
+    ...(onSlimmed === undefined ? {} : { onSlimmed }),
+    ...(onSlimSkipped === undefined ? {} : { onSlimSkipped }),
+    processRunner: runner,
+    slim,
+  });
+}
+
+/** Mirrors `#applySlimLabels`'s generated script -- keeps test expectations in sync by construction. */
+function slimScript(labels: readonly string[]): string {
+  return (
+    `for l in ${labels.join(" ")}; do launchctl disable "system/$l" ` +
+    `>/dev/null 2>&1 || echo "simlock-slim-failed $l"; done`
+  );
 }
 
 function scriptedListRunner(): ScriptedProcessRunner {

--- a/src/drivers/ios/index.test.ts
+++ b/src/drivers/ios/index.test.ts
@@ -1362,12 +1362,18 @@ describe("IosSimctlDriver", () => {
       expect(onSlimSkipped).not.toHaveBeenCalled();
     });
 
-    it("downgrades a failed post-apply shutdown to a skip instead of failing the lease (finding #3, issue #87 review)", async () => {
-      // The apply itself succeeded and the device is still running from the first boot at the
-      // top of this test -- `#shutdown` failing here (a non-zero exit `simctl shutdown` doesn't
-      // recognize as "already shutdown") means nothing was actually rebooted, so the device is
-      // still a healthy, leaseable one. `makeReady`'s own contract ("a failed or skipped slim
-      // never fails the lease") must hold: this downgrades to the skip path, not a rejection.
+    it("downgrades a failed post-apply shutdown to a skip instead of failing the lease, but always reboots first (finding #3 / second-review finding #2, issue #87)", async () => {
+      // CHANGED EXPECTATIONS (second adversarial review, finding #2): the previous version of
+      // this test asserted that a failed `#shutdown` call meant "nothing was actually rebooted,
+      // so the device is still healthy" and stopped right there, returning the device as-is with
+      // `featureProfile: "full"`. That inference doesn't hold -- `#shutdown` fails on a
+      // *non-zero exit* the same way it fails on a *timeout*, and a timeout is exactly the case
+      // where the shutdown may actually be in progress or have already completed. The fix stops
+      // guessing: it always runs a boot+bootstatus afterward regardless of how `#shutdown` came
+      // back, so the device handed back is verified running, not assumed running. Because
+      // whether the disable list survived is now genuinely unknown, the outcome is also
+      // downgraded from "full" to "reduced" -- the safe direction under uncertainty (see the
+      // comment on `#applySlimAndReboot`).
       const filesystem = new MemoryFilesystem();
       await filesystem.mkdirp(dataPath);
       const runner = new ScriptedProcessRunner([
@@ -1387,6 +1393,10 @@ describe("IosSimctlDriver", () => {
           match: { command: "xcrun", args: ["simctl", "shutdown", slim18_5.udid] },
           result: { code: 1, stderr: "unexpected shutdown failure", stdout: "" },
         },
+        // Always run after the shutdown call, whether or not it succeeded -- `boot` tolerates an
+        // already-booted device either way.
+        { match: { command: "xcrun", args: ["simctl", "boot", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", slim18_5.udid, "-b"] } },
       ]);
       const onSlimmed = vi.fn();
       const onSlimSkipped = vi.fn();
@@ -1401,21 +1411,154 @@ describe("IosSimctlDriver", () => {
       expect(result).toEqual({
         address: slim18_5.udid,
         deviceId: slim18_5.udid,
+        // Unchanged: no marker written, so the next `makeReady` retries the whole label set.
         driverData: slim18_5,
-        featureProfile: "full",
+        featureProfile: "reduced",
       });
-      // No second boot was ever attempted -- the shutdown that would have preceded it failed.
       expect(runner.calls.map((call) => call.args)).toEqual([
         ["simctl", "boot", slim18_5.udid],
         ["simctl", "bootstatus", slim18_5.udid, "-b"],
         ["simctl", "list", "-j", "devices"],
         ["simctl", "spawn", slim18_5.udid, "/bin/sh", "-c", slimScript(widgetsLabels)],
         ["simctl", "shutdown", slim18_5.udid],
+        ["simctl", "boot", slim18_5.udid],
+        ["simctl", "bootstatus", slim18_5.udid, "-b"],
       ]);
       expect(onSlimmed).not.toHaveBeenCalled();
       expect(onSlimSkipped).toHaveBeenCalledWith(
         expect.objectContaining({ deviceId: slim18_5.udid, reason: "apply-failed" }),
       );
+    });
+
+    it("recovers from a shutdown that timed out and reports it as an uncertain, skipped apply (second-review finding #2, issue #87)", async () => {
+      // A `simctl shutdown` *timeout* (as opposed to a clean non-zero exit) is exactly the case
+      // the fix targets: the shutdown may have completed, may still be in flight, or may never
+      // have taken effect. Rather than guess from the exception, the driver always re-establishes
+      // a known-good running device afterward and reports the apply as uncertain.
+      const filesystem = new MemoryFilesystem();
+      await filesystem.mkdirp(dataPath);
+      const clock = new FakeClock();
+      const runner = new ScriptedProcessRunner([
+        { match: { command: "xcrun", args: ["simctl", "boot", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", slim18_5.udid, "-b"] } },
+        {
+          match: listDevicesInvocation,
+          result: { code: 0, stderr: "", stdout: deviceListResponse("Booted") },
+        },
+        {
+          match: {
+            args: ["simctl", "spawn", slim18_5.udid, "/bin/sh", "-c", slimScript(widgetsLabels)],
+            command: "xcrun",
+          },
+        },
+        {
+          hangs: true,
+          match: { command: "xcrun", args: ["simctl", "shutdown", slim18_5.udid] },
+        },
+        { match: { command: "xcrun", args: ["simctl", "boot", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", slim18_5.udid, "-b"] } },
+      ]);
+      const onSlimmed = vi.fn();
+      const onSlimSkipped = vi.fn();
+      const driver = new IosSimctlDriver({
+        clock,
+        filesystem,
+        idGenerator: { generate: () => "device-1" },
+        onSlimSkipped,
+        onSlimmed,
+        processRunner: runner,
+        slim: slimOptions(),
+      });
+
+      const ready = driver.makeReady({
+        address: slim18_5.udid,
+        deviceId: slim18_5.udid,
+        driverData: slim18_5,
+      });
+
+      while (runner.calls.length < 5) {
+        await Promise.resolve();
+      }
+      clock.advance(30_000); // COMMAND_TIMEOUT_MS, the `#shutdown` call's own timeout
+
+      const result = await ready;
+
+      expect(result).toEqual({
+        address: slim18_5.udid,
+        deviceId: slim18_5.udid,
+        driverData: slim18_5,
+        featureProfile: "reduced",
+      });
+      expect(runner.calls.map((call) => call.args)).toEqual([
+        ["simctl", "boot", slim18_5.udid],
+        ["simctl", "bootstatus", slim18_5.udid, "-b"],
+        ["simctl", "list", "-j", "devices"],
+        ["simctl", "spawn", slim18_5.udid, "/bin/sh", "-c", slimScript(widgetsLabels)],
+        ["simctl", "shutdown", slim18_5.udid],
+        ["simctl", "boot", slim18_5.udid],
+        ["simctl", "bootstatus", slim18_5.udid, "-b"],
+      ]);
+      expect(onSlimmed).not.toHaveBeenCalled();
+      expect(onSlimSkipped).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: slim18_5.udid, reason: "apply-failed" }),
+      );
+    });
+
+    it("propagates BootTimeoutError when the shutdown succeeds but the post-slim reboot times out (second-review finding #2, issue #87)", async () => {
+      // Unlike the shutdown-failure cases above, the device here genuinely is shut down and the
+      // reboot that should bring it back never completes -- this must still surface as a boot
+      // failure, exactly like any other boot timeout, not as a skip.
+      const filesystem = new MemoryFilesystem();
+      await filesystem.mkdirp(dataPath);
+      const clock = new FakeClock();
+      const runner = new ScriptedProcessRunner([
+        { match: { command: "xcrun", args: ["simctl", "boot", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", slim18_5.udid, "-b"] } },
+        {
+          match: listDevicesInvocation,
+          result: { code: 0, stderr: "", stdout: deviceListResponse("Booted") },
+        },
+        {
+          match: {
+            args: ["simctl", "spawn", slim18_5.udid, "/bin/sh", "-c", slimScript(widgetsLabels)],
+            command: "xcrun",
+          },
+        },
+        { match: { command: "xcrun", args: ["simctl", "shutdown", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "boot", slim18_5.udid] } },
+        {
+          hangs: true,
+          match: { command: "xcrun", args: ["simctl", "bootstatus", slim18_5.udid, "-b"] },
+        },
+        // `#bootAndWait`'s best-effort shutdown after the bootstatus timeout.
+        { match: { command: "xcrun", args: ["simctl", "shutdown", slim18_5.udid] } },
+      ]);
+      const onSlimmed = vi.fn();
+      const onSlimSkipped = vi.fn();
+      const driver = new IosSimctlDriver({
+        clock,
+        filesystem,
+        idGenerator: { generate: () => "device-1" },
+        onSlimSkipped,
+        onSlimmed,
+        processRunner: runner,
+        slim: slimOptions(),
+      });
+
+      const ready = driver.makeReady({
+        address: slim18_5.udid,
+        deviceId: slim18_5.udid,
+        driverData: slim18_5,
+      });
+
+      while (runner.calls.length < 7) {
+        await Promise.resolve();
+      }
+      clock.advance(300_000); // slim.bootTimeoutMs -- the widened deadline applies to this reboot too
+
+      await expect(ready).rejects.toThrow(BootTimeoutError);
+      expect(onSlimmed).not.toHaveBeenCalled();
+      expect(onSlimSkipped).not.toHaveBeenCalled();
     });
 
     it("still fails the lease when the shutdown succeeds but the second boot doesn't -- the device really is left shut down (finding #3, issue #87 review)", async () => {
@@ -1705,14 +1848,19 @@ describe("IosSimctlDriver", () => {
       expect(onSlimmed).toHaveBeenCalledTimes(1);
     });
 
-    it("reports a failed launchd label as a partial apply: reboots but never marks slimmed (finding #2, issue #87 review)", async () => {
-      // A single label the script itself reports as failed (`simlock-slim-failed`) is enough to
-      // make this a *partial* apply, even though the chunk that carried it ran successfully.
-      // Writing the idempotence marker here would permanently mark the device "slim" with a
-      // launchd label never actually disabled -- see the comment on `#applySlimAndReboot`'s
-      // `applyOutcome.failedLabels.length > 0` branch. The device still reboots (the labels that
-      // did apply are worth keeping), but `driverData` must come back unchanged so the next
-      // `makeReady` retries the whole label set.
+    it("commits a boot with individually-rejected launchd labels instead of retrying it forever (finding #2, issue #87 review; corrected by second-review finding #3)", async () => {
+      // CHANGED EXPECTATIONS (second adversarial review, finding #3): the previous version of
+      // this test treated an individual `simlock-slim-failed` line the same as a whole chunk
+      // failing to run, and asserted the marker was withheld. That conflated two very different
+      // failures: a label the in-simulator script itself rejects (renamed/removed daemon on this
+      // runtime) is PERMANENT -- retrying it on every future boot can never change the outcome,
+      // and would cost this device an extra apply+reboot on every single `makeReady`, forever.
+      // Only a whole chunk that never ran at all is transient and worth retrying. The fix splits
+      // the two into `rejectedLabels` (this case) and `unattemptedLabels` (a failed chunk, see
+      // the "4 chunks, one times out" test below); a rejected label alone no longer blocks the
+      // marker -- it now travels in `SlimmedFact.unknownLabels` instead, so a runtime with a
+      // permanently-unknown daemon converges to "slim, minus the labels it doesn't have" after
+      // one boot rather than re-running the whole label set on every boot.
       const filesystem = new MemoryFilesystem();
       await filesystem.mkdirp(dataPath);
       const runner = new ScriptedProcessRunner([
@@ -1730,7 +1878,9 @@ describe("IosSimctlDriver", () => {
           result: {
             code: 0,
             stderr: "",
-            stdout: "simlock-slim-failed com.apple.chronod\n",
+            stdout:
+              "simlock-slim-failed com.apple.chronod\n" +
+              "simlock-slim-failed com.apple.liveactivitiesd\n",
           },
         },
         { match: { command: "xcrun", args: ["simctl", "shutdown", slim18_5.udid] } },
@@ -1750,8 +1900,10 @@ describe("IosSimctlDriver", () => {
       expect(result).toEqual({
         address: slim18_5.udid,
         deviceId: slim18_5.udid,
-        driverData: slim18_5,
-        featureProfile: "full",
+        // The marker IS written this time -- no `slimMarkToken` because no mark file exists yet
+        // in this test (mirrors "boots, applies the disable list..." above).
+        driverData: { ...slim18_5, slimSignature: widgetsSignature },
+        featureProfile: "reduced",
       });
       expect(runner.calls.map((call) => call.args)).toEqual([
         ["simctl", "boot", slim18_5.udid],
@@ -1762,20 +1914,75 @@ describe("IosSimctlDriver", () => {
         ["simctl", "boot", slim18_5.udid],
         ["simctl", "bootstatus", slim18_5.udid, "-b"],
       ]);
-      expect(onSlimmed).not.toHaveBeenCalled();
-      expect(onSlimSkipped).toHaveBeenCalledWith(
-        expect.objectContaining({ deviceId: slim18_5.udid, reason: "apply-failed" }),
-      );
+      expect(onSlimmed).toHaveBeenCalledTimes(1);
+      expect(onSlimmed).toHaveBeenCalledWith({
+        address: slim18_5.udid,
+        categories: ["widgets"],
+        deviceId: slim18_5.udid,
+        durationMs: expect.any(Number),
+        labelCount: 3,
+        signature: widgetsSignature,
+        unknownLabels: ["com.apple.chronod", "com.apple.liveactivitiesd"],
+      });
+      expect(onSlimSkipped).not.toHaveBeenCalled();
     });
 
-    it("4 chunks, one times out: reboots, writes no marker, and a later boot re-applies (finding #2, issue #87 review)", async () => {
+    it("a device already marked slim with a rejected-label history skips the whole pass on the next boot (second-review finding #3, issue #87)", async () => {
+      // The marker written by the test above lets `#checkAlreadySlimmed` short-circuit the next
+      // `makeReady` entirely -- proving the permanently-rejected label does not cost this device
+      // an apply+reboot on every future boot, unlike before the fix.
+      const filesystem = new MemoryFilesystem();
+      await filesystem.mkdirp(dataPath);
+      await filesystem.writeFileAtomic(erasableMarkPath, JSON.stringify({ token: "tok-1" }));
+      const alreadySlimmedData = {
+        ...slim18_5,
+        slimMarkToken: "tok-1",
+        slimSignature: widgetsSignature,
+      };
+      const runner = new ScriptedProcessRunner([
+        { match: { command: "xcrun", args: ["simctl", "boot", slim18_5.udid] } },
+        { match: { command: "xcrun", args: ["simctl", "bootstatus", slim18_5.udid, "-b"] } },
+        {
+          match: listDevicesInvocation,
+          result: { code: 0, stderr: "", stdout: deviceListResponse("Booted") },
+        },
+      ]);
+      const onSlimmed = vi.fn();
+      const driver = createSlimDriver(runner, filesystem, slimOptions(), onSlimmed);
+
+      const result = await driver.makeReady({
+        address: slim18_5.udid,
+        deviceId: slim18_5.udid,
+        driverData: alreadySlimmedData,
+      });
+
+      expect(result).toEqual({
+        address: slim18_5.udid,
+        deviceId: slim18_5.udid,
+        driverData: alreadySlimmedData,
+        featureProfile: "reduced",
+      });
+      expect(runner.calls.map((call) => call.args)).toEqual([
+        ["simctl", "boot", slim18_5.udid],
+        ["simctl", "bootstatus", slim18_5.udid, "-b"],
+        ["simctl", "list", "-j", "devices"],
+      ]);
+      expect(onSlimmed).not.toHaveBeenCalled();
+    });
+
+    it("4 chunks, one times out: reboots, writes no marker, and a later boot re-applies (finding #2, issue #87 review; second-review finding #3)", async () => {
       // The full, unfiltered label set (~170 labels, per the SLIM_CHUNK_SIZE=50 comment in
       // index.ts) chunks into 4 `simctl spawn` calls. If the last one times out under load, the
       // other 3 chunks still ran -- `#applySlimLabels` reports the whole apply as "applied"
-      // (`anyChunkSucceeded`), but with the timed-out chunk's labels folded into `failedLabels`.
-      // That must NOT be enough to write the idempotence marker: the device reboots (the labels
-      // that did apply are worth keeping), but comes back exactly as it went in, so the very
-      // next `makeReady` sees no stored `slimSignature` and re-applies the whole set again.
+      // (`anyChunkSucceeded`), but with the timed-out chunk's labels folded into
+      // `unattemptedLabels` (unlike an individual `simlock-slim-failed` line, which is permanent
+      // and now lands in `rejectedLabels` instead -- see the "individually-rejected launchd
+      // labels" test above). A whole unattempted chunk is transient and must NOT be enough to
+      // write the idempotence marker: the device reboots (the labels that did apply are worth
+      // keeping), but comes back exactly as it went in, so the very next `makeReady` sees no
+      // stored `slimSignature` and re-applies the whole set again. CHANGED EXPECTATION
+      // (second-review finding #3): the outcome here is `"reduced"`, not `"full"` -- the labels
+      // that did apply really are gone, so "full" would be a lie in the dangerous direction.
       const allLabels = labelsFor(resolveSlimCategories(undefined).categories);
       const chunkSize = 50;
       const chunks = [
@@ -1850,7 +2057,7 @@ describe("IosSimctlDriver", () => {
         // Unchanged: no `slimSignature`/`slimMarkToken` written, so the next `makeReady` will
         // find `#checkAlreadySlimmed` false and re-apply the whole set.
         driverData: slim18_5,
-        featureProfile: "full",
+        featureProfile: "reduced",
       });
       expect(runner.calls.map((call) => call.args)).toEqual([
         ["simctl", "boot", slim18_5.udid],

--- a/src/drivers/ios/index.test.ts
+++ b/src/drivers/ios/index.test.ts
@@ -1807,6 +1807,55 @@ describe("IosSimctlDriver", () => {
 
       expect(driver.estimate({ operation: "boot" }, spec)).toBe(150_000);
     });
+
+    describe("advisories()", () => {
+      it("reports slim-runtime-unsupported when an installed runtime predates 18.5", async () => {
+        const driver = createSlimDriver(
+          scriptedListRunner(),
+          new MemoryFilesystem(),
+          slimOptions(),
+        );
+
+        // listFixture installs iOS 18.4 (below the floor) alongside iOS 26.5 (above it).
+        await expect(driver.advisories()).resolves.toEqual([
+          {
+            code: "slim-runtime-unsupported",
+            message: expect.stringContaining("18.4"),
+          },
+        ]);
+      });
+
+      it("reports nothing when every installed runtime is 18.5+", async () => {
+        const onlyNewFixture = JSON.stringify({
+          devicetypes: (JSON.parse(listFixture) as { devicetypes: unknown }).devicetypes,
+          runtimes: (
+            JSON.parse(listFixture) as { runtimes: { version: string }[] }
+          ).runtimes.filter((runtime) => runtime.version !== "18.4"),
+        });
+        const runner = new ScriptedProcessRunner([
+          { match: listInvocation, result: { code: 0, stderr: "", stdout: onlyNewFixture } },
+        ]);
+        const driver = createSlimDriver(runner, new MemoryFilesystem(), slimOptions());
+
+        await expect(driver.advisories()).resolves.toEqual([]);
+      });
+
+      it("reports nothing when slim mode is off", async () => {
+        const driver = createDriver(scriptedListRunner());
+
+        await expect(driver.advisories()).resolves.toEqual([]);
+      });
+
+      it("reports nothing when slim is configured but disabled", async () => {
+        const driver = createSlimDriver(scriptedListRunner(), new MemoryFilesystem(), {
+          bootTimeoutMs: 300_000,
+          categories: ["widgets"],
+          enabled: false,
+        });
+
+        await expect(driver.advisories()).resolves.toEqual([]);
+      });
+    });
   });
 });
 

--- a/src/drivers/ios/index.ts
+++ b/src/drivers/ios/index.ts
@@ -73,6 +73,8 @@ const SLIM_CHUNK_SIZE = 50;
 // generous budget instead of reusing it.
 const SLIM_CHUNK_TIMEOUT_MS = 60_000;
 const SLIM_FAILED_MARKER = "simlock-slim-failed";
+/** See the comment in `#applySlimLabels`; must stay in sync with the test's `slimScript`. */
+const SLIM_SCRIPT_PRELUDE = '[ -n "$SIMULATOR_ROOT" ] && export DYLD_ROOT_PATH="$SIMULATOR_ROOT";';
 // Built from `SLIM_FAILED_MARKER` (rather than a second hardcoded literal) so a change to the
 // constant can never silently desync the script that emits the marker from the parser that reads
 // it back -- see `#applySlimLabels`.
@@ -891,6 +893,11 @@ export class IosSimctlDriver implements Driver {
   }
 
   /**
+   * Note (verified on iOS 26.4 / 27.0): `launchctl disable` exits 0 for a label that does not
+   * exist and records it anyway, so the per-label failure line below never fires for a renamed
+   * or removed daemon -- only for a crashed `launchctl` or a filtered label. Drift in the label
+   * list is therefore silent at apply time (see docs/known-pitfalls.md).
+   *
    * Batches `launchctl disable system/<label>` calls into shell loops of at most
    * `SLIM_CHUNK_SIZE`, one `simctl spawn` per chunk -- ~170 individual spawns would dominate the
    * slim budget (see `SLIM_CHUNK_SIZE`'s comment). Each label that `launchctl disable` itself
@@ -916,8 +923,14 @@ export class IosSimctlDriver implements Driver {
     let anyChunkSucceeded = false;
 
     for (const chunkLabels of chunks) {
+      // `DYLD_ROOT_PATH` is what makes a bare `launchctl` inside the simulator load the
+      // *simulator's* dyld shared cache; `simctl spawn` sets it for the process it starts, but
+      // dyld strips `DYLD_*` from the environment of a platform binary such as `/bin/sh`, so
+      // every child `launchctl` the script runs would otherwise die with an abort trap
+      // (verified on iOS 26.4 and 27.0 simulators). Re-exporting it from `SIMULATOR_ROOT`
+      // (which survives) is exactly what simslim's own batch script does first.
       const script =
-        `for l in ${chunkLabels.join(" ")}; do launchctl disable "system/$l" ` +
+        `${SLIM_SCRIPT_PRELUDE} for l in ${chunkLabels.join(" ")}; do launchctl disable "system/$l" ` +
         `>/dev/null 2>&1 || echo "${SLIM_FAILED_MARKER} $l"; done`;
       const outcome = await this.#invokeSimctl(
         ["spawn", udid, "/bin/sh", "-c", script],

--- a/src/drivers/ios/index.ts
+++ b/src/drivers/ios/index.ts
@@ -73,6 +73,10 @@ const SLIM_CHUNK_SIZE = 50;
 // generous budget instead of reusing it.
 const SLIM_CHUNK_TIMEOUT_MS = 60_000;
 const SLIM_FAILED_MARKER = "simlock-slim-failed";
+// Built from `SLIM_FAILED_MARKER` (rather than a second hardcoded literal) so a change to the
+// constant can never silently desync the script that emits the marker from the parser that reads
+// it back -- see `#applySlimLabels`.
+const SLIM_FAILED_MARKER_PATTERN = new RegExp(`^${SLIM_FAILED_MARKER} (\\S+)$`);
 // Slim labels are compile-time constants from our own data file (`slim-labels.ts`), so this can
 // never actually reject anything in production -- it exists purely as a second line of defense:
 // if that data file ever grew a label containing shell metacharacters, this stops it from
@@ -205,6 +209,13 @@ type ProcessOutcome =
 /** iOS simulator implementation. Its simctl details remain opaque to the core. */
 export class IosSimctlDriver implements Driver {
   readonly platform = "ios" as const;
+  /**
+   * `true` only when slim mode is actually enabled -- a `--full` request against this driver
+   * is only meaningful (and only earns its own, separate pool key -- see `Driver.reducesFeatures`)
+   * while this driver might otherwise hand back a reduced device. Static per driver instance:
+   * slim mode is process-wide configuration, not something that varies per request.
+   */
+  readonly reducesFeatures: boolean;
   readonly #clock: Clock;
   readonly #coreSimulatorRoot: string;
   readonly #diskSpaceGuard: DiskSpaceGuard;
@@ -232,6 +243,7 @@ export class IosSimctlDriver implements Driver {
     this.#onSlimSkipped = options.onSlimSkipped;
     this.#processRunner = options.processRunner;
     this.#slim = options.slim;
+    this.reducesFeatures = options.slim?.enabled === true;
   }
 
   async resolveSpec(
@@ -589,10 +601,21 @@ export class IosSimctlDriver implements Driver {
    * be made from `driverData` alone, ADR point 9) and, once booted, a slim pass may run: apply the
    * disable list, then reboot once more. A failed or skipped slim never fails the lease -- the
    * device is still returned, just not marked as slimmed.
+   *
+   * `options.purpose === "recover"` (the one caller: `ManagedDeviceLifecycle.recoverLeased`,
+   * safety rule 2's crash-recovery exception on an already-*leased* device) always takes the
+   * `"off"` path below -- a single ordinary boot, no slim apply, no second reboot -- regardless
+   * of slim configuration or this device's own eligibility. Recovery may only get a leased
+   * device running again, never change what it's running; a "prepare"-shaped slim pass under an
+   * active lease would silently strip push/Spotlight/StoreKit/universal-links mid-lease, which
+   * is exactly the broader privilege safety rule 2 says this exception does not grant.
    */
-  async makeReady(device: DriverDevice): Promise<DriverDevice> {
+  async makeReady(
+    device: DriverDevice,
+    options?: { readonly purpose: "prepare" | "recover" },
+  ): Promise<DriverDevice> {
     const data = iosDriverData(device);
-    const { plan, bootstatusTimeoutMs } = planSlimBoot(data, this.#slim);
+    const { plan, bootstatusTimeoutMs } = planSlimBoot(data, this.#slim, options?.purpose);
 
     await this.#bootAndWait(data.udid, device.deviceId, bootstatusTimeoutMs);
 
@@ -605,7 +628,12 @@ export class IosSimctlDriver implements Driver {
     }
 
     if (plan.kind !== "apply") {
-      return this.#asIs(device, data, "full");
+      // `undefined` (not "full") whenever slim mode isn't enabled at all -- `DriverDevice.
+      // featureProfile`'s contract is that `undefined` means "this driver does not reduce
+      // anything", which is only true while slim mode is off. Once slim mode is on, "full" is
+      // meaningful (this particular boot didn't reduce anything -- a per-device `full: true`
+      // opt-out, a `"recover"` boot, or a runtime-gate skip) and is reported as such.
+      return this.#asIs(device, data, this.#slim?.enabled === true ? "full" : undefined);
     }
 
     return this.#applySlimAndReboot(device, data, plan.slim, bootstatusTimeoutMs);
@@ -615,13 +643,13 @@ export class IosSimctlDriver implements Driver {
   #asIs(
     device: DriverDevice,
     data: IosDriverData,
-    featureProfile: "full" | "reduced",
+    featureProfile: "full" | "reduced" | undefined,
   ): DriverDevice {
     return {
       address: data.udid,
       deviceId: device.deviceId,
       driverData: device.driverData,
-      featureProfile,
+      ...(featureProfile === undefined ? {} : { featureProfile }),
     };
   }
 
@@ -687,9 +715,45 @@ export class IosSimctlDriver implements Driver {
 
     // The reboot below is what makes the disable entries take effect; never write the
     // idempotence marker or report `device.slimmed` on a device that hasn't actually rebooted
-    // with them applied.
-    await this.#shutdown(data.udid);
-    await this.#bootAndWait(data.udid, device.deviceId, bootstatusTimeoutMs);
+    // with them applied. `makeReady`'s own contract ("a failed or skipped slim never fails the
+    // lease") holds here too: a hiccup in this reboot must downgrade to the skip path rather
+    // than fail a lease that would otherwise have worked, *unless* the device has actually been
+    // left shut down by it -- see the two branches below.
+    let shutdownSucceeded = false;
+    try {
+      await this.#shutdown(data.udid);
+      shutdownSucceeded = true;
+      await this.#bootAndWait(data.udid, device.deviceId, bootstatusTimeoutMs);
+    } catch (error: unknown) {
+      if (!shutdownSucceeded) {
+        // The shutdown itself never completed (a non-zero exit or a timeout) -- the device is
+        // still in the state the first boot above left it in, i.e. still healthy and running.
+        // Nothing was actually rebooted, so there's nothing to commit; downgrade to skip.
+        return this.#skipApply(device, data, `slim shutdown failed: ${errorMessage(error)}`);
+      }
+      // Shutdown succeeded but the second boot didn't: the device is now genuinely shut down,
+      // not "ready" as returning it here would claim. Reporting this as a skip would hand the
+      // caller a device that isn't actually usable, so this must propagate like any other boot
+      // failure (`BootTimeoutError` / `DriverCrashError`).
+      throw error;
+    }
+
+    if (applyOutcome.failedLabels.length > 0) {
+      // Partial apply: at least one chunk failed to run outright, or the script itself reported
+      // an individual `launchctl disable` failure. The reboot above already happened -- the
+      // labels that did apply are worth keeping -- but the idempotence marker must NOT be
+      // written: writing it here would permanently mark this device "slim" (see
+      // `#checkAlreadySlimmed`) even though part of the disable list never took effect, and
+      // every later boot would then trust the marker and never retry the labels that failed,
+      // with no way back short of `reclaim`/`erase`. So a partial apply deliberately costs a
+      // re-attempt of the *whole* label set on the next `makeReady` instead -- applying an
+      // already-disabled label again is harmless (same comment on `#checkAlreadySlimmed`).
+      return this.#skipApply(
+        device,
+        data,
+        `${String(applyOutcome.failedLabels.length)} of ${String(labels.length)} labels failed to apply`,
+      );
+    }
 
     return this.#commitSlim(
       device,
@@ -811,7 +875,7 @@ export class IosSimctlDriver implements Driver {
 
       anyChunkSucceeded = true;
       for (const line of outcome.result.stdout.split("\n")) {
-        const match = /^simlock-slim-failed (\S+)$/.exec(line.trim());
+        const match = SLIM_FAILED_MARKER_PATTERN.exec(line.trim());
         if (match?.[1] !== undefined) {
           failedLabels.push(match[1]);
         }
@@ -890,15 +954,19 @@ export class IosSimctlDriver implements Driver {
     };
   }
 
-  estimate(estimate: DriverEstimate, _spec: DeviceSpec): number {
+  estimate(estimate: DriverEstimate, spec: DeviceSpec): number {
     switch (estimate.operation) {
       case "provision":
         return PROVISION_ESTIMATE_MS;
       case "boot":
         // Slim mode pays for a second boot plus a launchctl-disable pass on top of the usual
         // one -- quoting the plain cold-boot number here would make `doctor` flag every slim
-        // device as stalled.
-        return this.#slim?.enabled === true ? SLIM_BOOT_ESTIMATE_MS : COLD_BOOT_ESTIMATE_MS;
+        // device as stalled. But a `full` spec never slims (`planSlimBoot`'s `data.full === true`
+        // branch), so quoting the slim number to a request that will never pay it would make
+        // `doctor` flag a perfectly on-time `full` boot as stalled instead.
+        return this.#slim?.enabled === true && spec.full !== true
+          ? SLIM_BOOT_ESTIMATE_MS
+          : COLD_BOOT_ESTIMATE_MS;
       case "reclaim":
         // `reclaimStrategy` returns `erase` for both clean levels, so there is nothing to
         // branch on here -- the clean level only matters to a driver that has a fast path.
@@ -911,11 +979,15 @@ export class IosSimctlDriver implements Driver {
    * `makeReady`'s per-boot `SlimSkippedFact` -- an operator who never leases a device on an
    * old runtime would otherwise have no way to learn slimming is doing nothing for it. Reports
    * one `slim-runtime-unsupported` advisory naming every installed runtime that predates the
-   * 18.5 persistent-override floor, using the same `supportsPersistentSlim` gate `planSlimBoot`
-   * uses for the real per-device decision, so this can never drift from what `makeReady` will
-   * actually do. Nothing when slim mode is off (there is no gate to warn about) or when every
-   * installed runtime qualifies. Read-only: only `#loadCatalog` (a `simctl list`) runs, no
-   * boot, no download, no mutation -- matching `listCatalog`'s own contract.
+   * 18.5 persistent-override floor, using the same `supportsPersistentSlim(iosRuntimeVersionFromId
+   * (runtime.identifier))` call `planSlimBoot` makes for the real per-device decision -- not a
+   * second, independent parse of the catalog's marketing `runtime.version` -- so this can never
+   * drift from what `makeReady` will actually do: an identifier `iosRuntimeVersionFromId` can't
+   * parse is `undefined`, and `supportsPersistentSlim(undefined)` is `false`, so an unparseable
+   * runtime is reported unsupported here exactly as `makeReady` treats it as `"unknown-runtime"`.
+   * Nothing when slim mode is off (there is no gate to warn about) or when every installed
+   * runtime qualifies. Read-only: only `#loadCatalog` (a `simctl list`) runs, no boot, no
+   * download, no mutation -- matching `listCatalog`'s own contract.
    */
   async advisories(): Promise<readonly DriverAdvisory[]> {
     if (this.#slim === undefined || !this.#slim.enabled) {
@@ -927,7 +999,7 @@ export class IosSimctlDriver implements Driver {
       ...new Set(
         catalog.runtimes
           .filter((runtime) => runtime.isAvailable)
-          .filter((runtime) => !supportsPersistentSlim(runtimeVersionTuple(runtime.version)))
+          .filter((runtime) => !supportsPersistentSlim(iosRuntimeVersionFromId(runtime.identifier)))
           .map((runtime) => runtime.version),
       ),
     ].sort(compareVersions);
@@ -1396,17 +1468,6 @@ function versionTriple(version: string): readonly [number, number, number] {
   return [parts[0] ?? 0, parts[1] ?? 0, parts[2] ?? 0];
 }
 
-/**
- * `[major, minor]` from a catalog runtime's marketing version string (e.g. `"18.5"`) -- the
- * same shape `supportsPersistentSlim` already takes from `iosRuntimeVersionFromId`'s parse of a
- * `runtimeId`, so `#advisories` can reuse that one gate instead of re-deriving it. Built on the
- * existing `versionTriple` parse rather than a new one.
- */
-function runtimeVersionTuple(version: string): readonly [number, number] {
-  const [major, minor] = versionTriple(version);
-  return [major, minor];
-}
-
 function versionOrdinal(triple: readonly [number, number, number]): number {
   return triple[0] * 1_000_000 + triple[1] * 1_000 + triple[2];
 }
@@ -1525,14 +1586,16 @@ type SlimPlan =
 /**
  * Pure decision step extracted from `makeReady`: given only this device's driver data and the
  * driver's slim options, decides what this boot should do and how long the initial `bootstatus`
- * wait may take. Slim mode off, or this device's `full: true` opt-out, both read as `"off"` --
- * the two are equivalent from here on (same as-is return, same ordinary boot deadline).
+ * wait may take. Slim mode off, this device's `full: true` opt-out, and a `"recover"`-purpose
+ * call all read as `"off"` -- equivalent from here on (same as-is return, same ordinary boot
+ * deadline). `purpose` defaults to `"prepare"`, matching `Driver.makeReady`'s own default.
  */
 function planSlimBoot(
   data: IosDriverData,
   slim: SlimOptions | undefined,
+  purpose: "prepare" | "recover" = "prepare",
 ): { readonly plan: SlimPlan; readonly bootstatusTimeoutMs: number } {
-  if (slim === undefined || !slim.enabled || data.full === true) {
+  if (purpose === "recover" || slim === undefined || !slim.enabled || data.full === true) {
     return { bootstatusTimeoutMs: BOOTSTATUS_TIMEOUT_MS, plan: { kind: "off" } };
   }
 

--- a/src/drivers/ios/index.ts
+++ b/src/drivers/ios/index.ts
@@ -25,6 +25,7 @@ import type {
   ProcessRunner,
 } from "../../ports/index.js";
 import type { ComponentInstallDiagnostic } from "../diagnostics.js";
+import { labelsFor, resolveSlimCategories, slimSignature } from "./slim-labels.js";
 
 const COMMAND_TIMEOUT_MS = 30_000;
 const BOOTSTATUS_TIMEOUT_MS = 120_000;
@@ -54,12 +55,63 @@ const COLD_BOOT_ESTIMATE_MS = 60_000;
 // at either clean level, so this is the only reclaim number the driver has.
 const ERASE_ESTIMATE_MS = 34_000;
 const MARK_FILE_NAME = "simlock-mark.json";
+// Slim mode reboots the device a second time and runs a launchctl-disable pass on top of the
+// usual cold boot -- without a dedicated estimate, `doctor`'s provisioning-stall threshold would
+// be sized for a single boot and flag every slim device as stuck. Budget: one `COLD_BOOT_ESTIMATE_MS`
+// boot, a second one for the post-slim reboot, plus headroom for the chunked `simctl spawn` calls
+// (a handful of ~60s-capped chunks that in practice finish in a few seconds each).
+const SLIM_BOOT_ESTIMATE_MS = 150_000;
+// simslim batches ~170 individual `launchctl disable` calls into shell loops rather than one
+// `simctl spawn` per label -- at ~150ms/spawn that is well over half a minute of pure process
+// overhead per full slim, which would swamp the boot budget above. 50 labels/chunk keeps each
+// chunk's own script small (and its timeout comfortably generous) while still cutting spawn count
+// by ~50x versus one-label-per-call.
+const SLIM_CHUNK_SIZE = 50;
+// A chunk of 50 `launchctl disable` calls inside a simulator is not instant -- COMMAND_TIMEOUT_MS
+// (30s) has been observed to be tight for this under load, so slim chunks get their own, more
+// generous budget instead of reusing it.
+const SLIM_CHUNK_TIMEOUT_MS = 60_000;
+const SLIM_FAILED_MARKER = "simlock-slim-failed";
+// Slim labels are compile-time constants from our own data file (`slim-labels.ts`), so this can
+// never actually reject anything in production -- it exists purely as a second line of defense:
+// if that data file ever grew a label containing shell metacharacters, this stops it from
+// escaping the generated `sh -c` script instead of silently trusting the data.
+const SLIM_LABEL_SAFE_PATTERN = /^[A-Za-z0-9._-]+$/;
 
 interface IosDriverData {
   readonly deviceTypeId: string;
   readonly name: string;
   readonly runtimeId: string;
   readonly udid: string;
+  /** Per-lease override (set by `provision` from the device spec): never slim this device. */
+  readonly full?: boolean;
+  /** `slimSignature(...)` of the label set actually applied -- the idempotence marker. */
+  readonly slimSignature?: string;
+  /** The device's *erasable* provenance-mark token as read at the moment slimming was applied. */
+  readonly slimMarkToken?: string;
+}
+
+/** Fact reported to the daemon layer once a slim reboot has committed (`onSlimmed`). */
+export interface SlimmedFact {
+  readonly deviceId: string;
+  readonly address: string;
+  readonly categories: readonly string[];
+  readonly labelCount: number;
+  readonly durationMs: number;
+  readonly signature: string;
+  /**
+   * Category names `resolveSlimCategories` didn't recognize, plus individual launchd labels a
+   * chunk reported via `simlock-slim-failed` -- neither is fatal (ADR point 8), both are worth
+   * surfacing.
+   */
+  readonly unknownLabels: readonly string[];
+}
+
+/** Fact reported when a device that should have been slimmed wasn't. */
+export interface SlimSkippedFact {
+  readonly deviceId: string;
+  readonly reason: "runtime-too-old" | "unknown-runtime" | "apply-failed";
+  readonly detail: string;
 }
 
 export interface IosSimctlDriverOptions {
@@ -92,8 +144,29 @@ export interface IosSimctlDriverOptions {
    * driver's `onDiagnostic` option.
    */
   readonly onDiagnostic?: (diagnostic: ComponentInstallDiagnostic) => void;
+  /**
+   * Reports the `device.slimmed` fact for the daemon layer to bridge onto the event bus -- this
+   * driver never depends on the bus directly (architecture rule 5). Mirrors `onDiagnostic`.
+   */
+  readonly onSlimmed?: (fact: SlimmedFact) => void;
+  /** Reports why a device slim didn't happen when slim mode is on. Mirrors `onDiagnostic`. */
+  readonly onSlimSkipped?: (fact: SlimSkippedFact) => void;
   readonly processRunner: ProcessRunner;
+  /** Slim mode; omitted or `enabled: false` means today's behaviour exactly. */
+  readonly slim?: {
+    readonly enabled: boolean;
+    readonly categories?: readonly string[];
+    readonly bootTimeoutMs: number;
+  };
 }
+
+type SlimOptions = NonNullable<IosSimctlDriverOptions["slim"]>;
+
+/** Result of `#applySlimLabels`: either every label was attempted (some may still have failed
+ * individually, tracked in `failedLabels`), or the whole apply never ran. */
+type SlimApplyOutcome =
+  | { readonly kind: "applied"; readonly failedLabels: readonly string[] }
+  | { readonly kind: "failed"; readonly detail: string };
 
 interface DeviceType {
   readonly identifier: string;
@@ -139,8 +212,11 @@ export class IosSimctlDriver implements Driver {
   readonly #filesystem: Filesystem;
   readonly #idGenerator: IdGenerator;
   readonly #onDiagnostic: ((diagnostic: ComponentInstallDiagnostic) => void) | undefined;
+  readonly #onSlimmed: ((fact: SlimmedFact) => void) | undefined;
+  readonly #onSlimSkipped: ((fact: SlimSkippedFact) => void) | undefined;
   readonly #processRunner: ProcessRunner;
   readonly #resolvedSpecs = new Map<string, ResolvedIosSpec>();
+  readonly #slim: SlimOptions | undefined;
   #devicesRoot: string | undefined;
 
   constructor(options: IosSimctlDriverOptions) {
@@ -151,7 +227,10 @@ export class IosSimctlDriver implements Driver {
     this.#filesystem = options.filesystem;
     this.#idGenerator = options.idGenerator;
     this.#onDiagnostic = options.onDiagnostic;
+    this.#onSlimmed = options.onSlimmed;
+    this.#onSlimSkipped = options.onSlimSkipped;
     this.#processRunner = options.processRunner;
+    this.#slim = options.slim;
   }
 
   async resolveSpec(
@@ -494,32 +573,255 @@ export class IosSimctlDriver implements Driver {
         name,
         runtimeId: resolved.runtime.identifier,
         udid,
+        // Per-lease opt-out (`DeviceSpec.full`, ADR "serve from a separate pool key"): stamped
+        // onto driver data only when set, so a normal (non-`--full`) request's driver data stays
+        // byte-identical to a spec resolved before this field existed.
+        ...(spec.full === true ? { full: true } : {}),
       } satisfies IosDriverData,
     };
   }
 
-  /** The UDID never changes across a boot -- unlike Android's port, there is nothing to re-derive. */
+  /**
+   * The UDID never changes across a boot -- unlike Android's port, there is nothing to
+   * re-derive. When slim mode is on and this device qualifies (not `full`, runtime new enough --
+   * `#slimApplicable`), the boot deadline is widened *before* the first boot (that decision must
+   * be made from `driverData` alone, ADR point 9) and, once booted, a slim pass may run: apply the
+   * disable list, then reboot once more. A failed or skipped slim never fails the lease -- the
+   * device is still returned, just not marked as slimmed.
+   */
   async makeReady(device: DriverDevice): Promise<DriverDevice> {
     const data = iosDriverData(device);
-    const boot = await this.#invokeSimctl(["boot", data.udid], COMMAND_TIMEOUT_MS);
+    const { plan, bootstatusTimeoutMs } = planSlimBoot(data, this.#slim);
+
+    await this.#bootAndWait(data.udid, device.deviceId, bootstatusTimeoutMs);
+
+    if (plan.kind === "skip") {
+      this.#onSlimSkipped?.({
+        deviceId: device.deviceId,
+        detail: plan.detail,
+        reason: plan.reason,
+      });
+    }
+
+    if (plan.kind !== "apply") {
+      return this.#asIs(device, data, "full");
+    }
+
+    return this.#applySlimAndReboot(device, data, plan.slim, bootstatusTimeoutMs);
+  }
+
+  /** The device's current `address`/`driverData`, unmodified, tagged with the feature profile. */
+  #asIs(
+    device: DriverDevice,
+    data: IosDriverData,
+    featureProfile: "full" | "reduced",
+  ): DriverDevice {
+    return {
+      address: data.udid,
+      deviceId: device.deviceId,
+      driverData: device.driverData,
+      featureProfile,
+    };
+  }
+
+  /**
+   * Boot, tolerate already-booted, wait for `bootstatus -b`; on a bootstatus timeout, make a
+   * best-effort shutdown before surfacing `BootTimeoutError` so a hung device isn't left running.
+   * Shared by `makeReady`'s first boot and the post-slim reboot -- identical behaviour either way,
+   * only the deadline differs.
+   */
+  async #bootAndWait(udid: string, deviceId: string, bootstatusTimeoutMs: number): Promise<void> {
+    const boot = await this.#invokeSimctl(["boot", udid], COMMAND_TIMEOUT_MS);
     if (boot.kind === "timed-out") {
-      throw new BootTimeoutError(device.deviceId);
+      throw new BootTimeoutError(deviceId);
     }
     if (boot.result.code !== 0 && !alreadyBooted(boot.result.stderr)) {
-      this.#assertSuccessful(["boot", data.udid], boot.result);
+      this.#assertSuccessful(["boot", udid], boot.result);
     }
-    const outcome = await this.#invokeSimctl(
-      ["bootstatus", data.udid, "-b"],
-      BOOTSTATUS_TIMEOUT_MS,
-    );
+    const outcome = await this.#invokeSimctl(["bootstatus", udid, "-b"], bootstatusTimeoutMs);
 
     if (outcome.kind === "timed-out") {
-      await this.#bestEffortShutdown(data.udid);
-      throw new BootTimeoutError(device.deviceId);
+      await this.#bestEffortShutdown(udid);
+      throw new BootTimeoutError(deviceId);
     }
 
-    this.#assertSuccessful(["bootstatus", data.udid, "-b"], outcome.result);
-    return { address: data.udid, deviceId: device.deviceId, driverData: device.driverData };
+    this.#assertSuccessful(["bootstatus", udid, "-b"], outcome.result);
+  }
+
+  /**
+   * Runs after the first boot has already succeeded with the slim deadline. Idempotence: skip
+   * the whole step (no second boot) only when the stored signature *and* mark token both match
+   * what's true right now -- a missing/unreadable token or a differing one means the device was
+   * erased (by `reclaim`) since it was last slimmed, and a differing signature means the
+   * configured categories (or the shipped label list) changed; either way, re-apply. Applying
+   * twice is harmless.
+   */
+  async #applySlimAndReboot(
+    device: DriverDevice,
+    data: IosDriverData,
+    slim: SlimOptions,
+    bootstatusTimeoutMs: number,
+  ): Promise<DriverDevice> {
+    const resolved = resolveSlimCategories(slim.categories);
+    if (resolved.categories.length === 0) {
+      return this.#skipApply(
+        device,
+        data,
+        `none of the configured slim categories (${(slim.categories ?? []).join(", ")}) are known`,
+      );
+    }
+
+    const signature = slimSignature(resolved.categories);
+    const idempotence = await this.#checkAlreadySlimmed(data, signature);
+    if (idempotence.alreadySlimmed) {
+      return this.#asIs(device, data, "reduced");
+    }
+
+    const labels = labelsFor(resolved.categories);
+    const startedAt = this.#clock.now();
+    const applyOutcome = await this.#applySlimLabels(data.udid, labels);
+    if (applyOutcome.kind === "failed") {
+      return this.#skipApply(device, data, applyOutcome.detail);
+    }
+
+    // The reboot below is what makes the disable entries take effect; never write the
+    // idempotence marker or report `device.slimmed` on a device that hasn't actually rebooted
+    // with them applied.
+    await this.#shutdown(data.udid);
+    await this.#bootAndWait(data.udid, device.deviceId, bootstatusTimeoutMs);
+
+    return this.#commitSlim(
+      device,
+      data,
+      resolved,
+      labels,
+      signature,
+      idempotence.currentToken,
+      startedAt,
+      applyOutcome,
+    );
+  }
+
+  /** Reports `device.slim-skipped` with reason `apply-failed` and returns the device as-is. */
+  #skipApply(device: DriverDevice, data: IosDriverData, detail: string): DriverDevice {
+    this.#onSlimSkipped?.({ deviceId: device.deviceId, detail, reason: "apply-failed" });
+    return this.#asIs(device, data, "full");
+  }
+
+  /**
+   * Idempotence check split out of `#applySlimAndReboot`: skip the whole step (no second boot)
+   * only when the stored signature *and* mark token both match what's true right now -- a
+   * missing/unreadable token or a differing one means the device was erased (by `reclaim`) since
+   * it was last slimmed, and a differing signature means the configured categories (or the
+   * shipped label list) changed; either way, re-apply. Applying twice is harmless.
+   */
+  async #checkAlreadySlimmed(
+    data: IosDriverData,
+    signature: string,
+  ): Promise<{ readonly alreadySlimmed: boolean; readonly currentToken: string | undefined }> {
+    const dataPath = await this.#dataPathFor(data.udid);
+    const currentToken =
+      dataPath === undefined ? undefined : await this.#readToken(`${dataPath}/${MARK_FILE_NAME}`);
+
+    const alreadySlimmed =
+      data.slimSignature !== undefined &&
+      currentToken !== undefined &&
+      data.slimMarkToken !== undefined &&
+      data.slimSignature === signature &&
+      data.slimMarkToken === currentToken;
+
+    return { alreadySlimmed, currentToken };
+  }
+
+  /**
+   * Builds the post-reboot driver data (new signature + mark token) and reports `device.slimmed`
+   * -- split out of `#applySlimAndReboot` so the outer method's own branching stays about
+   * *whether* to apply, not the bookkeeping for a successful apply.
+   */
+  #commitSlim(
+    device: DriverDevice,
+    data: IosDriverData,
+    resolved: ReturnType<typeof resolveSlimCategories>,
+    labels: readonly string[],
+    signature: string,
+    currentToken: string | undefined,
+    startedAt: number,
+    applyOutcome: Extract<SlimApplyOutcome, { readonly kind: "applied" }>,
+  ): DriverDevice {
+    const newDriverData: Record<string, unknown> = {
+      ...(isRecord(device.driverData) ? device.driverData : {}),
+      slimSignature: signature,
+      // `currentToken` was read from the erasable mark *before* this reboot -- a reboot alone
+      // never touches the mark (only `provision`/`reclaim` rewrite it), so re-reading afterward
+      // would just repeat the same value at the cost of another filesystem round trip.
+      ...(currentToken === undefined ? {} : { slimMarkToken: currentToken }),
+    };
+
+    this.#onSlimmed?.({
+      address: data.udid,
+      categories: resolved.categories.map((category) => category.name),
+      deviceId: device.deviceId,
+      durationMs: this.#clock.now() - startedAt,
+      labelCount: labels.length,
+      signature,
+      unknownLabels: [...resolved.unknown, ...applyOutcome.failedLabels],
+    });
+
+    return {
+      address: data.udid,
+      deviceId: device.deviceId,
+      driverData: newDriverData,
+      featureProfile: "reduced",
+    };
+  }
+
+  /**
+   * Batches `launchctl disable system/<label>` calls into shell loops of at most
+   * `SLIM_CHUNK_SIZE`, one `simctl spawn` per chunk -- ~170 individual spawns would dominate the
+   * slim budget (see `SLIM_CHUNK_SIZE`'s comment). Each label that `launchctl disable` itself
+   * rejects (e.g. renamed/removed between runtimes) is caught by the script's own `|| echo` and
+   * reported back, never thrown (ADR point 8) -- only a chunk that fails to run at all (timeout,
+   * nonzero exit from the `sh -c` invocation itself) is treated as that chunk's labels failing
+   * outright. The whole apply is reported as failed only when *no* chunk ran successfully.
+   */
+  async #applySlimLabels(udid: string, labels: readonly string[]): Promise<SlimApplyOutcome> {
+    const { safe, rejected } = sanitizeSlimLabels(labels);
+    if (safe.length === 0) {
+      return { detail: "no labels passed the shell-safety filter", kind: "failed" };
+    }
+
+    const chunks = chunk(safe, SLIM_CHUNK_SIZE);
+    const failedLabels: string[] = [...rejected];
+    let anyChunkSucceeded = false;
+
+    for (const chunkLabels of chunks) {
+      const script =
+        `for l in ${chunkLabels.join(" ")}; do launchctl disable "system/$l" ` +
+        `>/dev/null 2>&1 || echo "${SLIM_FAILED_MARKER} $l"; done`;
+      const outcome = await this.#invokeSimctl(
+        ["spawn", udid, "/bin/sh", "-c", script],
+        SLIM_CHUNK_TIMEOUT_MS,
+      );
+
+      if (outcome.kind === "timed-out" || outcome.result.code !== 0) {
+        failedLabels.push(...chunkLabels);
+        continue;
+      }
+
+      anyChunkSucceeded = true;
+      for (const line of outcome.result.stdout.split("\n")) {
+        const match = /^simlock-slim-failed (\S+)$/.exec(line.trim());
+        if (match?.[1] !== undefined) {
+          failedLabels.push(match[1]);
+        }
+      }
+    }
+
+    if (!anyChunkSucceeded) {
+      return { detail: `all ${String(chunks.length)} chunk(s) failed to run`, kind: "failed" };
+    }
+
+    return { failedLabels, kind: "applied" };
   }
 
   async reclaim(
@@ -592,7 +894,10 @@ export class IosSimctlDriver implements Driver {
       case "provision":
         return PROVISION_ESTIMATE_MS;
       case "boot":
-        return COLD_BOOT_ESTIMATE_MS;
+        // Slim mode pays for a second boot plus a launchctl-disable pass on top of the usual
+        // one -- quoting the plain cold-boot number here would make `doctor` flag every slim
+        // device as stalled.
+        return this.#slim?.enabled === true ? SLIM_BOOT_ESTIMATE_MS : COLD_BOOT_ESTIMATE_MS;
       case "reclaim":
         // `reclaimStrategy` returns `erase` for both clean levels, so there is nothing to
         // branch on here -- the clean level only matters to a driver that has a fast path.
@@ -1109,7 +1414,115 @@ function iosDriverData(device: DriverDevice): IosDriverData {
     name: value.name,
     runtimeId: value.runtimeId,
     udid: value.udid,
+    // All three are optional and post-date `state.json` registries written before slim mode
+    // shipped -- absent or wrong-typed is tolerated (ignored) rather than rejected, so an old
+    // registry keeps loading (compatibility requirement).
+    ...(typeof value.full === "boolean" ? { full: value.full } : {}),
+    ...(typeof value.slimSignature === "string" ? { slimSignature: value.slimSignature } : {}),
+    ...(typeof value.slimMarkToken === "string" ? { slimMarkToken: value.slimMarkToken } : {}),
   };
+}
+
+/**
+ * Parses the iOS version out of a `simctl` runtime identifier, e.g.
+ * `com.apple.CoreSimulator.SimRuntime.iOS-18-5` -> `[18, 5]`. Handles a bare major
+ * (`iOS-18` -> `[18, 0]`) and a trailing patch segment (`iOS-18-5-1`, patch ignored) the same
+ * way. An unparseable or empty `runtimeId` returns `undefined`.
+ */
+export function iosRuntimeVersionFromId(runtimeId: string): readonly [number, number] | undefined {
+  const match = /iOS-(\d+)(?:-(\d+))?(?:-(\d+))?$/.exec(runtimeId);
+  if (match === null) {
+    return undefined;
+  }
+  const major = Number.parseInt(match[1] ?? "", 10);
+  const minor = match[2] === undefined ? 0 : Number.parseInt(match[2], 10);
+  if (Number.isNaN(major) || Number.isNaN(minor)) {
+    return undefined;
+  }
+  return [major, minor];
+}
+
+/**
+ * ADR point 4: `launchctl disable` overrides only persist across reboots on iOS 18.5+; older
+ * runtimes accept the commands but silently drop them on reboot, which would make slimming pay
+ * for a second boot for nothing. `undefined` (unparseable/empty `runtimeId`) is never supported --
+ * an unknown version is not assumed new enough.
+ */
+export function supportsPersistentSlim(version: readonly [number, number] | undefined): boolean {
+  if (version === undefined) {
+    return false;
+  }
+  const [major, minor] = version;
+  return major > 18 || (major === 18 && minor >= 5);
+}
+
+/**
+ * What `makeReady` should do about slimming this boot -- decided from `driverData` and the slim
+ * options alone, before any `simctl` call runs. `"off"` covers both slim mode being disabled
+ * entirely and this device's per-lease `full: true` opt-out; `"skip"` is the runtime-gate
+ * failure (too old / unparseable), carrying the `SlimSkippedFact` fields `makeReady` reports
+ * as-is; `"apply"` carries the resolved `slim` options `#applySlimAndReboot` needs.
+ */
+type SlimPlan =
+  | { readonly kind: "off" }
+  | { readonly kind: "skip"; readonly reason: SlimSkippedFact["reason"]; readonly detail: string }
+  | { readonly kind: "apply"; readonly slim: SlimOptions };
+
+/**
+ * Pure decision step extracted from `makeReady`: given only this device's driver data and the
+ * driver's slim options, decides what this boot should do and how long the initial `bootstatus`
+ * wait may take. Slim mode off, or this device's `full: true` opt-out, both read as `"off"` --
+ * the two are equivalent from here on (same as-is return, same ordinary boot deadline).
+ */
+function planSlimBoot(
+  data: IosDriverData,
+  slim: SlimOptions | undefined,
+): { readonly plan: SlimPlan; readonly bootstatusTimeoutMs: number } {
+  if (slim === undefined || !slim.enabled || data.full === true) {
+    return { bootstatusTimeoutMs: BOOTSTATUS_TIMEOUT_MS, plan: { kind: "off" } };
+  }
+
+  const version = iosRuntimeVersionFromId(data.runtimeId);
+  if (!supportsPersistentSlim(version)) {
+    return {
+      bootstatusTimeoutMs: BOOTSTATUS_TIMEOUT_MS,
+      plan: {
+        detail:
+          version === undefined
+            ? `runtimeId "${data.runtimeId}" does not parse to an iOS version`
+            : `iOS ${String(version[0])}.${String(version[1])} is below the 18.5 persistent-override floor`,
+        kind: "skip",
+        reason: version === undefined ? "unknown-runtime" : "runtime-too-old",
+      },
+    };
+  }
+
+  return { bootstatusTimeoutMs: slim.bootTimeoutMs, plan: { kind: "apply", slim } };
+}
+
+/**
+ * Defense in depth for the generated `sh -c` script (see `#applySlimLabels`): labels are
+ * compile-time constants from `slim-labels.ts`, so this should never actually reject anything in
+ * production, but a label containing shell metacharacters must never reach the script unfiltered.
+ */
+export function sanitizeSlimLabels(labels: readonly string[]): {
+  readonly safe: readonly string[];
+  readonly rejected: readonly string[];
+} {
+  const safe: string[] = [];
+  const rejected: string[] = [];
+  for (const label of labels) {
+    (SLIM_LABEL_SAFE_PATTERN.test(label) ? safe : rejected).push(label);
+  }
+  return { rejected, safe };
+}
+
+function chunk<T>(items: readonly T[], size: number): readonly (readonly T[])[] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
 }
 
 function alreadyShutdown(stderr: string): boolean {

--- a/src/drivers/ios/index.ts
+++ b/src/drivers/ios/index.ts
@@ -3,6 +3,7 @@ import {
   type DeviceRequest,
   DiskSpaceGuard,
   type Driver,
+  type DriverAdvisory,
   type DriverCatalogEntry,
   type DriverDevice,
   DriverCrashError,
@@ -906,6 +907,48 @@ export class IosSimctlDriver implements Driver {
   }
 
   /**
+   * ADR point 4 (issue #87): slim mode is silent about the runtime gate everywhere except
+   * `makeReady`'s per-boot `SlimSkippedFact` -- an operator who never leases a device on an
+   * old runtime would otherwise have no way to learn slimming is doing nothing for it. Reports
+   * one `slim-runtime-unsupported` advisory naming every installed runtime that predates the
+   * 18.5 persistent-override floor, using the same `supportsPersistentSlim` gate `planSlimBoot`
+   * uses for the real per-device decision, so this can never drift from what `makeReady` will
+   * actually do. Nothing when slim mode is off (there is no gate to warn about) or when every
+   * installed runtime qualifies. Read-only: only `#loadCatalog` (a `simctl list`) runs, no
+   * boot, no download, no mutation -- matching `listCatalog`'s own contract.
+   */
+  async advisories(): Promise<readonly DriverAdvisory[]> {
+    if (this.#slim === undefined || !this.#slim.enabled) {
+      return [];
+    }
+
+    const catalog = await this.#loadCatalog();
+    const unsupportedVersions = [
+      ...new Set(
+        catalog.runtimes
+          .filter((runtime) => runtime.isAvailable)
+          .filter((runtime) => !supportsPersistentSlim(runtimeVersionTuple(runtime.version)))
+          .map((runtime) => runtime.version),
+      ),
+    ].sort(compareVersions);
+
+    if (unsupportedVersions.length === 0) {
+      return [];
+    }
+
+    const plural = unsupportedVersions.length > 1;
+    return [
+      {
+        code: "slim-runtime-unsupported",
+        message:
+          `Slim mode is enabled, but iOS ${unsupportedVersions.join(", ")} ${plural ? "are" : "is"} ` +
+          `below the 18.5 persistent-override floor; devices on ${plural ? "those runtimes" : "that runtime"} ` +
+          `are never slimmed -- \`launchctl disable\` overrides do not survive a reboot below iOS 18.5`,
+      },
+    ];
+  }
+
+  /**
    * Data-container path for a device. `simctl create` returns only the UDID,
    * and a `simctl list` costs ~260ms -- enough to matter on `reclaim`, which
    * runs on every release. So the devices root is learned once from simctl's
@@ -1351,6 +1394,17 @@ function formatVersionRange(min: number, max: number): string {
 function versionTriple(version: string): readonly [number, number, number] {
   const parts = version.split(".").map(versionPart);
   return [parts[0] ?? 0, parts[1] ?? 0, parts[2] ?? 0];
+}
+
+/**
+ * `[major, minor]` from a catalog runtime's marketing version string (e.g. `"18.5"`) -- the
+ * same shape `supportsPersistentSlim` already takes from `iosRuntimeVersionFromId`'s parse of a
+ * `runtimeId`, so `#advisories` can reuse that one gate instead of re-deriving it. Built on the
+ * existing `versionTriple` parse rather than a new one.
+ */
+function runtimeVersionTuple(version: string): readonly [number, number] {
+  const [major, minor] = versionTriple(version);
+  return [major, minor];
 }
 
 function versionOrdinal(triple: readonly [number, number, number]): number {

--- a/src/drivers/ios/index.ts
+++ b/src/drivers/ios/index.ts
@@ -167,10 +167,28 @@ export interface IosSimctlDriverOptions {
 
 type SlimOptions = NonNullable<IosSimctlDriverOptions["slim"]>;
 
-/** Result of `#applySlimLabels`: either every label was attempted (some may still have failed
- * individually, tracked in `failedLabels`), or the whole apply never ran. */
+/**
+ * Result of `#applySlimLabels`: either every chunk was attempted (individual labels may still
+ * have been rejected, tracked separately below), or the whole apply never ran.
+ *
+ * The "applied" variant deliberately splits two very different kinds of not-fully-applied into
+ * separate fields rather than one bag:
+ * - `rejectedLabels`: the in-simulator script itself rejected this label (a `simlock-slim-failed`
+ *   line), or `sanitizeSlimLabels` filtered it before the script ever ran. This is ADR point 8's
+ *   "log and continue" case, and it is PERMANENT -- the daemon that owns this label is gone or
+ *   renamed on this runtime, and retrying on every boot would never change that outcome. It must
+ *   NOT block writing the idempotence marker (see `#applySlimAndReboot`), or a runtime with one
+ *   permanently-unknown daemon would re-apply the whole label set forever and never converge.
+ * - `unattemptedLabels`: a whole chunk timed out or exited nonzero, so those labels were never
+ *   attempted at all. This is transient (the daemon script itself never ran) and MUST be retried,
+ *   which is why it blocks the idempotence marker.
+ */
 type SlimApplyOutcome =
-  | { readonly kind: "applied"; readonly failedLabels: readonly string[] }
+  | {
+      readonly kind: "applied";
+      readonly rejectedLabels: readonly string[];
+      readonly unattemptedLabels: readonly string[];
+    }
   | { readonly kind: "failed"; readonly detail: string };
 
 interface DeviceType {
@@ -693,10 +711,13 @@ export class IosSimctlDriver implements Driver {
   ): Promise<DriverDevice> {
     const resolved = resolveSlimCategories(slim.categories);
     if (resolved.categories.length === 0) {
+      // Nothing was ever attempted and no reboot happened: this device is exactly as full-featured
+      // as it was before `makeReady` was called.
       return this.#skipApply(
         device,
         data,
         `none of the configured slim categories (${(slim.categories ?? []).join(", ")}) are known`,
+        "full",
       );
     }
 
@@ -710,51 +731,75 @@ export class IosSimctlDriver implements Driver {
     const startedAt = this.#clock.now();
     const applyOutcome = await this.#applySlimLabels(data.udid, labels);
     if (applyOutcome.kind === "failed") {
-      return this.#skipApply(device, data, applyOutcome.detail);
+      // Every chunk failed to run (or nothing passed the safety filter): nothing was applied and
+      // no reboot happened, so the device is still full-featured.
+      return this.#skipApply(device, data, applyOutcome.detail, "full");
     }
 
     // The reboot below is what makes the disable entries take effect; never write the
     // idempotence marker or report `device.slimmed` on a device that hasn't actually rebooted
     // with them applied. `makeReady`'s own contract ("a failed or skipped slim never fails the
-    // lease") holds here too: a hiccup in this reboot must downgrade to the skip path rather
-    // than fail a lease that would otherwise have worked, *unless* the device has actually been
-    // left shut down by it -- see the two branches below.
-    let shutdownSucceeded = false;
+    // lease") holds here too: a hiccup here must downgrade to the skip path rather than fail a
+    // lease that would otherwise have worked -- but the shutdown call's own outcome is never a
+    // reliable signal of what the device is actually doing (see below), so it is captured, not
+    // acted on directly.
+    let shutdownError: unknown;
     try {
       await this.#shutdown(data.udid);
-      shutdownSucceeded = true;
-      await this.#bootAndWait(data.udid, device.deviceId, bootstatusTimeoutMs);
     } catch (error: unknown) {
-      if (!shutdownSucceeded) {
-        // The shutdown itself never completed (a non-zero exit or a timeout) -- the device is
-        // still in the state the first boot above left it in, i.e. still healthy and running.
-        // Nothing was actually rebooted, so there's nothing to commit; downgrade to skip.
-        return this.#skipApply(device, data, `slim shutdown failed: ${errorMessage(error)}`);
-      }
-      // Shutdown succeeded but the second boot didn't: the device is now genuinely shut down,
-      // not "ready" as returning it here would claim. Reporting this as a skip would hand the
-      // caller a device that isn't actually usable, so this must propagate like any other boot
-      // failure (`BootTimeoutError` / `DriverCrashError`).
-      throw error;
+      shutdownError = error;
     }
+    // Always re-establish a known-good running device, whether or not the shutdown above actually
+    // completed. `#shutdown` throws on a *timeout* of `simctl shutdown`, which is exactly the
+    // moment the shutdown is most likely to still be in progress or to have already finished --
+    // there is no reliable way to tell which from the exception alone, so this stops guessing:
+    // `boot` already tolerates an already-booted device, so the boot below reaches a known-good
+    // running device either way. A genuine inability to get it running again propagates as
+    // `BootTimeoutError` / `DriverCrashError`, as it should -- that case really does mean the
+    // device is left shut down, not "ready" as returning it would falsely claim.
+    await this.#bootAndWait(data.udid, device.deviceId, bootstatusTimeoutMs);
 
-    if (applyOutcome.failedLabels.length > 0) {
-      // Partial apply: at least one chunk failed to run outright, or the script itself reported
-      // an individual `launchctl disable` failure. The reboot above already happened -- the
-      // labels that did apply are worth keeping -- but the idempotence marker must NOT be
-      // written: writing it here would permanently mark this device "slim" (see
-      // `#checkAlreadySlimmed`) even though part of the disable list never took effect, and
-      // every later boot would then trust the marker and never retry the labels that failed,
-      // with no way back short of `reclaim`/`erase`. So a partial apply deliberately costs a
-      // re-attempt of the *whole* label set on the next `makeReady` instead -- applying an
-      // already-disabled label again is harmless (same comment on `#checkAlreadySlimmed`).
+    if (shutdownError !== undefined) {
+      // The shutdown call itself failed, so whether the labels' reboot actually took effect is
+      // unknown -- this is an uncertain apply, not a confirmed one. Never write the idempotence
+      // marker on it (same reasoning as the partial-apply case below), and report "reduced" (not
+      // "full") under that uncertainty: telling a caller a device is slim when it is not is
+      // benign -- it just avoids features it could have used -- while telling it a device is full
+      // when it is not makes push / Spotlight / StoreKit fail with no explanation, exactly the
+      // confusion the `slim` flag exists to prevent.
       return this.#skipApply(
         device,
         data,
-        `${String(applyOutcome.failedLabels.length)} of ${String(labels.length)} labels failed to apply`,
+        `slim shutdown failed: ${errorMessage(shutdownError)}`,
+        "reduced",
       );
     }
 
+    if (applyOutcome.unattemptedLabels.length > 0) {
+      // Partial apply: at least one chunk failed to run outright, so those labels were never even
+      // attempted. The reboot above already happened -- the labels that did apply are worth
+      // keeping -- but the idempotence marker must NOT be written: writing it here would
+      // permanently mark this device "slim" (see `#checkAlreadySlimmed`) even though part of the
+      // disable list never took effect, and every later boot would then trust the marker and
+      // never retry the labels that were never attempted, with no way back short of
+      // `reclaim`/`erase`. So a partial apply deliberately costs a re-attempt of the *whole*
+      // label set on the next `makeReady` instead -- applying an already-disabled label again is
+      // harmless (same comment on `#checkAlreadySlimmed`). "reduced" because the labels that did
+      // apply really are gone.
+      return this.#skipApply(
+        device,
+        data,
+        `${String(applyOutcome.unattemptedLabels.length)} of ${String(labels.length)} labels were never attempted (a chunk failed to run)`,
+        "reduced",
+      );
+    }
+
+    // Every chunk ran (individual labels may still have been rejected by the script itself, or
+    // filtered by `sanitizeSlimLabels` -- `rejectedLabels`, which is permanent, ADR point 8's
+    // "log and continue" case). That is not grounds to withhold the marker: doing so would make a
+    // runtime with one permanently-unknown daemon re-apply the whole label set on every boot,
+    // forever, and never converge. The rejected labels travel in `SlimmedFact.unknownLabels`
+    // instead.
     return this.#commitSlim(
       device,
       data,
@@ -768,9 +813,14 @@ export class IosSimctlDriver implements Driver {
   }
 
   /** Reports `device.slim-skipped` with reason `apply-failed` and returns the device as-is. */
-  #skipApply(device: DriverDevice, data: IosDriverData, detail: string): DriverDevice {
+  #skipApply(
+    device: DriverDevice,
+    data: IosDriverData,
+    detail: string,
+    featureProfile: "full" | "reduced",
+  ): DriverDevice {
     this.#onSlimSkipped?.({ deviceId: device.deviceId, detail, reason: "apply-failed" });
-    return this.#asIs(device, data, "full");
+    return this.#asIs(device, data, featureProfile);
   }
 
   /**
@@ -829,7 +879,7 @@ export class IosSimctlDriver implements Driver {
       durationMs: this.#clock.now() - startedAt,
       labelCount: labels.length,
       signature,
-      unknownLabels: [...resolved.unknown, ...applyOutcome.failedLabels],
+      unknownLabels: [...resolved.unknown, ...applyOutcome.rejectedLabels],
     });
 
     return {
@@ -845,9 +895,11 @@ export class IosSimctlDriver implements Driver {
    * `SLIM_CHUNK_SIZE`, one `simctl spawn` per chunk -- ~170 individual spawns would dominate the
    * slim budget (see `SLIM_CHUNK_SIZE`'s comment). Each label that `launchctl disable` itself
    * rejects (e.g. renamed/removed between runtimes) is caught by the script's own `|| echo` and
-   * reported back, never thrown (ADR point 8) -- only a chunk that fails to run at all (timeout,
-   * nonzero exit from the `sh -c` invocation itself) is treated as that chunk's labels failing
-   * outright. The whole apply is reported as failed only when *no* chunk ran successfully.
+   * reported back into `rejectedLabels`, never thrown (ADR point 8) -- only a chunk that fails to
+   * run at all (timeout, nonzero exit from the `sh -c` invocation itself) is treated as that
+   * chunk's labels never having been attempted (`unattemptedLabels`). See `SlimApplyOutcome` for
+   * why the two are tracked separately. The whole apply is reported as failed only when *no*
+   * chunk ran successfully.
    */
   async #applySlimLabels(udid: string, labels: readonly string[]): Promise<SlimApplyOutcome> {
     const { safe, rejected } = sanitizeSlimLabels(labels);
@@ -856,7 +908,11 @@ export class IosSimctlDriver implements Driver {
     }
 
     const chunks = chunk(safe, SLIM_CHUNK_SIZE);
-    const failedLabels: string[] = [...rejected];
+    // `sanitizeSlimLabels`-filtered labels never reached any chunk, so they were rejected the
+    // same way an individual `simlock-slim-failed` line is -- not merely "unattempted" (that's
+    // reserved for a whole chunk that failed to run).
+    const rejectedLabels: string[] = [...rejected];
+    const unattemptedLabels: string[] = [];
     let anyChunkSucceeded = false;
 
     for (const chunkLabels of chunks) {
@@ -869,7 +925,7 @@ export class IosSimctlDriver implements Driver {
       );
 
       if (outcome.kind === "timed-out" || outcome.result.code !== 0) {
-        failedLabels.push(...chunkLabels);
+        unattemptedLabels.push(...chunkLabels);
         continue;
       }
 
@@ -877,7 +933,7 @@ export class IosSimctlDriver implements Driver {
       for (const line of outcome.result.stdout.split("\n")) {
         const match = SLIM_FAILED_MARKER_PATTERN.exec(line.trim());
         if (match?.[1] !== undefined) {
-          failedLabels.push(match[1]);
+          rejectedLabels.push(match[1]);
         }
       }
     }
@@ -886,7 +942,7 @@ export class IosSimctlDriver implements Driver {
       return { detail: `all ${String(chunks.length)} chunk(s) failed to run`, kind: "failed" };
     }
 
-    return { failedLabels, kind: "applied" };
+    return { kind: "applied", rejectedLabels, unattemptedLabels };
   }
 
   async reclaim(

--- a/src/drivers/ios/slim-labels.test.ts
+++ b/src/drivers/ios/slim-labels.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  labelsFor,
+  resolveSlimCategories,
+  SLIM_CATEGORIES,
+  SLIM_CATEGORY_NAMES,
+  slimSignature,
+} from "./slim-labels.js";
+
+describe("SLIM_CATEGORIES", () => {
+  it("every category has at least one label", () => {
+    for (const category of SLIM_CATEGORIES) {
+      expect(category.labels.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("no label is empty", () => {
+    for (const category of SLIM_CATEGORIES) {
+      for (const label of category.labels) {
+        expect(label.trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("SLIM_CATEGORY_NAMES matches the category list", () => {
+    expect(SLIM_CATEGORY_NAMES).toEqual(SLIM_CATEGORIES.map((c) => c.name));
+  });
+});
+
+describe("resolveSlimCategories", () => {
+  it("resolves to every category when undefined", () => {
+    const { categories, unknown } = resolveSlimCategories(undefined);
+    expect(categories).toEqual(SLIM_CATEGORIES);
+    expect(unknown).toEqual([]);
+  });
+
+  it("resolves a subset by name, preserving requested order", () => {
+    const { categories, unknown } = resolveSlimCategories(["telemetry", "siri"]);
+    expect(categories.map((c) => c.name)).toEqual(["telemetry", "siri"]);
+    expect(unknown).toEqual([]);
+  });
+
+  it("dedupes repeated requested names", () => {
+    const { categories } = resolveSlimCategories(["siri", "siri"]);
+    expect(categories.map((c) => c.name)).toEqual(["siri"]);
+  });
+
+  it("reports unknown names separately instead of throwing", () => {
+    const { categories, unknown } = resolveSlimCategories(["siri", "bogus", "also-bogus"]);
+    expect(categories.map((c) => c.name)).toEqual(["siri"]);
+    expect(unknown).toEqual(["bogus", "also-bogus"]);
+  });
+
+  it("resolves an empty request to no categories", () => {
+    const { categories, unknown } = resolveSlimCategories([]);
+    expect(categories).toEqual([]);
+    expect(unknown).toEqual([]);
+  });
+});
+
+describe("labelsFor", () => {
+  it("dedupes labels shared across categories and sorts them", () => {
+    const store = SLIM_CATEGORIES.find((c) => c.name === "store")!;
+    const icloud = SLIM_CATEGORIES.find((c) => c.name === "icloud")!;
+    // store and icloud both list com.apple.amsaccountsd et al.
+    const labels = labelsFor([store, icloud]);
+    const asSet = new Set(labels);
+    expect(asSet.size).toBe(labels.length);
+    expect([...labels]).toEqual([...labels].sort());
+    expect(labels).toContain("com.apple.amsaccountsd");
+  });
+
+  it("returns an empty array for no categories", () => {
+    expect(labelsFor([])).toEqual([]);
+  });
+
+  it("is deterministic across calls", () => {
+    const first = labelsFor(SLIM_CATEGORIES);
+    const second = labelsFor(SLIM_CATEGORIES);
+    expect(first).toEqual(second);
+  });
+});
+
+describe("slimSignature", () => {
+  it("is stable for the same input", () => {
+    const a = slimSignature(SLIM_CATEGORIES);
+    const b = slimSignature(SLIM_CATEGORIES);
+    expect(a).toBe(b);
+  });
+
+  it("is stable regardless of input category order", () => {
+    const forward = slimSignature(SLIM_CATEGORIES);
+    const reversed = slimSignature([...SLIM_CATEGORIES].reverse());
+    expect(forward).toBe(reversed);
+  });
+
+  it("is prefixed with a schema version", () => {
+    expect(slimSignature(SLIM_CATEGORIES)).toMatch(/^v1:[0-9a-f]{16}$/);
+  });
+
+  it("changes when the set of categories changes", () => {
+    const all = slimSignature(SLIM_CATEGORIES);
+    const subset = slimSignature(SLIM_CATEGORIES.slice(0, -1));
+    expect(all).not.toBe(subset);
+  });
+
+  it("changes when a category's labels change", () => {
+    const original = SLIM_CATEGORIES[0]!;
+    const mutated = { ...original, labels: [...original.labels, "com.apple.made-up-daemon"] };
+    const before = slimSignature([original]);
+    const after = slimSignature([mutated]);
+    expect(before).not.toBe(after);
+  });
+
+  it("returns the same signature for an empty category list regardless of call site", () => {
+    expect(slimSignature([])).toBe(slimSignature([]));
+  });
+});

--- a/src/drivers/ios/slim-labels.ts
+++ b/src/drivers/ios/slim-labels.ts
@@ -1,0 +1,349 @@
+import { createHash } from "node:crypto";
+
+// Data source: simslim (https://github.com/mobai-app/simslim), MIT licensed.
+// Category names, descriptions, and launchd label lists below are copied
+// verbatim from `Categories` in profiles.go at commit
+// 65bda5bd746a32abff14fa1160e4d802e2b057c4 (2026-08-03), the source simslim
+// uses to disable background daemons inside a booted simulator via
+// `xcrun simctl spawn <udid> launchctl disable system/<label>` before a
+// reboot (see docs/agent-rules for how simlock's own driver invokes this).
+//
+// Apple renames, adds, and removes these daemons between iOS runtime
+// versions, so this list is versioned *data*, not code: it is expected to
+// need periodic re-syncing against upstream simslim as new runtimes ship,
+// and is deliberately kept out of any logic module so that resyncing it
+// never requires touching driver behavior.
+
+/** A named group of launchd daemon labels a slim boot may disable together. */
+export interface SlimCategory {
+  readonly name: string;
+  readonly description: string;
+  readonly labels: readonly string[];
+}
+
+export const SLIM_CATEGORIES: readonly SlimCategory[] = [
+  {
+    name: "widgets",
+    description: "Home and lock screen posters, widgets, and Live Activities.",
+    labels: ["com.apple.PosterBoard", "com.apple.chronod", "com.apple.liveactivitiesd"],
+  },
+  {
+    name: "siri",
+    description: "Siri, Apple Intelligence, speech, and on-device ML model services.",
+    labels: [
+      "com.apple.assistantd",
+      "com.apple.assistant_cdmd",
+      "com.apple.assistant_service",
+      "com.apple.siriactionsd",
+      "com.apple.siriinferenced",
+      "com.apple.siriknowledged",
+      "com.apple.sirittsd",
+      "com.apple.siri.context.service",
+      "com.apple.siri.acousticsignature",
+      "com.apple.corespeechd",
+      "com.apple.voiced",
+      "com.apple.voicebankingd",
+      "com.apple.speechmodeltrainingd",
+      "com.apple.intelligenceplatformd",
+      "com.apple.intelligencecontextd",
+      "com.apple.intelligenceflowd",
+      "com.apple.intelligencetasksd",
+      "com.apple.generativeexperiencesd",
+      "com.apple.knowledgeconstructiond",
+      "com.apple.naturallanguaged",
+      "com.apple.textunderstandingd",
+      "com.apple.modelcatalogd",
+      "com.apple.modelmanagerd",
+      "com.apple.mlhostd",
+      "com.apple.mlruntimed",
+      "com.apple.suggestd",
+      "com.apple.parsecd",
+      "com.apple.parsec-fbf",
+      "com.apple.proactiveeventtrackerd",
+    ],
+  },
+  {
+    name: "search",
+    description: "On-device Spotlight and in-Settings search services.",
+    labels: [
+      "com.apple.searchd",
+      "com.apple.searchtoold",
+      "com.apple.spotlightknowledged",
+      "com.apple.spotlightknowledged.updater",
+      "com.apple.corespotlightservice",
+    ],
+  },
+  {
+    name: "icloud",
+    description: "iCloud sync, Apple Account, keychain, and backup services.",
+    labels: [
+      "com.apple.appleaccountd",
+      "com.apple.appleaccounttransparencyd",
+      "com.apple.appleidsetupd",
+      "com.apple.akd",
+      "com.apple.amsaccountsd",
+      "com.apple.amsengagementd",
+      "com.apple.amsondevicestoraged",
+      "com.apple.cloudd",
+      "com.apple.cloudphotod",
+      "com.apple.ckdiscretionaryd",
+      "com.apple.cloudsettingssyncagent",
+      "com.apple.bird",
+      "com.apple.syncdefaultsd",
+      "com.apple.cdpd",
+      "com.apple.sosd",
+      "com.apple.SecureBackupDaemon",
+      "com.apple.TrustedPeersHelper",
+      "com.apple.protectedcloudstorage.protectedcloudkeysyncing",
+      "com.apple.icloudmailagent",
+      "com.apple.icloudsubscriptionoptimizerd",
+      "com.apple.communicationtrustd",
+    ],
+  },
+  {
+    name: "store",
+    description: "App Store, push notification, StoreKit, and media services.",
+    labels: [
+      "com.apple.appstored",
+      "com.apple.appstorecomponentsd",
+      "com.apple.apsd",
+      "com.apple.itunescloudd",
+      "com.apple.itunesstored",
+      "com.apple.storekitd",
+      "com.apple.amsaccountsd",
+      "com.apple.amsengagementd",
+      "com.apple.amsondevicestoraged",
+      "com.apple.passd",
+      "com.apple.financed",
+      "com.apple.videosubscriptionsd",
+      "com.apple.assetsubscriptiond",
+      "com.apple.musicd",
+    ],
+  },
+  {
+    name: "pim",
+    description: "Mail, Calendar, Contacts, Reminders, and related sync services.",
+    labels: [
+      "com.apple.email.maild",
+      "com.apple.exchangesyncd",
+      "com.apple.dataaccess.dataaccessd",
+      "com.apple.calaccessd",
+      "com.apple.remindd",
+      "com.apple.contactsd",
+      "com.apple.contacts.postersyncd",
+      "com.apple.peopled",
+    ],
+  },
+  {
+    name: "web",
+    description: "Safari sync, web push, privacy, and universal-link services.",
+    labels: [
+      "com.apple.SafariBookmarksSyncAgent",
+      "com.apple.Safari.History",
+      "com.apple.Safari.passwordbreachd",
+      "com.apple.Safari.SafeBrowsing.Service",
+      "com.apple.safarifetcherd",
+      "com.apple.WebBookmarks.webbookmarksd",
+      "com.apple.webkit.adattributiond",
+      "com.apple.webkit.webpushd",
+      "com.apple.webprivacyd",
+      "com.apple.swcd",
+    ],
+  },
+  {
+    name: "family",
+    description: "Family Sharing, Screen Time, and usage tracking.",
+    labels: [
+      "com.apple.familycircled",
+      "com.apple.FamilyControlsAgent",
+      "com.apple.familynotification",
+      "com.apple.askpermissiond",
+      "com.apple.asktod",
+      "com.apple.ScreenTimeAgent",
+      "com.apple.ScreenTimeSettingsAgent",
+      "com.apple.UsageTrackingAgent",
+    ],
+  },
+  {
+    name: "health",
+    description: "HealthKit, HomeKit, and Fitness services.",
+    labels: [
+      "com.apple.healthd",
+      "com.apple.healthappd",
+      "com.apple.healthcontentd",
+      "com.apple.healtheventsd",
+      "com.apple.healthrecordsd",
+      "com.apple.finhealthd",
+      "com.apple.homed",
+      "com.apple.homeeventsd",
+      "com.apple.fitcore",
+      "com.apple.fitcore.session",
+      "com.apple.fitnesscoachingd",
+      "com.apple.fitnessintelligenced",
+      "com.apple.activityawardsd",
+      "com.apple.activitysharingd",
+    ],
+  },
+  {
+    name: "photos",
+    description: "Photos library, photo analysis, and media analysis services.",
+    labels: [
+      "com.apple.photoanalysisd",
+      "com.apple.photosface",
+      "com.apple.mediaanalysisd",
+      "com.apple.mediaanalysisd.service",
+      "com.apple.mediastream.mstreamd",
+      "com.apple.medialibraryd",
+      "com.apple.assetsd",
+      "com.apple.assetsd.nebulad",
+    ],
+  },
+  {
+    name: "apps",
+    description: "News, Weather, Maps, Tips, and game services.",
+    labels: [
+      "com.apple.newsd",
+      "com.apple.weatherd",
+      "com.apple.Maps.mapssyncd",
+      "com.apple.Maps.mapspushd",
+      "com.apple.Maps.geocorrectiond",
+      "com.apple.maps.destinationd",
+      "com.apple.MapKit.SnapshotService",
+      "com.apple.jetpackassetd",
+      "com.apple.tipsd",
+      "com.apple.gamed",
+      "com.apple.gamesaved",
+      "com.apple.GameController.gamecontrollerd",
+    ],
+  },
+  {
+    name: "messaging",
+    description: "iMessage, FaceTime, call, and identity services.",
+    labels: [
+      "com.apple.identityservicesd",
+      "com.apple.ids_simd",
+      "com.apple.imautomatichistorydeletionagent",
+      "com.apple.imcore.imtransferagent",
+      "com.apple.imdpersistence.IMDPersistenceAgent",
+      "com.apple.facetimemessagestored",
+      "com.apple.telephonyutilities.callservicesd",
+    ],
+  },
+  {
+    name: "connectivity",
+    description: "AirDrop, Continuity, CarPlay, Watch, and Find My services.",
+    labels: [
+      "com.apple.rapportd",
+      "com.apple.companiond",
+      "com.apple.carkitd",
+      "com.apple.wcd",
+      "com.apple.tvremoted",
+      "com.apple.avatarsd",
+      "com.apple.stickersd",
+      "com.apple.sociallayerd",
+      "com.apple.announced",
+      "com.apple.navd",
+      "com.apple.findmy.findmylocated",
+    ],
+  },
+  {
+    name: "telemetry",
+    description: "DeviceCheck, ad privacy, analytics, diagnostics, and feedback services.",
+    labels: [
+      "com.apple.ap.adprivacyd",
+      "com.apple.ap.promotedcontentd",
+      "com.apple.diagnosticextensionsd",
+      "com.apple.feedbackd",
+      "com.apple.rtcreportingd",
+      "com.apple.securityuploadd",
+      "com.apple.geoanalyticsd",
+      "com.apple.triald",
+      "com.apple.followupd",
+      "com.apple.purplebuddy.budd",
+      "com.apple.devicecheckd",
+    ],
+  },
+  {
+    name: "other",
+    description: "Wallet, business services, assets, and miscellaneous background daemons.",
+    labels: [
+      "com.apple.financed",
+      "com.apple.passd",
+      "com.apple.merchantd",
+      "com.apple.coreidvd",
+      "com.apple.businessservicesd",
+      "com.apple.deviceaccessd",
+      "com.apple.replicatord",
+      "com.apple.linkd",
+      "com.apple.ind",
+      "com.apple.storagedatad",
+      "com.apple.StatusKitAgent",
+      "com.apple.countryd",
+      "com.apple.mobileassetd",
+      "com.apple.managedconfiguration.passcodenagd",
+    ],
+  },
+];
+
+export const SLIM_CATEGORY_NAMES: readonly string[] = SLIM_CATEGORIES.map((c) => c.name);
+
+/**
+ * Resolves a set of requested category names to their {@link SlimCategory}
+ * definitions. `undefined` (no filter given) resolves to every category.
+ * Names that don't match any known category are reported separately as
+ * `unknown` rather than throwing, so a caller can warn and proceed with the
+ * categories it did recognize instead of failing the whole request.
+ */
+export function resolveSlimCategories(requested: readonly string[] | undefined): {
+  readonly categories: readonly SlimCategory[];
+  readonly unknown: readonly string[];
+} {
+  if (requested === undefined) {
+    return { categories: SLIM_CATEGORIES, unknown: [] };
+  }
+  const byName = new Map(SLIM_CATEGORIES.map((c) => [c.name, c] as const));
+  const categories: SlimCategory[] = [];
+  const seen = new Set<string>();
+  const unknown: string[] = [];
+  for (const name of requested) {
+    const category = byName.get(name);
+    if (category === undefined) {
+      unknown.push(name);
+      continue;
+    }
+    if (!seen.has(name)) {
+      seen.add(name);
+      categories.push(category);
+    }
+  }
+  return { categories, unknown };
+}
+
+/** Deduplicated, deterministically sorted labels across the given categories. */
+export function labelsFor(categories: readonly SlimCategory[]): readonly string[] {
+  const labels = new Set<string>();
+  for (const category of categories) {
+    for (const label of category.labels) {
+      labels.add(label);
+    }
+  }
+  return Array.from(labels).sort();
+}
+
+const SIGNATURE_SCHEMA_VERSION = "v1";
+
+/**
+ * A short, stable signature over the resolved category names and their
+ * labels. Used as an idempotence marker: it changes whenever either the
+ * requested category selection or the shipped label data changes, so a
+ * stored marker from a stale config or an older simlock version is detected
+ * as stale rather than silently trusted.
+ */
+export function slimSignature(categories: readonly SlimCategory[]): string {
+  // Pure computation over in-memory data (no filesystem/process/network
+  // access), so this does not need a port per architecture rule 9.
+  const sorted = [...categories].sort((a, b) => a.name.localeCompare(b.name));
+  const payload = sorted.map((c) => `${c.name}:${[...c.labels].sort().join(",")}`).join("|");
+  const hash = createHash("sha256").update(payload).digest("hex").slice(0, 16);
+  return `${SIGNATURE_SCHEMA_VERSION}:${hash}`;
+}

--- a/src/http/app.ts
+++ b/src/http/app.ts
@@ -31,6 +31,7 @@ import type { TokenIdentity } from "./token-store.js";
 import {
   buildLeasePayload,
   isTerminalStage,
+  type LeaseRequestInput,
   LeaseRequestTracker,
   type TrackedRequestView,
 } from "./tracker.js";
@@ -68,12 +69,33 @@ const MAX_IDEMPOTENCY_KEY_LENGTH = 200;
 const leaseRequestBodySchema = z.object({
   allowDownload: z.boolean().optional(),
   device: z.string().min(1),
+  full: z.boolean().optional(),
   noWait: z.boolean().optional(),
   os: z.string().min(1).optional(),
   platform: z.enum(["ios", "android"]),
   timeoutMs: z.number().int().positive().optional(),
   ttlMs: z.number().int().positive().optional(),
 });
+
+/**
+ * Validated request body -> the tracker's own input shape. Every optional key is omitted rather
+ * than passed as `undefined` so a request that did not name a flag stays byte-identical to one
+ * from before that flag existed. `allowDownload` and `full` pass through unclamped, matching the
+ * socket daemon's handling of the same flags; if a config-level policy ever gates either there,
+ * this route must gate through the same helper.
+ */
+function toLeaseRequestInput(body: z.infer<typeof leaseRequestBodySchema>): LeaseRequestInput {
+  return {
+    device: body.device,
+    platform: body.platform,
+    ...(body.os === undefined ? {} : { os: body.os }),
+    ...(body.ttlMs === undefined ? {} : { ttlMs: body.ttlMs }),
+    ...(body.timeoutMs === undefined ? {} : { timeoutMs: body.timeoutMs }),
+    ...(body.noWait === undefined ? {} : { noWait: body.noWait }),
+    ...(body.allowDownload === undefined ? {} : { allowDownload: body.allowDownload }),
+    ...(body.full === undefined ? {} : { full: body.full }),
+  };
+}
 
 /** The gateway-owned subscriptions `createHttpApp` starts, attached to the returned app so a caller can dispose them on shutdown without this module exposing the tracker/notices instances themselves. */
 export interface HttpAppDisposable {
@@ -159,22 +181,7 @@ export function createHttpApp(deps: HttpGatewayDeps): Hono<Env> & HttpAppDisposa
         );
       }
 
-      // `allowDownload` passes through unclamped, matching the socket daemon's handling of the
-      // same flag; if a config-level download policy ever gates it there, this route must gate
-      // through the same helper.
-      const outcome = await tracker.submit(
-        identity,
-        {
-          device: body.device,
-          platform: body.platform,
-          ...(body.os === undefined ? {} : { os: body.os }),
-          ...(body.ttlMs === undefined ? {} : { ttlMs: body.ttlMs }),
-          ...(body.timeoutMs === undefined ? {} : { timeoutMs: body.timeoutMs }),
-          ...(body.noWait === undefined ? {} : { noWait: body.noWait }),
-          ...(body.allowDownload === undefined ? {} : { allowDownload: body.allowDownload }),
-        },
-        idempotencyKey,
-      );
+      const outcome = await tracker.submit(identity, toLeaseRequestInput(body), idempotencyKey);
       if (outcome.kind === "rejected") {
         return errorResponse(c, outcome.error);
       }

--- a/src/http/test-fakes.ts
+++ b/src/http/test-fakes.ts
@@ -40,6 +40,7 @@ export function testConfig(overrides: Partial<Config["lease"]> = {}): Config {
     },
     http: { enabled: true, host: "127.0.0.1", port: 4700 },
     idle: { deleteAfterMs: 60_000, shutdownAfterMs: 10_000 },
+    ios: { slim: { enabled: false, bootTimeoutMs: 600_000 } },
     lease: {
       detachedTtlMs: 900_000,
       heartbeatIntervalMs: 5_000,

--- a/src/http/tracker.test.ts
+++ b/src/http/tracker.test.ts
@@ -289,6 +289,42 @@ describe("LeaseRequestTracker.submit with allowDownload", () => {
   });
 });
 
+describe("LeaseRequestTracker.submit with full", () => {
+  it("passes full through onto the DeviceRequest, and omits it otherwise", async () => {
+    const { leases, tracker } = buildTracker();
+    await createTracked(tracker, leases, { ...body, full: true } as typeof body);
+    expect(leases.calls[0]?.request).toMatchObject({ full: true });
+
+    const { leases: leases2, tracker: tracker2 } = buildTracker();
+    await createTracked(tracker2, leases2);
+    expect(leases2.calls[0]?.request).not.toHaveProperty("full");
+  });
+});
+
+describe("LeaseRequestTracker granted lease payload", () => {
+  it("reports slim: false when the granted device's featureProfile is absent", async () => {
+    const { leases, tracker } = buildTracker();
+    const { view, callIndex } = await createTracked(tracker, leases);
+    leases.calls[callIndex]?.resolve(makeGrant());
+    await Promise.resolve();
+    await Promise.resolve();
+    const state = tracker.get(view.id)?.state;
+    if (state?.stage !== "granted") throw new Error("expected granted");
+    expect(state.lease.slim).toBe(false);
+  });
+
+  it("reports slim: true when the granted device's featureProfile is reduced", async () => {
+    const { leases, tracker } = buildTracker();
+    const { view, callIndex } = await createTracked(tracker, leases);
+    leases.calls[callIndex]?.resolve(makeGrant({ device: { featureProfile: "reduced" } }));
+    await Promise.resolve();
+    await Promise.resolve();
+    const state = tracker.get(view.id)?.state;
+    if (state?.stage !== "granted") throw new Error("expected granted");
+    expect(state.lease.slim).toBe(true);
+  });
+});
+
 describe("LeaseRequestTracker.waitForChange abort", () => {
   it("finishes immediately when the caller's signal aborts", async () => {
     const { leases, tracker } = buildTracker();

--- a/src/http/tracker.ts
+++ b/src/http/tracker.ts
@@ -18,6 +18,7 @@ export interface LeaseRequestInput {
   readonly timeoutMs?: number;
   readonly noWait?: boolean;
   readonly allowDownload?: boolean;
+  readonly full?: boolean;
 }
 
 /** Matches the issue's lease object exactly; `dataPlane` is reserved and always `null` in v1. */
@@ -33,6 +34,8 @@ export interface LeasePayload {
   readonly expiresAt: string;
   readonly ttlMs: number;
   readonly dataPlane: null;
+  /** Whether the granted device had its feature set reduced -- see `DeviceRecord.featureProfile`. */
+  readonly slim: boolean;
 }
 
 /**
@@ -60,6 +63,7 @@ export function buildLeasePayload(
     expiresAt: new Date(lease.ttlDeadline).toISOString(),
     ttlMs: extra.ttlMs,
     dataPlane: null,
+    slim: device.featureProfile === "reduced",
   };
 }
 
@@ -189,6 +193,7 @@ export class LeaseRequestTracker {
       model: body.device,
       platform: body.platform,
       ...(body.os === undefined ? {} : { osVersion: body.os }),
+      ...(body.full === undefined ? {} : { full: body.full }),
     };
 
     // Races the grant/rejection against the request's *first* progress callback. A rejection

--- a/src/mcp/contracts.test.ts
+++ b/src/mcp/contracts.test.ts
@@ -13,9 +13,16 @@ describe("MCP contracts", () => {
     expect(leaseSimulatorInputSchema.parse({ device: "iPhone 17 Pro", platform: "ios" })).toEqual({
       allow_download: false,
       device: "iPhone 17 Pro",
+      full: false,
       no_wait: false,
       platform: "ios",
     });
+  });
+
+  it("accepts an explicit full: true lease input", () => {
+    expect(
+      leaseSimulatorInputSchema.parse({ device: "iPhone 17 Pro", full: true, platform: "ios" }),
+    ).toMatchObject({ full: true });
   });
 
   it.each([
@@ -38,6 +45,7 @@ describe("MCP contracts", () => {
         mode: "held",
         os: "26.5",
         platform: "ios",
+        slim: false,
         state: "leased",
         timing: {
           estimated_boot_ms: 20,
@@ -46,7 +54,7 @@ describe("MCP contracts", () => {
           estimated_ready_ms: 30,
         },
       }),
-    ).toMatchObject({ lease_id: "lse_9f2c", state: "leased" });
+    ).toMatchObject({ lease_id: "lse_9f2c", slim: false, state: "leased" });
     expect(releaseSimulatorInputSchema.parse({ lease_id: "lse_9f2c" })).toEqual({
       lease_id: "lse_9f2c",
     });

--- a/src/mcp/contracts.ts
+++ b/src/mcp/contracts.ts
@@ -7,6 +7,9 @@ export const MAX_TIMEOUT_SECONDS = Number.MAX_SAFE_INTEGER / 1_000;
 export const leaseSimulatorInputSchema = z.object({
   allow_download: z.boolean().default(false),
   device: nonEmptyString,
+  // Platform-neutral: "give me a device with no driver-side resource reduction". The iOS
+  // driver implements this as "do not slim"; other drivers ignore it.
+  full: z.boolean().default(false),
   no_wait: z.boolean().default(false),
   os: nonEmptyString.optional(),
   platform: z.enum(["ios", "android"]),
@@ -27,6 +30,8 @@ export const leaseSimulatorOutputSchema = z.object({
   mode: z.literal("held"),
   os: nonEmptyString,
   platform: z.enum(["ios", "android"]),
+  /** Whether the granted device had its feature set reduced -- see `RawLeaseGrant.slim`. */
+  slim: z.boolean(),
   state: z.literal("leased"),
   timing: z.object({
     estimated_boot_ms: finiteNumber,

--- a/src/mcp/session.test.ts
+++ b/src/mcp/session.test.ts
@@ -36,6 +36,7 @@ describe("McpSession", () => {
       mode: "held",
       os: "26.5",
       platform: "ios",
+      slim: false,
       state: "leased",
       timing: {
         estimated_boot_ms: 20,
@@ -52,6 +53,34 @@ describe("McpSession", () => {
           noWait: false,
           requesterId: "mcp-session-1",
           request: { model: "iPhone 17 Pro", platform: "ios" },
+        },
+        type: "lease.request",
+      },
+    ]);
+  });
+
+  it("sends full: true on the request when full is set, and slim: true when the grant reports a reduced feature profile", async () => {
+    const connection = new StubConnection();
+    connection.responses.push({
+      ...rawGrant,
+      device: { ...rawGrant.device, featureProfile: "reduced" },
+    });
+    const session = new McpSession({
+      connect: async () => connection,
+      requesterId: "mcp-session-1",
+    });
+
+    await expect(
+      session.lease(leaseSimulatorInputSchema.parse({ ...input, full: true })),
+    ).resolves.toMatchObject({ slim: true });
+    expect(connection.requests).toEqual([
+      {
+        payload: {
+          allowDownload: false,
+          mode: "held",
+          noWait: false,
+          requesterId: "mcp-session-1",
+          request: { full: true, model: "iPhone 17 Pro", platform: "ios" },
         },
         type: "lease.request",
       },

--- a/src/mcp/session.ts
+++ b/src/mcp/session.ts
@@ -580,6 +580,7 @@ function daemonLeaseRequest(
       model: input.device,
       ...(input.os === undefined ? {} : { osVersion: input.os }),
       platform: input.platform,
+      ...(input.full ? { full: true } : {}),
     },
     ...(input.timeout_seconds === undefined
       ? {}
@@ -628,6 +629,7 @@ function leaseSimulatorOutput(grant: RawLeaseGrant): LeaseSimulatorOutput {
     mode: "held",
     os: grant.device.spec.osVersion,
     platform: grant.device.spec.platform,
+    slim: grant.slim,
     state: "leased",
     timing: {
       estimated_boot_ms: grant.timing.estimatedBootMs,


### PR DESCRIPTION
Closes #87.

Adds an opt-in "slim" mode to the iOS driver: inside `makeReady`, and only there, the driver writes
persistent `launchctl disable` entries into the simulator's own launchd database and reboots, so
~170 background daemons across 15 categories stop launching. Default off.

## Design

- **Config.** `ios.slim.{enabled,categories,bootTimeoutMs}` (`false` / all categories / 10 minutes).
  A driver-level setting, not part of `DeviceSpec`, so the normal pool never fragments.
- **Label data.** `src/drivers/ios/slim-labels.ts` is versioned *data* transcribed from
  [simslim](https://github.com/mobai-app/simslim) (MIT, commit `65bda5b`), attributed in the file
  header. Apple renames daemons between runtimes, so it is expected to need periodic re-syncing and
  is kept out of any logic module.
- **Where it runs.** After the first `bootstatus -b` succeeds: chunked
  `simctl spawn <udid> /bin/sh -c 'for l in …; do launchctl disable "system/$l" || echo …; done'`,
  then `shutdown` → `boot` → `bootstatus`. Never host launchd, never a download, and only on
  registry-owned, claim-held, non-leased devices.
- **Idempotence.** A signature over the resolved categories *and* their labels, plus the device's
  erasable provenance-mark token, are stored in `driverData`. Matching both skips the second boot;
  a differing token is how an intervening `simctl erase` is detected.
- **Runtime gate.** iOS 18.5+ only (below that the overrides do not survive a reboot). A skip is a
  daemon log line, and `simlock doctor` reports it up front via a new `driver-advisory` finding
  (`slim-runtime-unsupported`).
- **Never fatal.** An unknown launchd label, a failed disable pass, or a hiccup in the slim reboot
  degrades to "not slimmed" — it never fails a lease.
- **Per-lease override.** `simlock lease --full` (MCP/HTTP/socket `full: true`) opts one lease out.
  The flag is driver-agnostic: `Driver.reducesFeatures` declares whether it means anything, and only
  then is `full` stamped onto the resolved spec, where `sameSpec` gives it its own pool key.
- **Lease response.** Every grant carries `slim: true|false`, derived from a driver-agnostic
  `featureProfile: "full" | "reduced"` that flows from `makeReady` through the registry.
- **Crash recovery.** `Driver.makeReady` gained `{ purpose: "prepare" | "recover" }`; `recoverLeased`
  passes `"recover"`, which is a plain reboot with no configuration change — safety rule 2's
  recovery exception grants a reboot and nothing more.
- **Boot deadline / estimate.** The bootstatus deadline widens to `ios.slim.bootTimeoutMs` only for
  a boot that will actually slim, and `Driver.estimate` quotes the double-boot cost so `doctor` does
  not read a slim boot as a stalled transition.

## Testing

- `pnpm run typecheck`, `pnpm run typecheck:e2e`, `pnpm run lint`, `pnpm run format:check` — pass.
- `pnpm test` — 994 passed, 2 skipped.
- `pnpm run test:e2e` — 34 passed, 1 expected fail, 3 skipped.
- `pnpm exec fallow audit` — clean on every changed file.
- New unit coverage: label resolution/signature stability, the full `makeReady` command sequence
  with and without slim, idempotence, erase detection, signature drift, the 18.5 gate (18.4/17.5/26.0
  and an unparseable runtime id), unknown-label handling, partial and total apply failure, the
  `--full` opt-out, shell-injection filtering, `featureProfile` persistence across the registry and
  both readiness paths, the doctor advisory, and the `device.slimmed` bridge.

No real simulator was exercised — all driver tests run against a fake `ProcessRunner`.

## Adversarial review

Two review passes were run against the full diff. Fixed:

- `featureProfile` was dropped by `Registry.parseDevice` and by the warm-pool and lease readiness
  paths, so every lease after a daemon restart reported `slim: false` (and a stale `"reduced"` could
  outlive slim mode being switched off). Now persisted and always cleared explicitly.
- Crash recovery ran the whole slim pass — including a second, unannounced reboot — on a *leased*
  device, exceeding safety rule 2's recovery exception. Now `purpose: "recover"`.
- A partial disable pass wrote the "already slim" marker, permanently marking a device slim with
  most daemons still running. Now the marker is written only when every chunk actually ran; a label
  the simulator itself rejected (permanent, per ADR point 8) is recorded and does not block it, so a
  runtime with a renamed daemon converges after one boot instead of re-applying forever.
- The post-apply reboot inferred "the device is still running" from a failed `simctl shutdown`,
  which is wrong precisely when the shutdown timed out. It now always reboots and verifies, and
  reports the feature profile conservatively when it cannot be sure.
- A slim reboot hiccup could fail a lease that would otherwise have worked.
- `doctor` could act on a device mid-boot; slim widened that pre-existing window from ~60s to
  minutes. Claimed devices are now excluded from run-state and provenance drift comparison.
- `--full` fragmented the Android pool for a flag Android ignores; `advisories()` parsed runtime
  versions differently from the boot path; `estimate` quoted the slim cost to `--full` requests.

Accepted, with documentation rather than code:

- `device.slimmed` is reported from the driver (bridged in `src/daemon/main.ts`, like
  `component.install-*`) once the post-slim reboot passes `bootstatus`. The fact it describes is
  committed to the simulator's own launchd database, not the registry; `docs/EVENTS.md` states this
  position explicitly.
- There is no `launchctl enable` pass, so narrowing `ios.slim.categories` does not re-enable
  previously disabled daemons — the device stays slimmer than any configuration asked for until it is
  reclaimed. Documented in `docs/known-pitfalls.md`.

## Known limitations

- Every `reclaim` runs `simctl erase`, which wipes the overrides, so each lease cycle re-slims and
  pays two boots. Accepted per the ADR: it runs off the critical path via the warm pool.
- Slim devices lose push, Spotlight, StoreKit, universal links, Siri, iCloud and some system
  pickers. `--full` and the `slim` flag are the mitigations.
- Whether `launchctl disable` exits non-zero for a label that no longer exists is unverified against
  a real runtime; if it exits 0, the per-label failure channel under-reports renamed daemons. The
  boot path is correct either way.
- Turning slim off strands already-provisioned `--full` devices as unmatchable until the idle
  cleanup rules reap them.
