### PR TITLE
feat(contract): declare every daemon operation once, negotiate protocol ranges

### DIFF
--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -309,7 +309,7 @@ describe("CLI boundary", () => {
     await expect(run).resolves.toBe(0);
 
     const leaseCall = connection.calls.find((call) => call.type === "lease.request");
-    expect(leaseCall?.payload).toMatchObject({ request: { full: true } });
+    expect(leaseCall?.payload).toMatchObject({ full: true });
     expect(JSON.parse(output.stdout)).toMatchObject({ slim: false });
   });
 
@@ -341,9 +341,7 @@ describe("CLI boundary", () => {
     await expect(run).resolves.toBe(0);
 
     const leaseCall = connection.calls.find((call) => call.type === "lease.request");
-    const requestPayload = (leaseCall?.payload as { request: Record<string, unknown> } | undefined)
-      ?.request;
-    expect(requestPayload).not.toHaveProperty("full");
+    expect(leaseCall?.payload).not.toHaveProperty("full");
     expect(JSON.parse(output.stdout)).toMatchObject({ slim: false });
   });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -389,17 +389,19 @@ async function runLease(argv: readonly string[], environment: CliEnvironment): P
     }
   });
   try {
+    // Flat fields, not the legacy `device`/`os` aliases or a nested `request` wrapper -- the
+    // wire moved to protocol 3 with no compatibility shim (ADR 0003 "Consequences"). Moving
+    // this onto the typed `simlock/client` (ADR 0003 §10-11) is PR 4's job; this is only the
+    // minimal payload-shape fix needed to keep the CLI working against this PR's daemon.
     const response = await connection.request("lease.request", {
       allowDownload: values["allow-download"] ?? false,
       mode: detached ? "detached" : "held",
       noWait: values["no-wait"] ?? false,
       requesterId,
-      request: {
-        model: values.device,
-        ...(typeof values.os === "string" ? { osVersion: values.os } : {}),
-        platform: values.platform,
-        ...(values.full === true ? { full: true } : {}),
-      },
+      model: values.device,
+      ...(typeof values.os === "string" ? { osVersion: values.os } : {}),
+      platform: values.platform,
+      ...(values.full === true ? { full: true } : {}),
       ...(timeoutMs === undefined ? {} : { timeoutMs }),
     });
     const result = leaseResult(response);
@@ -882,7 +884,11 @@ function progressLine(value: unknown): {
   readonly eta_seconds?: number;
   readonly queue_position?: number;
 } {
-  const progress = requireObject(value);
+  // ADR 0003 §8: `progress` pushes now wrap the stage payload under `progress`, alongside a
+  // `requestId` this CLI does not yet need (it never has more than one lease request in flight
+  // per connection).
+  const envelope = requireObject(value);
+  const progress = requireObject(envelope.progress);
   if (progress.stage === "queued" && typeof progress.queuePosition === "number") {
     return { event: "queued", queue_position: progress.queuePosition };
   }

--- a/src/contract/boundary.test.ts
+++ b/src/contract/boundary.test.ts
@@ -1,0 +1,58 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const contractDir = dirname(fileURLToPath(import.meta.url));
+
+const FORBIDDEN_IMPORT_PREFIXES = [
+  "../core",
+  "../daemon/",
+  "../daemon.js",
+  "../drivers",
+  "../http",
+  "../cli",
+  "../mcp",
+  "../ports",
+];
+
+/**
+ * ADR 0003 §1's central constraint: the contract module imports nothing from `core`,
+ * `daemon`, `drivers`, `http`, `cli`, `mcp`, or `ports`. This is what keeps core domain
+ * records off the public package surface. Enforced here at the source-text level (a relative
+ * import string check) rather than via a build/lint rule, so it runs under plain `vitest`
+ * with no extra tooling.
+ */
+describe("contract module boundary", () => {
+  const sourceFiles = readdirSync(contractDir).filter(
+    (name) => name.endsWith(".ts") && !name.endsWith(".test.ts"),
+  );
+
+  it("found the contract's own source files", () => {
+    expect(sourceFiles.length).toBeGreaterThan(0);
+  });
+
+  it.each(sourceFiles)("%s imports nothing outside the contract module", (fileName) => {
+    const contents = readFileSync(join(contractDir, fileName), "utf8");
+    const importLines = contents
+      .split("\n")
+      .filter((line) => /^\s*import\s/.test(line) || /^\s*export\s+\*\s+from/.test(line));
+
+    for (const line of importLines) {
+      const match = /from\s+["']([^"']+)["']/.exec(line);
+      if (match === null) continue;
+      const specifier: string | undefined = match[1];
+      if (specifier === undefined) continue;
+      if (specifier.startsWith(".")) {
+        // Relative imports must stay inside this directory (e.g. "./schemas.js"), never climb
+        // out to a sibling module.
+        expect(specifier.startsWith("./")).toBe(true);
+        continue;
+      }
+      for (const forbidden of FORBIDDEN_IMPORT_PREFIXES) {
+        expect(specifier.startsWith(forbidden)).toBe(false);
+      }
+    }
+  });
+});

--- a/src/contract/errors.test.ts
+++ b/src/contract/errors.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { ERROR_TABLE, fromWireError, isSimlockError, SimlockError } from "./errors.js";
+
+describe("SimlockError", () => {
+  it("narrows details by code", () => {
+    const error = fromWireError("REQUESTER_ALREADY_LEASED", "already leased", {
+      requesterId: "agent-1",
+      existingLeaseId: "lease_1",
+    });
+    expect(isSimlockError(error)).toBe(true);
+    if (isSimlockError(error) && error.code === "REQUESTER_ALREADY_LEASED") {
+      // Type-level assertion: this line only compiles if `details` narrowed.
+      expect(error.details.existingLeaseId).toBe("lease_1");
+      expect(error.details.requesterId).toBe("agent-1");
+    } else {
+      throw new Error("expected REQUESTER_ALREADY_LEASED");
+    }
+  });
+
+  it("wraps an unrecognized code as UNKNOWN_DAEMON_ERROR instead of throwing", () => {
+    const error = fromWireError("SOME_FUTURE_CODE", "a newer daemon said so");
+    expect(isSimlockError(error)).toBe(true);
+    expect(error.code).toBe("UNKNOWN_DAEMON_ERROR");
+    if (error.code === "UNKNOWN_DAEMON_ERROR") {
+      expect(error.details).toEqual({
+        code: "SOME_FUTURE_CODE",
+        message: "a newer daemon said so",
+      });
+    }
+  });
+
+  it("maps every known code to its table entry's kind", () => {
+    const error = fromWireError("NO_CAPACITY", "no capacity");
+    expect(error.kind).toBe("domain");
+  });
+
+  it("isSimlockError rejects a plain Error", () => {
+    expect(isSimlockError(new Error("boom"))).toBe(false);
+  });
+
+  it("every table entry's code matches its own key", () => {
+    for (const [key, entry] of Object.entries(ERROR_TABLE)) {
+      expect(entry.code).toBe(key);
+    }
+  });
+
+  it("constructs directly with typed details", () => {
+    const error = new SimlockError("UNKNOWN_LEASE", "domain", "no such lease", {
+      leaseId: "lease_9",
+    });
+    expect(error.details.leaseId).toBe("lease_9");
+  });
+});

--- a/src/contract/errors.ts
+++ b/src/contract/errors.ts
@@ -1,0 +1,217 @@
+/**
+ * One error class, a closed set of codes, typed details (ADR 0003 §7).
+ *
+ * `kind` is `transport` (unavailable, connection lost, startup timeout), `protocol` (version,
+ * handshake, bad request, forbidden, authentication), or `domain` (capacity, unknown lease,
+ * runtime missing, ...). `cliExitCode`/`httpStatus` are columns of the same table, per the
+ * ADR's explicit instruction -- not a second mapping a CLI or HTTP frontend maintains on its
+ * own. Nothing in this repo consumes those two columns yet; they land in later PRs (the CLI
+ * still has its own `DAEMON_ERROR_EXIT_CODES` map and HTTP its own `mapError`, both untouched
+ * by this PR -- wiring them to this table is follow-up work called out in the PR description).
+ */
+import type { Platform } from "./schemas.js";
+
+export type ErrorKind = "transport" | "protocol" | "domain";
+
+/** Per-code `details` shapes. `Record<string, never>` means "no details, an empty object". */
+export interface ErrorDetailsMap {
+  // -- protocol --
+  BAD_FRAME: Record<string, never>;
+  HANDSHAKE_REQUIRED: Record<string, never>;
+  BAD_REQUEST: Record<string, never>;
+  UNKNOWN_REQUEST: Record<string, never>;
+  /** ADR §6. Reported by the daemon on a failed `hello` range negotiation, and constructed by
+   * a client mapping a legacy protocol-2 daemon's exact-match mismatch onto this shape. */
+  PROTOCOL_VERSION_UNSUPPORTED: {
+    readonly client: { readonly min: number; readonly max: number };
+    readonly daemon: { readonly min: number; readonly max: number };
+    readonly daemonVersion: string;
+  };
+  /** ADR §5. Not yet thrown anywhere in this PR -- the credential handshake is PR 2 -- but
+   * part of the closed set from the start, per the ADR's explicit instruction. */
+  ADMIN_AUTHENTICATION_FAILED: Record<string, never>;
+  /** ADR §2 (dispatcher role check). Not yet thrown -- PR 2 -- declared for the same reason. */
+  FORBIDDEN: Record<string, never>;
+
+  // -- transport --
+  DAEMON_STOPPING: Record<string, never>;
+  DAEMON_STARTUP_FAILED: Record<string, never>;
+  DAEMON_CONNECTION_LOST: Record<string, never>;
+
+  // -- domain --
+  NO_CAPACITY: Record<string, never>;
+  QUEUE_TIMEOUT: { readonly requestId: string };
+  REQUESTER_ALREADY_LEASED: { readonly requesterId: string; readonly existingLeaseId?: string };
+  NO_DRIVER: { readonly platform: Platform };
+  RUNTIME_MISSING: {
+    readonly platform: Platform;
+    readonly osVersion: string;
+    readonly downloadable: boolean;
+  };
+  UNKNOWN_MODEL: { readonly platform: Platform; readonly model: string };
+  INSUFFICIENT_DISK_SPACE: {
+    readonly platform: Platform;
+    readonly requiredBytes: number;
+    readonly availableBytes: number;
+  };
+  LICENSE_NOT_ACCEPTED: { readonly platform: Platform; readonly componentName: string };
+  UNKNOWN_LEASE: { readonly leaseId: string };
+  DOCTOR_UNAVAILABLE: Record<string, never>;
+  NUKE_UNAVAILABLE: Record<string, never>;
+  INTERNAL: Record<string, never>;
+
+  /** ADR §7's forward-compatibility escape hatch: a code the client does not know (a newer
+   * daemon) wraps as this instead of throwing a parse failure. Never sent by a daemon this
+   * version of the contract can produce -- purely a client-side wrapping target. */
+  UNKNOWN_DAEMON_ERROR: { readonly code: string; readonly message: string };
+}
+
+export type SimlockErrorCode = keyof ErrorDetailsMap;
+
+export interface ErrorTableEntry<Code extends SimlockErrorCode = SimlockErrorCode> {
+  readonly code: Code;
+  readonly kind: ErrorKind;
+  /** Guessed/placeholder for codes that have no existing CLI mapping today -- see the module
+   * comment. Existing values (e.g. `NO_CAPACITY: 11`) are taken verbatim from
+   * `src/cli/index.ts`'s `DAEMON_ERROR_EXIT_CODES`. */
+  readonly cliExitCode: number;
+  /** Same caveat as `cliExitCode` -- existing values taken from `src/http/errors.ts`'s
+   * `mapError`. */
+  readonly httpStatus: number;
+}
+
+// fallow-ignore-next-line complexity -- one exhaustive table is the point (ADR §7: "columns of
+// the same error table, not second mappings").
+export const ERROR_TABLE: { readonly [Code in SimlockErrorCode]: ErrorTableEntry<Code> } = {
+  BAD_FRAME: { code: "BAD_FRAME", kind: "protocol", cliExitCode: 2, httpStatus: 400 },
+  HANDSHAKE_REQUIRED: {
+    code: "HANDSHAKE_REQUIRED",
+    kind: "protocol",
+    cliExitCode: 1,
+    httpStatus: 400,
+  },
+  BAD_REQUEST: { code: "BAD_REQUEST", kind: "protocol", cliExitCode: 2, httpStatus: 400 },
+  UNKNOWN_REQUEST: { code: "UNKNOWN_REQUEST", kind: "protocol", cliExitCode: 2, httpStatus: 400 },
+  PROTOCOL_VERSION_UNSUPPORTED: {
+    code: "PROTOCOL_VERSION_UNSUPPORTED",
+    kind: "protocol",
+    cliExitCode: 1,
+    httpStatus: 400,
+  },
+  ADMIN_AUTHENTICATION_FAILED: {
+    code: "ADMIN_AUTHENTICATION_FAILED",
+    kind: "protocol",
+    cliExitCode: 1,
+    httpStatus: 401,
+  },
+  FORBIDDEN: { code: "FORBIDDEN", kind: "protocol", cliExitCode: 1, httpStatus: 403 },
+  DAEMON_STOPPING: { code: "DAEMON_STOPPING", kind: "transport", cliExitCode: 1, httpStatus: 503 },
+  DAEMON_STARTUP_FAILED: {
+    code: "DAEMON_STARTUP_FAILED",
+    kind: "transport",
+    cliExitCode: 1,
+    httpStatus: 503,
+  },
+  DAEMON_CONNECTION_LOST: {
+    code: "DAEMON_CONNECTION_LOST",
+    kind: "transport",
+    cliExitCode: 1,
+    httpStatus: 503,
+  },
+  NO_CAPACITY: { code: "NO_CAPACITY", kind: "domain", cliExitCode: 11, httpStatus: 503 },
+  QUEUE_TIMEOUT: { code: "QUEUE_TIMEOUT", kind: "domain", cliExitCode: 10, httpStatus: 500 },
+  REQUESTER_ALREADY_LEASED: {
+    code: "REQUESTER_ALREADY_LEASED",
+    kind: "domain",
+    cliExitCode: 13,
+    httpStatus: 409,
+  },
+  NO_DRIVER: { code: "NO_DRIVER", kind: "domain", cliExitCode: 12, httpStatus: 422 },
+  RUNTIME_MISSING: { code: "RUNTIME_MISSING", kind: "domain", cliExitCode: 12, httpStatus: 422 },
+  UNKNOWN_MODEL: { code: "UNKNOWN_MODEL", kind: "domain", cliExitCode: 12, httpStatus: 422 },
+  INSUFFICIENT_DISK_SPACE: {
+    code: "INSUFFICIENT_DISK_SPACE",
+    kind: "domain",
+    cliExitCode: 12,
+    httpStatus: 422,
+  },
+  LICENSE_NOT_ACCEPTED: {
+    code: "LICENSE_NOT_ACCEPTED",
+    kind: "domain",
+    cliExitCode: 12,
+    httpStatus: 422,
+  },
+  UNKNOWN_LEASE: { code: "UNKNOWN_LEASE", kind: "domain", cliExitCode: 1, httpStatus: 404 },
+  DOCTOR_UNAVAILABLE: {
+    code: "DOCTOR_UNAVAILABLE",
+    kind: "domain",
+    cliExitCode: 1,
+    httpStatus: 503,
+  },
+  NUKE_UNAVAILABLE: { code: "NUKE_UNAVAILABLE", kind: "domain", cliExitCode: 1, httpStatus: 503 },
+  INTERNAL: { code: "INTERNAL", kind: "domain", cliExitCode: 1, httpStatus: 500 },
+  UNKNOWN_DAEMON_ERROR: {
+    code: "UNKNOWN_DAEMON_ERROR",
+    kind: "protocol",
+    cliExitCode: 1,
+    httpStatus: 500,
+  },
+};
+
+/**
+ * `SimlockError<Code>` carries `details` typed exactly for its own `Code`. A bare
+ * `SimlockError` (the default `Code = SimlockErrorCode`) does NOT narrow on `.code ===` checks
+ * -- a generic class's fields are not a discriminated union to the type checker. Use
+ * `AnySimlockError` (below) for that; `isSimlockError` produces one from an `unknown` catch
+ * value.
+ */
+export class SimlockError<Code extends SimlockErrorCode = SimlockErrorCode> extends Error {
+  constructor(
+    readonly code: Code,
+    readonly kind: ErrorKind,
+    message: string,
+    readonly details: ErrorDetailsMap[Code],
+  ) {
+    super(message);
+    this.name = "SimlockError";
+  }
+}
+
+/**
+ * The same class, expressed as a discriminated union over every code -- this is the type that
+ * actually narrows: `if (isSimlockError(e) && e.code === "REQUESTER_ALREADY_LEASED")` narrows
+ * `e.details` to `{requesterId, existingLeaseId?}` because each union member's `code` and
+ * `details` share one type parameter.
+ */
+export type AnySimlockError = { [Code in SimlockErrorCode]: SimlockError<Code> }[SimlockErrorCode];
+
+export function isSimlockError(error: unknown): error is AnySimlockError {
+  return error instanceof SimlockError;
+}
+
+/**
+ * Builds a typed `SimlockError` from a raw wire `{code, message}` (and optional already-parsed
+ * `details`), the client-side half of ADR §7's forward-compatibility rule: a `code` this
+ * contract does not recognize wraps as `UNKNOWN_DAEMON_ERROR` with the raw code and message
+ * preserved, rather than throwing a parse failure. This is deliberately permissive about
+ * `details` -- it trusts the caller's parsed value rather than re-validating per-code detail
+ * shapes against `ErrorDetailsMap`, since the wire's `error.details` has no schema of its own
+ * yet (today's daemon does not even send one for most codes -- see `DaemonServer#respondError`
+ * in this PR, which now accepts but does not populate `details` for most cases). Tightening
+ * this with real per-code detail schemas is left as follow-up.
+ */
+export function fromWireError(code: string, message: string, details?: unknown): AnySimlockError {
+  const entry = (ERROR_TABLE as Record<string, ErrorTableEntry>)[code];
+  if (entry === undefined) {
+    return new SimlockError("UNKNOWN_DAEMON_ERROR", "protocol", message, {
+      code,
+      message,
+    }) as AnySimlockError;
+  }
+  return new SimlockError(
+    entry.code,
+    entry.kind,
+    message,
+    (details ?? {}) as never,
+  ) as AnySimlockError;
+}

--- a/src/contract/index.ts
+++ b/src/contract/index.ts
@@ -1,0 +1,6 @@
+export * from "./errors.js";
+export * from "./operations.js";
+export * from "./protocol.js";
+export * from "./pushes.js";
+export * from "./roles.js";
+export * from "./schemas.js";

--- a/src/contract/operations.test.ts
+++ b/src/contract/operations.test.ts
@@ -1,0 +1,224 @@
+import { z } from "zod";
+import { describe, expect, it } from "vitest";
+
+import { defineOperation, OPERATIONS, type OperationName } from "./operations.js";
+import { ROLES, type Role } from "./roles.js";
+
+describe("defineOperation", () => {
+  it("returns the definition unchanged, typed from its zod schemas", () => {
+    const echo = defineOperation({
+      name: "test.echo",
+      role: "agent",
+      input: z.object({ value: z.string() }),
+      output: z.object({ value: z.string() }),
+    });
+    expect(echo.input.parse({ value: "hi" })).toEqual({ value: "hi" });
+    expect(echo.output.parse({ value: "hi" })).toEqual({ value: "hi" });
+    expect(echo.role).toBe("agent");
+  });
+});
+
+/**
+ * The ADR §3 operation matrix, name -> role. A table-driven test against this makes
+ * "forgetting a role" (or getting one wrong) a test failure, not just a type-level one --
+ * `doctor.run` gets two rows since its role is a function of `fix`.
+ */
+const ROLE_MATRIX: ReadonlyArray<{
+  readonly name: OperationName;
+  readonly input: unknown;
+  readonly role: Role;
+}> = [
+  { name: "catalog.get", input: {}, role: "agent" },
+  { name: "status.get", input: {}, role: "agent" },
+  { name: "lease.request", input: { model: "iPhone 17", platform: "ios" }, role: "agent" },
+  { name: "lease.cancel", input: {}, role: "agent" },
+  { name: "lease.renew", input: { leaseId: "lease_1" }, role: "agent" },
+  { name: "lease.release", input: { leaseId: "lease_1" }, role: "agent" },
+  { name: "lease.list", input: {}, role: "agent" },
+  { name: "lease.heartbeat", input: {}, role: "agent" },
+  { name: "doctor.run", input: { fix: false }, role: "agent" },
+  { name: "doctor.run", input: {}, role: "agent" },
+  { name: "doctor.run", input: { fix: true }, role: "admin" },
+  { name: "lease.release-all", input: {}, role: "admin" },
+  { name: "list.get", input: {}, role: "admin" },
+  { name: "cleanup.run", input: {}, role: "admin" },
+  { name: "nuke.run", input: {}, role: "admin" },
+  { name: "config.get", input: {}, role: "admin" },
+  { name: "daemon.stop", input: {}, role: "admin" },
+  { name: "events.replay", input: {}, role: "admin" },
+  { name: "events.subscribe", input: {}, role: "admin" },
+  { name: "events.unsubscribe", input: {}, role: "admin" },
+  { name: "token.create", input: { role: "agent" }, role: "admin" },
+  { name: "token.list", input: {}, role: "admin" },
+  { name: "token.revoke", input: { id: "tok_1" }, role: "admin" },
+];
+
+describe("operation role matrix", () => {
+  it("declares every operation the ADR's §3 matrix names", () => {
+    const declaredNames = new Set(Object.keys(OPERATIONS));
+    const matrixNames = new Set(ROLE_MATRIX.map((row) => row.name));
+    expect(declaredNames).toEqual(matrixNames);
+  });
+
+  it("only ever resolves to one of the two declared roles", () => {
+    for (const row of ROLE_MATRIX) expect(ROLES).toContain(row.role);
+  });
+
+  it.each(ROLE_MATRIX)("$name with $input resolves to role $role", ({ name, input, role }) => {
+    const operation = OPERATIONS[name];
+    const roleFn = operation.role as Role | ((input: unknown) => Role);
+    const resolved = typeof roleFn === "function" ? roleFn(input) : roleFn;
+    expect(resolved).toBe(role);
+  });
+});
+
+describe("operation input/output round trips", () => {
+  it("lease.request: round-trips a representative held request and rejects legacy aliases", () => {
+    const input = OPERATIONS["lease.request"].input.parse({
+      model: "iPhone 17 Pro",
+      platform: "ios",
+      osVersion: "18.0",
+    });
+    expect(input).toMatchObject({ model: "iPhone 17 Pro", platform: "ios", osVersion: "18.0" });
+
+    expect(() =>
+      OPERATIONS["lease.request"].input.parse({ device: "iPhone 17 Pro", platform: "ios" }),
+    ).toThrow();
+    expect(() =>
+      OPERATIONS["lease.request"].input.parse({
+        request: { model: "iPhone 17 Pro", platform: "ios" },
+      }),
+    ).toThrow();
+  });
+
+  it("lease.request: rejects ttlMs on a held lease as a schema-level BAD_REQUEST", () => {
+    expect(() =>
+      OPERATIONS["lease.request"].input.parse({
+        model: "iPhone 17 Pro",
+        platform: "ios",
+        mode: "held",
+        ttlMs: 60_000,
+      }),
+    ).toThrow();
+  });
+
+  it("lease.request: accepts ttlMs on a detached lease", () => {
+    expect(() =>
+      OPERATIONS["lease.request"].input.parse({
+        model: "iPhone 17 Pro",
+        platform: "ios",
+        mode: "detached",
+        ttlMs: 60_000,
+      }),
+    ).not.toThrow();
+  });
+
+  it("lease.request: round-trips a representative output grant", () => {
+    const grant = {
+      device: {
+        id: "dev_1",
+        driverDeviceId: "sim-1",
+        spec: { platform: "ios", model: "iPhone 17 Pro", osVersion: "18.0" },
+        state: "leased",
+        driverData: { udid: "abc" },
+        createdAt: 1,
+      },
+      lease: {
+        id: "lease_1",
+        deviceId: "dev_1",
+        requesterId: "req_1",
+        mode: "held",
+        grantedAt: 1,
+        ttlDeadline: 2,
+      },
+      timing: {
+        estimatedProvisionMs: 1,
+        estimatedBootMs: 1,
+        estimatedReclaimMs: 1,
+        estimatedReadyMs: 1,
+      },
+    };
+    expect(OPERATIONS["lease.request"].output.parse(grant)).toBeDefined();
+  });
+
+  it("lease.request: rejects a malformed input (missing model)", () => {
+    expect(() => OPERATIONS["lease.request"].input.parse({ platform: "ios" })).toThrow();
+  });
+
+  it("doctor.run: round-trips a driver-advisory finding", () => {
+    const report = {
+      findings: [{ kind: "driver-advisory", platform: "ios", code: "slim-disabled", message: "x" }],
+    };
+    expect(OPERATIONS["doctor.run"].output.parse(report)).toBeDefined();
+  });
+
+  it("status.get: round-trips a representative status snapshot", () => {
+    const status = {
+      devices: [],
+      leases: [],
+      capacity: {
+        ios: {
+          running: 0,
+          maxRunning: 1,
+          reserved: 0,
+          overLimit: false,
+          limit: 1,
+          warm: 0,
+          used: 0,
+        },
+        android: {
+          running: 0,
+          maxRunning: 1,
+          reserved: 0,
+          overLimit: false,
+          limit: 1,
+          warm: 0,
+          used: 0,
+        },
+        global: { running: 0, maxRunning: 2, reserved: 0, overLimit: false, warm: 0 },
+      },
+      health: "running",
+      queueDepth: 0,
+    };
+    expect(OPERATIONS["status.get"].output.parse(status)).toBeDefined();
+  });
+
+  it("list.get: accepts each kind's array shape", () => {
+    expect(OPERATIONS["list.get"].output.parse([])).toEqual([]);
+    expect(OPERATIONS["list.get"].output.parse([{ name: "idle-shutdown" }])).toEqual([
+      { name: "idle-shutdown" },
+    ]);
+  });
+
+  it("config.get: round-trips a representative config", () => {
+    const config = {
+      capacity: { strategy: "fixed", config: { maxRunning: 4 } },
+      downloads: { policy: "on-request", acceptAndroidLicenses: false, timeoutMs: 1_000 },
+      idle: { shutdownAfterMs: 1, deleteAfterMs: 2 },
+      warmPool: {
+        quarantine: {
+          maxRetries: 1,
+          retryBackoffMs: 1,
+          retryBackoffMultiplier: 1,
+          maxRetryBackoffMs: 1,
+        },
+      },
+      lease: { heldTtlBackstopMs: 1, detachedTtlMs: 1, heartbeatIntervalMs: 1 },
+      diskPressure: { freeBytesThreshold: 1 },
+      eventBuffer: { capacity: 1 },
+      log: { level: "info", rotateBytes: 1 },
+      http: { enabled: false, host: "127.0.0.1", port: 4700 },
+      health: {
+        enabled: true,
+        probeIntervalMs: 1,
+        stableObservations: 1,
+        maxRecoveryAttempts: 1,
+        recoveryBackoffMs: 1,
+        maxConcurrentRecoveries: 1,
+      },
+      ios: { slim: { enabled: false, bootTimeoutMs: 1 } },
+      stalledTransition: { thresholdMultiplier: 1, minimumThresholdMs: 1 },
+    };
+    expect(OPERATIONS["config.get"].output.parse(config)).toBeDefined();
+  });
+});

--- a/src/contract/operations.ts
+++ b/src/contract/operations.ts
@@ -1,0 +1,348 @@
+/**
+ * Every daemon operation, declared once (ADR 0003 §1). Name, role, input schema, output
+ * schema, optional `authorize` hook. Public TypeScript types are inferred from the zod
+ * schemas, never hand-written in parallel -- see each operation's `Input`/`Output` export.
+ *
+ * `defineOperation` returning a typed record whose `role` may be a plain `Role` or a function
+ * of the (already-validated) input is what lets `doctor.run` model an input-dependent role
+ * honestly (see its declaration below) without a second gating mechanism next to `authorize`.
+ */
+import { z } from "zod";
+
+import type { AuthorizeContext, Role } from "./roles.js";
+import {
+  cleanupRuleSummarySchema,
+  configSchema,
+  daemonHealthSchema,
+  deviceRecordSchema,
+  doctorReportSchema,
+  eventEnvelopeSchema,
+  leaseGrantSchema,
+  leaseModeSchema,
+  leaseRecordSchema,
+  nukeReportSchema,
+  platformCatalogSchema,
+  platformSchema,
+  proposalSchema,
+  statusCapacitySchema,
+  tokenRecordSchema,
+  tokenRoleSchema,
+} from "./schemas.js";
+
+export interface OperationDefinition<
+  Name extends string = string,
+  InputSchema extends z.ZodTypeAny = z.ZodTypeAny,
+  OutputSchema extends z.ZodTypeAny = z.ZodTypeAny,
+> {
+  readonly name: Name;
+  readonly role: Role | ((input: z.infer<InputSchema>) => Role);
+  readonly input: InputSchema;
+  readonly output: OutputSchema;
+  /** Ownership/ownership-adjacent gating a session-aware dispatcher would run after the role
+   * check (ADR §1's `ownsLease` example). Declared for typing purposes only in this PR --
+   * nothing sets it, and nothing calls it; PR 2 adds both. */
+  readonly authorize?: (input: z.infer<InputSchema>, context: AuthorizeContext) => boolean;
+}
+
+export function defineOperation<
+  Name extends string,
+  InputSchema extends z.ZodTypeAny,
+  OutputSchema extends z.ZodTypeAny,
+>(
+  definition: OperationDefinition<Name, InputSchema, OutputSchema>,
+): OperationDefinition<Name, InputSchema, OutputSchema> {
+  return definition;
+}
+
+// ---- catalog.get ------------------------------------------------------------------------------
+
+export const catalogGet = defineOperation({
+  name: "catalog.get",
+  role: "agent",
+  input: z.object({ platform: platformSchema.optional() }),
+  output: z.object({ platforms: z.array(platformCatalogSchema) }),
+});
+
+// ---- status.get ---------------------------------------------------------------------------
+
+export const statusGet = defineOperation({
+  name: "status.get",
+  role: "agent",
+  input: z.object({}),
+  output: z.object({
+    devices: z.array(deviceRecordSchema),
+    leases: z.array(leaseRecordSchema),
+    capacity: statusCapacitySchema,
+    health: daemonHealthSchema,
+    queueDepth: z.number(),
+  }),
+});
+
+// ---- lease.request --------------------------------------------------------------------------
+
+/**
+ * No `device`/`os` legacy aliases and no nested `request` wrapper -- both accepted by today's
+ * daemon (`server.ts:559-565`), neither carried forward. The wire moves to protocol 3 with no
+ * compatibility shim (ADR "Consequences"); this is a deliberate break, called out in the PR
+ * description. `.strict()` on top of dropping the fields: an old client sending `device`/`os`/
+ * `request` now gets a clear `BAD_REQUEST` instead of those keys silently vanishing.
+ */
+const leaseRequestInputSchema = z
+  .object({
+    model: z.string().min(1),
+    platform: platformSchema,
+    osVersion: z.string().optional(),
+    full: z.boolean().optional(),
+    mode: leaseModeSchema.optional(),
+    requesterId: z.string().optional(),
+    allowDownload: z.boolean().optional(),
+    noWait: z.boolean().optional(),
+    timeoutMs: z.number().finite().positive().optional(),
+    /** ADR §9: initial TTL for a detached lease. Supplying it for a held lease is
+     * `BAD_REQUEST` -- held TTL is the backstop, not the caller's to shorten -- enforced below
+     * via `superRefine` rather than left to the handler, so the rule is part of the contract
+     * itself. NOTE: not yet wired to a grant's actual TTL -- see the PR description's "known
+     * gaps"; `LeaseRequestOptions` (src/core/wait-queue.ts) has no `ttlMs` field yet, and
+     * adding one is core-side plumbing beyond this PR's "daemon validates inputs" scope. */
+    ttlMs: z.number().finite().positive().optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (value.ttlMs !== undefined && (value.mode ?? "held") === "held") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "ttlMs is BAD_REQUEST for a held lease: held TTL is the backstop, not the caller's to shorten",
+        path: ["ttlMs"],
+      });
+    }
+  });
+
+export const leaseRequest = defineOperation({
+  name: "lease.request",
+  role: "agent",
+  input: leaseRequestInputSchema,
+  output: leaseGrantSchema,
+});
+
+// ---- lease.cancel (new, ADR §9) --------------------------------------------------------------
+
+export const leaseCancel = defineOperation({
+  name: "lease.cancel",
+  role: "agent",
+  input: z.object({ requesterId: z.string().optional() }),
+  output: z.object({ result: z.enum(["cancelled", "not-found", "not-cancellable"]) }),
+});
+
+// ---- lease.renew ----------------------------------------------------------------------------
+
+export const leaseRenew = defineOperation({
+  name: "lease.renew",
+  role: "agent",
+  input: z.object({ leaseId: z.string(), ttlMs: z.number().finite().positive().optional() }),
+  output: leaseRecordSchema,
+});
+
+// ---- lease.release --------------------------------------------------------------------------
+
+export const leaseRelease = defineOperation({
+  name: "lease.release",
+  role: "agent",
+  input: z.object({ leaseId: z.string() }),
+  output: z.object({ leaseId: z.string() }),
+});
+
+// ---- lease.list (new, ADR §9) -----------------------------------------------------------------
+
+export const leaseList = defineOperation({
+  name: "lease.list",
+  role: "agent",
+  input: z.object({}),
+  output: z.object({ leases: z.array(leaseRecordSchema) }),
+});
+
+// ---- lease.heartbeat ------------------------------------------------------------------------
+
+export const leaseHeartbeat = defineOperation({
+  name: "lease.heartbeat",
+  role: "agent",
+  input: z.object({}),
+  output: z.object({
+    leases: z.array(z.object({ leaseId: z.string(), ttlDeadline: z.number() })),
+  }),
+});
+
+// ---- doctor.run -------------------------------------------------------------------------------
+
+const doctorRunInputSchema = z.object({ fix: z.boolean().optional() });
+
+export const doctorRun = defineOperation({
+  name: "doctor.run",
+  /**
+   * The role genuinely depends on the input: `fix: false` (read-only, shells out per device)
+   * is agent-visible; `fix: true` (applies safe fixes to registry-owned devices) is admin
+   * only -- see ADR §3's matrix, which lists `doctor.run` twice for exactly this reason. A
+   * function-of-input role, rather than an `authorize` hook, is the right tool here: `authorize`
+   * (ADR §1's `ownsLease` example) is for *ownership* checks against a specific resource once a
+   * role has already cleared the gate; this is a *role* decision, and it is entirely computable
+   * from the already-validated input with no session/resource context needed. Keeping it as
+   * `role` also means the dispatcher's role-check step (PR 2) stays uniform -- "compute the
+   * required role from the input, compare to the session role" -- for every operation, instead
+   * of `doctor.run` needing a second, bespoke gating path.
+   */
+  role: (input: z.infer<typeof doctorRunInputSchema>): Role => (input.fix ? "admin" : "agent"),
+  input: doctorRunInputSchema,
+  output: doctorReportSchema,
+});
+
+// ---- lease.release-all ------------------------------------------------------------------------
+
+export const leaseReleaseAll = defineOperation({
+  name: "lease.release-all",
+  role: "admin",
+  input: z.object({}),
+  output: z.object({ leaseIds: z.array(z.string()) }),
+});
+
+// ---- list.get -----------------------------------------------------------------------------
+
+export const listGet = defineOperation({
+  name: "list.get",
+  role: "admin",
+  input: z.object({ kind: z.enum(["devices", "leases", "rules"]).optional() }),
+  output: z.union([
+    z.array(deviceRecordSchema),
+    z.array(leaseRecordSchema),
+    z.array(cleanupRuleSummarySchema),
+  ]),
+});
+
+// ---- cleanup.run --------------------------------------------------------------------------
+
+export const cleanupRun = defineOperation({
+  name: "cleanup.run",
+  role: "admin",
+  input: z.object({ dryRun: z.boolean().optional(), rule: z.string().optional() }),
+  output: z.array(proposalSchema),
+});
+
+// ---- nuke.run -----------------------------------------------------------------------------
+
+export const nukeRun = defineOperation({
+  name: "nuke.run",
+  role: "admin",
+  input: z.object({ deleteDevices: z.boolean().optional() }),
+  output: nukeReportSchema,
+});
+
+// ---- config.get ---------------------------------------------------------------------------
+
+export const configGet = defineOperation({
+  name: "config.get",
+  role: "admin",
+  input: z.object({}),
+  output: configSchema,
+});
+
+// ---- daemon.stop --------------------------------------------------------------------------
+//
+// Part of the closed OPERATIONS registry (ADR §3); `daemon.stop` is handled as a
+// frozen-exception special case in `DaemonServer#dispatchLine` rather than through the normal
+// dispatch switch, so nothing imports this declaration by name yet. Declared here because the
+// contract must still describe its input/output/role.
+
+// fallow-ignore-next-line unused-export -- see the comment above.
+export const daemonStop = defineOperation({
+  name: "daemon.stop",
+  role: "admin",
+  input: z.object({}),
+  output: z.object({ stopping: z.literal(true) }),
+});
+
+// ---- events.replay ------------------------------------------------------------------------
+
+export const eventsReplay = defineOperation({
+  name: "events.replay",
+  role: "admin",
+  input: z.object({ sinceTs: z.number().optional() }),
+  output: z.array(eventEnvelopeSchema),
+});
+
+// ---- events.subscribe ---------------------------------------------------------------------
+
+export const eventsSubscribe = defineOperation({
+  name: "events.subscribe",
+  role: "admin",
+  input: z.object({}),
+  output: z.object({ subscribed: z.literal(true), subscriptionId: z.string() }),
+});
+
+// ---- events.unsubscribe -------------------------------------------------------------------
+
+export const eventsUnsubscribe = defineOperation({
+  name: "events.unsubscribe",
+  role: "admin",
+  input: z.object({}),
+  output: z.object({ subscribed: z.literal(false) }),
+});
+
+// ---- token.create / token.list / token.revoke --------------------------------------------
+//
+// ADR §11: "token create|list|revoke become daemon operations. The daemon is the only owner of
+// tokens.json." No daemon-side handler exists for these yet -- today `TokenStore` is read and
+// written directly by the CLI (`src/cli/index.ts`, `src/http/token-store.ts`). Declaring the
+// operation here, with no matching case in `DaemonServer#handleRequest`, is expected and fine
+// per this PR's brief ("declaring an operation whose handler does not exist yet"); moving the
+// CLI onto a daemon round-trip for these is later work (PR 4, per the ADR's sequencing).
+
+// fallow-ignore-next-line unused-export -- see the block comment above; declared now per this PR's brief.
+export const tokenCreate = defineOperation({
+  name: "token.create",
+  role: "admin",
+  input: z.object({ role: tokenRoleSchema, label: z.string().optional() }),
+  output: z.object({ secret: z.string(), token: tokenRecordSchema }),
+});
+
+// fallow-ignore-next-line unused-export -- same as tokenCreate above.
+export const tokenList = defineOperation({
+  name: "token.list",
+  role: "admin",
+  input: z.object({}),
+  output: z.object({ tokens: z.array(tokenRecordSchema) }),
+});
+
+// fallow-ignore-next-line unused-export -- same as tokenCreate above.
+export const tokenRevoke = defineOperation({
+  name: "token.revoke",
+  role: "admin",
+  input: z.object({ id: z.string() }),
+  output: z.object({ revoked: z.boolean() }),
+});
+
+// ---- the full registry ----------------------------------------------------------------------
+
+export const OPERATIONS = {
+  "catalog.get": catalogGet,
+  "status.get": statusGet,
+  "lease.request": leaseRequest,
+  "lease.cancel": leaseCancel,
+  "lease.renew": leaseRenew,
+  "lease.release": leaseRelease,
+  "lease.list": leaseList,
+  "lease.heartbeat": leaseHeartbeat,
+  "doctor.run": doctorRun,
+  "lease.release-all": leaseReleaseAll,
+  "list.get": listGet,
+  "cleanup.run": cleanupRun,
+  "nuke.run": nukeRun,
+  "config.get": configGet,
+  "daemon.stop": daemonStop,
+  "events.replay": eventsReplay,
+  "events.subscribe": eventsSubscribe,
+  "events.unsubscribe": eventsUnsubscribe,
+  "token.create": tokenCreate,
+  "token.list": tokenList,
+  "token.revoke": tokenRevoke,
+} as const;
+
+export type OperationName = keyof typeof OPERATIONS;

--- a/src/contract/protocol.test.ts
+++ b/src/contract/protocol.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  helloRequestSchema,
+  LEGACY_DAEMON_PROTOCOL_VERSION,
+  mapLegacyProtocolMismatch,
+  negotiateProtocolVersion,
+  normalizeProtocolVersion,
+  PROTOCOL_VERSION_RANGE,
+} from "./protocol.js";
+
+describe("negotiateProtocolVersion", () => {
+  it("picks the highest version present in both ranges", () => {
+    expect(negotiateProtocolVersion({ min: 1, max: 3 }, { min: 2, max: 4 })).toBe(3);
+    expect(negotiateProtocolVersion({ min: 3, max: 3 }, { min: 3, max: 3 })).toBe(3);
+  });
+
+  it("returns undefined when the ranges do not overlap", () => {
+    expect(negotiateProtocolVersion({ min: 1, max: 2 }, { min: 3, max: 4 })).toBeUndefined();
+  });
+});
+
+describe("normalizeProtocolVersion", () => {
+  it("treats a bare number as {n, n}", () => {
+    expect(normalizeProtocolVersion(2)).toEqual({ min: 2, max: 2 });
+  });
+
+  it("passes a range through unchanged", () => {
+    expect(normalizeProtocolVersion({ min: 1, max: 3 })).toEqual({ min: 1, max: 3 });
+  });
+});
+
+describe("mapLegacyProtocolMismatch", () => {
+  it("reports the daemon range as {2, 2} and an unknown daemon version", () => {
+    const error = mapLegacyProtocolMismatch(
+      PROTOCOL_VERSION_RANGE,
+      "Protocol version 3 is not supported",
+    );
+    expect(error.code).toBe("PROTOCOL_VERSION_UNSUPPORTED");
+    expect(error.details).toEqual({
+      client: PROTOCOL_VERSION_RANGE,
+      daemon: { min: LEGACY_DAEMON_PROTOCOL_VERSION, max: LEGACY_DAEMON_PROTOCOL_VERSION },
+      daemonVersion: "unknown",
+    });
+  });
+});
+
+describe("helloRequestSchema", () => {
+  it("accepts a bare legacy protocolVersion with no range", () => {
+    expect(() =>
+      helloRequestSchema.parse({ clientVersion: "1.0.0", protocolVersion: 3 }),
+    ).not.toThrow();
+  });
+
+  it("accepts a range with no legacy protocolVersion", () => {
+    expect(() =>
+      helloRequestSchema.parse({ clientVersion: "1.0.0", protocolRange: { min: 3, max: 3 } }),
+    ).not.toThrow();
+  });
+
+  it("rejects hello with neither protocolVersion nor protocolRange", () => {
+    expect(() => helloRequestSchema.parse({ clientVersion: "1.0.0" })).toThrow();
+  });
+});

--- a/src/contract/protocol.ts
+++ b/src/contract/protocol.ts
@@ -1,0 +1,95 @@
+/**
+ * Protocol version range negotiation (ADR 0003 §6). Client and daemon each advertise
+ * `{min, max}`; the negotiated version is the highest value both ranges contain.
+ */
+import { z } from "zod";
+
+import { SimlockError } from "./errors.js";
+
+export interface ProtocolRange {
+  readonly min: number;
+  readonly max: number;
+}
+
+const protocolRangeSchema = z.object({ min: z.number().int(), max: z.number().int() });
+
+/**
+ * The range this contract's daemon speaks. Both ends are 3 today: the socket wire moves to
+ * protocol 3 with no compatibility shim (ADR "Consequences") -- the range widens only once a
+ * second version is actually kept alive side by side with the first, which nothing here does
+ * yet.
+ */
+export const PROTOCOL_VERSION_RANGE: ProtocolRange = { min: 3, max: 3 };
+
+/**
+ * The one protocol version that ever existed before ranges did. Used only to build the
+ * `{min:2,max:2}` "daemon range" a client reports when it detects a legacy daemon's old-style
+ * exact-match mismatch (see `mapLegacyProtocolMismatch`) -- there is no live protocol-2 daemon
+ * in this repository to negotiate with; this constant documents the historical fact the ADR's
+ * compatibility note depends on.
+ */
+export const LEGACY_DAEMON_PROTOCOL_VERSION = 2;
+
+/** Highest version present in both ranges, or `undefined` if they do not overlap at all. */
+export function negotiateProtocolVersion(
+  client: ProtocolRange,
+  daemon: ProtocolRange,
+): number | undefined {
+  const overlapMin = Math.max(client.min, daemon.min);
+  const overlapMax = Math.min(client.max, daemon.max);
+  return overlapMin <= overlapMax ? overlapMax : undefined;
+}
+
+/** A new daemon treats a bare number as `{n, n}` (ADR §6). */
+export function normalizeProtocolVersion(value: number | ProtocolRange): ProtocolRange {
+  return typeof value === "number" ? { min: value, max: value } : value;
+}
+
+/**
+ * Builds the client-side error the ADR's compatibility note describes: a legacy protocol-2
+ * daemon replies to `hello` with its own old-style `PROTOCOL_VERSION_MISMATCH` (no `{min,max}`
+ * of its own -- that concept did not exist), so the client cannot learn the daemon's real
+ * range from the wire. It reports the range as `{2,2}` because 2 is the only protocol version
+ * that ever shipped without ranges -- see `LEGACY_DAEMON_PROTOCOL_VERSION`. `daemonVersion` is
+ * `"unknown"` for the same reason: the legacy mismatch error carries no version string either.
+ */
+export function mapLegacyProtocolMismatch(
+  clientRange: ProtocolRange,
+  message: string,
+): SimlockError<"PROTOCOL_VERSION_UNSUPPORTED"> {
+  return new SimlockError("PROTOCOL_VERSION_UNSUPPORTED", "protocol", message, {
+    client: clientRange,
+    daemon: { min: LEGACY_DAEMON_PROTOCOL_VERSION, max: LEGACY_DAEMON_PROTOCOL_VERSION },
+    daemonVersion: "unknown",
+  });
+}
+
+/** What a client sends at `hello` (ADR §5, §6). `principal`/`credential` are declared now --
+ * the reply shape and this input need to exist together -- but not read or enforced by the
+ * daemon until PR 2's credential handshake. */
+export const helloRequestSchema = z
+  .object({
+    clientVersion: z.string(),
+    /** Legacy exact version, sent alongside `protocolRange` so an old protocol-2 daemon (which
+     * only ever compares this field) still answers intelligibly. */
+    protocolVersion: z.number().int().optional(),
+    protocolRange: protocolRangeSchema.optional(),
+    capabilities: z.object({ heartbeat: z.boolean().optional() }).optional(),
+    principal: z.string().optional(),
+    credential: z.string().optional(),
+  })
+  .refine((value) => value.protocolVersion !== undefined || value.protocolRange !== undefined, {
+    message: "hello requires protocolVersion, protocolRange, or both",
+  });
+
+/**
+ * What the daemon replies with. `role` is declared now (every field a client will eventually
+ * need to assert it got what it asked for, per ADR §5) but is a fixed value until PR 2 resolves
+ * it from a real credential -- see `DaemonServer#handleHello`.
+ */
+export const helloReplySchema = z.object({
+  protocolVersion: z.number().int(),
+  daemonProtocolRange: protocolRangeSchema,
+  version: z.string(),
+  role: z.enum(["agent", "admin"]),
+});

--- a/src/contract/pushes.ts
+++ b/src/contract/pushes.ts
@@ -1,0 +1,66 @@
+/**
+ * Server pushes (ADR 0003 §8). Three families, each with its correlation key required by
+ * schema:
+ *
+ * - Request-scoped (`progress`): carries the originating request's frame id.
+ * - Lease-scoped (`lease-lost`, `device-unhealthy`, `device-recovered`): carries the lease id.
+ * - Connection-scoped (`lease.heartbeat`, `event` -- `event` carries a subscription id).
+ *
+ * Today's `progress` push carries no correlation id at all (see the daemon inventory); adding
+ * one to the schema is this PR's job. Actually routing a push to "every live connection whose
+ * principal owns the lease" (§8) is not -- that needs the `ownerId`/principal work in PR 2. The
+ * schemas here describe the target shape; `src/daemon/server.ts` is updated in this PR to
+ * populate the two ids that don't need ownership at all (`progress`'s request id, `event`'s
+ * subscription id) but still routes lease-scoped pushes the old way (single
+ * `heldLeaseIds`-membership lookup) until PR 2.
+ */
+import { z } from "zod";
+
+import { eventEnvelopeSchema, leaseProgressSchema } from "./schemas.js";
+
+/**
+ * Per-kind schemas are intentionally not exported individually -- `PUSH_SCHEMAS` (below) is the
+ * one public surface for these, keyed by wire push kind, which is how `DaemonServer` actually
+ * consumes them (`this.#parseOutput(PUSH_SCHEMAS.progress, ...)`). Frame ids are `string |
+ * number` on the wire (see `daemon-protocol`'s `RequestId`).
+ */
+const requestIdSchema = z.union([z.string(), z.number()]);
+
+const progressPushSchema = z.object({
+  requestId: requestIdSchema,
+  progress: leaseProgressSchema,
+});
+
+const leaseLostPushSchema = z.object({
+  leaseId: z.string(),
+  deviceId: z.string(),
+  reason: z.string(),
+});
+
+const deviceUnhealthyPushSchema = z.object({
+  leaseId: z.string(),
+  deviceId: z.string(),
+  reason: z.literal("crashed"),
+});
+
+const deviceRecoveredPushSchema = z.object({
+  leaseId: z.string(),
+  deviceId: z.string(),
+  attempts: z.number(),
+});
+
+const heartbeatPushSchema = z.object({ nonce: z.number() });
+
+const eventPushSchema = z.object({
+  subscriptionId: z.string(),
+  event: eventEnvelopeSchema,
+});
+
+export const PUSH_SCHEMAS = {
+  progress: progressPushSchema,
+  "lease-lost": leaseLostPushSchema,
+  "device-unhealthy": deviceUnhealthyPushSchema,
+  "device-recovered": deviceRecoveredPushSchema,
+  "lease.heartbeat": heartbeatPushSchema,
+  event: eventPushSchema,
+} as const;

--- a/src/contract/roles.ts
+++ b/src/contract/roles.ts
@@ -1,0 +1,19 @@
+/**
+ * The two daemon session roles (ADR 0003 §3). Enforcement -- rejecting a session whose role is
+ * below an operation's -- is the dispatcher's job (§2), which is PR 2. This module only
+ * declares the vocabulary the rest of the contract is typed against.
+ */
+export const ROLES = ["agent", "admin"] as const;
+export type Role = (typeof ROLES)[number];
+
+/**
+ * Minimal shape a future `authorize` hook will be given (ADR §1's `ownsLease` example, §4's
+ * principal/ownerId comparisons). Declared now so `defineOperation`'s `authorize` field has a
+ * real type to point at; no operation in this PR actually sets `authorize`, and nothing calls
+ * it -- the dispatcher that would is PR 2. `ownerId` is optional here because the field it
+ * would compare against (`LeaseRecord.ownerId`) does not exist on the wire yet either (PR 2).
+ */
+export interface AuthorizeContext {
+  readonly principal: string;
+  readonly role: Role;
+}

--- a/src/contract/schemas.ts
+++ b/src/contract/schemas.ts
@@ -1,0 +1,333 @@
+/**
+ * Zod schemas re-declaring today's wire shapes for the contract module (ADR 0003 §1).
+ *
+ * These schemas deliberately do NOT import their "real" counterparts from `src/core` --
+ * `DeviceRecord`, `LeaseRecord`, `Config`, `DoctorFinding`, `Proposal`, `EventEnvelope`, and so
+ * on are core-private types. Re-declaring their fields here, by hand, is exactly what keeps
+ * private domain records off the public package surface (the daemon maps its own records onto
+ * these shapes in exactly one place -- `src/daemon/server.ts`). If a core type's shape changes
+ * without a matching edit here, that is a compile-time or (for shapes structurally compatible
+ * but semantically different) a runtime output-validation failure at the daemon boundary --
+ * see `DaemonServer`'s output parsing -- not a silent drift.
+ *
+ * This module must never import from src/core, src/daemon, src/drivers, src/http, src/cli,
+ * src/mcp, or src/ports -- enforced by a test, see `boundary.test.ts`.
+ */
+import { z } from "zod";
+
+export const platformSchema = z.enum(["ios", "android"]);
+export type Platform = z.infer<typeof platformSchema>;
+
+const deviceStateSchema = z.enum([
+  "provisioning",
+  "ready",
+  "leased",
+  "reclaiming",
+  "quarantined",
+  "shutdown",
+  "deleted",
+]);
+
+const featureProfileSchema = z.enum(["full", "reduced"]);
+
+const deviceSpecSchema = z.object({
+  platform: platformSchema,
+  model: z.string(),
+  osVersion: z.string(),
+  full: z.boolean().optional(),
+});
+
+/** Mirrors `DeviceRecord` (src/core/domain.ts) field for field, plus the `status`/`list`
+ * decoration's derived `transitionAgeMs` (see `DaemonServer#decorateDevice`). */
+export const deviceRecordSchema = z.object({
+  id: z.string(),
+  driverDeviceId: z.string(),
+  spec: deviceSpecSchema,
+  state: deviceStateSchema,
+  driverData: z.unknown(),
+  createdAt: z.number(),
+  lastLeaseEndedAt: z.number().optional(),
+  foreignStateDetectedAt: z.number().optional(),
+  foreignProvenanceDetectedAt: z.number().optional(),
+  recoveringSince: z.number().optional(),
+  recoveryAttempts: z.number().optional(),
+  quarantinedAt: z.number().optional(),
+  quarantineAttempts: z.number().optional(),
+  quarantineNextRetryAt: z.number().optional(),
+  address: z.string().optional(),
+  featureProfile: featureProfileSchema.optional(),
+  /** Decoration added by `status.get`/`list.get`; absent for a device not mid-transition. */
+  transitionAgeMs: z.number().optional(),
+});
+
+export const leaseModeSchema = z.enum(["held", "detached"]);
+
+/**
+ * Mirrors `LeaseRecord` (src/core/domain.ts) plus the `status`/`list` decoration's derived
+ * `lastHeartbeatAt` (see `DaemonServer#decorateLease`). Deliberately does NOT include
+ * `ownerId` -- that field, and the ownership semantics behind it, are PR 2's job (ADR §4).
+ */
+export const leaseRecordSchema = z.object({
+  id: z.string(),
+  deviceId: z.string(),
+  requesterId: z.string(),
+  mode: leaseModeSchema,
+  grantedAt: z.number(),
+  ttlDeadline: z.number(),
+  lastHeartbeatAt: z.number().optional(),
+});
+
+const leaseTimingSchema = z.object({
+  estimatedProvisionMs: z.number(),
+  estimatedBootMs: z.number(),
+  estimatedReclaimMs: z.number(),
+  estimatedReadyMs: z.number(),
+});
+
+export const leaseGrantSchema = z.object({
+  device: deviceRecordSchema,
+  lease: leaseRecordSchema,
+  timing: leaseTimingSchema,
+});
+
+export const leaseProgressSchema = z.discriminatedUnion("stage", [
+  z.object({ stage: z.literal("queued"), queuePosition: z.number() }),
+  z.object({ stage: z.literal("provisioning"), etaMs: z.number() }),
+  z.object({ stage: z.literal("booting"), etaMs: z.number() }),
+  z.object({ stage: z.literal("reclaiming"), etaMs: z.number() }),
+]);
+
+const runningCapacityEntrySchema = z.object({
+  running: z.number(),
+  maxRunning: z.number(),
+  reserved: z.number(),
+  overLimit: z.boolean(),
+});
+
+export const statusCapacitySchema = z.object({
+  ios: runningCapacityEntrySchema.extend({ limit: z.number(), warm: z.number(), used: z.number() }),
+  android: runningCapacityEntrySchema.extend({
+    limit: z.number(),
+    warm: z.number(),
+    used: z.number(),
+  }),
+  global: runningCapacityEntrySchema.extend({ warm: z.number() }),
+});
+
+export const daemonHealthSchema = z.enum(["starting", "running", "failed"]);
+
+export const platformCatalogSchema = z.object({
+  platform: platformSchema,
+  models: z.array(z.string()),
+  runtimes: z.array(z.string()),
+  defaultRuntime: z.string().optional(),
+});
+
+export const proposalSchema = z.object({
+  action: z.enum(["shutdown", "destroy"]),
+  reason: z.string(),
+  rule: z.string(),
+  target: z.string(),
+});
+
+export const cleanupRuleSummarySchema = z.object({ name: z.string() });
+
+/** Mirrors `DriverDevice` (src/core/driver.ts) -- `driverData` stays opaque `unknown` on
+ * purpose, exactly as the core treats it. */
+const driverDeviceSchema = z.object({
+  deviceId: z.string(),
+  driverData: z.unknown(),
+  address: z.string(),
+  featureProfile: featureProfileSchema.optional(),
+});
+
+/** Mirrors the `DoctorFinding` discriminated union (src/core/doctor.ts) field for field. */
+const doctorFindingSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("registry-device-missing"),
+    deviceId: z.string(),
+    platform: platformSchema,
+  }),
+  z.object({
+    kind: z.literal("orphan-device"),
+    device: driverDeviceSchema,
+    platform: platformSchema,
+  }),
+  z.object({
+    kind: z.literal("orphan-process"),
+    device: driverDeviceSchema,
+    platform: platformSchema,
+  }),
+  z.object({ kind: z.literal("expired-live-lease"), leaseId: z.string(), deviceId: z.string() }),
+  z.object({
+    kind: z.literal("foreign-state-change"),
+    deviceId: z.string(),
+    platform: platformSchema,
+    expected: z.enum(["running", "stopped"]),
+    observed: z.enum(["running", "stopped"]),
+  }),
+  z.object({
+    kind: z.literal("foreign-provenance-change"),
+    deviceId: z.string(),
+    platform: platformSchema,
+    detail: z.enum(["erased", "mark-mismatch", "durable-mark-missing"]),
+  }),
+  z.object({
+    kind: z.literal("stalled-transition"),
+    deviceId: z.string(),
+    platform: platformSchema,
+    state: z.enum(["provisioning", "reclaiming"]),
+    enteredAt: z.number(),
+    ageMs: z.number(),
+    thresholdMs: z.number(),
+  }),
+  z.object({
+    kind: z.literal("driver-advisory"),
+    platform: platformSchema,
+    code: z.string(),
+    message: z.string(),
+  }),
+]);
+
+export const doctorReportSchema = z.object({ findings: z.array(doctorFindingSchema) });
+
+export const nukeReportSchema = z.object({
+  deletedDevices: z.array(z.string()),
+  releasedLeaseIds: z.array(z.string()),
+});
+
+/**
+ * Mirrors `EventEnvelope` (src/bus/index.ts) at the envelope level only. `event` stays a plain
+ * string and `payload` stays `z.unknown()` rather than redeclaring all ~30 `EventMap` payload
+ * shapes here -- see docs/EVENTS.md for the authoritative catalog. This is a deliberate,
+ * documented simplification: re-declaring every business event's payload shape a second time,
+ * next to `events.md`'s existing documentation requirement, is a lot of near-duplicate surface
+ * for a channel this PR does not change the routing of. Tightening this (e.g. a discriminated
+ * union keyed on `event`) is left as follow-up work; flagged in the PR description.
+ */
+export const eventEnvelopeSchema = z.object({
+  seq: z.number(),
+  timestamp: z.number(),
+  event: z.string(),
+  payload: z.unknown(),
+  module: z.string(),
+});
+
+// ---- config.get -----------------------------------------------------------------------------
+
+const platformCapacityOptionsSchema = z.object({
+  maxDevices: z.number().optional(),
+  maxRunning: z.number().optional(),
+});
+
+const fixedCapacityConfigSchema = z.object({
+  strategy: z.literal("fixed"),
+  config: z.object({
+    maxRunning: z.number(),
+    ios: platformCapacityOptionsSchema.optional(),
+    android: platformCapacityOptionsSchema.optional(),
+  }),
+});
+
+const capacityLimitsSchema = z.object({
+  maxRunning: z.number(),
+  ios: z.object({ maxDevices: z.number(), maxRunning: z.number() }),
+  android: z.object({ maxDevices: z.number(), maxRunning: z.number() }),
+});
+
+const resourceCapacityConfigSchema = z.object({
+  strategy: z.literal("resource"),
+  config: z.object({
+    limits: capacityLimitsSchema,
+    ramBudget: z.object({
+      iosBytesPerDevice: z.number(),
+      androidBytesPerDevice: z.number(),
+    }),
+  }),
+});
+
+/**
+ * Mirrors `CapacityConfig` (src/core/capacity/strategies/index.ts), discriminated on
+ * `strategy` exactly as the core type is. Adding a third strategy needs a matching edit here --
+ * there is no way around that with a hand-declared contract; it is the same trade-off the ADR
+ * accepts for every other core-private shape.
+ */
+const capacityConfigSchema = z.discriminatedUnion("strategy", [
+  fixedCapacityConfigSchema,
+  resourceCapacityConfigSchema,
+]);
+
+/** Mirrors `Config` (src/core/config.ts) field for field. */
+export const configSchema = z.object({
+  capacity: capacityConfigSchema,
+  downloads: z.object({
+    policy: z.enum(["never", "on-request", "always"]),
+    acceptAndroidLicenses: z.boolean(),
+    timeoutMs: z.number(),
+  }),
+  idle: z.object({
+    shutdownAfterMs: z.number(),
+    deleteAfterMs: z.number(),
+  }),
+  warmPool: z.object({
+    quarantine: z.object({
+      maxRetries: z.number(),
+      retryBackoffMs: z.number(),
+      retryBackoffMultiplier: z.number(),
+      maxRetryBackoffMs: z.number(),
+    }),
+  }),
+  lease: z.object({
+    heldTtlBackstopMs: z.number(),
+    detachedTtlMs: z.number(),
+    heartbeatIntervalMs: z.number(),
+  }),
+  diskPressure: z.object({ freeBytesThreshold: z.number() }),
+  eventBuffer: z.object({ capacity: z.number() }),
+  log: z.object({
+    level: z.enum(["debug", "info", "warn", "error"]),
+    rotateBytes: z.number(),
+  }),
+  http: z.object({
+    enabled: z.boolean(),
+    host: z.string(),
+    port: z.number(),
+  }),
+  health: z.object({
+    enabled: z.boolean(),
+    probeIntervalMs: z.number(),
+    stableObservations: z.number(),
+    maxRecoveryAttempts: z.number(),
+    recoveryBackoffMs: z.number(),
+    maxConcurrentRecoveries: z.number(),
+  }),
+  ios: z.object({
+    slim: z.object({
+      enabled: z.boolean(),
+      categories: z.array(z.string()).optional(),
+      bootTimeoutMs: z.number(),
+    }),
+  }),
+  stalledTransition: z.object({
+    thresholdMultiplier: z.number(),
+    minimumThresholdMs: z.number(),
+  }),
+});
+
+// ---- tokens -----------------------------------------------------------------------------------
+
+/**
+ * `TokenRole` (agent/operator token store roles, src/http/token-store.ts) is a deliberately
+ * different vocabulary from the daemon session `Role` (agent/admin, see `roles.ts`) -- a
+ * `token.create --role operator` mints a credential that *resolves to* the admin session role
+ * at `hello` (ADR §5), it is not itself that role. Keeping the two enums textually distinct
+ * here (rather than reusing `roleSchema`) is deliberate, not an oversight.
+ */
+export const tokenRoleSchema = z.enum(["agent", "operator"]);
+
+export const tokenRecordSchema = z.object({
+  id: z.string(),
+  role: tokenRoleSchema,
+  label: z.string().optional(),
+  createdAt: z.number(),
+});

--- a/src/daemon-client/connector.test.ts
+++ b/src/daemon-client/connector.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { PROTOCOL_VERSION_RANGE } from "../contract/index.js";
 import { DAEMON_PROTOCOL_VERSION } from "../daemon-protocol/index.js";
 import { MemoryIpcTransport } from "../ports/index.js";
 import { IpcDaemonConnector } from "./connector.js";
@@ -17,7 +18,13 @@ describe("IpcDaemonConnector", () => {
     });
     const connection = await new IpcDaemonConnector(ipc, "/daemon.sock").connect();
     await connection.close();
-    expect(payload).toEqual({ clientVersion: "1.0.0", protocolVersion: DAEMON_PROTOCOL_VERSION });
+    // Sends both the legacy exact protocolVersion and the new range (ADR 0003 §6), so an old
+    // protocol-2 daemon (which only ever reads the former) still answers intelligibly.
+    expect(payload).toEqual({
+      clientVersion: "1.0.0",
+      protocolVersion: DAEMON_PROTOCOL_VERSION,
+      protocolRange: PROTOCOL_VERSION_RANGE,
+    });
   });
 
   it("declares capabilities at hello only when given some, per capability negotiation rules", async () => {

--- a/src/daemon-client/connector.ts
+++ b/src/daemon-client/connector.ts
@@ -1,3 +1,4 @@
+import { PROTOCOL_VERSION_RANGE } from "../contract/index.js";
 import { DAEMON_PROTOCOL_VERSION } from "../daemon-protocol/index.js";
 import type { IpcConnector } from "../ports/index.js";
 import { IpcDaemonConnection } from "./connection.js";
@@ -25,7 +26,12 @@ export class IpcDaemonConnector implements DaemonConnector {
     try {
       await connection.request("hello", {
         clientVersion: "1.0.0",
+        // Sent alongside `protocolRange` (ADR 0003 §6) so a legacy protocol-2 daemon, which
+        // only ever compares this field for an exact match, still answers intelligibly instead
+        // of choking on an unknown `protocolRange` key. A new daemon prefers `protocolRange`
+        // and treats this bare number as `{n, n}` only when `protocolRange` is absent.
         protocolVersion: DAEMON_PROTOCOL_VERSION,
+        protocolRange: PROTOCOL_VERSION_RANGE,
         ...(this.capabilities === undefined ? {} : { capabilities: this.capabilities }),
       });
       return connection;

--- a/src/daemon-client/contracts.ts
+++ b/src/daemon-client/contracts.ts
@@ -159,8 +159,17 @@ export type RawLeaseProgress =
   | { readonly stage: "provisioning" | "booting" | "reclaiming"; readonly etaMs: number };
 
 /** Parses a "progress" push frame delivered to the requesting connection while a lease is in flight. */
+/**
+ * ADR 0003 §8: the `progress` push now wraps the stage payload under `progress`, alongside a
+ * `requestId` correlating it to the request that caused it -- see `DaemonServer#pushProgress`.
+ * `requestId` is not read here yet: nothing on this side of the wire multiplexes progress by
+ * request id today (both the CLI and MCP have at most one lease request in flight per
+ * connection), so unwrapping straight to the stage union is enough for now. Routing by
+ * `requestId` is later-PR work per the ADR's own sequencing (the dispatcher/typed client).
+ */
 export function parseRawLeaseProgress(value: unknown): RawLeaseProgress {
-  const payload = requireObject(value, "Daemon sent an invalid progress notification");
+  const envelope = requireObject(value, "Daemon sent an invalid progress notification");
+  const payload = requireObject(envelope.progress, "Daemon sent an invalid progress notification");
   if (payload.stage === "queued") {
     if (typeof payload.queuePosition !== "number") {
       throw new Error("Daemon sent an invalid progress notification");

--- a/src/daemon-client/startup-coordinator.ts
+++ b/src/daemon-client/startup-coordinator.ts
@@ -41,6 +41,15 @@ function delay(clock: Clock, milliseconds: number): Promise<void> {
   return new Promise((resolve) => clock.setTimer(milliseconds, resolve));
 }
 
+/**
+ * True only for "nothing is listening yet" -- a refused/missing socket. A `hello` failure for
+ * any other reason (including a protocol version mismatch: `DaemonClientError` with code
+ * `PROTOCOL_VERSION_MISMATCH`/`PROTOCOL_VERSION_UNSUPPORTED`, never an `IpcError`) is NOT
+ * unavailable and propagates straight out of `connect()` without ever reaching
+ * `launcher.launch()` below. This is what ADR 0003 §6 means by "the client never restarts the
+ * daemon on mismatch": `DaemonStartupCoordinator` only ever launches when the socket itself
+ * could not be reached, never when a daemon answered and refused the handshake.
+ */
 function isUnavailable(error: unknown): boolean {
   return (
     error instanceof IpcError &&

--- a/src/daemon-protocol/index.test.ts
+++ b/src/daemon-protocol/index.test.ts
@@ -9,7 +9,8 @@ import {
 
 describe("daemon protocol", () => {
   it("keeps the current protocol version and newline framing", () => {
-    expect(DAEMON_PROTOCOL_VERSION).toBe(2);
+    // ADR 0003 §6: protocol 3, no compatibility shim.
+    expect(DAEMON_PROTOCOL_VERSION).toBe(3);
     expect(serializeFrame({ id: 1, type: "hello" })).toBe('{"id":1,"type":"hello"}\n');
   });
 

--- a/src/daemon-protocol/index.ts
+++ b/src/daemon-protocol/index.ts
@@ -1,5 +1,13 @@
-/** The version of the newline-delimited JSON protocol spoken by daemon clients. */
-export const DAEMON_PROTOCOL_VERSION = 2;
+import { PROTOCOL_VERSION_RANGE } from "../contract/index.js";
+
+/**
+ * The version of the newline-delimited JSON protocol spoken by daemon clients. Derived from
+ * the contract's `PROTOCOL_VERSION_RANGE` (its `max`) rather than declared separately, so the
+ * two constants cannot drift. See ADR 0003 §6: protocol versions are now negotiated as ranges;
+ * this single-number export is what a legacy exact-match client/daemon (and this file's own
+ * framing helpers, which predate range negotiation) still reads.
+ */
+export const DAEMON_PROTOCOL_VERSION = PROTOCOL_VERSION_RANGE.max;
 
 export type RequestId = string | number;
 

--- a/src/daemon/main.test.ts
+++ b/src/daemon/main.test.ts
@@ -126,7 +126,9 @@ describe("startDaemon startup readiness", () => {
 
       const parkedLease = client.request("lease.request", {
         mode: "detached",
-        request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+        model: "iPhone 16",
+        osVersion: "26.5",
+        platform: "ios",
       });
       let leaseSettled = false;
       void parkedLease.then(() => {

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -14,6 +14,7 @@ import {
   Registry,
   RuntimeMissingError,
 } from "../core/index.js";
+import { PROTOCOL_VERSION_RANGE } from "../contract/index.js";
 import { AndroidLicenseNotAcceptedError } from "../drivers/android/index.js";
 import {
   FakeClock,
@@ -76,7 +77,9 @@ describe("DaemonServer", () => {
     const grant = await holder.request("lease.request", {
       mode: "held",
       requesterId: "agent-1",
-      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
     });
     expect(grant.ok).toBe(true);
     expect(harness.registry.snapshot.leases).toHaveLength(1);
@@ -106,6 +109,12 @@ describe("DaemonServer", () => {
     });
     await missingHello.close();
 
+    // ADR 0003 §6: protocol versions are now negotiated as ranges. A bare `protocolVersion`
+    // with no overlap against the daemon's range is `PROTOCOL_VERSION_UNSUPPORTED`, carrying
+    // both ranges and the daemon version -- there is no more exact-match
+    // `PROTOCOL_VERSION_MISMATCH` on this daemon (a real protocol-2 daemon out in the world
+    // still answers with the old code; see `contract/protocol.test.ts`'s
+    // `mapLegacyProtocolMismatch` for how a client maps that).
     const wrongVersion = await createClient(harness.socketPath);
     await expect(
       wrongVersion.request("hello", {
@@ -113,14 +122,22 @@ describe("DaemonServer", () => {
         protocolVersion: DAEMON_PROTOCOL_VERSION + 1,
       }),
     ).resolves.toMatchObject({
-      error: { code: "PROTOCOL_VERSION_MISMATCH" },
+      error: {
+        code: "PROTOCOL_VERSION_UNSUPPORTED",
+        details: {
+          client: { min: DAEMON_PROTOCOL_VERSION + 1, max: DAEMON_PROTOCOL_VERSION + 1 },
+          daemon: PROTOCOL_VERSION_RANGE,
+        },
+      },
       ok: false,
     });
   });
 
   // Protocol 2 added the `heartbeat` capability and the sliding held-lease TTL that
   // depends on it, and shipped without back-compat shims. Rejecting v1 is therefore a
-  // deliberate product decision, not just arithmetic on the current constant.
+  // deliberate product decision, not just arithmetic on the current constant. Protocol 3
+  // (ADR 0003) widened the rejection to a range check, but a v1 client (no overlap with
+  // `PROTOCOL_VERSION_RANGE`) is still rejected outright, now as `PROTOCOL_VERSION_UNSUPPORTED`.
   it("rejects a protocol v1 client outright rather than serving it without heartbeats", async () => {
     const harness = await createHarness();
     const legacy = await createClient(harness.socketPath);
@@ -128,7 +145,7 @@ describe("DaemonServer", () => {
     await expect(
       legacy.request("hello", { clientVersion: "test", protocolVersion: 1 }),
     ).resolves.toMatchObject({
-      error: { code: "PROTOCOL_VERSION_MISMATCH" },
+      error: { code: "PROTOCOL_VERSION_UNSUPPORTED" },
       ok: false,
     });
   });
@@ -142,13 +159,17 @@ describe("DaemonServer", () => {
     await holder.request("lease.request", {
       mode: "held",
       requesterId: "holder",
-      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
     });
 
     const queuedGrant = waiter.request("lease.request", {
       mode: "held",
       requesterId: "waiter",
-      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
     });
     await expect
       .poll(() => harness.eventBus.replay().some((event) => event.event === "lease.queued"))
@@ -168,16 +189,22 @@ describe("DaemonServer", () => {
     await holder.request("lease.request", {
       mode: "held",
       requesterId: "holder",
-      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
     });
 
     const queuedGrant = waiter.request("lease.request", {
       mode: "held",
       requesterId: "waiter",
-      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
     });
+    // ADR 0003 §8: `progress` now carries the originating request's frame id alongside the
+    // progress payload, under `progress`, rather than the bare stage object at the top level.
     await expect(waiter.nextFrame((frame) => frame.push === "progress")).resolves.toMatchObject({
-      payload: { queuePosition: 1, stage: "queued" },
+      payload: { progress: { queuePosition: 1, stage: "queued" } },
       push: "progress",
     });
 
@@ -187,7 +214,8 @@ describe("DaemonServer", () => {
         .filter(
           (frame) =>
             frame.push === "progress" &&
-            (frame.payload as { readonly stage?: unknown } | undefined)?.stage === "queued",
+            (frame.payload as { readonly progress?: { readonly stage?: unknown } } | undefined)
+              ?.progress?.stage === "queued",
         ),
     ).toEqual([]);
     await holder.close();
@@ -224,7 +252,9 @@ describe("DaemonServer", () => {
       .request("lease.request", {
         mode: "detached",
         requesterId: "agent-1",
-        request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+        model: "iPhone 16",
+        osVersion: "26.5",
+        platform: "ios",
       })
       .then((response) => {
         requestSettled = true;
@@ -234,7 +264,7 @@ describe("DaemonServer", () => {
     await expect(
       client.nextFrame((frame) => frame.push === "progress" && frame.payload !== undefined),
     ).resolves.toMatchObject({
-      payload: { etaMs: 60, stage: "provisioning" },
+      payload: { progress: { etaMs: 60, stage: "provisioning" } },
       push: "progress",
     });
     expect(requestSettled).toBe(false);
@@ -312,7 +342,9 @@ describe("DaemonServer", () => {
     const grant = await client.request("lease.request", {
       mode: "detached",
       requesterId: "agent-1",
-      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
     });
     const leaseId = (grant.payload as { readonly lease: { readonly id: string } }).lease.id;
     await expect(client.request("lease.renew", { leaseId, ttlMs: 120_000 })).resolves.toMatchObject(
@@ -385,7 +417,9 @@ describe("DaemonServer", () => {
     await client.request("lease.request", {
       mode: "held",
       requesterId: "agent-1",
-      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
     });
 
     await expect(client.request("daemon.stop", {})).resolves.toMatchObject({ ok: true });
@@ -403,7 +437,9 @@ describe("DaemonServer", () => {
     const grant = await holder.request("lease.request", {
       mode: "held",
       requesterId: "holder",
-      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
     });
     const leaseId = leaseIdOf(grant);
     const deviceId = harness.registry.snapshot.leases.find(
@@ -434,7 +470,9 @@ describe("DaemonServer", () => {
     const grant = await holder.request("lease.request", {
       mode: "held",
       requesterId: "holder",
-      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
     });
     const leaseId = leaseIdOf(grant);
 
@@ -464,7 +502,9 @@ describe("DaemonServer", () => {
     const grant = await holder.request("lease.request", {
       mode: "held",
       requesterId: "holder",
-      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
     });
     const leaseId = leaseIdOf(grant);
 
@@ -500,7 +540,9 @@ describe("DaemonServer", () => {
     const grant = await holder.request("lease.request", {
       mode: "held",
       requesterId: "holder",
-      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
     });
     const leaseId = leaseIdOf(grant);
     const deviceId = harness.registry.snapshot.leases.find(
@@ -533,7 +575,9 @@ describe("DaemonServer", () => {
     const grant = await holder.request("lease.request", {
       mode: "held",
       requesterId: "holder",
-      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
     });
     const leaseId = leaseIdOf(grant);
     const deviceId = harness.registry.snapshot.leases.find(
@@ -582,7 +626,9 @@ describe("DaemonServer", () => {
     const grant = await holder.request("lease.request", {
       mode: "held",
       requesterId: "holder",
-      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
     });
     const leaseId = leaseIdOf(grant);
     const deviceId = harness.registry.snapshot.leases.find(
@@ -707,7 +753,9 @@ describe("DaemonServer startup readiness", () => {
     const parkedGrant = holder.request("lease.request", {
       mode: "held",
       requesterId: "holder",
-      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
     });
 
     converge.resolve();
@@ -767,7 +815,9 @@ describe("DaemonServer lease heartbeat", () => {
     const grant = await holder.request("lease.request", {
       mode: "held",
       requesterId: "agent-1",
-      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
     });
     const leaseId = leaseIdOf(grant);
     expect((grant.payload as { lease: { ttlDeadline: number } }).lease.ttlDeadline).toBe(1_040);
@@ -809,7 +859,9 @@ describe("DaemonServer lease heartbeat", () => {
     const grant = await holder.request("lease.request", {
       mode: "held",
       requesterId: "agent-1",
-      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
     });
     const leaseId = leaseIdOf(grant);
 
@@ -843,7 +895,9 @@ describe("DaemonServer lease heartbeat", () => {
     const grant = await holder.request("lease.request", {
       mode: "held",
       requesterId: "agent-1",
-      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
     });
     const leaseId = leaseIdOf(grant);
     const deviceId = (grant.payload as { device: { id: string } }).device.id;
@@ -890,7 +944,9 @@ describe("DaemonServer lease heartbeat", () => {
     const grant = await holder.request("lease.request", {
       mode: "held",
       requesterId: "agent-1",
-      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
     });
     const leaseId = leaseIdOf(grant);
 
@@ -1001,7 +1057,9 @@ describe("DaemonServer lease heartbeat", () => {
       await holder.request("lease.request", {
         mode: "held",
         requesterId: "holder",
-        request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+        model: "iPhone 16",
+        osVersion: "26.5",
+        platform: "ios",
       });
 
       const stopping = harness.daemon.stop("test-drain");
@@ -1035,7 +1093,9 @@ describe("DaemonServer lease heartbeat", () => {
       await holder.request("lease.request", {
         mode: "held",
         requesterId: "holder",
-        request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+        model: "iPhone 16",
+        osVersion: "26.5",
+        platform: "ios",
       });
 
       await harness.daemon.stop("test-stop-auxiliary");
@@ -1079,7 +1139,12 @@ describe("DaemonServer lease heartbeat", () => {
       );
     });
 
-    it("logs an unhandled request error at error level", async () => {
+    // `doctor.run`/`nuke.run` used to surface an unconfigured collaborator as a plain `Error`,
+    // which `errorCode()` had no choice but to map to `INTERNAL` -- logged at error level
+    // indistinguishably from a real bug. `DoctorUnavailableError`/`NukeUnavailableError` (ADR
+    // 0003 §7: "one error class, closed codes") give this its own typed code, so it is now a
+    // *handled*, debug-level error like any other expected domain refusal.
+    it("logs an unconfigured doctor as a handled DOCTOR_UNAVAILABLE, not an unhandled error", async () => {
       const { logger: log, sink } = logger();
       const harness = await createHarness({ logger: log });
       const client = await createClient(harness.socketPath);
@@ -1089,10 +1154,13 @@ describe("DaemonServer lease heartbeat", () => {
 
       expect(sink.records).toContainEqual(
         expect.objectContaining({
-          level: "error",
-          message: "Unhandled request error",
-          fields: expect.objectContaining({ type: "doctor.run" }),
+          level: "debug",
+          message: "Handled request error",
+          fields: { code: "DOCTOR_UNAVAILABLE", type: "doctor.run" },
         }),
+      );
+      expect(sink.records).not.toContainEqual(
+        expect.objectContaining({ level: "error", message: "Unhandled request error" }),
       );
       await client.close();
     });
@@ -1131,7 +1199,9 @@ describe("DaemonServer download policy", () => {
     const grant = await client.request("lease.request", {
       mode: "held",
       requesterId: "agent-1",
-      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
     });
 
     expect(grant.ok).toBe(true);
@@ -1153,7 +1223,9 @@ describe("DaemonServer download policy", () => {
       allowDownload: true,
       mode: "held",
       requesterId: "agent-1",
-      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
     });
 
     expect(response.ok).toBe(false);
@@ -1179,7 +1251,9 @@ describe("DaemonServer download policy", () => {
     const response = await client.request("lease.request", {
       mode: "held",
       requesterId: "agent-1",
-      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
     });
 
     expect(response.ok).toBe(false);
@@ -1201,7 +1275,9 @@ describe("DaemonServer download policy", () => {
     const response = await client.request("lease.request", {
       mode: "held",
       requesterId: "agent-1",
-      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
     });
 
     expect(response.ok).toBe(false);
@@ -1228,7 +1304,9 @@ describe("DaemonServer download policy", () => {
       allowDownload: true,
       mode: "held",
       requesterId: "agent-1",
-      request: { model: "iPhone 16", osVersion: "12.0", platform: "ios" },
+      model: "iPhone 16",
+      osVersion: "12.0",
+      platform: "ios",
     });
 
     expect(response.ok).toBe(false);
@@ -1250,7 +1328,10 @@ describe("DaemonServer full request flag", () => {
     const grant = await client.request("lease.request", {
       mode: "held",
       requesterId: "agent-1",
-      request: { full: true, model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      full: true,
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
     });
 
     expect(grant.ok).toBe(true);
@@ -1268,7 +1349,9 @@ describe("DaemonServer full request flag", () => {
     const grant = await client.request("lease.request", {
       mode: "held",
       requesterId: "agent-1",
-      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
     });
 
     expect(grant.ok).toBe(true);
@@ -1291,7 +1374,9 @@ describe("DaemonServer error code mapping", () => {
     const response = await client.request("lease.request", {
       mode: "held",
       requesterId: "agent-1",
-      request: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
+      model: "iPhone 16",
+      osVersion: "26.5",
+      platform: "ios",
     });
 
     expect(response.ok).toBe(false);
@@ -1314,7 +1399,9 @@ describe("DaemonServer error code mapping", () => {
     const response = await client.request("lease.request", {
       mode: "held",
       requesterId: "agent-1",
-      request: { model: "Pixel 8", osVersion: "35", platform: "android" },
+      model: "Pixel 8",
+      osVersion: "35",
+      platform: "android",
     });
 
     expect(response.ok).toBe(false);

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import { type EventBus, type EventEnvelope } from "../bus/index.js";
 import {
   type Config,
@@ -30,12 +32,33 @@ import type {
 } from "../core/lease-ports.js";
 import type { Clock, IpcConnection, Logger, TimerHandle } from "../ports/index.js";
 import { NoopLogger } from "../ports/index.js";
+import { parseRequestFrame, serializeFrame, type RequestFrame } from "../daemon-protocol/index.js";
 import {
-  DAEMON_PROTOCOL_VERSION,
-  parseRequestFrame,
-  serializeFrame,
-  type RequestFrame,
-} from "../daemon-protocol/index.js";
+  catalogGet,
+  cleanupRun,
+  configGet,
+  doctorRun,
+  eventsReplay,
+  eventsSubscribe,
+  eventsUnsubscribe,
+  helloRequestSchema,
+  helloReplySchema,
+  leaseCancel,
+  leaseHeartbeat,
+  leaseList,
+  leaseRelease,
+  leaseReleaseAll,
+  leaseRenew,
+  leaseRequest,
+  listGet,
+  negotiateProtocolVersion,
+  normalizeProtocolVersion,
+  nukeRun,
+  PROTOCOL_VERSION_RANGE,
+  PUSH_SCHEMAS,
+  statusGet,
+  type ProtocolRange,
+} from "../contract/index.js";
 import type { ConnectionHost } from "./connection-host.js";
 
 type RequestId = string | number;
@@ -50,6 +73,11 @@ interface Connection {
   heartbeatCapability: boolean;
   closed: boolean;
   unsubscribeEvents: (() => void) | undefined;
+  /** Set while this connection has an active `events.subscribe`; correlates `event` pushes
+   * (ADR 0003 §8). Minted per-subscription from `#eventSubscriptionSeq` rather than injected --
+   * `DaemonServer` has no `IdGenerator` dependency today, and this only needs to be unique per
+   * connection lifetime, not globally unpredictable. */
+  subscriptionId: string | undefined;
   releasing: Promise<void> | undefined;
 }
 
@@ -64,7 +92,9 @@ export interface DaemonServerOptions {
   readonly host: ConnectionHost;
   readonly leases: LeaseCommands;
   readonly logger?: Logger;
-  readonly protocolVersion?: number;
+  /** Overrides the daemon's advertised protocol range (ADR 0003 §6); defaults to
+   * `PROTOCOL_VERSION_RANGE`. A bare number is normalized to `{n, n}`, same as a client's. */
+  readonly protocolVersion?: number | ProtocolRange;
   readonly queue: QueueControl;
   readonly reaper: CleanupReaper;
   readonly healthMonitor?: LeaseHealthMonitor;
@@ -100,11 +130,12 @@ type DaemonHealth = "starting" | "running" | "failed";
 
 export class DaemonServer {
   readonly #connections = new Set<Connection>();
-  readonly #protocolVersion: number;
+  readonly #protocolRange: ProtocolRange;
   readonly #unsubscribeLeaseLost: Array<() => void> = [];
   readonly #logger: Logger;
   #heartbeatTimer: TimerHandle | undefined;
   #heartbeatNonce = 0;
+  #eventSubscriptionSeq = 0;
   #stopping = false;
   #stopPromise: Promise<void> | undefined;
   #health: DaemonHealth = "starting";
@@ -119,7 +150,10 @@ export class DaemonServer {
   readonly #parkedDispatches = new Set<Promise<void>>();
 
   constructor(private readonly options: DaemonServerOptions) {
-    this.#protocolVersion = options.protocolVersion ?? DAEMON_PROTOCOL_VERSION;
+    this.#protocolRange =
+      options.protocolVersion === undefined
+        ? PROTOCOL_VERSION_RANGE
+        : normalizeProtocolVersion(options.protocolVersion);
     this.#logger = options.logger ?? new NoopLogger();
   }
 
@@ -215,7 +249,8 @@ export class DaemonServer {
     );
     this.#logger.info("Daemon started", {
       config: this.options.config,
-      protocolVersion: this.#protocolVersion,
+      protocolVersion: this.#protocolRange.max,
+      protocolRange: this.#protocolRange,
       socketPath: this.options.host.endpoint,
       version: this.options.version,
     });
@@ -306,6 +341,7 @@ export class DaemonServer {
       progressRequesters: new Set(),
       socket,
       releasing: undefined,
+      subscriptionId: undefined,
       unsubscribeEvents: undefined,
     };
     this.#connections.add(connection);
@@ -369,6 +405,20 @@ export class DaemonServer {
       return;
     }
 
+    // `daemon.stop` is a frozen exception (ADR 0003 §6): accepted at any protocol version the
+    // daemon has ever spoken, before `hello`, during a version-mismatch standoff, even while
+    // already `#stopping`. This bypasses the handshake and protocol-version gate entirely --
+    // deliberately, not an oversight -- so that `npm upgrade` against a still-running old
+    // daemon (leases held) can always be stopped without releasing every held lease on the
+    // machine by restarting it instead (see ADR §6's "the client never restarts the daemon on
+    // mismatch"). It is intentionally idempotent: `stop()` itself dedups concurrent callers via
+    // `#stopPromise`, so a second `daemon.stop` here just gets the same success reply again.
+    if (frame.type === "daemon.stop") {
+      await writeFrame(connection.socket, { id: frame.id, ok: true, payload: { stopping: true } });
+      void this.stop("requested");
+      return;
+    }
+
     if (!connection.helloReceived) {
       await this.#handleHello(connection, frame);
       return;
@@ -386,9 +436,6 @@ export class DaemonServer {
     try {
       const payload = await this.#handleRequest(connection, frame);
       await writeFrame(connection.socket, { id: frame.id, ok: true, payload });
-      if (frame.type === "daemon.stop") {
-        void this.stop("requested");
-      }
     } catch (error: unknown) {
       const code = errorCode(error);
       if (code === "INTERNAL") {
@@ -415,40 +462,55 @@ export class DaemonServer {
       await connection.socket.close();
       return;
     }
-    const payload = objectPayload(frame.payload);
-    if (typeof payload.clientVersion !== "string") {
+    const parsedHello = helloRequestSchema.safeParse(frame.payload);
+    if (!parsedHello.success) {
       await this.#respondError(
         connection.socket,
         frame.id,
         "BAD_REQUEST",
-        "hello requires a clientVersion string",
+        parsedHello.error.issues.map((issue) => issue.message).join("; "),
       );
       await connection.socket.close();
       return;
     }
-    if (payload.protocolVersion !== this.#protocolVersion) {
+    const payload = parsedHello.data;
+    // ADR 0003 §6: the daemon prefers the client's `protocolRange` when present, and treats a
+    // bare `protocolVersion` as `{n, n}` only when it is not -- `helloRequestSchema` already
+    // guarantees at least one of the two is present.
+    const clientRange: ProtocolRange =
+      payload.protocolRange ?? normalizeProtocolVersion(payload.protocolVersion as number);
+    const negotiated = negotiateProtocolVersion(clientRange, this.#protocolRange);
+    if (negotiated === undefined) {
       await this.#respondError(
         connection.socket,
         frame.id,
-        "PROTOCOL_VERSION_MISMATCH",
-        `Protocol version ${String(payload.protocolVersion)} is not supported`,
+        "PROTOCOL_VERSION_UNSUPPORTED",
+        `No overlapping protocol version: client supports ${clientRange.min}-${clientRange.max}, daemon supports ${this.#protocolRange.min}-${this.#protocolRange.max}`,
+        { client: clientRange, daemon: this.#protocolRange, daemonVersion: this.options.version },
       );
       await connection.socket.close();
       return;
     }
     connection.helloReceived = true;
-    connection.heartbeatCapability = isObject(payload.capabilities)
-      ? payload.capabilities.heartbeat === true
-      : false;
+    connection.heartbeatCapability = payload.capabilities?.heartbeat === true;
     this.#logger.info("Connection opened", {
       clientVersion: payload.clientVersion,
       heartbeatCapability: connection.heartbeatCapability,
+      protocolVersion: negotiated,
     });
-    await writeFrame(connection.socket, {
-      id: frame.id,
-      ok: true,
-      payload: { protocolVersion: this.#protocolVersion, version: this.options.version },
-    });
+    // `role` is fixed to "agent" until PR 2 resolves it from a real credential (ADR §5); the
+    // reply shape carries the field now so a client can start asserting against it early.
+    const reply = this.#parseOutput(
+      helloReplySchema,
+      {
+        protocolVersion: negotiated,
+        daemonProtocolRange: this.#protocolRange,
+        version: this.options.version,
+        role: "agent",
+      },
+      "hello",
+    );
+    await writeFrame(connection.socket, { id: frame.id, ok: true, payload: reply });
   }
 
   // fallow-ignore-next-line complexity -- command dispatch is intentionally centralized at the protocol boundary.
@@ -458,120 +520,162 @@ export class DaemonServer {
     }
     switch (frame.type) {
       case "lease.request":
-        return this.#requestLease(connection, frame.payload);
+        return this.#requestLease(connection, frame.id, frame.payload);
       case "lease.release": {
-        const leaseId = requiredString(objectPayload(frame.payload), "leaseId");
+        const input = parseInput(leaseRelease.input, frame.payload);
         // Clear before the request commits so a lease-lost push (triggered by the
         // resulting lease.released event) does not also fire back at this same
         // connection for the release it just asked for itself.
-        const wasHeld = connection.heldLeaseIds.delete(leaseId);
+        const wasHeld = connection.heldLeaseIds.delete(input.leaseId);
         try {
-          await this.options.leases.release(leaseId, "explicit");
+          await this.options.leases.release(input.leaseId, "explicit");
         } catch (error: unknown) {
-          if (wasHeld) connection.heldLeaseIds.add(leaseId);
+          if (wasHeld) connection.heldLeaseIds.add(input.leaseId);
           throw error;
         }
-        return { leaseId };
+        return this.#parseOutput(leaseRelease.output, { leaseId: input.leaseId }, "lease.release");
       }
       case "lease.release-all": {
+        parseInput(leaseReleaseAll.input, frame.payload ?? {});
         const previouslyHeld = [...connection.heldLeaseIds];
         connection.heldLeaseIds.clear();
         try {
           const leaseIds = await this.options.leases.releaseAll("explicit");
-          return { leaseIds };
+          return this.#parseOutput(leaseReleaseAll.output, { leaseIds }, "lease.release-all");
         } catch (error: unknown) {
           for (const leaseId of previouslyHeld) connection.heldLeaseIds.add(leaseId);
           throw error;
         }
       }
       case "lease.renew": {
-        const payload = objectPayload(frame.payload);
-        const leaseId = requiredString(payload, "leaseId");
+        const input = parseInput(leaseRenew.input, frame.payload);
         // Omitted ttlMs falls back to the lease's own mode-aware default (core's
         // `#ttlFor`) rather than always assuming detached -- substituting the detached
         // TTL here would silently shorten a held lease's hour-long backstop to 15m.
-        const ttlMs = payload.ttlMs === undefined ? undefined : requiredNumber(payload, "ttlMs");
-        return this.options.leases.renew(leaseId, ttlMs);
+        const record = await this.options.leases.renew(input.leaseId, input.ttlMs);
+        return this.#parseOutput(leaseRenew.output, record, "lease.renew");
+      }
+      case "lease.cancel": {
+        const input = parseInput(leaseCancel.input, frame.payload ?? {});
+        const requesterId = input.requesterId ?? this.options.defaultRequesterId;
+        const result = await this.options.queue.cancelPending(requesterId);
+        return this.#parseOutput(leaseCancel.output, { result }, "lease.cancel");
+      }
+      case "lease.list": {
+        parseInput(leaseList.input, frame.payload ?? {});
+        const leases = this.options.registry.snapshot.leases.map((lease) =>
+          this.#decorateLease(lease),
+        );
+        return this.#parseOutput(leaseList.output, { leases }, "lease.list");
       }
       case "lease.heartbeat": {
+        parseInput(leaseHeartbeat.input, frame.payload ?? {});
         if (!connection.heartbeatCapability) {
           throw new ProtocolError(
             "BAD_REQUEST",
             "Connection did not declare the heartbeat capability",
           );
         }
-        return { leases: await this.#heartbeatHeldLeases(connection) };
+        const leases = await this.#heartbeatHeldLeases(connection);
+        return this.#parseOutput(leaseHeartbeat.output, { leases }, "lease.heartbeat");
       }
-      case "status.get":
-        return this.#status();
-      case "list.get":
-        return this.#list(objectPayload(frame.payload));
+      case "status.get": {
+        parseInput(statusGet.input, frame.payload ?? {});
+        return this.#parseOutput(statusGet.output, this.#status(), "status.get");
+      }
+      case "list.get": {
+        const input = parseInput(listGet.input, frame.payload ?? {});
+        return this.#parseOutput(listGet.output, this.#list(input), "list.get");
+      }
       case "catalog.get": {
-        const payload = objectPayload(frame.payload);
-        return { platforms: await this.options.catalog.listCatalog(optionalPlatform(payload)) };
+        const input = parseInput(catalogGet.input, frame.payload ?? {});
+        const result = { platforms: await this.options.catalog.listCatalog(input.platform) };
+        return this.#parseOutput(catalogGet.output, result, "catalog.get");
       }
       case "cleanup.run": {
-        const payload = objectPayload(frame.payload);
-        return this.options.reaper.run({
-          dryRun: optionalBoolean(payload, "dryRun") ?? false,
-          ...(typeof payload.rule === "string" ? { rule: payload.rule } : {}),
+        const input = parseInput(cleanupRun.input, frame.payload ?? {});
+        const result = await this.options.reaper.run({
+          dryRun: input.dryRun ?? false,
+          ...(input.rule === undefined ? {} : { rule: input.rule }),
         });
+        return this.#parseOutput(cleanupRun.output, result, "cleanup.run");
       }
       case "doctor.run": {
-        const payload = objectPayload(frame.payload);
-        if (this.options.doctor === undefined) throw new Error("Doctor is unavailable");
-        return this.options.doctor.reconcile({ fix: optionalBoolean(payload, "fix") ?? false });
+        const input = parseInput(doctorRun.input, frame.payload ?? {});
+        if (this.options.doctor === undefined) throw new DoctorUnavailableError();
+        const report = await this.options.doctor.reconcile({ fix: input.fix ?? false });
+        return this.#parseOutput(doctorRun.output, report, "doctor.run");
       }
       case "nuke.run": {
-        const payload = objectPayload(frame.payload);
-        if (this.options.nuke === undefined) throw new Error("Nuke is unavailable");
-        return this.options.nuke.run({
-          deleteDevices: optionalBoolean(payload, "deleteDevices") ?? false,
-        });
+        const input = parseInput(nukeRun.input, frame.payload ?? {});
+        if (this.options.nuke === undefined) throw new NukeUnavailableError();
+        const result = await this.options.nuke.run({ deleteDevices: input.deleteDevices ?? false });
+        return this.#parseOutput(nukeRun.output, result, "nuke.run");
       }
       case "events.replay": {
-        const payload = objectPayload(frame.payload);
-        return this.options.eventBus.replay(
-          typeof payload.sinceTs === "number" ? { sinceTs: payload.sinceTs } : {},
+        const input = parseInput(eventsReplay.input, frame.payload ?? {});
+        const result = this.options.eventBus.replay(
+          input.sinceTs === undefined ? {} : { sinceTs: input.sinceTs },
+        );
+        return this.#parseOutput(eventsReplay.output, result, "events.replay");
+      }
+      case "events.subscribe": {
+        parseInput(eventsSubscribe.input, frame.payload ?? {});
+        connection.unsubscribeEvents?.();
+        this.#eventSubscriptionSeq += 1;
+        const subscriptionId = `sub_${this.#eventSubscriptionSeq}`;
+        connection.subscriptionId = subscriptionId;
+        connection.unsubscribeEvents = this.options.eventBus.subscribeAll((event) => {
+          void this.#pushEvent(connection.socket, subscriptionId, event);
+        });
+        return this.#parseOutput(
+          eventsSubscribe.output,
+          { subscribed: true, subscriptionId },
+          "events.subscribe",
         );
       }
-      case "events.subscribe":
-        connection.unsubscribeEvents?.();
-        connection.unsubscribeEvents = this.options.eventBus.subscribeAll((event) => {
-          void this.#pushEvent(connection.socket, event);
-        });
-        return { subscribed: true };
-      case "events.unsubscribe":
+      case "events.unsubscribe": {
+        parseInput(eventsUnsubscribe.input, frame.payload ?? {});
         connection.unsubscribeEvents?.();
         connection.unsubscribeEvents = undefined;
-        return { subscribed: false };
-      case "config.get":
-        return this.options.config;
-      case "daemon.stop":
-        return { stopping: true };
+        connection.subscriptionId = undefined;
+        return this.#parseOutput(
+          eventsUnsubscribe.output,
+          { subscribed: false },
+          "events.unsubscribe",
+        );
+      }
+      case "config.get": {
+        parseInput(configGet.input, frame.payload ?? {});
+        return this.#parseOutput(configGet.output, this.options.config, "config.get");
+      }
+      // "daemon.stop" is deliberately absent from this switch: `#dispatchLine` intercepts it
+      // before hello/dispatch entirely, as the frozen exception ADR §6 describes, so it never
+      // reaches `#handleRequest`.
       default:
         throw new ProtocolError("UNKNOWN_REQUEST", `Unknown request type: ${frame.type}`);
     }
   }
 
   // fallow-ignore-next-line complexity -- lease payload validation and held-connection lifecycle are one transaction.
-  async #requestLease(connection: Connection, value: unknown): Promise<unknown> {
-    const payload = objectPayload(value);
-    const requestPayload = isObject(payload.request) ? payload.request : payload;
-    const osVersion = optionalString(requestPayload, "osVersion", "os");
-    const full = optionalBoolean(requestPayload, "full") ?? false;
+  async #requestLease(
+    connection: Connection,
+    requestId: RequestId,
+    value: unknown,
+  ): Promise<unknown> {
+    const input = parseInput(leaseRequest.input, value ?? {});
     const request: DeviceRequest = {
-      model: requiredString(requestPayload, "model", "device"),
-      platform: requiredPlatform(requestPayload),
-      ...(osVersion === undefined ? {} : { osVersion }),
-      ...(full ? { full: true } : {}),
+      model: input.model,
+      platform: input.platform,
+      ...(input.osVersion === undefined ? {} : { osVersion: input.osVersion }),
+      ...(input.full ? { full: true } : {}),
     };
-    const mode = payload.mode === "detached" ? "detached" : "held";
-    const requesterId = optionalString(payload, "requesterId") ?? this.options.defaultRequesterId;
+    const mode = input.mode ?? "held";
+    const requesterId = input.requesterId ?? this.options.defaultRequesterId;
     // The request's own flag is only the input to the policy, not the final answer: `never`
     // overrides an explicit `true` (and is what should show up in the eventual "runtime
     // missing" message below), `always` grants it without the caller asking.
-    const requestedAllowDownload = optionalBoolean(payload, "allowDownload") ?? false;
+    const requestedAllowDownload = input.allowDownload ?? false;
     const downloadsPolicy = this.options.config.downloads.policy;
     let progressSocket: IpcConnection | undefined = connection.socket;
     const disposeProgress = () => {
@@ -584,14 +688,19 @@ export class DaemonServer {
       grant = await this.options.leases.request(request, {
         allowDownload: effectiveAllowDownload(downloadsPolicy, requestedAllowDownload),
         mode,
-        noWait: optionalBoolean(payload, "noWait") ?? false,
+        noWait: input.noWait ?? false,
         onProgress: (progress) => {
           if (progressSocket !== undefined) {
-            void this.#pushProgress(progressSocket, progress);
+            void this.#pushProgress(progressSocket, requestId, progress);
           }
         },
         requesterId,
-        ...(typeof payload.timeoutMs === "number" ? { timeoutMs: payload.timeoutMs } : {}),
+        ...(input.timeoutMs === undefined ? {} : { timeoutMs: input.timeoutMs }),
+        // NOTE: `input.ttlMs` is validated by the contract (BAD_REQUEST for a held lease, via
+        // `leaseRequestInputSchema`'s `superRefine`) but not forwarded here --
+        // `LeaseRequestOptions` (src/core/wait-queue.ts) has no `ttlMs` field yet. Threading an
+        // initial TTL for a detached lease through core (`WaitQueue`/`LeaseEngine`) is later-PR
+        // plumbing, beyond this PR's "daemon validates inputs" scope -- see the PR description.
       });
     } catch (error: unknown) {
       // The driver only ever sees the clamped-to-false permission, so its own
@@ -623,12 +732,12 @@ export class DaemonServer {
     } else if (mode === "held") {
       connection.heldLeaseIds.add(grant.lease.id);
     }
-    return grant;
+    return this.#parseOutput(leaseRequest.output, grant, "lease.request");
   }
 
-  #list(payload: Record<string, unknown>): unknown {
+  #list(input: { readonly kind?: "devices" | "leases" | "rules" | undefined }): unknown {
     const snapshot = this.options.registry.snapshot;
-    switch (payload.kind) {
+    switch (input.kind) {
       case "leases":
         return snapshot.leases.map((lease) => this.#decorateLease(lease));
       case "rules":
@@ -636,8 +745,6 @@ export class DaemonServer {
       case "devices":
       case undefined:
         return snapshot.devices.map((device) => this.#decorateDevice(device));
-      default:
-        throw new ProtocolError("BAD_REQUEST", "list kind must be devices, leases, or rules");
     }
   }
 
@@ -669,6 +776,31 @@ export class DaemonServer {
   }
 
   /**
+   * Validates a handler's return value against its contract output schema before it goes on
+   * the wire. A mismatch here is always a daemon-side bug (the schema or the mapping is wrong,
+   * per the PR brief -- never loosen the schema to whatever happens to be emitted), so it is
+   * logged at error level with the full issue list, then rethrown as a plain `Error` (maps to
+   * `INTERNAL` in `errorCode`). Two things follow from throwing rather than silently coercing:
+   * a unit test that asserts a happy-path response fails loudly the moment a handler and its
+   * schema drift, and a production caller gets a controlled `INTERNAL` response instead of
+   * either a malformed payload or an unhandled exception tearing down the connection. `.parse`
+   * (not `.strict()`) is deliberately non-strict here: an additive field a handler starts
+   * returning before its schema is updated to include it is silently dropped, not a failure --
+   * only a missing/mistyped *declared* field is a bug worth failing loudly over.
+   */
+  #parseOutput<Output>(schema: z.ZodType<Output>, value: unknown, operationName: string): Output {
+    const result = schema.safeParse(value);
+    if (result.success) return result.data;
+    this.#logger.error("Operation output failed contract validation", {
+      operation: operationName,
+      issues: result.error.issues,
+    });
+    throw new Error(
+      `Internal: ${operationName} produced a response that does not match its contract output schema`,
+    );
+  }
+
+  /**
    * Adds a derived `lastHeartbeatAt` for held leases, without a new `LeaseRecord` field:
    * since `heartbeat()` writes through the registry, `ttlDeadline - heldTtlBackstopMs` is
    * exactly the moment of the most recent slide (or grant, if there hasn't been one yet).
@@ -693,15 +825,29 @@ export class DaemonServer {
     return { ...device, transitionAgeMs: this.options.clock.now() - enteredAt };
   }
 
-  async #pushProgress(socket: IpcConnection, progress: LeaseProgress): Promise<void> {
+  /** ADR §8: `progress` carries the originating request's frame id, so a client with more than
+   * one lease request in flight on the same connection can route each push to its own call. */
+  async #pushProgress(
+    socket: IpcConnection,
+    requestId: RequestId,
+    progress: LeaseProgress,
+  ): Promise<void> {
     return writeFrame(socket, {
       push: "progress",
-      payload: progress,
+      payload: this.#parseOutput(PUSH_SCHEMAS.progress, { requestId, progress }, "push:progress"),
     });
   }
 
-  async #pushEvent(socket: IpcConnection, event: EventEnvelope): Promise<void> {
-    await writeFrame(socket, { push: "event", payload: event });
+  /** ADR §8: `event` carries the subscribing connection's subscription id. */
+  async #pushEvent(
+    socket: IpcConnection,
+    subscriptionId: string,
+    event: EventEnvelope,
+  ): Promise<void> {
+    await writeFrame(socket, {
+      push: "event",
+      payload: this.#parseOutput(PUSH_SCHEMAS.event, { subscriptionId, event }, "push:event"),
+    });
   }
 
   /**
@@ -729,7 +875,14 @@ export class DaemonServer {
   }
 
   async #pushHeartbeat(socket: IpcConnection, nonce: number): Promise<void> {
-    await writeFrame(socket, { push: "lease.heartbeat", payload: { nonce } });
+    await writeFrame(socket, {
+      push: "lease.heartbeat",
+      payload: this.#parseOutput(
+        PUSH_SCHEMAS["lease.heartbeat"],
+        { nonce },
+        "push:lease.heartbeat",
+      ),
+    });
   }
 
   /**
@@ -769,7 +922,10 @@ export class DaemonServer {
     socket: IpcConnection,
     payload: { readonly deviceId: string; readonly leaseId: string; readonly reason: string },
   ): Promise<void> {
-    await writeFrame(socket, { push: "lease-lost", payload });
+    await writeFrame(socket, {
+      push: "lease-lost",
+      payload: this.#parseOutput(PUSH_SCHEMAS["lease-lost"], payload, "push:lease-lost"),
+    });
   }
 
   /**
@@ -798,7 +954,14 @@ export class DaemonServer {
     socket: IpcConnection,
     payload: { readonly deviceId: string; readonly leaseId: string; readonly reason: "crashed" },
   ): Promise<void> {
-    await writeFrame(socket, { push: "device-unhealthy", payload });
+    await writeFrame(socket, {
+      push: "device-unhealthy",
+      payload: this.#parseOutput(
+        PUSH_SCHEMAS["device-unhealthy"],
+        payload,
+        "push:device-unhealthy",
+      ),
+    });
   }
 
   /** Reacts to the post-commit `device.recovered` fact; observer-only, nothing awaits this. */
@@ -812,7 +975,14 @@ export class DaemonServer {
     socket: IpcConnection,
     payload: { readonly attempts: number; readonly deviceId: string; readonly leaseId: string },
   ): Promise<void> {
-    await writeFrame(socket, { push: "device-recovered", payload });
+    await writeFrame(socket, {
+      push: "device-recovered",
+      payload: this.#parseOutput(
+        PUSH_SCHEMAS["device-recovered"],
+        payload,
+        "push:device-recovered",
+      ),
+    });
   }
 
   async #respondError(
@@ -820,8 +990,13 @@ export class DaemonServer {
     id: RequestId | null,
     code: string,
     message: string,
+    details?: unknown,
   ): Promise<void> {
-    await writeFrame(socket, { error: { code, message }, id, ok: false });
+    await writeFrame(socket, {
+      error: { code, message, ...(details === undefined ? {} : { details }) },
+      id,
+      ok: false,
+    });
   }
 
   #closeConnection(connection: Connection): void {
@@ -896,67 +1071,37 @@ class StartupFailedError extends Error {
   }
 }
 
-function objectPayload(value: unknown): Record<string, unknown> {
-  if (!isObject(value)) {
-    throw new ProtocolError("BAD_REQUEST", "Payload must be an object");
+/**
+ * `doctor.run`/`nuke.run` used to throw a plain `new Error("... is unavailable")` when their
+ * optional collaborator was never wired up, which `errorCode()` had no choice but to map to
+ * `INTERNAL` -- indistinguishable from a real bug. Real, typed errors give these their own
+ * codes in the contract's closed set (`DOCTOR_UNAVAILABLE`/`NUKE_UNAVAILABLE`), per ADR §7 ("one
+ * error class, closed codes").
+ */
+class DoctorUnavailableError extends Error {
+  constructor() {
+    super("Doctor is unavailable");
+    this.name = "DoctorUnavailableError";
   }
-  return value;
 }
 
-function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+class NukeUnavailableError extends Error {
+  constructor() {
+    super("Nuke is unavailable");
+    this.name = "NukeUnavailableError";
+  }
 }
 
-function requiredString(payload: Record<string, unknown>, ...keys: string[]): string {
-  const value = optionalString(payload, ...keys);
-  if (value === undefined) {
-    throw new ProtocolError("BAD_REQUEST", `Missing required string: ${keys[0]}`);
-  }
-  return value;
-}
-
-function optionalString(payload: Record<string, unknown>, ...keys: string[]): string | undefined {
-  for (const key of keys) {
-    const value = payload[key];
-    if (typeof value === "string") {
-      return value;
-    }
-  }
-  return undefined;
-}
-
-function requiredNumber(payload: Record<string, unknown>, key: string): number {
-  const value = payload[key];
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    throw new ProtocolError("BAD_REQUEST", `Missing required number: ${key}`);
-  }
-  return value;
-}
-
-function optionalBoolean(payload: Record<string, unknown>, key: string): boolean | undefined {
-  const value = payload[key];
-  if (value === undefined) {
-    return undefined;
-  }
-  if (typeof value !== "boolean") {
-    throw new ProtocolError("BAD_REQUEST", `Expected boolean: ${key}`);
-  }
-  return value;
-}
-
-function requiredPlatform(payload: Record<string, unknown>): "ios" | "android" {
-  const platform = payload.platform;
-  if (platform !== "ios" && platform !== "android") {
-    throw new ProtocolError("BAD_REQUEST", "platform must be ios or android");
-  }
-  return platform;
-}
-
-function optionalPlatform(payload: Record<string, unknown>): "ios" | "android" | undefined {
-  if (payload.platform === undefined) {
-    return undefined;
-  }
-  return requiredPlatform(payload);
+/** Parses a request payload through its contract input schema, translating a validation
+ * failure into the daemon's own `ProtocolError("BAD_REQUEST", ...)` rather than letting a raw
+ * `ZodError` escape (its shape is not part of the wire contract). */
+function parseInput<Output>(schema: z.ZodType<Output>, value: unknown): Output {
+  const result = schema.safeParse(value);
+  if (result.success) return result.data;
+  const description = result.error.issues
+    .map((issue) => `${issue.path.length > 0 ? `${issue.path.join(".")}: ` : ""}${issue.message}`)
+    .join("; ");
+  throw new ProtocolError("BAD_REQUEST", description);
 }
 
 // fallow-ignore-next-line complexity -- preserves stable protocol error mapping.
@@ -993,6 +1138,12 @@ function errorCode(error: unknown): string {
   }
   if (error instanceof StartupFailedError) {
     return "DAEMON_STARTUP_FAILED";
+  }
+  if (error instanceof DoctorUnavailableError) {
+    return "DOCTOR_UNAVAILABLE";
+  }
+  if (error instanceof NukeUnavailableError) {
+    return "NUKE_UNAVAILABLE";
   }
   return "INTERNAL";
 }

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -398,8 +398,11 @@ class StubConnection implements DaemonConnection {
     for (const listener of this.#listeners) listener("lease-lost", payload);
   }
 
+  /** Wraps the given stage payload under `{requestId, progress}` -- ADR 0003 §8's push
+   * correlation shape -- so callers can keep passing the bare stage object. */
   pushProgress(payload: unknown): void {
-    for (const listener of this.#listeners) listener("progress", payload);
+    for (const listener of this.#listeners)
+      listener("progress", { progress: payload, requestId: "test-request" });
   }
 
   pushDeviceUnhealthy(payload: unknown): void {

--- a/src/mcp/session.test.ts
+++ b/src/mcp/session.test.ts
@@ -50,9 +50,10 @@ describe("McpSession", () => {
         payload: {
           allowDownload: false,
           mode: "held",
+          model: "iPhone 17 Pro",
           noWait: false,
+          platform: "ios",
           requesterId: "mcp-session-1",
-          request: { model: "iPhone 17 Pro", platform: "ios" },
         },
         type: "lease.request",
       },
@@ -77,10 +78,12 @@ describe("McpSession", () => {
       {
         payload: {
           allowDownload: false,
+          full: true,
           mode: "held",
+          model: "iPhone 17 Pro",
           noWait: false,
+          platform: "ios",
           requesterId: "mcp-session-1",
-          request: { full: true, model: "iPhone 17 Pro", platform: "ios" },
         },
         type: "lease.request",
       },
@@ -107,9 +110,11 @@ describe("McpSession", () => {
     expect(connection.requests[0]?.payload).toEqual({
       allowDownload: true,
       mode: "held",
+      model: "iPhone 17 Pro",
       noWait: true,
+      osVersion: "26.5",
+      platform: "ios",
       requesterId: "mcp-session-1",
-      request: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
       timeoutMs: 1_250,
     });
   });
@@ -1048,8 +1053,14 @@ class StubConnection implements DaemonConnection {
     for (const listener of this.#listeners) listener("device-recovered", payload);
   }
 
+  /**
+   * Wraps the given stage payload under `{requestId, progress}` -- ADR 0003 §8's push
+   * correlation shape (see `DaemonServer#pushProgress`) -- so callers can keep passing the bare
+   * stage object `parseRawLeaseProgress` ultimately unwraps this back to.
+   */
   pushProgress(payload: unknown): void {
-    for (const listener of this.#listeners) listener("progress", payload);
+    for (const listener of this.#listeners)
+      listener("progress", { progress: payload, requestId: "test-request" });
   }
 
   /**

--- a/src/mcp/session.ts
+++ b/src/mcp/session.ts
@@ -567,6 +567,13 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+/**
+ * Flat fields, not the legacy `device`/`os` aliases or a nested `request` wrapper -- the wire
+ * moved to protocol 3 with no compatibility shim (ADR 0003 "Consequences"). Deriving this from
+ * the contract's `lease.request` input schema (ADR 0003 §11: "MCP tool schemas are derived from
+ * the contract schemas") is PR 4's job; this is only the minimal payload-shape fix needed to
+ * keep MCP working against this PR's daemon.
+ */
 function daemonLeaseRequest(
   input: LeaseSimulatorInput,
   requesterId: string,
@@ -576,12 +583,10 @@ function daemonLeaseRequest(
     mode: "held",
     noWait: input.no_wait,
     requesterId,
-    request: {
-      model: input.device,
-      ...(input.os === undefined ? {} : { osVersion: input.os }),
-      platform: input.platform,
-      ...(input.full ? { full: true } : {}),
-    },
+    model: input.device,
+    ...(input.os === undefined ? {} : { osVersion: input.os }),
+    platform: input.platform,
+    ...(input.full ? { full: true } : {}),
     ...(input.timeout_seconds === undefined
       ? {}
       : { timeoutMs: timeoutMilliseconds(input.timeout_seconds) }),


### PR DESCRIPTION
**Stacked on #92.** PR 1 of 5 implementing ADR 0003 (§1, §6, §7, §8).

## What lands

**A contract module** (`src/contract/`) that imports nothing from `core`, `daemon`, `drivers`, `ports`, or any frontend — enforced by `boundary.test.ts`. This is what keeps core domain records (`DeviceRecord`, `LeaseRecord`, `LeaseGrant`) off the public package surface; the contract re-declares the fields it needs rather than importing the types.

- `defineOperation({ name, role, input, output, authorize? })`. Schemas are zod; public types are inferred, never written in parallel.
- All 21 operations from the ADR's §3 matrix are declared, including the three additions from §9 (`lease.cancel`, `lease.list`, `ttlMs` on `lease.request`). Operations whose handlers arrive in later PRs are declared now.
- `doctor.run`'s role is a **function of its input** (`fix ? "admin" : "agent"`) rather than an `authorize` hook — role and ownership are different gates, and collapsing them would make the matrix unreadable.
- A table-driven test asserts name→role against the ADR matrix, so forgetting a role is a test failure as well as a type error.
- Every server push from §8 declares its correlation key as **required**: `progress` now carries the originating frame id (today it carries none), lease-scoped pushes carry the lease id, `event` carries a subscription id.
- `SimlockError`: one class, closed code union, `details` narrowed per code, `kind` of `transport`/`protocol`/`domain`. CLI exit codes and HTTP statuses are columns on the same table. An unknown code from a newer daemon wraps as `UNKNOWN_DAEMON_ERROR` rather than throwing — deliberate, per §7.

**Protocol range negotiation** (§6). Protocol moves to 3. Both ends advertise `{min, max}` and take the highest overlap. The client also sends the legacy exact `protocolVersion`, so an old protocol-2 daemon still answers with its legacy mismatch, which maps to `PROTOCOL_VERSION_UNSUPPORTED` with the daemon range reported as `{2,2}`. A bare number is normalized to `{n,n}`. `daemon.stop` is a frozen exception accepted at any version — without it, an `npm upgrade` against a running old daemon could not be stopped without releasing every held lease on the machine. Mismatch never restarts the daemon.

**The daemon validates through the contract.** Every request payload and response in `DaemonServer` parses through its declared schemas; the hand-rolled `requiredString`/`optionalBoolean`/`requiredPlatform` helpers are gone.

## Deliberate wire breaks

The wire moves to protocol 3 with no compatibility shim (the ADR's own consequence — nobody consumes it yet):

- `lease.request` drops the `device`/`os` aliases and the nested `request` wrapper; the input is flat and `.strict()`.
- `progress` pushes become `{requestId, progress}`; `event` pushes become `{subscriptionId, event}`.
- `PROTOCOL_VERSION_MISMATCH` → `PROTOCOL_VERSION_UNSUPPORTED`.

CLI and MCP payload construction is updated minimally to keep the tree working end to end. Moving those frontends onto the typed client is PR 4, not this PR.

## Deliberately not in scope

The dispatcher, role *enforcement*, `authorize` hooks, `ownerId`, and the credential handshake are all PR 2. This PR declares roles; it does not enforce them.

## Known gaps carried forward

- `ttlMs` on `lease.request` is declared and validated (supplying it for a held lease is `BAD_REQUEST`) but not yet forwarded to core — `LeaseRequestOptions` has no such field. PR 2 wires it.
- Lease-scoped pushes still route via the old single-connection `heldLeaseIds` lookup rather than owner-based broadcast; that needs `ownerId` (PR 2).
- Bus event payloads are `z.unknown()` rather than ~30 redeclared `EventMap` shapes.

`typecheck`, `lint`, `format:check`, `typecheck:e2e`, `fallow audit` clean; 1052 unit tests pass.