### PR TITLE
fix(daemon): let the daemon exit while a detached lease is outstanding

### DIFF
--- a/e2e/daemon-lifecycle.test.ts
+++ b/e2e/daemon-lifecycle.test.ts
@@ -101,6 +101,35 @@ describe("daemon lifecycle & recovery", () => {
       expect(existsSync(env.logPath)).toBe(true);
     });
   });
+
+  it("stops while a detached lease is still outstanding", async () => {
+    const env = await withDaemon();
+    await env.driverScript.set({
+      ios: { knownModels: ["iPhone 16"], availableOsVersions: ["18.4"] },
+    });
+    const lease = await env.cli([
+      "lease",
+      "--platform",
+      "ios",
+      "--device",
+      "iPhone 16",
+      "--agent-id",
+      "outliving-agent",
+      "--detach",
+    ]);
+    expect(lease.code).toBe(0);
+
+    // A detached lease is deliberately left alone by shutdown -- its liveness is the TTL,
+    // not a connection -- and its armed TTL timer used to keep the process alive for the
+    // full fifteen minutes after `daemon stop` returned. Teardown's stray-process check is
+    // the assertion: it fails the test if the daemon that was told to stop is still there.
+    const stop = await env.cli(["daemon", "stop"]);
+    expect(stop.code).toBe(0);
+    await waitFor(() => !existsSync(env.socketPath), {
+      timeout: 10_000,
+      label: "daemon socket removed",
+    });
+  });
 });
 
 function countOccurrences(haystack: string, needle: string): number {

--- a/src/core/lease-engine.test.ts
+++ b/src/core/lease-engine.test.ts
@@ -1223,4 +1223,21 @@ describe("LeaseEngine startup reclaim backgrounding (#43)", () => {
     expect(driver.calls.filter((call) => call.operation === "reclaim")).toHaveLength(1);
     expect(driver.calls.filter((call) => call.operation === "shutdown")).toHaveLength(1);
   });
+
+  it("leaves no armed timer behind for a detached lease it is disposed with", async () => {
+    const harness = await createHarness({ lease: { detachedTtlMs: 900_000 } });
+    await harness.engine.request(request, { mode: "detached", requesterId: "detached-holder" });
+    expect(harness.clock.pendingTimerCount).toBeGreaterThan(0);
+
+    harness.engine.dispose();
+
+    // A real `setTimeout` holds the event loop open, so a timer surviving disposal is a
+    // daemon that has decided to stop and cannot: `daemon stop` used to hang for the
+    // fifteen minutes of an outstanding detached lease's TTL. Held leases hid it, because
+    // shutdown releases them and releasing cancels the timer.
+    expect(harness.clock.pendingTimerCount).toBe(0);
+    // The lease itself is untouched -- disposal cancels a timer, it does not expire a
+    // lease, which is what lets a detached lease survive the restart.
+    expect(harness.registry.snapshot.leases).toHaveLength(1);
+  });
 });

--- a/src/core/lease-engine.ts
+++ b/src/core/lease-engine.ts
@@ -263,9 +263,23 @@ export class LeaseEngine {
     await this.#releaseCoordinator.settleBackgroundReclaims();
   }
 
-  /** Cancels the quarantine coordinator's armed retry timers on daemon shutdown. */
+  /**
+   * Cancels every timer this engine armed, so the process can actually exit.
+   *
+   * The expiry timers matter as much as the quarantine ones and were missed: a lease's
+   * TTL is a `setTimeout` that outlives the decision to shut down, so a daemon with an
+   * outstanding *detached* lease kept running long after `daemon stop` -- up to the
+   * fifteen minutes of its own TTL. Held leases hid it, because releasing them on the way
+   * out cancels their timers; detached leases are deliberately left alone, since their
+   * liveness is the TTL rather than a connection.
+   *
+   * Cancelling expires nothing early and loses nothing: `ttlDeadline` is persisted with
+   * the lease, and `LeaseExpiryScheduler.restore` re-arms it on the next start, which is
+   * also what makes a detached lease survive a restart intact.
+   */
   dispose(): void {
     this.#quarantine.dispose();
+    this.#expiry.dispose();
   }
 
   /** Read-only device catalog; a platform without a registered driver is omitted. */


### PR DESCRIPTION
Replaces #85, rebased directly onto `main` instead of the owned-device-roots stack — this defect predates that work and is unrelated to it.

## The defect

`simlock daemon stop` returns promptly and the process stays alive. The operator is left with a stopped daemon still holding its socket, and whatever restarts it finds the address in use.

`LeaseEngine.dispose` — the hook `DaemonServer#stop` invokes — cancelled the quarantine coordinator's timers and not the expiry scheduler's:

```ts
/** Cancels the quarantine coordinator's armed retry timers on daemon shutdown. */
dispose(): void {
  this.#quarantine.dispose();
}
```

A lease's TTL is a real `setTimeout`, so an outstanding lease kept Node's event loop alive for as long as its deadline had left — fifteen minutes by default for a detached one. `LeaseExpiryScheduler.dispose()` existed and was never called from production code.

**Held leases hid it**: shutdown releases them, and releasing cancels the timer. Detached leases are deliberately left alone, since their liveness is the TTL rather than a connection, so they were the only ones left armed.

## Why the fix is safe

Cancelling expires nothing early and loses nothing: `ttlDeadline` is persisted with the lease and re-armed by `LeaseExpiryScheduler.restore` on the next start. That is the same mechanism that lets a detached lease outlive a restart in the first place, which is the property that had to be preserved — the fix must not become "release everything on shutdown".

## Not part of the owned-device-roots stack

It reproduces on `main`, with none of that stack applied. #85 carried it as the sixth of six stacked PRs and additionally picked up unrelated review fixes from #84 along the way, which drew [a request](https://github.com/callstackincubator/simlock/pull/85#issuecomment-5512284548) to split this fix out and land it directly on `main`. This PR is that split: only `LeaseEngine.dispose` and its tests, cherry-picked from #85's `08abd5de53`. The comment-only hunk in `e2e/lease-environment-passthrough.test.ts` is dropped here since that file doesn't exist on `main` yet — it's introduced by #83.

## Verification

The unit test fails against the old code: removing `this.#expiry.dispose()` gives `expected 1 to be +0`, an armed timer surviving disposal. Coverage is in two places:

- a unit test asserting no timer survives disposal **and** that the lease itself is untouched, since cancelling a timer must not expire a lease;
- an e2e case in `daemon lifecycle & recovery` that leases detached, stops the daemon, and lets teardown's stray-process check be the assertion.

`pnpm run check` green: typecheck, typecheck:e2e, lint, format, 995 unit tests, e2e 35 passed / 1 expected fail / 9 skipped. `fallow audit` clean across 3 changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ia6AUpUzuF7aL3Z4CKUCx

---
_Generated by [Claude Code](https://claude.ai/code/session_015ia6AUpUzuF7aL3Z4CKUCx)_