### PR TITLE
fix: resolve hardware verification findings B1, B2, D1, D2, D3

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,6 +90,15 @@ platform command to it: iOS through `xcrun simctl --set`, Android through
 `ANDROID_AVD_HOME` plus a private adb server on a port the shared server does
 not scan. Devices inside a root are invisible to Xcode, Android Studio, and a
 plain `simctl` / `adb`; conversely Simlock cannot address anything outside it.
+There is one deliberate exception: a device stranded in the pre-root location
+by the migration, which `doctor` reports and `--fix` destroys through the old
+unscoped path — permitted because a registry record names it, which is what
+registry-only destruction asks for.
+
+Ownership is proven when the driver starts, and re-proven
+(`Driver.revalidateRoot()`) immediately before `doctor --purge-orphans`
+destroys anything in a root: reporting can live with a proof taken days ago,
+destroying cannot (see [known-pitfalls.md](known-pitfalls.md)).
 
 This is what lets `listManaged()` answer from membership rather than from a
 name prefix — the difference between *proving* ownership and *guessing* it.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -379,7 +379,7 @@ each rule *would* take (rule name, target, reason) without executing.
 `--rule` restricts to a single named rule (e.g. `--rule idle-destroy`); see
 `simlock list --rules` for the registered rules.
 
-## `simlock doctor [--fix] [--purge-orphans]`
+## `simlock doctor [--fix] [--purge-orphans] [--yes]`
 
 Reconcile the daemon's state with reality (`simctl list`, `adb devices`,
 running emulator processes): report orphaned processes, registry entries
@@ -392,9 +392,18 @@ record — almost always a daemon that died between creating a device and writin
 it down. Because it is inside a root Simlock provably owns, it cannot be a
 device of yours, so it is safe to destroy; but `--fix` never touches it.
 Destroying orphans requires `--purge-orphans`, which asks for confirmation
-unless `--yes` is given. Keeping it on its own flag means a `doctor --fix`
-already running unattended in CI does not start deleting things after an
-upgrade.
+unless `--yes` is given, and refuses (exit 2, `USAGE`) when confirmation is
+declined or there is no terminal to ask at. Keeping it on its own flag means a
+`doctor --fix` already running unattended in CI does not start deleting things
+after an upgrade.
+
+Before the first device of a purge is destroyed, each root the purge is about
+to reach into is re-validated — ownership is proven at startup and then trusted
+for the life of the daemon, which is fine for reporting and not fine for
+destroying (see [known-pitfalls.md](known-pitfalls.md)). A root that no longer
+proves ownership abandons the whole purge and leaves every finding standing. So
+does a device that could not be destroyed: it stays reported, and the rest of
+the run continues.
 
 Registry devices left behind in the *old* pre-device-root locations are
 reported the same way and are destroyed by `--fix`, since they are in the

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -487,6 +487,11 @@ for tests. Two instances on one machine also need distinct
 `SIMLOCK_HOME` cannot isolate it. When the CLI or MCP server auto-starts the daemon, the daemon
 process inherits the variable like the rest of the environment.
 
+Keep it short: `daemon.sock` lives directly under it, and the kernel caps a Unix
+socket path at 104 bytes on macOS (108 on Linux). A deeper `SIMLOCK_HOME` is
+refused up front by every frontend with a `USAGE` error naming the limit, rather
+than failing on connect with a bare `EINVAL`.
+
 ### `SIMLOCK_DRIVERS_MODULE` (advanced / testing hook)
 
 Overrides driver discovery (`discoverDrivers` in `src/daemon/main.ts`) with a

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -39,7 +39,7 @@ in short: `subject.past-tense-fact`, emitted post-commit, facts not commands.
 | `device.crash-detected` | device id, lease id, platform, observed | a leased device was observed `stopped` for `health.stableObservations` consecutive ticks | LeaseHealthMonitor | implemented |
 | `device.recovered` | device id, lease id, attempts, duration | a crashed leased device was rebooted under its existing lease and passed readiness | LeaseHealthMonitor | implemented |
 | `device.recovery-failed` | device id, lease id, attempts, reason, error | recovery could not restore a leased device (absent from driver reality, provenance drift, or attempts exhausted) and its lease was released | LeaseHealthMonitor | implemented |
-| `device.orphan-purged` | driver device id, platform, device root | `simlock doctor --purge-orphans` destroyed a device that sat inside a validly-marked Simlock device root with no registry record — see [ADR 0001](adr/0001-simlock-owned-device-roots.md) | Doctor | planned |
+| `device.orphan-purged` | driver device id, platform, device root | `simlock doctor --purge-orphans` destroyed a device that sat inside a validly-marked Simlock device root with no registry record — see [ADR 0001](adr/0001-simlock-owned-device-roots.md) | Doctor | implemented |
 
 ## System
 

--- a/docs/adr/0001-simlock-owned-device-roots.md
+++ b/docs/adr/0001-simlock-owned-device-roots.md
@@ -1,6 +1,6 @@
 # 0001. Simlock-owned device roots
 
-- **Status:** Accepted — not yet implemented
+- **Status:** Accepted
 - **Date:** 2026-09-02
 - **Issue:** [#73](https://github.com/callstackincubator/simlock/issues/73),
   part of [#70](https://github.com/callstackincubator/simlock/issues/70)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,4 +20,4 @@ Status values:
 
 | ADR | Title | Status |
 |---|---|---|
-| [0001](0001-simlock-owned-device-roots.md) | Simlock-owned device roots | Accepted — not yet implemented |
+| [0001](0001-simlock-owned-device-roots.md) | Simlock-owned device roots | Accepted |

--- a/docs/known-pitfalls.md
+++ b/docs/known-pitfalls.md
@@ -100,10 +100,7 @@ destroys it (registry-only, as always). The device stays visible as
 `device.quarantine-recovered`, and `device.quarantine-abandoned` are the new
 follow-up facts (see `docs/EVENTS.md`).
 
-## Device roots are an accident boundary, not a security boundary (planned)
-
-> Status: describes the state after
-> [ADR 0001](adr/0001-simlock-owned-device-roots.md) lands.
+## Device roots are an accident boundary, not a security boundary
 
 Simlock keeps its devices in roots it owns and scopes every platform command
 to them, so Xcode, Android Studio, and a plain `simctl` / `adb` do not see
@@ -129,10 +126,38 @@ it is*, the marks prove *what happened to it*.
 (multi-tenant machines, untrusted agents) needs OS-level isolation, which is
 out of scope for a device control plane.
 
-## Simlock's adb server has to be supervised by pid (planned)
+## A root's ownership is proven at startup and trusted for the daemon's life
 
-> Status: describes the state after
-> [ADR 0001](adr/0001-simlock-owned-device-roots.md) lands.
+`ensureOwnedRoot` runs once per driver, at daemon start. Every later answer to
+"is this device Simlock's?" — `listManaged`, every `simctl --set`, every
+`ANDROID_AVD_HOME` — is computed against that path again and again, but the
+*proof* behind it is the one taken at boot and never retaken.
+
+**The pitfall:** a daemon can be up for days. In that time the path can become
+a symlink, or an `mv` can leave the user's own device set standing exactly
+where Simlock's root was. Nothing re-checks, so `listManaged` starts answering
+with the user's simulators, every one of them has no registry record, and
+`doctor` reports the lot as orphans. This is a different case from the accident
+boundary above, which is about someone deliberately reaching *into* the root;
+this one is the root being swapped *under* Simlock, and it turns a report into
+a claim over devices that were never Simlock's.
+
+**Fix, and the deliberate half-measure in it:** destroying re-proves the root
+and reporting does not. `doctor --purge-orphans` calls `Driver.revalidateRoot()`
+— the same validation `create` was judged by, with the same arguments —
+immediately before its first destroy, and abandons the whole purge if any root
+refuses. Nothing else does, and that asymmetry is the point: a stale proof
+behind a *report* costs a confusing `doctor` run, while a stale proof behind a
+`destroy` costs the user their devices. Re-validating on every reconcile tick,
+or before every `listManaged`, would buy nothing for the case that matters and
+would put a filesystem check on the reaper's path.
+
+**Status:** accepted, and bounded by design — the purge is the only destructive
+path root membership alone can authorise (safety rule 1), so it is the only one
+that needs the re-proof. Restarting the daemon re-proves everything; a driver
+whose root has gone bad then simply does not start.
+
+## Simlock's adb server has to be supervised by pid
 
 Android containment needs Simlock to run its own adb server, because `adb` has
 no equivalent of `simctl --set`. That server is started with

--- a/e2e/doctor-drift.test.ts
+++ b/e2e/doctor-drift.test.ts
@@ -198,4 +198,71 @@ describe("doctor and drift", () => {
     heldB.kill("SIGKILL");
     await heldB.waitForExit(15_000).catch(() => undefined);
   });
+
+  it("purges orphans only when asked and confirmed, and re-proves the root first", async () => {
+    const env = await withDaemon();
+    await env.driverScript.set({
+      ios: {
+        knownModels: ["iPhone 16"],
+        availableOsVersions: ["18.4"],
+        managedReality: {
+          devices: [{ deviceId: "fake-ios-orphan", runState: "running" }],
+          processes: [{ deviceId: "fake-ios-orphan" }],
+        },
+      },
+    });
+
+    const reported = await env.cli(["doctor"]);
+    expect(reported.code).toBe(0);
+    expect((reported.json as { findings: Finding[] }).findings.map((f) => f.kind)).toEqual([
+      "orphan-device",
+      "orphan-process",
+    ]);
+
+    // No TTY behind the e2e CLI, so `confirm` answers no: the refusal is the documented
+    // `USAGE`/exit 2 contract `release --all` already has (safety rule 5).
+    await env.driverLog.clear();
+    const declined = await env.cli(["doctor", "--purge-orphans"]);
+    expect(declined.code).toBe(2);
+    expect(declined.error?.code).toBe("USAGE");
+    expect((await env.driverLog.calls()).map((call) => call.operation)).not.toContain("destroy");
+
+    await env.driverLog.clear();
+    const purged = await env.cli(["doctor", "--purge-orphans", "--yes"]);
+    expect(purged.code).toBe(0);
+
+    // Both findings go: destroying the device covers the process it was running.
+    expect((purged.json as { findings: Finding[] }).findings).toEqual([]);
+    const operations = (await env.driverLog.calls())
+      .map((call) => call.operation)
+      .filter((operation) => operation !== "listManaged");
+    expect(operations, "the root is re-proven before anything is destroyed").toEqual([
+      "revalidateRoot",
+      "destroy",
+    ]);
+    await env.expectEvents(["device.orphan-purged"]);
+  });
+
+  it("destroys nothing when the root can no longer be proven", async () => {
+    const env = await withDaemon();
+    await env.driverScript.set({
+      ios: {
+        knownModels: ["iPhone 16"],
+        availableOsVersions: ["18.4"],
+        failures: { revalidateRoot: { type: "generic", message: "root is a symlink now" } },
+        managedReality: { devices: [{ deviceId: "fake-ios-orphan", runState: "stopped" }] },
+      },
+    });
+
+    await env.driverLog.clear();
+    const refused = await env.cli(["doctor", "--purge-orphans", "--yes"]);
+
+    // The orphan stays reported, and stays on disk: a root that stopped proving ownership
+    // is exactly the case where `listManaged` may be describing the user's own devices.
+    expect(refused.code).toBe(0);
+    expect((refused.json as { findings: Finding[] }).findings.map((f) => f.kind)).toEqual([
+      "orphan-device",
+    ]);
+    expect((await env.driverLog.calls()).map((call) => call.operation)).not.toContain("destroy");
+  });
 });

--- a/e2e/fake-driver/fake-driver.ts
+++ b/e2e/fake-driver/fake-driver.ts
@@ -124,6 +124,15 @@ export class OutOfProcessFakeDriver implements Driver {
     this.#scriptPath = options.scriptPath;
   }
 
+  /**
+   * Logged like every other call, so a flow can assert the purge re-proved the root before
+   * it destroyed anything -- and refusable through `failures.revalidateRoot`, which is how
+   * a flow stages the root going bad under a running daemon.
+   */
+  async revalidateRoot(): Promise<void> {
+    await this.#beforeCall("revalidateRoot", []);
+  }
+
   async resolveSpec(
     request: DeviceRequest,
     options: { readonly allowDownload: boolean },

--- a/e2e/fake-driver/types.ts
+++ b/e2e/fake-driver/types.ts
@@ -15,7 +15,9 @@ export type FakeDriverOperation =
   | "shutdown"
   | "destroy"
   | "listManaged"
-  | "listCatalog";
+  | "listCatalog"
+  /** The root re-proof `doctor --purge-orphans` takes before its first destroy. */
+  | "revalidateRoot";
 
 export type FakeDriverEstimateOperation = "provision" | "boot" | "reclaim";
 

--- a/src/bus/index.test.ts
+++ b/src/bus/index.test.ts
@@ -136,6 +136,7 @@ describe("EventBus", () => {
       | "device.foreign-state-detected"
       | "device.foreign-provenance-detected"
       | "device.stalled-transition-detected"
+      | "device.orphan-purged"
       | "daemon.started"
       | "daemon.stopping"
       | "disk.pressure-detected"

--- a/src/bus/index.ts
+++ b/src/bus/index.ts
@@ -84,6 +84,11 @@ export interface EventMap {
     readonly attempts: number;
     readonly error: string;
   };
+  "device.orphan-purged": {
+    readonly driverDeviceId: string;
+    readonly platform: string;
+    readonly deviceRoot: string;
+  };
   "device.shutdown": { readonly deviceId: string; readonly initiator: string };
   "device.deleted": { readonly deviceId: string; readonly initiator: string };
   "daemon.started": { readonly version: string; readonly configSnapshot: unknown };

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -1133,6 +1133,87 @@ describe("CLI boundary", () => {
     await expect(runCli(["catalog", "--platform", "windows"], output.environment)).resolves.toBe(2);
     expect(output.stderr).toContain("--platform must be ios or android");
   });
+
+  it("asks the daemon to purge orphans only once the operator has confirmed", async () => {
+    const output = outputCapture();
+    const connection = new StubConnection();
+    connection.response("doctor.run", { findings: [] });
+
+    await expect(
+      runCli(
+        ["doctor", "--purge-orphans"],
+        output.environmentWith({ confirm: async () => true, connect: async () => connection }),
+      ),
+    ).resolves.toBe(0);
+
+    expect(connection.calls).toEqual([
+      { payload: { fix: false, purgeOrphans: true }, type: "doctor.run" },
+    ]);
+  });
+
+  it("keeps --purge-orphans off the wire when --fix is all that was asked for", async () => {
+    const output = outputCapture();
+    const connection = new StubConnection();
+    connection.response("doctor.run", { findings: [] });
+
+    await expect(
+      runCli(["doctor", "--fix"], output.environmentWith({ connect: async () => connection })),
+    ).resolves.toBe(0);
+
+    // The upgrade contract: `doctor --fix` running unattended in CI never becomes
+    // destructive on its own (ADR 0001, decision 6).
+    expect(connection.calls).toEqual([
+      { payload: { fix: true, purgeOrphans: false }, type: "doctor.run" },
+    ]);
+  });
+
+  it.each([
+    ["declined", async () => false],
+    ["unavailable", undefined],
+  ] as const)(
+    "refuses --purge-orphans and contacts nobody when confirmation is %s",
+    async (_case, confirm) => {
+      const output = outputCapture();
+      const connection = new StubConnection();
+
+      await expect(
+        runCli(
+          ["doctor", "--purge-orphans"],
+          output.environmentWith({
+            ...(confirm === undefined ? {} : { confirm }),
+            connect: async () => connection,
+          }),
+        ),
+      ).resolves.toBe(2);
+
+      expect(connection.calls).toEqual([]);
+      expect(JSON.parse(output.stderr)).toEqual({
+        error: { code: "USAGE", message: expect.stringContaining("--yes") },
+      });
+    },
+  );
+
+  it("takes --yes as the confirmation, so an unattended purge needs no terminal", async () => {
+    const output = outputCapture();
+    const connection = new StubConnection();
+    connection.response("doctor.run", { findings: [] });
+
+    await expect(
+      runCli(
+        ["doctor", "--purge-orphans", "--yes"],
+        output.environmentWith({
+          confirm: async () => {
+            throw new Error("--yes must not ask");
+          },
+          connect: async () => connection,
+        }),
+      ),
+    ).resolves.toBe(0);
+
+    expect(connection.calls).toEqual([
+      { payload: { fix: false, purgeOrphans: true }, type: "doctor.run" },
+    ]);
+  });
 });
 
 class StubConnection implements DaemonConnection {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -579,14 +579,25 @@ async function runDoctor(argv: readonly string[], environment: CliEnvironment): 
   const values = commandArgs(argv, {
     fix: { type: "boolean" },
     help: { type: "boolean", short: "h" },
+    "purge-orphans": { type: "boolean" },
+    yes: { type: "boolean" },
   });
   if (values.help) {
-    environment.stdout.write("Usage: simlock doctor [--fix]\n");
+    environment.stdout.write("Usage: simlock doctor [--fix] [--purge-orphans] [--yes]\n");
     return 0;
+  }
+  const purgeOrphans = values["purge-orphans"] ?? false;
+  if (purgeOrphans) {
+    // Destructive, so it confirms exactly as `release --all` and `nuke` do (safety rule 5),
+    // and a missing confirm hook refuses rather than proceeds: a non-interactive caller
+    // that meant it says `--yes`.
+    const confirmed =
+      values.yes ?? (await environment.confirm?.("Destroy every orphaned device? [y/N] "));
+    if (!confirmed) throw new UsageError("doctor --purge-orphans requires confirmation or --yes");
   }
   writeResult(
     environment,
-    await requestOnce(environment, "doctor.run", { fix: values.fix ?? false }),
+    await requestOnce(environment, "doctor.run", { fix: values.fix ?? false, purgeOrphans }),
   );
   return 0;
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,7 +7,9 @@ import {
   NodeFilesystem,
   NodeIpcTransport,
   NodeParentWatch,
+  resolveDaemonSocketPath,
   resolveSimlockHome,
+  SocketPathTooLongError,
   SystemClock,
   type Filesystem,
   type ParentWatch,
@@ -145,7 +147,7 @@ function defaultCliEnvironment(env: NodeJS.ProcessEnv = process.env): CliEnviron
   const filesystem = new NodeFilesystem();
   const clock = new SystemClock();
   const ipc = new NodeIpcTransport();
-  const socketPath = join(dataDirectory, "daemon.sock");
+  const socketPath = resolveDaemonSocketPath(dataDirectory);
   const configPath = join(dataDirectory, "config.json");
   const logPath = join(dataDirectory, "daemon.log");
   return {
@@ -258,7 +260,7 @@ function writeError(environment: CliEnvironment, error: unknown): void {
 }
 
 function cliErrorCode(error: unknown): string {
-  if (error instanceof UsageError) return "USAGE";
+  if (error instanceof UsageError || error instanceof SocketPathTooLongError) return "USAGE";
   if (error instanceof DaemonClientError) return error.code;
   return "INTERNAL";
 }

--- a/src/core/doctor.test.ts
+++ b/src/core/doctor.test.ts
@@ -1330,7 +1330,225 @@ describe("Doctor with a platform it cannot observe", () => {
     expect(report.findings).toEqual([]);
     expect(registry.snapshot.devices[0]?.state).toBe("ready");
   });
+
+  it("destroys orphans only when the purge is asked for, and reports what it destroyed", async () => {
+    const clock = new FakeClock(10_000);
+    const eventBus = new EventBus(clock);
+    const registry = await loadRegistry(clock, eventBus);
+    const driver = new FakeDriver({ clock, deviceRoot: "/roots/ios", platform: "ios" });
+    driver.setManagedReality({
+      devices: [observed("orphan-1", "running")],
+      processes: [driverDevice("orphan-1")],
+    });
+    const doctor = new Doctor({ clock, config: config(), drivers: [driver], eventBus, registry });
+
+    const reported = await doctor.reconcile({ fix: true });
+    expect(reported.findings.map((finding) => finding.kind)).toEqual([
+      "orphan-device",
+      "orphan-process",
+    ]);
+    expect(driver.calls.filter((call) => call.operation === "destroy")).toEqual([]);
+
+    const purged = await doctor.reconcile({ purgeOrphans: true });
+
+    // The process is the device's: destroying the device covers it, so reporting the
+    // process afterwards would name something that no longer exists.
+    expect(purged.findings).toEqual([]);
+    expect(eventBus.replay()).toContainEqual(
+      expect.objectContaining({
+        event: "device.orphan-purged",
+        payload: { deviceRoot: "/roots/ios", driverDeviceId: "orphan-1", platform: "ios" },
+      }),
+    );
+  });
+
+  it("re-proves the root before the first destroy of a purge", async () => {
+    const clock = new FakeClock(10_000);
+    const eventBus = new EventBus(clock);
+    const registry = await loadRegistry(clock, eventBus);
+    const driver = new FakeDriver({ clock, platform: "ios" });
+    driver.setManagedReality({ devices: [observed("orphan-1", "stopped")], processes: [] });
+
+    await new Doctor({ clock, config: config(), drivers: [driver], eventBus, registry }).reconcile({
+      purgeOrphans: true,
+    });
+
+    expect(driver.calls.map((call) => call.operation)).toEqual([
+      "listManaged",
+      "revalidateRoot",
+      "destroy",
+    ]);
+  });
+
+  it("destroys nothing at all when a root can no longer be proven", async () => {
+    const clock = new FakeClock(10_000);
+    const eventBus = new EventBus(clock);
+    const registry = await loadRegistry(clock, eventBus);
+    const iosDriver = new FakeDriver({ clock, platform: "ios" });
+    iosDriver.setManagedReality({ devices: [observed("ios-orphan", "stopped")], processes: [] });
+    const androidDriver = new FakeDriver({ clock, platform: "android" });
+    androidDriver.setManagedReality({
+      devices: [observed("android-orphan", "stopped")],
+      processes: [],
+    });
+    androidDriver.failOn("revalidateRoot", 1, new Error("Refusing the android device root"));
+
+    const report = await new Doctor({
+      clock,
+      config: config(),
+      drivers: [iosDriver, androidDriver],
+      eventBus,
+      registry,
+    }).reconcile({ purgeOrphans: true });
+
+    // A daemon that cannot prove one of its roots is not one to keep destroying on, and
+    // the roots are proven before anything is destroyed -- so this costs a re-run, never a
+    // half-purge.
+    expect(
+      [...iosDriver.calls, ...androidDriver.calls].filter((call) => call.operation === "destroy"),
+    ).toEqual([]);
+    expect(report.findings.map((finding) => finding.kind)).toEqual([
+      "orphan-device",
+      "orphan-device",
+    ]);
+    expect(eventBus.replay().some((event) => event.event === "device.orphan-purged")).toBe(false);
+  });
+
+  it("leaves an orphan it could not destroy standing and purges the rest", async () => {
+    const clock = new FakeClock(10_000);
+    const eventBus = new EventBus(clock);
+    const registry = await loadRegistry(clock, eventBus);
+    const driver = new FakeDriver({ clock, platform: "ios" });
+    driver.setManagedReality({
+      devices: [observed("stubborn", "stopped"), observed("orphan-2", "stopped")],
+      processes: [],
+    });
+    driver.failOn("destroy", 1, new Error("simctl delete failed"));
+
+    const report = await new Doctor({
+      clock,
+      config: config(),
+      drivers: [driver],
+      eventBus,
+      registry,
+    }).reconcile({ purgeOrphans: true });
+
+    expect(report.findings).toEqual([
+      {
+        device: expect.objectContaining({ deviceId: "stubborn" }),
+        kind: "orphan-device",
+        platform: "ios",
+      },
+    ]);
+    expect(
+      eventBus.replay().filter((event) => event.event === "device.orphan-purged"),
+    ).toHaveLength(1);
+  });
+
+  it("reports a device left in the pre-root location as legacy rather than missing", async () => {
+    const { clock, driver, eventBus, registry } = await legacyDeviceSetup();
+
+    const report = await new Doctor({
+      clock,
+      config: config(),
+      drivers: [driver],
+      eventBus,
+      registry,
+    }).reconcile();
+
+    expect(report.findings).toEqual([
+      {
+        device: expect.objectContaining({ deviceId: "stranded" }),
+        deviceId: registry.snapshot.devices[0]?.id,
+        kind: "legacy-device",
+        path: "/Library/Devices/stranded",
+        platform: "ios",
+      },
+    ]);
+  });
+
+  it("destroys a legacy device through its old path and then records it missing", async () => {
+    const { clock, driver, eventBus, registry } = await legacyDeviceSetup();
+
+    await new Doctor({ clock, config: config(), drivers: [driver], eventBus, registry }).reconcile({
+      fix: true,
+    });
+
+    expect(driver.calls.filter((call) => call.operation === "destroyLegacy")).toHaveLength(1);
+    expect(registry.snapshot.devices[0]?.state).toBe("deleted");
+  });
+
+  it("never destroys a legacy device that a lease still references", async () => {
+    const { clock, driver, eventBus, registry } = await legacyDeviceSetup();
+    const device = registry.snapshot.devices[0]!;
+    await registry.createLease({
+      deviceId: device.id,
+      mode: "held",
+      requesterId: "agent",
+      ttlDeadline: 90_000,
+    });
+
+    await new Doctor({ clock, config: config(), drivers: [driver], eventBus, registry }).reconcile({
+      fix: true,
+    });
+
+    expect(driver.calls.filter((call) => call.operation === "destroyLegacy")).toEqual([]);
+    expect(registry.snapshot.devices[0]?.state).toBe("leased");
+  });
+
+  it("reports a missing device as missing when the legacy lookup itself fails", async () => {
+    const { clock, driver, eventBus, registry } = await legacyDeviceSetup();
+    driver.failOn("findLegacy", 1, new Error("simctl list failed"));
+
+    const report = await new Doctor({
+      clock,
+      config: config(),
+      drivers: [driver],
+      eventBus,
+      registry,
+    }).reconcile({ fix: true });
+
+    // "I could not look outside the root" is not "it is out there": the conservative
+    // finding is the one whose fix only writes to the registry.
+    expect(report.findings.map((finding) => finding.kind)).toEqual(["registry-device-missing"]);
+    expect(driver.calls.filter((call) => call.operation === "destroyLegacy")).toEqual([]);
+  });
 });
+
+/** A registry device the root no longer holds, which the driver still finds outside it. */
+async function legacyDeviceSetup() {
+  const clock = new FakeClock(10_000);
+  const eventBus = new EventBus(clock);
+  const registry = await loadRegistry(clock, eventBus);
+  await readyDevice(registry, "stranded", "ios");
+  const driver = new FakeDriver({
+    clock,
+    legacyDevices: {
+      stranded: { device: driverDevice("stranded"), path: "/Library/Devices/stranded" },
+    },
+    platform: "ios",
+  });
+  driver.setManagedReality({ devices: [], processes: [] });
+  return { clock, driver, eventBus, registry };
+}
+
+function loadRegistry(clock: FakeClock, eventBus: EventBus): Promise<Registry> {
+  return Registry.load({
+    clock,
+    eventBus,
+    filesystem: new MemoryFilesystem(),
+    idGenerator: sequence(),
+    statePath: "/state.json",
+  });
+}
+
+function driverDevice(deviceId: string) {
+  return { address: `${deviceId}-address`, deviceId, driverData: { fakeDeviceId: deviceId } };
+}
+
+function observed(deviceId: string, runState: "running" | "stopped") {
+  return { ...driverDevice(deviceId), runState };
+}
 
 /** One `ready` iOS device in an otherwise empty registry. */
 async function readyIosDevice() {

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -1,5 +1,5 @@
 import type { EventBus } from "../bus/index.js";
-import type { Clock } from "../ports/index.js";
+import { type Clock, type Logger, NoopLogger } from "../ports/index.js";
 import type { Config } from "./config.js";
 import {
   type DeviceRecord,
@@ -50,6 +50,17 @@ export type DoctorFinding =
       readonly detail: string;
     }
   | {
+      /**
+       * A registry device that outlived the move to owned roots: absent from this
+       * driver's root, still present in the location the platform used before it.
+       */
+      readonly kind: "legacy-device";
+      readonly deviceId: string;
+      readonly platform: Platform;
+      readonly device: DriverDevice;
+      readonly path?: string;
+    }
+  | {
       readonly kind: "stalled-transition";
       readonly deviceId: string;
       readonly platform: Platform;
@@ -70,6 +81,8 @@ export type DoctorFinding =
  * the prefix match in `listManaged` would otherwise adopt silently.
  */
 export type ProvenanceDrift = "erased" | "mark-mismatch" | "durable-mark-missing";
+
+type OrphanDeviceFinding = Extract<DoctorFinding, { readonly kind: "orphan-device" }>;
 
 export interface DoctorReport {
   readonly findings: readonly DoctorFinding[];
@@ -99,17 +112,31 @@ export interface DoctorOptions {
    * ever since, and `doctor` is where `docs/CLI.md` promises the reason turns up.
    */
   readonly driverRejections?: readonly DriverRejection[];
+  readonly logger?: Logger;
   readonly registry: Registry;
 }
 
 export interface DoctorReconcileOptions {
   readonly fix?: boolean;
+  /**
+   * Destroys the orphans this run finds. Safety rule 1's single opt-in exception, and
+   * deliberately not part of `fix`: someone already running `doctor --fix` unattended in
+   * CI must not acquire a destructive behaviour by upgrading (ADR 0001, decision 6).
+   */
+  readonly purgeOrphans?: boolean;
 }
 
 export class Doctor {
-  constructor(private readonly options: DoctorOptions) {}
+  readonly #logger: Logger;
 
-  async reconcile({ fix = false }: DoctorReconcileOptions = {}): Promise<DoctorReport> {
+  constructor(private readonly options: DoctorOptions) {
+    this.#logger = options.logger?.child("doctor") ?? new NoopLogger();
+  }
+
+  async reconcile({
+    fix = false,
+    purgeOrphans = false,
+  }: DoctorReconcileOptions = {}): Promise<DoctorReport> {
     const snapshot = this.options.registry.snapshot;
     const realities = await Promise.all(
       this.options.drivers.map(async (driver) => ({ driver, reality: await driver.listManaged() })),
@@ -144,7 +171,11 @@ export class Doctor {
 
     for (const device of snapshot.devices) {
       if (observedPlatforms.has(device.spec.platform)) {
-        const deviceFindings = registryDriftFindings(device, realDeviceKeys, observedDevices);
+        const deviceFindings = await this.#withLegacyDevice(
+          device,
+          registryDriftFindings(device, realDeviceKeys, observedDevices),
+          driversByPlatform.get(device.spec.platform),
+        );
         findings.push(...deviceFindings);
         if (deviceFindings.some((finding) => finding.kind === "foreign-state-change")) {
           await this.options.registry.markForeignStateDetected(device.id, this.options.clock.now());
@@ -171,13 +202,167 @@ export class Doctor {
     findings.push(...orphanFindings(realities, registryDeviceKeys));
     findings.push(...expiredLeaseFindings(snapshot.leases, this.options.clock.now()));
 
-    const report = { findings };
     if (fix) {
-      await this.#applySafeFixes(findings);
+      await this.#applySafeFixes(findings, driversByPlatform);
     }
-    this.#emitFindingEvents(findings);
-    this.options.eventBus.emit("doctor.reconciled", { driftFindings: findings }, "doctor");
+    const remaining = purgeOrphans
+      ? await this.#purgeOrphans(findings, driversByPlatform)
+      : findings;
+
+    const report = { findings: remaining };
+    this.#emitFindingEvents(remaining);
+    this.options.eventBus.emit("doctor.reconciled", { driftFindings: remaining }, "doctor");
     return report;
+  }
+
+  /**
+   * Destroys every orphan this run found, and reports back the findings that outlived the
+   * attempt.
+   *
+   * This is the one place Simlock destroys something the registry has never heard of, and
+   * the residual risk is accepted rather than mitigated: an orphan has no registry record,
+   * so no central safety filter and no `DeviceOperationClaims` entry can protect it --
+   * including a device this very daemon is between `driver.provision` and
+   * `registry.registerDevice` on, which is precisely the window that creates orphans in the
+   * first place. Nothing here can tell that device apart from the leak it looks like. That
+   * is why the command is opt-in, confirmed, and unreachable from the reaper, a cleanup
+   * rule, an idle tier or `--fix` (safety rule 1) -- not an oversight to be "fixed" later
+   * by wiring it into something automatic.
+   *
+   * A destroy that fails is logged and leaves its finding standing: the orphan is still
+   * there to report, and one unlucky device must not cost the rest of the run.
+   */
+  async #purgeOrphans(
+    findings: readonly DoctorFinding[],
+    driversByPlatform: ReadonlyMap<Platform, Driver>,
+  ): Promise<readonly DoctorFinding[]> {
+    const orphans = findings.filter(
+      (finding): finding is OrphanDeviceFinding => finding.kind === "orphan-device",
+    );
+    if (orphans.length === 0 || !(await this.#rootsStillProven(orphans, driversByPlatform))) {
+      return findings;
+    }
+
+    const purged = new Set<string>();
+    for (const orphan of orphans) {
+      const driver = driversByPlatform.get(orphan.platform);
+      if (driver === undefined) continue;
+      try {
+        await driver.destroy(orphan.device);
+      } catch (error: unknown) {
+        this.#logger.error("Could not purge orphan device", {
+          deviceId: orphan.device.deviceId,
+          platform: orphan.platform,
+          reason: errorMessage(error),
+        });
+        continue;
+      }
+      purged.add(key(orphan.platform, orphan.device.deviceId));
+      this.options.eventBus.emit(
+        "device.orphan-purged",
+        {
+          deviceRoot: driver.deviceRoot,
+          driverDeviceId: orphan.device.deviceId,
+          platform: orphan.platform,
+        },
+        "doctor",
+      );
+    }
+
+    // An `orphan-process` for a device that is now gone is gone with it: destroying the
+    // device covers the process it was running, so reporting both would ask the operator
+    // to deal with something that no longer exists.
+    return findings.filter(
+      (finding) =>
+        !(
+          (finding.kind === "orphan-device" || finding.kind === "orphan-process") &&
+          purged.has(key(finding.platform, finding.device.deviceId))
+        ),
+    );
+  }
+
+  /**
+   * Re-proves each root the purge is about to reach into, before its first destroy.
+   *
+   * The proof a purge acts on is the one taken at startup, and the thing it authorises is
+   * recomputed on every reconcile: a root replaced by a symlink, or a `mv` that leaves the
+   * user's own device set at the configured path, turns `listManaged` into a claim over
+   * their simulators and this command into the thing that deletes them. Reporting can live
+   * with a stale proof; destroying cannot.
+   *
+   * A refusal aborts the whole purge rather than the one platform: the roots are validated
+   * before anything is destroyed, so an abort costs a re-run and never a half-purge, and a
+   * daemon that cannot prove one of its roots is not a daemon to keep destroying on.
+   */
+  async #rootsStillProven(
+    orphans: readonly OrphanDeviceFinding[],
+    driversByPlatform: ReadonlyMap<Platform, Driver>,
+  ): Promise<boolean> {
+    const platforms = new Set(orphans.map((orphan) => orphan.platform));
+    for (const platform of platforms) {
+      const driver = driversByPlatform.get(platform);
+      if (driver === undefined) continue;
+      try {
+        await driver.revalidateRoot();
+      } catch (error: unknown) {
+        this.#logger.error(
+          "Refusing to purge orphans: the device root no longer proves ownership",
+          {
+            deviceRoot: driver.deviceRoot,
+            platform,
+            reason: errorMessage(error),
+          },
+        );
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Rewrites a `registry-device-missing` finding as `legacy-device` when the driver still
+   * finds the device where the platform kept it before roots existed. Absent from the root
+   * is what both findings have in common; where the device actually is decides which one it
+   * is, and only the driver can look there.
+   *
+   * A driver that cannot answer -- no legacy location, or a lookup that failed -- leaves
+   * the original finding alone. `registry-device-missing` is the conservative of the two:
+   * its fix only writes to the registry, while the legacy fix destroys.
+   */
+  async #withLegacyDevice(
+    device: DeviceRecord,
+    findings: readonly DoctorFinding[],
+    driver: Driver | undefined,
+  ): Promise<readonly DoctorFinding[]> {
+    const findLegacy = driver?.findLegacy?.bind(driver);
+    if (findLegacy === undefined || !findings.some((f) => f.kind === "registry-device-missing")) {
+      return findings;
+    }
+
+    let legacy;
+    try {
+      legacy = await findLegacy(device.driverDeviceId);
+    } catch (error: unknown) {
+      this.#logger.warn("Could not look for a pre-root copy of a missing device", {
+        deviceId: device.id,
+        platform: device.spec.platform,
+        reason: errorMessage(error),
+      });
+      return findings;
+    }
+    if (legacy === undefined) return findings;
+
+    return findings.map((finding) =>
+      finding.kind === "registry-device-missing"
+        ? {
+            device: legacy.device,
+            deviceId: device.id,
+            kind: "legacy-device" as const,
+            platform: device.spec.platform,
+            ...(legacy.path === undefined ? {} : { path: legacy.path }),
+          }
+        : finding,
+    );
   }
 
   #emitFindingEvents(findings: readonly DoctorFinding[]): void {
@@ -218,7 +403,10 @@ export class Doctor {
   }
 
   // fallow-ignore-next-line complexity -- one exhaustive arm per finding kind, each a single call or a documented no-op.
-  async #applySafeFixes(findings: readonly DoctorFinding[]): Promise<void> {
+  async #applySafeFixes(
+    findings: readonly DoctorFinding[],
+    driversByPlatform: ReadonlyMap<Platform, Driver>,
+  ): Promise<void> {
     for (const finding of findings) {
       switch (finding.kind) {
         case "registry-device-missing":
@@ -243,6 +431,9 @@ export class Doctor {
           // Nothing here can repair a refused root or an occupied port without doing the
           // one thing failing closed exists to prevent: adopting what it refused.
           break;
+        case "legacy-device":
+          await this.#fixLegacyDevice(finding, driversByPlatform.get(finding.platform));
+          break;
         case "stalled-transition":
           await this.#fixStalledTransition(finding);
           break;
@@ -259,6 +450,43 @@ export class Doctor {
     if (device !== undefined && device.state !== "deleted") {
       await this.options.registry.markDeviceMissing(deviceId, "doctor");
     }
+  }
+
+  /**
+   * Destroys a stranded pre-root device and then records what that leaves behind.
+   *
+   * The destroy reaches outside the driver's root, which every other path in Simlock is
+   * forbidden to do -- and is permitted here for one reason: the device is in the registry.
+   * Registry-only destruction (safety rule 1) is a rule about *what may be destroyed*, and
+   * a registry record satisfies it exactly as a root membership would; the record is also
+   * the only thing that names this device at all. The lease guard every other fix applies
+   * still applies, first and hardest, because the device is real and someone may be on it.
+   *
+   * The registry record is only marked missing once the device is actually gone. Marking it
+   * first would strand the device: the record naming it would be `deleted` and nothing would
+   * ever mention its old path again.
+   */
+  async #fixLegacyDevice(
+    finding: Extract<DoctorFinding, { readonly kind: "legacy-device" }>,
+    driver: Driver | undefined,
+  ): Promise<void> {
+    const destroyLegacy = driver?.destroyLegacy?.bind(driver);
+    if (destroyLegacy === undefined) return;
+    const snapshot = this.options.registry.snapshot;
+    if (snapshot.leases.some((lease) => lease.deviceId === finding.deviceId)) {
+      return;
+    }
+    try {
+      await destroyLegacy(finding.device);
+    } catch (error: unknown) {
+      this.#logger.error("Could not destroy a pre-root device", {
+        deviceId: finding.deviceId,
+        platform: finding.platform,
+        reason: errorMessage(error),
+      });
+      return;
+    }
+    await this.#fixMissingDevice(finding.deviceId);
   }
 
   async #fixForeignStateChange(
@@ -546,4 +774,8 @@ function expectedRunState(state: DeviceState): "running" | "stopped" | undefined
 
 function key(platform: string, deviceId: string): string {
   return `${platform}:${deviceId}`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/src/core/domain.test.ts
+++ b/src/core/domain.test.ts
@@ -45,6 +45,36 @@ describe("transition", () => {
   ] as const)("rejects %s -> %s", (from, to) => {
     expect(() => transition({ ...baseDevice, state: from }, to)).toThrow(IllegalTransition);
   });
+
+  it.each([
+    ["ready", "shutdown"],
+    ["reclaiming", "shutdown"],
+    ["reclaiming", "quarantined"],
+    ["provisioning", "quarantined"],
+  ] as const)("drops the address on %s -> %s, since nothing runs there any more", (from, to) => {
+    const result = transition({ ...baseDevice, address: "emulator-5586", state: from }, to);
+
+    expect(result).toEqual({ ...baseDevice, state: to });
+    expect(result).not.toHaveProperty("address");
+  });
+
+  it("keeps the address across transitions between running states", () => {
+    const leased = transition(
+      { ...baseDevice, address: "emulator-5586", state: "ready" },
+      "leased",
+    );
+
+    expect(leased.address).toBe("emulator-5586");
+    expect(transition(leased, "reclaiming").address).toBe("emulator-5586");
+  });
+
+  it("takes the address a stop supplies over the one it drops", () => {
+    const result = transition({ ...baseDevice, address: "old", state: "ready" }, "shutdown", {
+      address: "new",
+    });
+
+    expect(result.address).toBe("new");
+  });
 });
 
 describe("transitionEnteredAt", () => {

--- a/src/core/domain.ts
+++ b/src/core/domain.ts
@@ -107,6 +107,14 @@ export function transition(
     throw new IllegalTransition(record.state, to);
   }
 
+  if (to === "shutdown" || to === "quarantined") {
+    // Nothing is running at the old address once the device stops: Android hands the
+    // console port to the next boot, so keeping it would let `list --devices` show two
+    // records claiming one port. The next `makeReady` supplies a fresh one.
+    const { address: _stale, ...stopped } = record;
+    return { ...stopped, ...update, state: to };
+  }
+
   return { ...record, ...update, state: to };
 }
 

--- a/src/core/driver-catalog.ts
+++ b/src/core/driver-catalog.ts
@@ -36,6 +36,12 @@ export class DriverCatalog {
     return driver;
   }
 
+  /** Whether a driver started for this platform; false for one discovery refused. */
+  // fallow-ignore-next-line unused-class-member -- reached through StartupDriverAvailability by StartupConverger.
+  has(platform: Platform): boolean {
+    return this.#drivers.has(platform);
+  }
+
   /**
    * Routes `simlock <tool> <args>` to whichever driver claims that tool name. Routing is
    * all this does: which flag scopes the tool, which verbs it refuses, and what its

--- a/src/core/driver.ts
+++ b/src/core/driver.ts
@@ -105,6 +105,19 @@ export interface Driver {
    * around without interpreting it, the same way it carries `address`.
    */
   readonly deviceRoot: string;
+  /**
+   * Re-runs this driver's own root validation, resolving only while the root still proves
+   * ownership and rejecting with the driver's own refusal (an `OwnedRootError`) when it
+   * does not.
+   *
+   * Ownership is proven once, at startup, and then trusted for the life of the process --
+   * tolerable for reporting, not for destroying. A daemon that has been up for days is one
+   * `mv` or one symlink away from `deviceRoot` naming the user's own device set, at which
+   * point `listManaged` answers with every simulator on the machine and
+   * `doctor --purge-orphans` would destroy them. Only the driver can re-run the check,
+   * because only it knows how its root was built (architecture rule 2).
+   */
+  revalidateRoot(): Promise<void>;
   resolveSpec(
     request: DeviceRequest,
     options: { readonly allowDownload: boolean },
@@ -154,6 +167,32 @@ export interface Driver {
    * change a device's lifecycle behind the registry's back (ADR 0001, decision 7).
    */
   passthrough?(args: readonly string[]): PassthroughCommand;
+  /**
+   * Looks for a registry device in the location this platform used before Simlock owned a
+   * root, and reports it without touching it. Optional: a driver with no pre-root history
+   * has nothing to find. The core only ever asks about a device the root itself no longer
+   * holds, so a "yes" here is what separates "stranded by the migration" from "gone".
+   */
+  findLegacy?(driverDeviceId: string): Promise<LegacyDevice | undefined>;
+  /**
+   * Destroys such a device through the old, unscoped path it actually lives on. This is
+   * the only Simlock call that reaches outside an owned root, and it is permitted because
+   * the device is in the registry: registry-only destruction (safety rule 1) is satisfied
+   * by the record, not by the root (ADR 0001, Migration).
+   */
+  destroyLegacy?(device: DriverDevice): Promise<void>;
+}
+
+/**
+ * A device this driver created before Simlock owned a root, still sitting where the
+ * platform put it. Neither CoreSimulator nor the Android SDK can relocate a device, so
+ * these are reported and destroyed rather than migrated, and users re-provision.
+ */
+export interface LegacyDevice {
+  /** Addressed through the driver's unscoped path, never through the root's. */
+  readonly device: DriverDevice;
+  /** Where the driver found it, for the report. Absent when the tool does not say. */
+  readonly path?: string;
 }
 
 /**

--- a/src/core/fake-driver.ts
+++ b/src/core/fake-driver.ts
@@ -7,6 +7,7 @@ import {
   type DriverDevice,
   type DriverEstimate,
   type DriverReality,
+  type LegacyDevice,
   type ObservedRunState,
   type PassthroughCommand,
   PassthroughRefusedError,
@@ -22,7 +23,11 @@ export type FakeDriverOperation =
   | "shutdown"
   | "destroy"
   | "listManaged"
-  | "listCatalog";
+  | "listCatalog"
+  /** Recorded like every other call, so a test can pin that it precedes the first destroy. */
+  | "revalidateRoot"
+  | "findLegacy"
+  | "destroyLegacy";
 
 export type DriverEstimateOperation = "provision" | "boot" | "reclaim";
 
@@ -59,6 +64,12 @@ export interface FakeDriverOptions {
    */
   readonly passthrough?: (args: readonly string[]) => PassthroughCommand;
   readonly platform: Platform;
+  /**
+   * What this driver claims to find outside its root for a given device id, keyed by
+   * `driverDeviceId`. Empty by default: a driver that has never had a pre-root life finds
+   * nothing, which is what keeps every other test's missing device simply missing.
+   */
+  readonly legacyDevices?: Readonly<Record<string, LegacyDevice>>;
   readonly reclaimResult?: "ready" | "shutdown";
   readonly reclaimStrategy?: "erase" | "snapshot" | "wipe";
 }
@@ -91,6 +102,7 @@ export class FakeDriver implements Driver {
   readonly #reclaimResult: "ready" | "shutdown";
   readonly #reclaimStrategy: "erase" | "snapshot" | "wipe";
   readonly #devices = new Map<string, "provisioned" | "ready" | "shutdown">();
+  readonly #legacyDevices: Map<string, LegacyDevice>;
   /** Bumped on every `makeReady` boot -- mirrors a real driver reassigning a port per boot. */
   readonly #bootCounts = new Map<string, number>();
   #managedReality: DriverReality | undefined;
@@ -104,6 +116,7 @@ export class FakeDriver implements Driver {
       options.knownModels === undefined ? undefined : new Set(options.knownModels);
     this.#latencyMs = options.latencyMs;
     this.#leaseEnvironment = options.leaseEnvironment ?? {};
+    this.#legacyDevices = new Map(Object.entries(options.legacyDevices ?? {}));
     this.passthroughTool = options.passthroughTool;
     this.#passthrough = options.passthrough;
     this.platform = options.platform;
@@ -114,6 +127,25 @@ export class FakeDriver implements Driver {
 
   get calls(): readonly FakeDriverCall[] {
     return this.#calls.map((call) => ({ ...call, arguments: [...call.arguments] }));
+  }
+
+  /**
+   * Succeeds unless a test fails it through `failOn`. A real driver re-runs the filesystem
+   * checks here; the fake only has to be refusable, since what `Doctor` does with a refusal
+   * is the behaviour under test.
+   */
+  async revalidateRoot(): Promise<void> {
+    await this.#beforeCall("revalidateRoot");
+  }
+
+  async findLegacy(driverDeviceId: string): Promise<LegacyDevice | undefined> {
+    await this.#beforeCall("findLegacy", driverDeviceId);
+    return this.#legacyDevices.get(driverDeviceId);
+  }
+
+  async destroyLegacy(device: DriverDevice): Promise<void> {
+    await this.#beforeCall("destroyLegacy", device);
+    this.#legacyDevices.delete(device.deviceId);
   }
 
   async resolveSpec(

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -20,6 +20,7 @@ export {
   type DriverEstimate,
   type DriverReality,
   type DriverRejection,
+  type LegacyDevice,
   type ObservedDevice,
   type ObservedRunState,
   type PassthroughCommand,
@@ -32,7 +33,6 @@ export { UnknownPassthroughToolError } from "./driver-catalog.js";
 export type { AdbServerRejectionReason, DriverRejectionReason } from "./driver.js";
 export { Doctor } from "./doctor.js";
 export { ensureOwnedRoot, OWNED_ROOT_MARKER_FILE, OwnedRootError } from "./device-root.js";
-// fallow-ignore-next-line unused-type -- public options contract for the drivers that own a root.
 export type { EnsureOwnedRootOptions } from "./device-root.js";
 // fallow-ignore-next-line unused-type -- wire-visible rejection vocabulary, carried in the driver.root-rejected payload.
 export type { RootRejectionReason } from "./device-root.js";

--- a/src/core/lease-engine.test.ts
+++ b/src/core/lease-engine.test.ts
@@ -939,6 +939,18 @@ describe("LeaseEngine", () => {
     ).resolves.toMatchObject({ lease: { requesterId: "agent-1" } });
   });
 
+  it("cancels a detached lease's expiry timer on dispose, so a stopped daemon can exit", async () => {
+    const harness = await createHarness({ lease: { detachedTtlMs: 15 * 60_000 } });
+    await harness.engine.request(request, { mode: "detached", requesterId: "agent-1" });
+    expect(harness.clock.pendingTimerCount).toBe(1);
+
+    harness.engine.dispose();
+
+    expect(harness.clock.pendingTimerCount).toBe(0);
+    // The lease itself is untouched: a restart restores its timer from the registry.
+    expect(harness.registry.snapshot.leases).toHaveLength(1);
+  });
+
   it("retries after a provision failure without leaking capacity", async () => {
     const clock = new FakeClock(1_000);
     const driver = new FakeDriver({ availableOsVersions: ["26.5"], clock, platform: "ios" });

--- a/src/core/lease-engine.ts
+++ b/src/core/lease-engine.ts
@@ -194,6 +194,7 @@ export class LeaseEngine {
       claims: this.#claims,
       cleanup: this.cleanup,
       decisions: this.#decisions,
+      drivers: this.#drivers,
       interruptedReclaimRecovery: {
         recoverInterruptedReclaim: async (device) => {
           await this.#warmPool.recoverInterrupted(device.id);
@@ -262,9 +263,14 @@ export class LeaseEngine {
     await this.#releaseCoordinator.settleBackgroundReclaims();
   }
 
-  /** Cancels the quarantine coordinator's armed retry timers on daemon shutdown. */
+  /**
+   * Cancels every timer the engine armed on daemon shutdown: quarantine retries and lease
+   * TTL expiries. A detached lease's expiry timer is otherwise still pending after
+   * "Daemon stopped", holding the process open until the TTL runs out.
+   */
   dispose(): void {
     this.#quarantine.dispose();
+    this.#expiry.dispose();
   }
 
   /** Read-only device catalog; a platform without a registered driver is omitted. */

--- a/src/core/startup-converger.test.ts
+++ b/src/core/startup-converger.test.ts
@@ -50,6 +50,7 @@ function createHarness(
   devices: DeviceRecord[],
   leases: LeaseRecord[] = [],
   limits = { android: 3, global: 3, ios: 3 },
+  darkPlatforms: ReadonlySet<Platform> = new Set(),
 ) {
   const order: string[] = [];
   const claimed = new Set<string>();
@@ -100,6 +101,7 @@ function createHarness(
     claims: { isClaimed: (deviceId) => claimed.has(deviceId) },
     cleanup,
     decisions: new SerializedDecision(),
+    drivers: { has: (platform) => !darkPlatforms.has(platform) },
     interruptedReclaimRecovery: recovery,
     quarantineRestore,
     registry: {
@@ -227,6 +229,28 @@ describe("StartupConverger", () => {
     expect(harness.cleanup.execute).toHaveBeenCalledWith(
       expect.objectContaining({ target: refused.id }),
     );
+  });
+
+  it("leaves a platform without a driver untouched instead of failing convergence", async () => {
+    const interrupted = device("ios-reclaiming", "ios", "reclaiming", 1);
+    const excess = device("ios-ready", "ios", "ready", 2);
+    const androidInterrupted = device("android-reclaiming", "android", "reclaiming", 3);
+    const harness = createHarness(
+      [interrupted, excess, androidInterrupted],
+      [],
+      { android: 1, global: 1, ios: 0 },
+      new Set<Platform>(["ios"]),
+    );
+
+    await harness.converger.converge();
+
+    expect(harness.recovery.recoverInterruptedReclaim).toHaveBeenCalledOnce();
+    expect(harness.recovery.recoverInterruptedReclaim).toHaveBeenCalledWith(
+      expect.objectContaining({ id: androidInterrupted.id }),
+    );
+    expect(harness.cleanupCalls).toEqual([]);
+    expect(harness.devices.find((item) => item.id === interrupted.id)?.state).toBe("reclaiming");
+    expect(harness.devices.find((item) => item.id === excess.id)?.state).toBe("ready");
   });
 
   it("is idempotent after recovery and successful convergence", async () => {

--- a/src/core/startup-converger.ts
+++ b/src/core/startup-converger.ts
@@ -1,5 +1,5 @@
 import type { CleanupActionExecutor } from "./cleanup-executor.js";
-import type { DeviceRecord, LeaseRecord } from "./domain.js";
+import type { DeviceRecord, LeaseRecord, Platform } from "./domain.js";
 import type { CapacityReader } from "./lease-ports.js";
 import type { SerializedDecision } from "./serialized-decision.js";
 import { compareLeastRecentlyUsed } from "./warm-pool.js";
@@ -41,11 +41,17 @@ export interface DeviceClaimReader {
   isClaimed(deviceId: string): boolean;
 }
 
+/** Which platforms have a driver this daemon can drive devices through. */
+export interface StartupDriverAvailability {
+  has(platform: Platform): boolean;
+}
+
 export interface StartupConvergerOptions {
   readonly capacity: CapacityReader;
   readonly claims: DeviceClaimReader;
   readonly cleanup: CleanupActionExecutor;
   readonly decisions: SerializedDecision;
+  readonly drivers: StartupDriverAvailability;
   readonly interruptedReclaimRecovery: InterruptedReclaimRecovery;
   readonly quarantineRestore: QuarantineRestorer;
   readonly registry: StartupRegistry;
@@ -56,6 +62,13 @@ export interface StartupConvergerOptions {
 /**
  * Directly coordinates the required startup recovery sequence. It emits no
  * events itself; recovery and cleanup own their post-commit lifecycle facts.
+ *
+ * Devices of a platform whose driver was refused at discovery are left exactly as the
+ * registry found them. Recovering or shutting one down needs a driver call there is no
+ * driver for, and a `NoDriverError` out of convergence stops the whole daemon -- costing
+ * the healthy platform for a root the other one rejected, which is the opposite of the
+ * per-platform fail-closed behaviour discovery promises. `simlock doctor` reports the
+ * rejection; the inventory waits for the driver to come back.
  */
 export class StartupConverger {
   constructor(private readonly options: StartupConvergerOptions) {}
@@ -110,6 +123,7 @@ export class StartupConverger {
       return snapshot.devices.filter(
         (device) =>
           device.state === "reclaiming" &&
+          this.options.drivers.has(device.spec.platform) &&
           !leasedDeviceIds.has(device.id) &&
           !this.options.claims.isClaimed(device.id),
       );
@@ -134,6 +148,7 @@ export class StartupConverger {
       .filter(
         (device) =>
           device.state === "ready" &&
+          this.options.drivers.has(device.spec.platform) &&
           !leasedDeviceIds.has(device.id) &&
           !this.options.claims.isClaimed(device.id) &&
           !refused.has(device.id) &&

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -156,6 +156,7 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
     driverRejections: rejections,
     eventBus,
     leaseExpirer: leaseEngine,
+    logger,
     quarantine: leaseEngine,
     registry,
   });

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -40,6 +40,7 @@ import {
   NodeProcessSupervisor,
   NodeSystemStats,
   NodeTcpProbe,
+  resolveDaemonSocketPath,
   resolveSimlockHome,
   SystemClock,
   type SystemStats,
@@ -84,7 +85,7 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
   const tcpProbe = options.tcpProbe ?? new NodeTcpProbe();
   const configPath = options.configPath ?? join(dataDirectory, "config.json");
   const statePath = options.statePath ?? join(dataDirectory, "state.json");
-  const socketPath = options.socketPath ?? join(dataDirectory, "daemon.sock");
+  const socketPath = options.socketPath ?? resolveDaemonSocketPath(dataDirectory);
   const config = await loadConfig({
     configPath,
     filesystem,

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -549,7 +549,12 @@ export class DaemonServer {
       case "doctor.run": {
         const payload = objectPayload(frame.payload);
         if (this.options.doctor === undefined) throw new Error("Doctor is unavailable");
-        return this.options.doctor.reconcile({ fix: optionalBoolean(payload, "fix") ?? false });
+        return this.options.doctor.reconcile({
+          fix: optionalBoolean(payload, "fix") ?? false,
+          // Its own flag all the way down the wire, never folded into `fix`: an older CLI
+          // that only knows `--fix` cannot ask a newer daemon to destroy anything.
+          purgeOrphans: optionalBoolean(payload, "purgeOrphans") ?? false,
+        });
       }
       case "nuke.run": {
         const payload = objectPayload(frame.payload);

--- a/src/drivers/android/index.test.ts
+++ b/src/drivers/android/index.test.ts
@@ -1191,6 +1191,59 @@ describe("AndroidDriver emulator registration", () => {
   });
 });
 
+describe("AndroidDriver pre-root devices", () => {
+  it("re-proves an intact root by re-running the validation its start was judged by", async () => {
+    const driver = await createDriver(await androidFilesystem(), new ScriptedProcessRunner([]));
+
+    await expect(driver.revalidateRoot()).resolves.toBeUndefined();
+  });
+
+  it("refuses to re-prove a root that has become a symlink since startup", async () => {
+    const filesystem = await androidFilesystem();
+    const driver = await createDriver(filesystem, new ScriptedProcessRunner([]));
+    // The case the re-proof exists for: the path was proven at startup and swapped since,
+    // so `listManaged` would now answer with the user's own AVDs.
+    filesystem.defineSymlink(avdDirectory, `${home}/.android/avd`);
+
+    await expect(driver.revalidateRoot()).rejects.toMatchObject({
+      name: "OwnedRootError",
+      reason: "symlink",
+    });
+  });
+
+  it("finds an AVD stranded in the pre-root AVD home", async () => {
+    const filesystem = await androidFilesystem();
+    await filesystem.mkdirp(`${home}/.android/avd/simlock_old.avd`);
+    const driver = await createDriver(filesystem, new ScriptedProcessRunner([]));
+
+    await expect(driver.findLegacy("simlock_old")).resolves.toMatchObject({
+      device: { deviceId: "simlock_old" },
+      path: `${home}/.android/avd/simlock_old.avd`,
+    });
+    await expect(driver.findLegacy("simlock_never_existed")).resolves.toBeUndefined();
+  });
+
+  it("deletes a stranded AVD against the legacy AVD home, not Simlock's root", async () => {
+    const filesystem = await androidFilesystem();
+    await filesystem.mkdirp(`${home}/.android/avd/simlock_old.avd`);
+    const runner = new ScriptedProcessRunner([
+      processResult(binaries.avdmanager, ["delete", "avd", "-n", "simlock_old"]),
+    ]);
+    const driver = await createDriver(filesystem, runner);
+    const legacy = await driver.findLegacy("simlock_old");
+
+    await driver.destroyLegacy(legacy!.device);
+
+    // Pointed at the home the AVD is actually in, and deliberately carrying no
+    // `ANDROID_ADB_SERVER_PORT`: a device this old is not on Simlock's server, and the
+    // user's is not one Simlock may drive.
+    expect(runner.calls.at(-1)?.options?.env).toEqual({
+      ANDROID_AVD_HOME: `${home}/.android/avd`,
+      ANDROID_HOME: sdk,
+    });
+  });
+});
+
 function bootProbes(runner: ScriptedProcessRunner): number {
   return runner.calls.filter((call) => call.args.includes("sys.boot_completed")).length;
 }

--- a/src/drivers/android/index.test.ts
+++ b/src/drivers/android/index.test.ts
@@ -41,6 +41,8 @@ const scopedEnv = {
   ANDROID_HOME: sdk,
 } as const;
 const scopedOptions = { env: scopedEnv } as const;
+// The emulator outlives the daemon and is never read from, so it is spawned detached.
+const emulatorOptions = { env: scopedEnv, stdio: "ignore" } as const;
 const binaries = {
   adb: `${sdk}/platform-tools/adb`,
   avdmanager: `${sdk}/cmdline-tools/latest/bin/avdmanager`,
@@ -222,7 +224,7 @@ describe("AndroidDriver", () => {
     expect(harness.runner.calls).toContainEqual({
       args: ["-avd", "simlock_one", "-port", "5586", "-no-snapshot-save", "-no-snapshot-load"],
       command: binaries.emulator,
-      options: scopedOptions,
+      options: emulatorOptions,
     });
   });
 
@@ -245,7 +247,7 @@ describe("AndroidDriver", () => {
         "simlock_clean_baseline",
       ],
       command: binaries.emulator,
-      options: scopedOptions,
+      options: emulatorOptions,
     });
   });
 
@@ -337,7 +339,7 @@ describe("AndroidDriver", () => {
         "-no-snapshot-load",
       ],
       command: binaries.emulator,
-      options: scopedOptions,
+      options: emulatorOptions,
     });
   });
 
@@ -511,7 +513,7 @@ describe("AndroidDriver", () => {
     const spec = { model: "Pixel 8", osVersion: "34", platform: "android" } as const;
 
     expect(driver.estimate({ operation: "provision" }, spec)).toBe(1_000);
-    expect(driver.estimate({ operation: "boot" }, spec)).toBe(31_000);
+    expect(driver.estimate({ operation: "boot" }, spec)).toBe(70_000);
   });
 
   it("prices reclaim by the strategy the clean level selects", async () => {

--- a/src/drivers/android/index.ts
+++ b/src/drivers/android/index.ts
@@ -18,7 +18,12 @@ import {
   RuntimeMissingError,
   UnknownModelError,
 } from "../../core/driver.js";
-import { ensureOwnedRoot, OwnedRootError } from "../../core/index.js";
+import {
+  ensureOwnedRoot,
+  type EnsureOwnedRootOptions,
+  type LegacyDevice,
+  OwnedRootError,
+} from "../../core/index.js";
 import type {
   Clock,
   Filesystem,
@@ -212,6 +217,7 @@ export class AndroidDriver implements Driver {
   readonly #filesystem: Filesystem;
   readonly #hostAbi: string;
   readonly #idGenerator: IdGenerator;
+  readonly #legacyAvdHome: string;
   readonly #locks = new Map<string, Promise<void>>();
   readonly #onDiagnostic: ((diagnostic: AndroidDriverDiagnostic) => void) | undefined;
   readonly #portAllocator: PortAllocator;
@@ -219,12 +225,14 @@ export class AndroidDriver implements Driver {
   readonly #profiles = new Map<string, DeviceProfile>();
   readonly #readinessTimeoutMs: number;
   readonly #registrar: AdbRegistrar;
+  readonly #rootOptions: EnsureOwnedRootOptions;
   readonly #sdk: AndroidSdkPaths;
 
   private constructor(
     options: AndroidDriverOptions,
     sdk: AndroidSdkPaths,
     deviceRoot: string,
+    rootOptions: EnsureOwnedRootOptions,
     adbServer: AdbServerSupervisor,
     adbServerPort: number,
   ) {
@@ -240,7 +248,14 @@ export class AndroidDriver implements Driver {
     this.#processRunner = options.processRunner;
     this.#readinessTimeoutMs = options.readinessTimeoutMs ?? DEFAULT_READINESS_TIMEOUT_MS;
     this.#registrar = new AdbRegistrar({ serverPort: adbServerPort, tcp: options.tcpProbe });
+    this.#rootOptions = rootOptions;
     this.#sdk = sdk;
+    // Where an AVD Simlock made before it owned a root still sits: the AVD home the user
+    // had configured then, or the SDK's own default. Read only by `findLegacy` /
+    // `destroyLegacy` -- the fallback CP3 deleted from the driver proper, kept exactly here
+    // because a stranded device cannot be found anywhere else (ADR 0001, Migration).
+    this.#legacyAvdHome =
+      options.env.ANDROID_AVD_HOME ?? join(options.homeDirectory, ".android", "avd");
     this.#portAllocator = portAllocatorFor(options.processRunner, sdk.adb);
   }
 
@@ -259,14 +274,15 @@ export class AndroidDriver implements Driver {
     // provenance tokens all come from the same generator, so a caller that injected one
     // controls all three rather than two of them.
     const idGenerator = options.idGenerator ?? new SequentialIdGenerator();
-    const deviceRoot = await ensureOwnedRoot({
+    const rootOptions: EnsureOwnedRootOptions = {
       filesystem: options.filesystem,
       idGenerator,
       instanceId: options.instanceId,
       path: configuredDeviceRoot(options),
       platform: "android",
       ...(options.uid === undefined ? {} : { uid: options.uid }),
-    });
+    };
+    const deviceRoot = await ensureOwnedRoot(rootOptions);
     const adbServer = new AdbServerSupervisor({
       adbPath: sdk.adb,
       clock: options.clock,
@@ -284,6 +300,7 @@ export class AndroidDriver implements Driver {
       { ...options, idGenerator },
       sdk,
       deviceRoot,
+      rootOptions,
       adbServer,
       adbServerPort,
     );
@@ -297,6 +314,65 @@ export class AndroidDriver implements Driver {
 
   get deviceRoot(): string {
     return this.#deviceRoot;
+  }
+
+  /**
+   * The same call `create` made, with the same arguments, because the proof *is* that call:
+   * a cheaper second check here would be a second validator, free to drift from the one
+   * every start is judged by. It is asked for immediately before Simlock destroys anything
+   * inside this root, since between then and startup the path can have become a symlink, or
+   * a `mv` can have left the user's own AVD home standing where this root was.
+   */
+  async revalidateRoot(): Promise<void> {
+    await ensureOwnedRoot(this.#rootOptions);
+  }
+
+  /**
+   * Looks for an AVD Simlock created before it owned a root, in the AVD home it would have
+   * used then. Reached only for a registry device this root no longer holds, and it only
+   * reads the filesystem. A legacy home that *is* the root means there is nothing pre-root
+   * about the device -- it is simply gone -- and must never be answered through the
+   * unscoped path below.
+   */
+  async findLegacy(driverDeviceId: string): Promise<LegacyDevice | undefined> {
+    if (this.#legacyAvdHome === this.#deviceRoot) {
+      return undefined;
+    }
+    const path = join(this.#legacyAvdHome, `${driverDeviceId}.avd`);
+    if (!(await this.#filesystem.exists(path))) {
+      return undefined;
+    }
+
+    return {
+      device: {
+        address: driverDeviceId,
+        deviceId: driverDeviceId,
+        // A stranded AVD has no console port and no serial: it is not running on Simlock's
+        // server, and it is not this driver's business to look for it on anyone else's.
+        driverData: {
+          avdName: driverDeviceId,
+          configHash: "",
+          port: 0,
+          serial: "",
+        } satisfies AndroidDriverData,
+      },
+      path,
+    };
+  }
+
+  /**
+   * Deletes a pre-root AVD through the AVD home it actually lives in. Permitted despite
+   * sitting outside this driver's root because the registry names it: registry-only
+   * destruction (safety rule 1) is satisfied by the record, not by the root. The
+   * environment points at the legacy home and deliberately not at Simlock's adb server --
+   * an AVD that is somehow still running is running on the user's, and stopping devices on
+   * a server Simlock does not own is not something this may do.
+   */
+  async destroyLegacy(device: DriverDevice): Promise<void> {
+    const { avdName } = this.#dataFor(device);
+    await this.#runOrThrow(this.#sdk.avdmanager, ["delete", "avd", "-n", avdName], {
+      env: { ...this.#baseEnv, ANDROID_AVD_HOME: this.#legacyAvdHome },
+    });
   }
 
   leaseEnvironment(): Readonly<Record<string, string>> {
@@ -1111,9 +1187,15 @@ export class AndroidDriver implements Driver {
   async #runOrThrow(
     command: string,
     args: readonly string[],
-    options: { readonly timeoutMs?: number } = {},
+    options: { readonly timeoutMs?: number; readonly env?: NodeJS.ProcessEnv } = {},
   ) {
-    const result = await this.#processRunner.run(command, args, { ...options, env: this.#env() });
+    // The scoped environment unless a caller supplies its own, which only the two legacy
+    // methods do -- pointing a command at a root this driver does not own is the whole of
+    // what they are for, and nothing else here may.
+    const result = await this.#processRunner.run(command, args, {
+      ...options,
+      env: options.env ?? this.#env(),
+    });
     if (result.code !== 0) {
       throw new DriverCrashError(
         `${command} ${args.join(" ")} failed: ${result.stderr || result.stdout}`,

--- a/src/drivers/android/index.ts
+++ b/src/drivers/android/index.ts
@@ -41,7 +41,11 @@ import { isAndroidDriverData, type AndroidDriverData } from "./data.js";
 export { AdbServerUnavailableError } from "./adb-server.js";
 
 const DEFAULT_READINESS_TIMEOUT_MS = 180_000;
-const COLD_BOOT_ESTIMATE_MS = 31_000;
+// Measured at 60-71s for a cold boot to `sys.boot_completed` on an M-series Mac against
+// Pixel 8 / API 35 (ADR-era hardware verification), against the 31s this first quoted.
+// Under-quoting matters more than over-quoting: `Doctor` derives its stalled-transition
+// threshold from this number, so a low estimate flags healthy boots on a slower machine.
+const COLD_BOOT_ESTIMATE_MS = 70_000;
 // Console ports, even ones only, each paired with the odd adb port above it. The range
 // starts above the 5585 ceiling a default adb server scans, so the user's server and
 // Android Studio cannot see, drive, or kill a Simlock emulator (ADR 0001, decision 4).
@@ -1076,11 +1080,18 @@ export class AndroidDriver implements Driver {
     fromSnapshot: boolean,
   ): Promise<void> {
     const startedAt = this.#clock.now();
+    // `stdio: "ignore"` and `unref()` for the same reason the adb server gets them: an
+    // emulator outlives the daemon by design (`#reattachRunningEmulators` adopts it after
+    // a restart) and is reaped through adb and by pid, never by awaiting its exit. Left
+    // referenced, its handle and stdio pipes would hold the event loop open, and a
+    // `daemon stop` that had logged "Daemon stopped" would leave the process alive for as
+    // long as any emulator ran.
     const handle = this.#processRunner.spawn(
       this.#sdk.emulator,
       ["-avd", data.avdName, "-port", String(data.port), "-no-snapshot-save", ...launchArgs],
-      { env: this.#env() },
+      { env: this.#env(), stdio: "ignore" },
     );
+    handle.unref();
     state.handle = handle;
     // No announcement here, deliberately. adb answers `host:emulator:<port>` by connecting
     // *out* to that port, and the emulator has not opened it yet a millisecond after the

--- a/src/drivers/ios/index.test.ts
+++ b/src/drivers/ios/index.test.ts
@@ -58,6 +58,22 @@ function simctlArgs(...args: readonly string[]): string[] {
 /** Runners handed to a driver built by `createDriver`; drained by the invariant below. */
 const scopedRunners: ScriptedProcessRunner[] = [];
 
+const legacyUdid = "00000000-0000-0000-0000-0000000000ff";
+
+/**
+ * The complete argv of every call the pre-root path is allowed to make without `--set`,
+ * spelled out rather than pattern-matched: `findLegacy` / `destroyLegacy` deliberately
+ * address the machine's default set (ADR 0001, Migration), and every *other* call must
+ * still fail the invariant below if its scoping ever goes missing.
+ */
+const UNSCOPED_LEGACY_CALLS = new Set(
+  [
+    ["simctl", "list", "-j", "devices"],
+    ["simctl", "shutdown", legacyUdid],
+    ["simctl", "delete", legacyUdid],
+  ].map((argv) => argv.join(" ")),
+);
+
 /**
  * The one global invariant, asserted over everything every test in this file recorded
  * rather than per call site: scoping is what makes ownership provable, so a spawn that
@@ -69,6 +85,7 @@ const scopedRunners: ScriptedProcessRunner[] = [];
 afterEach(() => {
   for (const call of scopedRunners.splice(0).flatMap((runner) => runner.calls)) {
     expect(call.command).toBe("xcrun");
+    if (UNSCOPED_LEGACY_CALLS.has(call.args.join(" "))) continue;
     expect(call.args.slice(0, 3)).toEqual(["simctl", "--set", deviceRoot]);
   }
 });
@@ -591,6 +608,89 @@ describe("IosSimctlDriver", () => {
     expect(failure).toBeInstanceOf(OwnedRootError);
     expect(failure).toMatchObject({ platform: "ios", reason: "not-absolute" });
     expect(failure).toMatchObject({ message: expect.stringContaining("true") });
+  });
+
+  it("re-proves an intact root by re-running the validation its start was judged by", async () => {
+    const driver = await createDriver(new ScriptedProcessRunner([]));
+
+    await expect(driver.revalidateRoot()).resolves.toBeUndefined();
+  });
+
+  it("refuses to re-prove a root that has become a symlink since startup", async () => {
+    const filesystem = new MemoryFilesystem();
+    const driver = await createDriver(new ScriptedProcessRunner([]), new FakeClock(), filesystem);
+    // The case the re-proof exists for: ownership was proven at startup and the path has
+    // been swapped since, so `listManaged` now answers from somewhere else entirely.
+    filesystem.defineSymlink(deviceRoot, "/Users/someone/Library/Developer/CoreSimulator/Devices");
+
+    const failure = await driver
+      .revalidateRoot()
+      .then(() => undefined)
+      .catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(OwnedRootError);
+    expect(failure).toMatchObject({ platform: "ios", reason: "symlink" });
+  });
+
+  it("finds a pre-root device in the machine's default set, without --set", async () => {
+    const runner = new ScriptedProcessRunner([
+      {
+        match: { args: ["simctl", "list", "-j", "devices"], command: "xcrun" },
+        result: {
+          code: 0,
+          stderr: "",
+          stdout: JSON.stringify({
+            devices: {
+              "com.apple.CoreSimulator.SimRuntime.iOS-26-5": [
+                {
+                  dataPath: `/Library/Devices/${legacyUdid}/data`,
+                  name: "simlock-old",
+                  state: "Shutdown",
+                  udid: legacyUdid,
+                },
+              ],
+            },
+          }),
+        },
+      },
+    ]);
+    const driver = await createDriver(runner);
+
+    await expect(driver.findLegacy(legacyUdid)).resolves.toMatchObject({
+      device: { deviceId: legacyUdid },
+      path: `/Library/Devices/${legacyUdid}`,
+    });
+  });
+
+  it("reports no pre-root device when the default set does not hold the udid", async () => {
+    const runner = new ScriptedProcessRunner([
+      {
+        match: { args: ["simctl", "list", "-j", "devices"], command: "xcrun" },
+        result: { code: 0, stderr: "", stdout: JSON.stringify({ devices: {} }) },
+      },
+    ]);
+    const driver = await createDriver(runner);
+
+    await expect(driver.findLegacy(legacyUdid)).resolves.toBeUndefined();
+  });
+
+  it("destroys a pre-root device through the unscoped path it actually lives on", async () => {
+    const runner = new ScriptedProcessRunner([
+      { match: { args: ["simctl", "shutdown", legacyUdid], command: "xcrun" } },
+      { match: { args: ["simctl", "delete", legacyUdid], command: "xcrun" } },
+    ]);
+    const driver = await createDriver(runner);
+
+    await driver.destroyLegacy({
+      address: legacyUdid,
+      deviceId: legacyUdid,
+      driverData: { ...driverData, udid: legacyUdid },
+    });
+
+    expect(runner.calls.map((call) => call.args)).toEqual([
+      ["simctl", "shutdown", legacyUdid],
+      ["simctl", "delete", legacyUdid],
+    ]);
   });
 
   it("hands a lease holder the device set its simulator cannot be addressed without", async () => {

--- a/src/drivers/ios/index.ts
+++ b/src/drivers/ios/index.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import {
   BootTimeoutError,
@@ -10,6 +10,8 @@ import {
   type DriverEstimate,
   type DriverReality,
   ensureOwnedRoot,
+  type EnsureOwnedRootOptions,
+  type LegacyDevice,
   type ObservedDevice,
   OwnedRootError,
   type PassthroughCommand,
@@ -140,13 +142,19 @@ export class IosSimctlDriver implements Driver {
   readonly #processRunner: ProcessRunner;
   readonly #resolvedSpecs = new Map<string, ResolvedIosSpec>();
   readonly #deviceRoot: string;
+  readonly #rootOptions: EnsureOwnedRootOptions;
 
-  private constructor(options: IosSimctlDriverOptions, deviceRoot: string) {
+  private constructor(
+    options: IosSimctlDriverOptions,
+    deviceRoot: string,
+    rootOptions: EnsureOwnedRootOptions,
+  ) {
     this.#clock = options.clock;
     this.#filesystem = options.filesystem;
     this.#idGenerator = options.idGenerator;
     this.#processRunner = options.processRunner;
     this.#deviceRoot = deviceRoot;
+    this.#rootOptions = rootOptions;
   }
 
   /**
@@ -158,20 +166,32 @@ export class IosSimctlDriver implements Driver {
    * machine's default device set (safety rule 9).
    */
   static async create(options: IosSimctlDriverOptions): Promise<IosSimctlDriver> {
-    const deviceRoot = await ensureOwnedRoot({
+    const rootOptions: EnsureOwnedRootOptions = {
       filesystem: options.filesystem,
       idGenerator: options.idGenerator,
       instanceId: options.instanceId,
       path: configuredDeviceRoot(options),
       platform: "ios",
       ...(options.uid === undefined ? {} : { uid: options.uid }),
-    });
+    };
+    const deviceRoot = await ensureOwnedRoot(rootOptions);
 
-    return new IosSimctlDriver(options, deviceRoot);
+    return new IosSimctlDriver(options, deviceRoot, rootOptions);
   }
 
   get deviceRoot(): string {
     return this.#deviceRoot;
+  }
+
+  /**
+   * The same call `create` made, with the same arguments, because the proof *is* that call:
+   * a cheaper second check here would be a second validator, free to drift from the one
+   * every start is judged by. It is asked for immediately before Simlock destroys anything
+   * inside this set, since between then and startup the path can have become a symlink, or
+   * a `mv` can have left the user's own device set standing where this one was.
+   */
+  async revalidateRoot(): Promise<void> {
+    await ensureOwnedRoot(this.#rootOptions);
   }
 
   async resolveSpec(
@@ -287,6 +307,52 @@ export class IosSimctlDriver implements Driver {
     const data = iosDriverData(device);
     await this.#shutdown(data.udid);
     await this.#simctl(["delete", data.udid], COMMAND_TIMEOUT_MS);
+  }
+
+  /**
+   * Looks for a UDID in the machine's default device set -- where every simulator Simlock
+   * created before it owned one still lives. Reached only for a registry device the root no
+   * longer holds, and it reads: `simctl list` is the one unscoped call that mutates nothing.
+   */
+  async findLegacy(driverDeviceId: string): Promise<LegacyDevice | undefined> {
+    const result = await this.#legacySimctl(["list", "-j", "devices"], COMMAND_TIMEOUT_MS);
+    const found = parseManagedDevices(JSON.parse(result.stdout) as unknown).find(
+      (device) => device.udid === driverDeviceId,
+    );
+    if (found === undefined) {
+      return undefined;
+    }
+
+    return {
+      device: {
+        address: found.udid,
+        deviceId: found.udid,
+        driverData: {
+          deviceTypeId: "",
+          name: found.name,
+          runtimeId: "",
+          udid: found.udid,
+        } satisfies IosDriverData,
+      },
+      // CoreSimulator lays every set out as `<set>/<UDID>`, data container included, so the
+      // container's parent is the device directory -- and where the *old* set is is exactly
+      // what this driver no longer knows any other way (ADR 0001, consequences).
+      ...(found.dataPath === undefined ? {} : { path: dirname(found.dataPath) }),
+    };
+  }
+
+  /**
+   * Destroys a pre-root simulator through the unscoped path it actually sits on. Permitted
+   * despite living outside this driver's root because the registry names it: registry-only
+   * destruction (safety rule 1) is satisfied by the record, not by the root. `doctor --fix`
+   * is the only caller, and it checks the lease guard before asking.
+   */
+  async destroyLegacy(device: DriverDevice): Promise<void> {
+    const { udid } = iosDriverData(device);
+    // Best effort, exactly as the scoped `#shutdown` is: a device that is already shut down
+    // reports a failure that says nothing about whether the delete can proceed.
+    await this.#invokeLegacySimctl(["shutdown", udid], COMMAND_TIMEOUT_MS);
+    await this.#legacySimctl(["delete", udid], COMMAND_TIMEOUT_MS);
   }
 
   async listManaged(): Promise<DriverReality> {
@@ -548,8 +614,14 @@ export class IosSimctlDriver implements Driver {
   }
 
   async #simctl(args: readonly string[], timeoutMs: number): Promise<ProcessResult> {
-    const outcome = await this.#invokeSimctl(args, timeoutMs);
+    return this.#checked(args, timeoutMs, await this.#invokeSimctl(args, timeoutMs));
+  }
 
+  async #legacySimctl(args: readonly string[], timeoutMs: number): Promise<ProcessResult> {
+    return this.#checked(args, timeoutMs, await this.#invokeLegacySimctl(args, timeoutMs));
+  }
+
+  #checked(args: readonly string[], timeoutMs: number, outcome: ProcessOutcome): ProcessResult {
     if (outcome.kind === "timed-out") {
       throw new DriverCrashError(`simctl ${args.join(" ")} timed out after ${timeoutMs}ms`);
     }
@@ -558,20 +630,34 @@ export class IosSimctlDriver implements Driver {
     return outcome.result;
   }
 
+  /**
+   * The single insertion point for `--set`, which scopes every subcommand to the root this
+   * driver owns and must therefore precede the subcommand. Every call in this file is
+   * spawned through here or through `#invokeLegacySimctl`, and nothing else: a scoped call
+   * that slipped past both would address the machine's default set, where Simlock can prove
+   * nothing about what it touches.
+   */
   async #invokeSimctl(args: readonly string[], timeoutMs: number): Promise<ProcessOutcome> {
+    return this.#invokeXcrun(["simctl", "--set", this.#deviceRoot, ...args], timeoutMs);
+  }
+
+  /**
+   * Deliberately unscoped, and the only thing in Simlock that is: the pre-root devices
+   * `findLegacy` / `destroyLegacy` deal with are in the machine's default set, which is
+   * where a `--set` would stop reaching them. Only those two may call it, and only for a
+   * UDID a registry record names -- registry-only destruction (safety rule 1) is satisfied
+   * by that record, not by the root.
+   */
+  async #invokeLegacySimctl(args: readonly string[], timeoutMs: number): Promise<ProcessOutcome> {
+    return this.#invokeXcrun(["simctl", ...args], timeoutMs);
+  }
+
+  async #invokeXcrun(argv: readonly string[], timeoutMs: number): Promise<ProcessOutcome> {
     let process;
     try {
-      // The single insertion point for `--set`, which scopes every subcommand to the root
-      // this driver owns and must therefore precede the subcommand. Nothing in this file
-      // spawns simctl any other way: a call that slipped past here would address the
-      // machine's default set, where Simlock can prove nothing about what it touches.
-      process = this.#processRunner.spawn("xcrun", ["simctl", "--set", this.#deviceRoot, ...args], {
-        timeoutMs,
-      });
+      process = this.#processRunner.spawn("xcrun", [...argv], { timeoutMs });
     } catch (error: unknown) {
-      throw new DriverCrashError(
-        `Could not start simctl ${args.join(" ")}: ${errorMessage(error)}`,
-      );
+      throw new DriverCrashError(`Could not start ${argv.join(" ")}: ${errorMessage(error)}`);
     }
 
     let resolveTimeout: (() => void) | undefined;
@@ -593,7 +679,7 @@ export class IosSimctlDriver implements Driver {
         timedOut.then(() => ({ kind: "timed-out" as const })),
       ]);
     } catch (error: unknown) {
-      throw new DriverCrashError(`simctl ${args.join(" ")} failed: ${errorMessage(error)}`);
+      throw new DriverCrashError(`${argv.join(" ")} failed: ${errorMessage(error)}`);
     } finally {
       this.#clock.cancel(timer);
     }
@@ -651,6 +737,8 @@ function configuredDeviceRoot(options: IosSimctlDriverOptions): string {
 }
 
 interface ParsedManagedDevice {
+  /** Only `findLegacy` reads this; a scoped listing already knows where its devices are. */
+  readonly dataPath?: string;
   readonly name: string;
   readonly runState: ObservedRunState;
   readonly udid: string;
@@ -660,21 +748,25 @@ function parseManagedDevices(value: unknown): ParsedManagedDevice[] {
   if (!isRecord(value) || !isRecord(value.devices)) {
     throw new DriverCrashError("Invalid simctl device list JSON");
   }
-  const devices: ParsedManagedDevice[] = [];
-  for (const runtimeDevices of Object.values(value.devices)) {
-    if (!Array.isArray(runtimeDevices)) continue;
-    for (const device of runtimeDevices) {
-      if (!isRecord(device) || typeof device.name !== "string" || typeof device.udid !== "string") {
-        continue;
-      }
-      devices.push({
-        name: device.name,
-        runState: simctlRunState(device.state),
-        udid: device.udid,
-      });
-    }
+  return Object.values(value.devices).flatMap((runtimeDevices) =>
+    Array.isArray(runtimeDevices) ? runtimeDevices.flatMap(parseManagedDevice) : [],
+  );
+}
+
+/** An entry simctl reports without a name or a udid is not addressable, so it is skipped. */
+function parseManagedDevice(value: unknown): readonly ParsedManagedDevice[] {
+  if (!isRecord(value) || typeof value.name !== "string" || typeof value.udid !== "string") {
+    return [];
   }
-  return devices;
+
+  return [
+    {
+      name: value.name,
+      runState: simctlRunState(value.state),
+      udid: value.udid,
+      ...(typeof value.dataPath === "string" ? { dataPath: value.dataPath } : {}),
+    },
+  ];
 }
 
 /** `simctl` reports `Booting` / `Shutting Down` mid-transition; both must read as `transitioning`, never as drift. */

--- a/src/mcp/main.ts
+++ b/src/mcp/main.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import {
   NodeDaemonLauncher,
   NodeIpcTransport,
+  resolveDaemonSocketPath,
   resolveSimlockHome,
   SystemClock,
 } from "../ports/index.js";
@@ -141,7 +142,7 @@ function defaultEnvironment(): Required<Pick<McpStdioEnvironment, "connect" | "c
   const dataDirectory = resolveSimlockHome();
   const clock = new SystemClock();
   const ipc = new NodeIpcTransport();
-  const socketPath = join(dataDirectory, "daemon.sock");
+  const socketPath = resolveDaemonSocketPath(dataDirectory);
   const logPath = join(dataDirectory, "daemon.log");
   return {
     connect: () =>

--- a/src/ports/index.ts
+++ b/src/ports/index.ts
@@ -1,6 +1,6 @@
 export { type Filesystem, MemoryFilesystem, NodeFilesystem } from "./filesystem.js";
 export type { PathDetails } from "./filesystem.js";
-export { resolveSimlockHome } from "./paths.js";
+export { resolveDaemonSocketPath, resolveSimlockHome, SocketPathTooLongError } from "./paths.js";
 export { type DaemonLauncher, FakeDaemonLauncher, NodeDaemonLauncher } from "./daemon-launcher.js";
 export {
   type IpcConnection,

--- a/src/ports/paths.test.ts
+++ b/src/ports/paths.test.ts
@@ -2,7 +2,29 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { resolveSimlockHome } from "./paths.js";
+import { resolveDaemonSocketPath, resolveSimlockHome, SocketPathTooLongError } from "./paths.js";
+
+describe("resolveDaemonSocketPath", () => {
+  it("places the socket under the data directory", () => {
+    expect(resolveDaemonSocketPath("/tmp/simlock-home", "darwin")).toBe(
+      "/tmp/simlock-home/daemon.sock",
+    );
+  });
+
+  it("refuses a path the kernel could never bind, naming SIMLOCK_HOME as the fix", () => {
+    const home = `/private/tmp/${"x".repeat(120)}`;
+
+    expect(() => resolveDaemonSocketPath(home, "darwin")).toThrow(SocketPathTooLongError);
+    expect(() => resolveDaemonSocketPath(home, "darwin")).toThrow(/SIMLOCK_HOME/);
+  });
+
+  it("allows Linux its longer sun_path", () => {
+    const home = `/tmp/${"x".repeat(88)}`;
+
+    expect(() => resolveDaemonSocketPath(home, "darwin")).toThrow(SocketPathTooLongError);
+    expect(resolveDaemonSocketPath(home, "linux")).toBe(`${home}/daemon.sock`);
+  });
+});
 
 describe("resolveSimlockHome", () => {
   it("defaults to ~/.simlock when SIMLOCK_HOME is unset", () => {

--- a/src/ports/paths.ts
+++ b/src/ports/paths.ts
@@ -18,3 +18,44 @@ export function resolveSimlockHome(env: NodeJS.ProcessEnv = process.env): string
   const configured = env.SIMLOCK_HOME;
   return configured === undefined ? join(homedir(), ".simlock") : resolve(configured);
 }
+
+/**
+ * The longest AF_UNIX socket path the kernel accepts, in bytes, excluding the trailing
+ * NUL: `sun_path` is 104 bytes on macOS and the BSDs and 108 on Linux. Windows named
+ * pipes have no such limit.
+ */
+function maxSocketPathLength(platform: NodeJS.Platform = process.platform): number {
+  if (platform === "win32") return Number.POSITIVE_INFINITY;
+  return (platform === "linux" ? 108 : 104) - 1;
+}
+
+/** A `SIMLOCK_HOME` so deep that no socket can be bound or connected under it. */
+export class SocketPathTooLongError extends Error {
+  constructor(
+    readonly path: string,
+    readonly maxLength: number,
+  ) {
+    super(
+      `Daemon socket path is ${Buffer.byteLength(path)} bytes, but this platform allows at most ${maxLength}: ${path}. ` +
+        `Point SIMLOCK_HOME at a shorter directory.`,
+    );
+    this.name = "SocketPathTooLongError";
+  }
+}
+
+/**
+ * Where the daemon listens under a data directory. Checked here, once, for every process
+ * that derives it: a path past the kernel's limit otherwise fails on connect as a bare
+ * `EINVAL`, which says nothing about `SIMLOCK_HOME` being the cause.
+ */
+export function resolveDaemonSocketPath(
+  dataDirectory: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const socketPath = join(dataDirectory, "daemon.sock");
+  const maxLength = maxSocketPathLength(platform);
+  if (Buffer.byteLength(socketPath) > maxLength) {
+    throw new SocketPathTooLongError(socketPath, maxLength);
+  }
+  return socketPath;
+}


### PR DESCRIPTION
Stacked on #84. Fixes the defects found by the Phase 1-4 hardware verification run against `feat/owned-device-roots-5-doctor`.

## B1 — `daemon stop` left the process alive
Two handles kept the event loop open after "Daemon stopped":
- The Android emulator was spawned with piped stdio and never unref'd, so the daemon lived as long as any emulator did. It is now spawned with `stdio: "ignore"` and `unref()`, the same treatment the adb server gets: nothing read those pipes, and the emulator is designed to outlive the daemon (a restart re-attaches it).
- Detached-lease TTL timers were never cancelled on shutdown. `LeaseEngine.dispose()` now disposes the expiry scheduler too; the leases stay in the registry and their timers are restored on the next start.

## B2 — rejected root + interrupted reclaim crashed the whole daemon
Startup convergence assumed every platform in the registry had a driver; the resulting `NoDriverError` was fatal and took the healthy platform down. `StartupConverger` now takes a driver-availability port and skips devices of a platform without a driver for both interrupted-reclaim recovery and excess-capacity shutdown. Those devices stay as found (the documented "dark platform keeps its inventory" behaviour) and `doctor` still reports the rejection.

## D1 — socket path length
`resolveDaemonSocketPath` validates `daemon.sock` against the kernel's `sun_path` limit (104 bytes on macOS, 108 on Linux) and throws a message naming `SIMLOCK_HOME` as the fix. CLI, MCP server, and daemon all derive the path through it; the CLI reports it as `USAGE`. Documented in CLI.md.

## D2 — Android boot estimate
Cold-boot estimate raised from 31s to the measured 70s (measurement recorded in the comment). Affects the doctor stall threshold and ETA reporting only.

## D3 — stale address on quarantined devices
`transition()` drops `address` on entry to `shutdown` or `quarantined`, since nothing runs there and Android reuses the console port. The next `makeReady` supplies a fresh one.

## Not changed
- D4 (recovery-budget exhaustion time) is bounded by the driver readiness timeout per attempt, by design; a shorter recovery timeout would be a product decision.
- D5 was a test-harness `sed` mismatch.

## Verification
- `pnpm run typecheck`, `typecheck:e2e`, `lint`, `format:check`, `fallow`: clean
- `pnpm run test`: 960 passed (new tests for the converger skip, expiry-timer disposal, address clearing, socket-path check)
- `pnpm run test:e2e` (fake driver): 40 passed, 1 expected fail
- The slow real-hardware lane was not run; `slow-android-smoke.test.ts` is the test that exercises B1 for real.
