### PR TITLE
feat(client): a typed, single-connection daemon client

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,16 @@
     "!dist/**/*.test.d.ts"
   ],
   "type": "module",
+  "exports": {
+    "./client": {
+      "types": "./dist/client/index.d.ts",
+      "default": "./dist/client/index.js"
+    },
+    "./admin": {
+      "types": "./dist/admin/index.d.ts",
+      "default": "./dist/admin/index.js"
+    }
+  },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "build:e2e": "tsc -p e2e/fake-driver/tsconfig.json",

--- a/src/admin/index.ts
+++ b/src/admin/index.ts
@@ -1,0 +1,89 @@
+/**
+ * `simlock/admin` (ADR 0003 §10). Extends `simlock/client`'s agent surface with the `admin`
+ * rows of ADR §3's operation matrix. The split from `simlock/client` is by import path only --
+ * the daemon's own role check is what actually stops an agent-role session from calling one of
+ * these; nothing here enforces roles client-side beyond simply not exposing the methods.
+ */
+import { NodeIpcTransport, type IpcConnection, type IpcConnector } from "../ports/index.js";
+import {
+  connectSimlockClient,
+  type ConnectOptions,
+  type SimlockAdminClient,
+} from "../simlock-client/client.js";
+
+export type {
+  AnySimlockError,
+  CatalogGetInput,
+  CatalogGetOutput,
+  CleanupRunInput,
+  CleanupRunOutput,
+  DaemonStopOutput,
+  DeviceRecoveredPush,
+  DeviceUnhealthyPush,
+  DoctorReport,
+  DoctorRunInput,
+  EventPush,
+  EventsReplayInput,
+  EventsReplayOutput,
+  EventsSubscribeOutput,
+  EventsUnsubscribeOutput,
+  LeaseCancelInput,
+  LeaseCancelOutput,
+  LeaseGrant,
+  LeaseHeartbeatOutput,
+  LeaseListOutput,
+  LeaseLostPush,
+  LeaseProgress,
+  LeaseReleaseAllOutput,
+  LeaseReleaseInput,
+  LeaseReleaseOutput,
+  LeaseRenewInput,
+  LeaseRecord,
+  LeaseRequestInput,
+  ListGetInput,
+  ListGetOutput,
+  NukeReport,
+  NukeRunInput,
+  RequestLeaseOptions,
+  SimlockAdminClient,
+  SimlockConfig,
+  SimlockErrorCode,
+  StatusGetOutput,
+  TokenCreateInput,
+  TokenCreateOutput,
+  TokenListOutput,
+  TokenRevokeInput,
+  TokenRevokeOutput,
+} from "../simlock-client/client.js";
+export { isSimlockError, SimlockError } from "../simlock-client/client.js";
+
+/** Same as `simlock/client`'s `ConnectSimlockOptions`, plus `credential` -- ADR §5's first
+ * resolution source ("the `credential` connect option (programmatic client)"). A missing or
+ * wrong credential fails the handshake with `ADMIN_AUTHENTICATION_FAILED` before any other
+ * request is ever sent on this connection. */
+export interface ConnectSimlockAdminOptions {
+  readonly connection?: IpcConnection;
+  readonly endpoint?: string;
+  readonly ipc?: IpcConnector;
+  readonly principal?: string;
+  readonly credential?: string;
+  readonly heartbeat?: boolean;
+}
+
+/** Opens one connection to the daemon and completes the `hello` handshake, requesting the
+ * admin role via `credential`. */
+export async function connectSimlockAdmin(
+  options: ConnectSimlockAdminOptions,
+): Promise<SimlockAdminClient> {
+  const resolved: ConnectOptions = {
+    ...(options.connection === undefined ? {} : { connection: options.connection }),
+    ...(options.connection === undefined
+      ? { connector: options.ipc ?? new NodeIpcTransport() }
+      : {}),
+    ...(options.endpoint === undefined ? {} : { endpoint: options.endpoint }),
+    ...(options.principal === undefined ? {} : { principal: options.principal }),
+    ...(options.credential === undefined ? {} : { credential: options.credential }),
+    ...(options.heartbeat === undefined ? {} : { heartbeat: options.heartbeat }),
+  };
+  return connectSimlockClient(resolved, true);
+}

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,0 +1,76 @@
+/**
+ * `simlock/client` (ADR 0003 §10). The one supported way for a host process to allocate
+ * devices over the daemon's unix socket without spawning a command. No reconnect, no retry --
+ * see `../simlock-client/client.ts`'s module comment for why.
+ *
+ * This module (and `simlock/admin`) is the entire public surface: everything it exports is
+ * derived from `src/contract`'s zod schemas, never a core-private type
+ * (`DeviceRecord`/`LeaseRecord`/`LeaseGrant`-the-core-type stay inside the daemon) -- see
+ * `no-core-leak.test.ts`.
+ */
+import { NodeIpcTransport, type IpcConnection, type IpcConnector } from "../ports/index.js";
+import {
+  connectSimlockClient,
+  type ConnectOptions,
+  type SimlockClient,
+} from "../simlock-client/client.js";
+
+export type {
+  AnySimlockError,
+  CatalogGetInput,
+  CatalogGetOutput,
+  DeviceRecoveredPush,
+  DeviceUnhealthyPush,
+  DoctorReport,
+  DoctorRunInput,
+  LeaseCancelInput,
+  LeaseCancelOutput,
+  LeaseGrant,
+  LeaseHeartbeatOutput,
+  LeaseListOutput,
+  LeaseLostPush,
+  LeaseProgress,
+  LeaseReleaseInput,
+  LeaseReleaseOutput,
+  LeaseRenewInput,
+  LeaseRecord,
+  LeaseRequestInput,
+  RequestLeaseOptions,
+  SimlockClient,
+  SimlockErrorCode,
+  StatusGetOutput,
+} from "../simlock-client/client.js";
+export { isSimlockError, SimlockError } from "../simlock-client/client.js";
+
+/** A caller-facing subset of `ConnectOptions` -- `credential` is deliberately not accepted
+ * here (ADR §10: "the split is by import path"). Use `connectSimlockAdmin` from
+ * `simlock/admin` for an admin-role connection. */
+export interface ConnectSimlockOptions {
+  /** A pre-connected transport -- mainly for tests (a scripted `IpcConnection`). Exactly one of
+   * `connection`/`endpoint` must be given. */
+  readonly connection?: IpcConnection;
+  /** The daemon's unix socket path. Connected via `ipc` (defaults to the real
+   * `NodeIpcTransport`) when `connection` is not given directly. */
+  readonly endpoint?: string;
+  readonly ipc?: IpcConnector;
+  readonly principal?: string;
+  readonly heartbeat?: boolean;
+}
+
+/** Opens one connection to the daemon and completes the `hello` handshake as an agent-role
+ * session. Rejects with a `SimlockError` (`PROTOCOL_VERSION_UNSUPPORTED`,
+ * `ADMIN_AUTHENTICATION_FAILED` never applies here since no credential is sent,
+ * `DAEMON_CONNECTION_LOST` if the socket cannot be reached) without ever restarting the
+ * daemon -- see `docs/adr/0003-...md` §6. */
+export async function connectSimlock(options: ConnectSimlockOptions): Promise<SimlockClient> {
+  const resolved: ConnectOptions = {
+    ...(options.connection === undefined ? {} : { connection: options.connection }),
+    ...(options.connection === undefined
+      ? { connector: options.ipc ?? new NodeIpcTransport() }
+      : {}),
+    ...(options.endpoint === undefined ? {} : { endpoint: options.endpoint }),
+    ...(options.principal === undefined ? {} : { principal: options.principal }),
+    ...(options.heartbeat === undefined ? {} : { heartbeat: options.heartbeat }),
+  };
+  return connectSimlockClient(resolved, false);
+}

--- a/src/client/smoke.test.ts
+++ b/src/client/smoke.test.ts
@@ -1,0 +1,62 @@
+/**
+ * ADR 0003 §12: "one smoke test per frontend (CLI, MCP, HTTP, client)". This walks
+ * `connectSimlock` end to end against a scripted connection: handshake, one full lease
+ * lifecycle (request -> grant -> release), and clean disconnect. It deliberately does not
+ * re-walk every operation -- `src/simlock-client/client.test.ts` already covers push routing,
+ * abort, and error mapping in depth; this file only proves the frontend wiring holds together.
+ */
+import { describe, expect, it } from "vitest";
+
+import { completeHello, ScriptedConnection } from "../simlock-client/test-support.js";
+import { connectSimlock } from "./index.js";
+
+describe("simlock/client smoke test", () => {
+  it("connects, requests a lease, and releases it", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection, principal: "agent-smoke" });
+    await Promise.resolve();
+    completeHello(connection, { role: "agent" });
+    const client = await connectPromise;
+    expect(client.role).toBe("agent");
+
+    const leasePromise = client.requestLease({ model: "iPhone 17", platform: "ios" });
+    await Promise.resolve();
+    const requestFrame = connection.lastSentOf("lease.request")!;
+    connection.reply(requestFrame.id, {
+      device: {
+        createdAt: 0,
+        driverData: null,
+        driverDeviceId: "sim-1",
+        id: "device_1",
+        spec: { model: "iPhone 17", osVersion: "18.0", platform: "ios" },
+        state: "leased",
+      },
+      lease: {
+        deviceId: "device_1",
+        grantedAt: 0,
+        id: "lease_1",
+        mode: "held",
+        ownerId: "agent-smoke",
+        requesterId: "agent-smoke",
+        ttlDeadline: 1_000,
+      },
+      timing: {
+        estimatedBootMs: 1,
+        estimatedProvisionMs: 1,
+        estimatedReadyMs: 1,
+        estimatedReclaimMs: 1,
+      },
+    });
+    const grant = await leasePromise;
+    expect(grant.lease.id).toBe("lease_1");
+
+    const releasePromise = client.releaseLease({ leaseId: grant.lease.id });
+    await Promise.resolve();
+    const releaseFrame = connection.lastSentOf("lease.release")!;
+    connection.reply(releaseFrame.id, { leaseId: "lease_1" });
+    await expect(releasePromise).resolves.toEqual({ leaseId: "lease_1" });
+
+    await client.close();
+    expect(connection.closed).toBe(true);
+  });
+});

--- a/src/contract/errors.ts
+++ b/src/contract/errors.ts
@@ -64,6 +64,12 @@ export interface ErrorDetailsMap {
    * daemon) wraps as this instead of throwing a parse failure. Never sent by a daemon this
    * version of the contract can produce -- purely a client-side wrapping target. */
   UNKNOWN_DAEMON_ERROR: { readonly code: string; readonly message: string };
+
+  /** ADR §10: the outcome `requestLease`'s `AbortSignal` surfaces for all four abort paths.
+   * Never sent by the daemon over the wire -- purely a client-side construction, the same way
+   * `UNKNOWN_DAEMON_ERROR` is. Kept in the closed set (rather than a separate ad hoc class) so
+   * callers can `isSimlockError(e) && e.code === "CANCELLED"` exactly like any other outcome. */
+  CANCELLED: Record<string, never>;
 }
 
 export type SimlockErrorCode = keyof ErrorDetailsMap;
@@ -156,6 +162,10 @@ export const ERROR_TABLE: { readonly [Code in SimlockErrorCode]: ErrorTableEntry
     cliExitCode: 1,
     httpStatus: 500,
   },
+  // Never sent over the wire (see the field comment on `ErrorDetailsMap.CANCELLED`); the
+  // `httpStatus` follows the conventional "client closed request" code even though HTTP never
+  // actually produces this error today.
+  CANCELLED: { code: "CANCELLED", kind: "domain", cliExitCode: 1, httpStatus: 499 },
 };
 
 /**

--- a/src/simlock-client/client.test.ts
+++ b/src/simlock-client/client.test.ts
@@ -1,0 +1,403 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { connectSimlockAdmin } from "../admin/index.js";
+import { connectSimlock } from "../client/index.js";
+import type { LeaseGrant } from "./types.js";
+import { completeHello, ScriptedConnection } from "./test-support.js";
+
+async function flushMicrotasks(times = 10): Promise<void> {
+  for (let index = 0; index < times; index += 1) await Promise.resolve();
+}
+
+function sampleGrant(
+  overrides: {
+    readonly leaseId?: string;
+    readonly deviceId?: string;
+    readonly mode?: "held" | "detached";
+  } = {},
+): LeaseGrant {
+  const leaseId = overrides.leaseId ?? "lease_1";
+  const deviceId = overrides.deviceId ?? "device_1";
+  return {
+    device: {
+      createdAt: 0,
+      driverData: null,
+      driverDeviceId: "sim-1",
+      id: deviceId,
+      spec: { model: "iPhone 17", osVersion: "18.0", platform: "ios" },
+      state: "leased",
+    },
+    lease: {
+      deviceId,
+      grantedAt: 0,
+      id: leaseId,
+      mode: overrides.mode ?? "held",
+      ownerId: "agent-1",
+      requesterId: "agent-1",
+      ttlDeadline: 1_000,
+    },
+    timing: {
+      estimatedBootMs: 1,
+      estimatedProvisionMs: 1,
+      estimatedReadyMs: 1,
+      estimatedReclaimMs: 1,
+    },
+  };
+}
+
+describe("connectSimlock: handshake", () => {
+  it("rejects a version mismatch before any other request is sent", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    const hello = connection.lastSentOf("hello");
+    expect(hello).toBeDefined();
+    connection.fail(hello!.id, "PROTOCOL_VERSION_UNSUPPORTED", "no overlap", {
+      client: { max: 3, min: 3 },
+      daemon: { max: 5, min: 5 },
+      daemonVersion: "9.9.9",
+    });
+
+    await expect(connectPromise).rejects.toMatchObject({
+      code: "PROTOCOL_VERSION_UNSUPPORTED",
+      details: { daemon: { max: 5, min: 5 }, daemonVersion: "9.9.9" },
+    });
+    expect(connection.sent).toHaveLength(1);
+  });
+
+  it("maps a legacy protocol-2 daemon's mismatch code onto the contract's shape", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    const hello = connection.lastSentOf("hello")!;
+    connection.fail(hello.id, "PROTOCOL_VERSION_MISMATCH", "old daemon says no");
+
+    await expect(connectPromise).rejects.toMatchObject({
+      code: "PROTOCOL_VERSION_UNSUPPORTED",
+      details: { daemon: { max: 2, min: 2 }, daemonVersion: "unknown" },
+    });
+    expect(connection.sent).toHaveLength(1);
+  });
+
+  it("a bad admin credential causes zero requests after hello", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlockAdmin({ connection, credential: "wrong" });
+    await flushMicrotasks();
+    const hello = connection.lastSentOf("hello")!;
+    expect((hello.payload as { credential?: string }).credential).toBe("wrong");
+    connection.fail(hello.id, "ADMIN_AUTHENTICATION_FAILED", "nope");
+
+    await expect(connectPromise).rejects.toMatchObject({ code: "ADMIN_AUTHENTICATION_FAILED" });
+    expect(connection.sent).toHaveLength(1);
+  });
+
+  it("agent role: a FORBIDDEN reply from the daemon surfaces as a typed error", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection, { role: "agent" });
+    const client = await connectPromise;
+
+    const callPromise = client.cancelLease();
+    await flushMicrotasks();
+    const call = connection.lastSentOf("lease.cancel")!;
+    connection.fail(call.id, "FORBIDDEN", "agents cannot do this");
+
+    await expect(callPromise).rejects.toMatchObject({ code: "FORBIDDEN", kind: "protocol" });
+  });
+
+  it("rejects client-side invalid input without sending a frame", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const before = connection.sent.length;
+    // `model` is required and non-empty per the contract's input schema.
+    await expect(client.requestLease({ model: "", platform: "ios" })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    });
+    expect(connection.sent).toHaveLength(before);
+  });
+
+  it("wraps a malformed daemon response instead of throwing a raw parse failure", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const callPromise = client.getCatalog();
+    await flushMicrotasks();
+    const call = connection.lastSentOf("catalog.get")!;
+    connection.reply(call.id, { notPlatforms: true });
+
+    await expect(callPromise).rejects.toMatchObject({ code: "BAD_FRAME" });
+  });
+
+  it("wraps an error code it does not recognize as UNKNOWN_DAEMON_ERROR", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const callPromise = client.getStatus();
+    await flushMicrotasks();
+    const call = connection.lastSentOf("status.get")!;
+    connection.fail(call.id, "SOME_FUTURE_CODE", "a newer daemon said so");
+
+    await expect(callPromise).rejects.toMatchObject({
+      code: "UNKNOWN_DAEMON_ERROR",
+      details: { code: "SOME_FUTURE_CODE" },
+    });
+  });
+});
+
+describe("connection death", () => {
+  it("rejects in-flight calls and fires onLeaseLost for held leases", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const leaseLost = vi.fn();
+    client.onLeaseLost(leaseLost);
+    const connectionLost = vi.fn();
+    client.onConnectionLost(connectionLost);
+
+    const grantPromise = client.requestLease({ model: "iPhone 17", platform: "ios" });
+    await flushMicrotasks();
+    const requestCall = connection.lastSentOf("lease.request")!;
+    connection.reply(requestCall.id, sampleGrant({ leaseId: "lease_held" }));
+    await grantPromise;
+
+    const statusPromise = client.getStatus();
+    await flushMicrotasks();
+
+    connection.simulateDeath();
+
+    await expect(statusPromise).rejects.toMatchObject({ code: "DAEMON_CONNECTION_LOST" });
+    expect(leaseLost).toHaveBeenCalledWith({
+      deviceId: "device_1",
+      leaseId: "lease_held",
+      reason: "daemon-connection-lost",
+    });
+    expect(connectionLost).toHaveBeenCalledTimes(1);
+
+    await expect(client.getStatus()).rejects.toMatchObject({ code: "DAEMON_CONNECTION_LOST" });
+    expect(connection.sent.filter((f) => f.type === "status.get")).toHaveLength(1);
+  });
+});
+
+describe("pushes", () => {
+  it("routes progress to the originating call and drops it once the call is no longer tracked", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const onProgress = vi.fn();
+    const grantPromise = client.requestLease(
+      { model: "iPhone 17", platform: "ios" },
+      { onProgress },
+    );
+    await flushMicrotasks();
+    const requestCall = connection.lastSentOf("lease.request")!;
+
+    // A push can arrive before the response to the request that caused it (ADR §8).
+    connection.push("progress", {
+      progress: { etaMs: 500, stage: "provisioning" },
+      requestId: requestCall.id,
+    });
+    connection.reply(requestCall.id, sampleGrant());
+    await grantPromise;
+
+    expect(onProgress).toHaveBeenCalledWith({ etaMs: 500, stage: "provisioning" });
+
+    // Dropped: no call is tracked under this id any more.
+    connection.push("progress", {
+      progress: { etaMs: 1, stage: "booting" },
+      requestId: requestCall.id,
+    });
+    expect(onProgress).toHaveBeenCalledTimes(1);
+  });
+
+  it("de-duplicates lease-scoped pushes by lease id", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const unhealthy = vi.fn();
+    client.onDeviceUnhealthy(unhealthy);
+
+    connection.push("device-unhealthy", {
+      deviceId: "device_1",
+      leaseId: "lease_1",
+      reason: "crashed",
+    });
+    connection.push("device-unhealthy", {
+      deviceId: "device_1",
+      leaseId: "lease_1",
+      reason: "crashed",
+    });
+
+    expect(unhealthy).toHaveBeenCalledTimes(1);
+  });
+
+  it("never fires onLeaseLost for a release this client itself asked for", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const leaseLost = vi.fn();
+    client.onLeaseLost(leaseLost);
+
+    const grantPromise = client.requestLease({ model: "iPhone 17", platform: "ios" });
+    await flushMicrotasks();
+    connection.reply(
+      connection.lastSentOf("lease.request")!.id,
+      sampleGrant({ leaseId: "lease_1" }),
+    );
+    await grantPromise;
+
+    const releasePromise = client.releaseLease({ leaseId: "lease_1" });
+    await flushMicrotasks();
+    const releaseCall = connection.lastSentOf("lease.release")!;
+    // The daemon pushes lease-lost for the same release the client itself just asked for --
+    // this must be swallowed, not surfaced.
+    connection.push("lease-lost", { deviceId: "device_1", leaseId: "lease_1", reason: "explicit" });
+    connection.reply(releaseCall.id, { leaseId: "lease_1" });
+    await releasePromise;
+
+    expect(leaseLost).not.toHaveBeenCalled();
+  });
+});
+
+describe("requestLease abort (ADR §10)", () => {
+  it("before the request is sent: rejects CANCELLED, nothing sent", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const controller = new AbortController();
+    controller.abort();
+    const before = connection.sent.length;
+
+    await expect(
+      client.requestLease({ model: "iPhone 17", platform: "ios" }, { signal: controller.signal }),
+    ).rejects.toMatchObject({ code: "CANCELLED" });
+    expect(connection.sent).toHaveLength(before);
+  });
+
+  it("while queued: sends lease.cancel, waits for the original to reject, surfaces CANCELLED", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const controller = new AbortController();
+    const leasePromise = client.requestLease(
+      { model: "iPhone 17", platform: "ios" },
+      { signal: controller.signal },
+    );
+    await flushMicrotasks();
+    const requestCall = connection.lastSentOf("lease.request")!;
+
+    controller.abort();
+    await flushMicrotasks();
+    const cancelCall = connection.lastSentOf("lease.cancel")!;
+    expect(cancelCall).toBeDefined();
+
+    connection.reply(cancelCall.id, { result: "cancelled" });
+    await flushMicrotasks();
+    connection.fail(requestCall.id, "QUEUE_TIMEOUT", "cancelled by request", { requestId: "r1" });
+
+    await expect(leasePromise).rejects.toMatchObject({ code: "CANCELLED" });
+  });
+
+  it("while device work is in flight: releases a grant that still arrives, then rejects CANCELLED", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const controller = new AbortController();
+    const leasePromise = client.requestLease(
+      { model: "iPhone 17", platform: "ios" },
+      { signal: controller.signal },
+    );
+    await flushMicrotasks();
+    const requestCall = connection.lastSentOf("lease.request")!;
+
+    controller.abort();
+    await flushMicrotasks();
+    const cancelCall = connection.lastSentOf("lease.cancel")!;
+    connection.reply(cancelCall.id, { result: "not-cancellable" });
+    await flushMicrotasks();
+
+    connection.reply(requestCall.id, sampleGrant({ leaseId: "lease_abandoned" }));
+    await flushMicrotasks();
+    const releaseCall = connection.lastSentOf("lease.release")!;
+    expect(releaseCall).toBeDefined();
+    expect((releaseCall.payload as { leaseId: string }).leaseId).toBe("lease_abandoned");
+    connection.reply(releaseCall.id, { leaseId: "lease_abandoned" });
+
+    await expect(leasePromise).rejects.toMatchObject({ code: "CANCELLED" });
+  });
+
+  it("after the grant resolved: abort is ignored", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const controller = new AbortController();
+    const leasePromise = client.requestLease(
+      { model: "iPhone 17", platform: "ios" },
+      { signal: controller.signal },
+    );
+    await flushMicrotasks();
+    const requestCall = connection.lastSentOf("lease.request")!;
+    connection.reply(requestCall.id, sampleGrant({ leaseId: "lease_kept" }));
+
+    const grant = await leasePromise;
+    expect(grant.lease.id).toBe("lease_kept");
+
+    const before = connection.sent.length;
+    controller.abort();
+    await flushMicrotasks();
+
+    // No lease.cancel was ever sent for an already-resolved request.
+    expect(connection.sent).toHaveLength(before);
+  });
+});
+
+describe("simlock/admin", () => {
+  it("exposes the admin operations and sends daemon.stop like any other request", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlockAdmin({ connection, credential: "operator-secret" });
+    await flushMicrotasks();
+    completeHello(connection, { role: "admin" });
+    const admin = await connectPromise;
+    expect(admin.role).toBe("admin");
+
+    const stopPromise = admin.stopDaemon();
+    await flushMicrotasks();
+    const stopCall = connection.lastSentOf("daemon.stop")!;
+    connection.reply(stopCall.id, { stopping: true });
+    await expect(stopPromise).resolves.toEqual({ stopping: true });
+  });
+});

--- a/src/simlock-client/client.ts
+++ b/src/simlock-client/client.ts
@@ -1,0 +1,598 @@
+/**
+ * The typed client (ADR 0003 §10): one connection, methods derived from the contract, and one
+ * stateful behaviour -- abort. `connectSimlock`/`connectSimlockAdmin` (the two public entry
+ * points, `../client/index.ts` and `../admin/index.ts`) both funnel through
+ * `connectSimlockClient` here; the split between them is only which type the caller gets back
+ * and whether a `credential` is accepted, exactly as the ADR specifies ("the split is by
+ * import path; the enforcement is the daemon's role check").
+ *
+ * This class does not reconnect and does not retry, not even for reads (ADR §10): a dead
+ * connection ends the client for good, and every in-flight call rejects with
+ * `DAEMON_CONNECTION_LOST` rather than being silently queued for a retry that would need a
+ * whole second policy (and would make "reconnecting never implicitly acquires a device" a
+ * claim this module could no longer prove).
+ */
+import type { z } from "zod";
+
+import {
+  fromWireError,
+  isSimlockError,
+  OPERATIONS,
+  SimlockError,
+  type AnySimlockError,
+  type OperationName,
+  type Role,
+} from "../contract/index.js";
+import type { IpcConnection, IpcConnector } from "../ports/index.js";
+import { SimlockWire, WireCallError, type LeaseScopedPush } from "./wire.js";
+import type {
+  CatalogGetInput,
+  CatalogGetOutput,
+  CleanupRunInput,
+  CleanupRunOutput,
+  DaemonStopOutput,
+  DeviceRecoveredPush,
+  DeviceUnhealthyPush,
+  DoctorReport,
+  DoctorRunInput,
+  EventPush,
+  EventsReplayInput,
+  EventsReplayOutput,
+  LeaseCancelInput,
+  LeaseCancelOutput,
+  LeaseGrant,
+  LeaseHeartbeatOutput,
+  LeaseListOutput,
+  LeaseLostPush,
+  LeaseProgress,
+  LeaseReleaseAllOutput,
+  LeaseReleaseInput,
+  LeaseReleaseOutput,
+  LeaseRenewInput,
+  LeaseRecord,
+  LeaseRequestInput,
+  ListGetInput,
+  ListGetOutput,
+  NukeReport,
+  NukeRunInput,
+  RequestLeaseOptions,
+  SimlockConfig,
+  StatusGetOutput,
+  TokenCreateInput,
+  TokenCreateOutput,
+  TokenListOutput,
+  TokenRevokeInput,
+  TokenRevokeOutput,
+} from "./types.js";
+
+export type {
+  CatalogGetInput,
+  CatalogGetOutput,
+  CleanupRunInput,
+  CleanupRunOutput,
+  DaemonStopOutput,
+  DeviceRecoveredPush,
+  DeviceUnhealthyPush,
+  DoctorReport,
+  DoctorRunInput,
+  EventPush,
+  EventsReplayInput,
+  EventsReplayOutput,
+  EventsSubscribeOutput,
+  EventsUnsubscribeOutput,
+  LeaseCancelInput,
+  LeaseCancelOutput,
+  LeaseGrant,
+  LeaseHeartbeatOutput,
+  LeaseListOutput,
+  LeaseLostPush,
+  LeaseProgress,
+  LeaseReleaseAllOutput,
+  LeaseReleaseInput,
+  LeaseReleaseOutput,
+  LeaseRenewInput,
+  LeaseRecord,
+  LeaseRequestInput,
+  ListGetInput,
+  ListGetOutput,
+  NukeReport,
+  NukeRunInput,
+  RequestLeaseOptions,
+  SimlockConfig,
+  StatusGetOutput,
+  TokenCreateInput,
+  TokenCreateOutput,
+  TokenListOutput,
+  TokenRevokeInput,
+  TokenRevokeOutput,
+} from "./types.js";
+export {
+  isSimlockError,
+  SimlockError,
+  type AnySimlockError,
+  type SimlockErrorCode,
+} from "../contract/index.js";
+
+export interface ConnectOptions {
+  /** Pre-connected transport (a scripted `IpcConnection` in tests, or the real result of an
+   * `IpcConnector`). Exactly one of `connection`/`connector` must be given. */
+  readonly connection?: IpcConnection;
+  /** A connector plus its endpoint -- the normal production path (`NodeIpcTransport` +
+   * a socket path). */
+  readonly connector?: IpcConnector;
+  readonly endpoint?: string;
+  /** ADR §4: the connection's fixed principal. Defaults to whatever the daemon assigns when
+   * omitted (today: its own default requester id). */
+  readonly principal?: string;
+  /** ADR §5's first credential source in the resolution order: "the `credential` connect
+   * option (programmatic client)". Only meaningful via `connectSimlockAdmin` -- the base
+   * `connectSimlock` does not accept one, by design (ADR §10: "the split is by import path"). */
+  readonly credential?: string;
+  /** Declares heartbeat support at `hello`; defaults to `true` so held leases keep sliding
+   * without the caller doing anything. */
+  readonly heartbeat?: boolean;
+}
+
+/** The full agent-visible method surface (ADR §3's operation matrix, `agent` rows) plus the
+ * pushes and lifecycle every frontend needs. `simlock/admin`'s `SimlockAdminClient` extends
+ * this with the `admin` rows. */
+export interface SimlockClient {
+  readonly principal: string;
+  readonly role: Role;
+  readonly daemonVersion: string;
+
+  getCatalog(input?: CatalogGetInput): Promise<CatalogGetOutput>;
+  getStatus(): Promise<StatusGetOutput>;
+  requestLease(input: LeaseRequestInput, options?: RequestLeaseOptions): Promise<LeaseGrant>;
+  cancelLease(input?: LeaseCancelInput): Promise<LeaseCancelOutput>;
+  renewLease(input: LeaseRenewInput): Promise<LeaseRecord>;
+  releaseLease(input: LeaseReleaseInput): Promise<LeaseReleaseOutput>;
+  listLeases(): Promise<LeaseListOutput>;
+  heartbeat(): Promise<LeaseHeartbeatOutput>;
+  runDoctor(input?: DoctorRunInput): Promise<DoctorReport>;
+
+  onLeaseLost(listener: (push: LeaseLostPush) => void): () => void;
+  onDeviceUnhealthy(listener: (push: DeviceUnhealthyPush) => void): () => void;
+  onDeviceRecovered(listener: (push: DeviceRecoveredPush) => void): () => void;
+  /** Fires exactly once, when the connection dies for any reason (including a deliberate
+   * `close()`). Every in-flight call has already rejected `DAEMON_CONNECTION_LOST` and every
+   * `onLeaseLost` for a held lease has already fired by the time this listener runs. */
+  onConnectionLost(listener: (error: AnySimlockError) => void): () => void;
+
+  close(): Promise<void>;
+}
+
+/** `simlock/admin`'s extension: the `admin` rows of ADR §3's matrix. */
+export interface SimlockAdminClient extends SimlockClient {
+  releaseAllLeases(): Promise<LeaseReleaseAllOutput>;
+  list(input?: ListGetInput): Promise<ListGetOutput>;
+  runCleanup(input?: CleanupRunInput): Promise<CleanupRunOutput>;
+  runNuke(input?: NukeRunInput): Promise<NukeReport>;
+  getConfig(): Promise<SimlockConfig>;
+  /** ADR §6's frozen exception: accepted by the daemon at any protocol version it has ever
+   * spoken, even before `hello`/role resolve. Exposed here rather than on the base client
+   * purely as an API-surface choice matching the ADR's operation matrix (the daemon itself
+   * does not gate this operation by role at all -- see the caveat in the PR report). */
+  stopDaemon(): Promise<DaemonStopOutput>;
+  replayEvents(input?: EventsReplayInput): Promise<EventsReplayOutput>;
+  subscribeEvents(listener: (event: EventPush) => void): Promise<() => Promise<void>>;
+  createToken(input: TokenCreateInput): Promise<TokenCreateOutput>;
+  listTokens(): Promise<TokenListOutput>;
+  revokeToken(input: TokenRevokeInput): Promise<TokenRevokeOutput>;
+}
+
+/** Internal: builds either client. `admin` toggles only which methods the returned object
+ * carries (an object literal with/without the extra methods) -- the daemon's own role check is
+ * what actually stops an agent-role session from calling one of them; this flag exists purely
+ * so `simlock/client` doesn't even show the admin methods in a caller's editor. */
+export async function connectSimlockClient(
+  options: ConnectOptions,
+  admin: false,
+): Promise<SimlockClient>;
+export async function connectSimlockClient(
+  options: ConnectOptions,
+  admin: true,
+): Promise<SimlockAdminClient>;
+export async function connectSimlockClient(
+  options: ConnectOptions,
+  admin: boolean,
+): Promise<SimlockClient | SimlockAdminClient> {
+  const connection = await resolveConnection(options);
+  const wire = new SimlockWire(connection);
+  let hello: Awaited<ReturnType<SimlockWire["hello"]>>;
+  try {
+    hello = await wire.hello({
+      ...(options.principal === undefined ? {} : { principal: options.principal }),
+      ...(options.credential === undefined ? {} : { credential: options.credential }),
+      capabilities: { heartbeat: options.heartbeat ?? true },
+    });
+  } catch (error: unknown) {
+    await connection.close();
+    throw error;
+  }
+  const impl = new SimlockClientImpl(
+    wire,
+    hello.role,
+    options.principal ?? "",
+    hello.daemonVersion,
+  );
+  return admin ? impl.asAdmin() : impl;
+}
+
+async function resolveConnection(options: ConnectOptions): Promise<IpcConnection> {
+  if (options.connection !== undefined) return options.connection;
+  if (options.connector !== undefined && options.endpoint !== undefined) {
+    return options.connector.connect(options.endpoint);
+  }
+  throw new Error(
+    "connectSimlock requires either `connection` (a pre-connected transport) or both `connector` and `endpoint`",
+  );
+}
+
+/**
+ * The single implementation both `SimlockClient` and `SimlockAdminClient` are backed by --
+ * `asAdmin()` returns the same instance typed with the extra methods, since every admin
+ * operation is a plain operation call like any other and there is nothing role-specific to
+ * duplicate. Held-lease bookkeeping (`#heldLeaseIds`) exists for exactly one reason: so a
+ * connection death can synthesize `onLeaseLost` for each lease this client held, per ADR §10.
+ */
+class SimlockClientImpl {
+  readonly #wire: SimlockWire;
+  readonly #heldLeaseIds = new Map<string, string>(); // leaseId -> deviceId
+  readonly #leaseLostListeners = new Set<(push: LeaseLostPush) => void>();
+  readonly #deviceUnhealthyListeners = new Set<(push: DeviceUnhealthyPush) => void>();
+  readonly #deviceRecoveredListeners = new Set<(push: DeviceRecoveredPush) => void>();
+  readonly #connectionLostListeners = new Set<(error: AnySimlockError) => void>();
+  #eventSubscriptionId: string | undefined;
+
+  constructor(
+    wire: SimlockWire,
+    readonly role: Role,
+    readonly principal: string,
+    readonly daemonVersion: string,
+  ) {
+    this.#wire = wire;
+    wire.onLeaseScopedPush((push) => this.#handleLeaseScopedPush(push));
+    wire.onDeath((error) => this.#handleConnectionLost(error));
+  }
+
+  asAdmin(): SimlockAdminClient {
+    // `this` already implements every method the interface below needs (see the class body) --
+    // this cast documents that the split is purely at the type layer.
+    return this as unknown as SimlockAdminClient;
+  }
+
+  // ---- agent-visible operations --------------------------------------------------------------
+
+  getCatalog(input: CatalogGetInput = {}): Promise<CatalogGetOutput> {
+    return this.#call("catalog.get", input);
+  }
+
+  getStatus(): Promise<StatusGetOutput> {
+    return this.#call("status.get", {});
+  }
+
+  async requestLease(
+    input: LeaseRequestInput,
+    options: RequestLeaseOptions = {},
+  ): Promise<LeaseGrant> {
+    const parsed = this.#parseInput("lease.request", input);
+    const requesterId = parsed.requesterId ?? this.principal;
+    const { signal, onProgress } = options;
+
+    if (signal?.aborted === true) throw cancelledError();
+
+    const requestPromise = this.#callRaw("lease.request", parsed, onProgress).then((grant) => {
+      this.#trackGrant(grant as LeaseGrant);
+      return grant as LeaseGrant;
+    });
+
+    if (signal === undefined) return requestPromise;
+    return this.#requestLeaseWithAbort(requestPromise, signal, requesterId);
+  }
+
+  cancelLease(input: LeaseCancelInput = {}): Promise<LeaseCancelOutput> {
+    return this.#call("lease.cancel", input);
+  }
+
+  renewLease(input: LeaseRenewInput): Promise<LeaseRecord> {
+    return this.#call("lease.renew", input);
+  }
+
+  async releaseLease(input: LeaseReleaseInput): Promise<LeaseReleaseOutput> {
+    const parsed = this.#parseInput("lease.release", input);
+    this.#wire.markSelfInitiatedRelease(parsed.leaseId);
+    const result = await this.#call("lease.release", parsed);
+    this.#heldLeaseIds.delete(parsed.leaseId);
+    return result;
+  }
+
+  listLeases(): Promise<LeaseListOutput> {
+    return this.#call("lease.list", {});
+  }
+
+  heartbeat(): Promise<LeaseHeartbeatOutput> {
+    return this.#call("lease.heartbeat", {});
+  }
+
+  runDoctor(input: DoctorRunInput = {}): Promise<DoctorReport> {
+    return this.#call("doctor.run", input);
+  }
+
+  onLeaseLost(listener: (push: LeaseLostPush) => void): () => void {
+    this.#leaseLostListeners.add(listener);
+    return () => this.#leaseLostListeners.delete(listener);
+  }
+
+  onDeviceUnhealthy(listener: (push: DeviceUnhealthyPush) => void): () => void {
+    this.#deviceUnhealthyListeners.add(listener);
+    return () => this.#deviceUnhealthyListeners.delete(listener);
+  }
+
+  onDeviceRecovered(listener: (push: DeviceRecoveredPush) => void): () => void {
+    this.#deviceRecoveredListeners.add(listener);
+    return () => this.#deviceRecoveredListeners.delete(listener);
+  }
+
+  onConnectionLost(listener: (error: AnySimlockError) => void): () => void {
+    this.#connectionLostListeners.add(listener);
+    return () => this.#connectionLostListeners.delete(listener);
+  }
+
+  async close(): Promise<void> {
+    await this.#wire.close();
+  }
+
+  // ---- admin-only operations ------------------------------------------------------------------
+
+  releaseAllLeases(): Promise<LeaseReleaseAllOutput> {
+    for (const leaseId of this.#heldLeaseIds.keys()) this.#wire.markSelfInitiatedRelease(leaseId);
+    return this.#call("lease.release-all", {}).then((result) => {
+      this.#heldLeaseIds.clear();
+      return result;
+    });
+  }
+
+  list(input: ListGetInput = {}): Promise<ListGetOutput> {
+    return this.#call("list.get", input);
+  }
+
+  runCleanup(input: CleanupRunInput = {}): Promise<CleanupRunOutput> {
+    return this.#call("cleanup.run", input);
+  }
+
+  runNuke(input: NukeRunInput = {}): Promise<NukeReport> {
+    return this.#call("nuke.run", input);
+  }
+
+  getConfig(): Promise<SimlockConfig> {
+    return this.#call("config.get", {});
+  }
+
+  stopDaemon(): Promise<DaemonStopOutput> {
+    return this.#call("daemon.stop", {});
+  }
+
+  replayEvents(input: EventsReplayInput = {}): Promise<EventsReplayOutput> {
+    return this.#call("events.replay", input);
+  }
+
+  async subscribeEvents(listener: (event: EventPush) => void): Promise<() => Promise<void>> {
+    const unsubscribePush = this.#wire.onEvent((payload) => listener(payload as EventPush));
+    const result = await this.#call("events.subscribe", {});
+    this.#eventSubscriptionId = result.subscriptionId;
+    return async () => {
+      unsubscribePush();
+      if (this.#eventSubscriptionId === undefined) return;
+      this.#eventSubscriptionId = undefined;
+      await this.#call("events.unsubscribe", {});
+    };
+  }
+
+  createToken(input: TokenCreateInput): Promise<TokenCreateOutput> {
+    return this.#call("token.create", input);
+  }
+
+  listTokens(): Promise<TokenListOutput> {
+    return this.#call("token.list", {});
+  }
+
+  revokeToken(input: TokenRevokeInput): Promise<TokenRevokeOutput> {
+    return this.#call("token.revoke", input);
+  }
+
+  // ---- abort (ADR §10) ------------------------------------------------------------------------
+
+  /**
+   * The four behaviours, all funneled through one function once we know the request was sent
+   * and a signal was given:
+   *
+   * - already resolved by the time abort fires -> `#requestDone` guards the raw promise's own
+   *   `.then` from resolving twice; the abort handler itself never runs any cancellation logic
+   *   because `#requestDone` is also checked there.
+   * - queued / in-flight / not-found are all resolved by `#cancelOnAbort`, driven entirely by
+   *   `lease.cancel`'s own three-way result.
+   */
+  #requestLeaseWithAbort(
+    requestPromise: Promise<LeaseGrant>,
+    signal: AbortSignal,
+    requesterId: string,
+  ): Promise<LeaseGrant> {
+    return new Promise((resolve, reject) => {
+      let requestDone = false;
+      let aborted = false;
+
+      const onAbort = (): void => {
+        if (requestDone) return; // after the grant resolved (or it already failed) -> ignored.
+        aborted = true;
+        void this.#cancelOnAbort(requestPromise, requesterId).then(resolve, reject);
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+
+      requestPromise.then(
+        (grant) => {
+          requestDone = true;
+          signal.removeEventListener("abort", onAbort);
+          if (!aborted) resolve(grant);
+        },
+        (error: unknown) => {
+          requestDone = true;
+          signal.removeEventListener("abort", onAbort);
+          if (!aborted) reject(error as Error);
+        },
+      );
+    });
+  }
+
+  async #cancelOnAbort(
+    requestPromise: Promise<LeaseGrant>,
+    requesterId: string,
+  ): Promise<LeaseGrant> {
+    let outcome: LeaseCancelOutput["result"];
+    try {
+      outcome = (await this.#call("lease.cancel", { requesterId })).result;
+    } catch {
+      // The connection itself may have died mid-cancel; fall through and let awaiting
+      // `requestPromise` below surface whatever that produces (most likely
+      // `DAEMON_CONNECTION_LOST`, which is a more accurate rejection than a manufactured
+      // `CANCELLED` would be here).
+      return requestPromise;
+    }
+
+    if (outcome === "not-found") {
+      // Either genuinely never existed, or -- per ADR §10's fourth case -- the grant already
+      // resolved before the cancel reached the daemon: "after the grant resolved -> ignored".
+      // Both cases defer entirely to the original outcome.
+      return requestPromise;
+    }
+
+    if (outcome === "cancelled") {
+      // Queued: the daemon rejects the original waiter; wait for that, then surface CANCELLED
+      // regardless of the rejection's own code/message.
+      await requestPromise.catch(() => undefined);
+      throw cancelledError();
+    }
+
+    // "not-cancellable": device work already in flight. Wait for the outcome; a grant that
+    // still arrives is abandoned immediately so the caller never holds a lease it walked away
+    // from, then CANCELLED is surfaced either way.
+    try {
+      const grant = await requestPromise;
+      await this.#releaseAbandonedGrant(grant);
+    } catch {
+      // The request failed on its own (e.g. ran out of capacity mid-flight) -- nothing to
+      // release, and CANCELLED is still the right thing to tell a caller who asked to abort.
+    }
+    throw cancelledError();
+  }
+
+  async #releaseAbandonedGrant(grant: LeaseGrant): Promise<void> {
+    try {
+      await this.releaseLease({ leaseId: grant.lease.id });
+    } catch {
+      // Best-effort: the caller already gets CANCELLED either way. A failed release here means
+      // the daemon may still show the lease held -- see the PR report's weak-spots list.
+    }
+  }
+
+  // ---- pushes -----------------------------------------------------------------------------
+
+  #handleLeaseScopedPush(push: LeaseScopedPush): void {
+    switch (push.kind) {
+      case "lease-lost":
+        this.#heldLeaseIds.delete(push.leaseId);
+        for (const listener of this.#leaseLostListeners) {
+          listener({ deviceId: push.deviceId, leaseId: push.leaseId, reason: push.reason });
+        }
+        return;
+      case "device-unhealthy":
+        for (const listener of this.#deviceUnhealthyListeners) {
+          listener({ deviceId: push.deviceId, leaseId: push.leaseId });
+        }
+        return;
+      case "device-recovered":
+        for (const listener of this.#deviceRecoveredListeners) {
+          listener({ attempts: push.attempts, deviceId: push.deviceId, leaseId: push.leaseId });
+        }
+        return;
+    }
+  }
+
+  #handleConnectionLost(error: AnySimlockError): void {
+    const held = [...this.#heldLeaseIds.entries()];
+    this.#heldLeaseIds.clear();
+    for (const [leaseId, deviceId] of held) {
+      for (const listener of this.#leaseLostListeners) {
+        listener({ deviceId, leaseId, reason: "daemon-connection-lost" });
+      }
+    }
+    for (const listener of this.#connectionLostListeners) listener(error);
+  }
+
+  #trackGrant(grant: LeaseGrant): void {
+    if (grant.lease.mode === "held") this.#heldLeaseIds.set(grant.lease.id, grant.lease.deviceId);
+  }
+
+  // ---- call plumbing --------------------------------------------------------------------------
+
+  #parseInput<Name extends OperationName>(
+    name: Name,
+    input: unknown,
+  ): z.infer<(typeof OPERATIONS)[Name]["input"]> {
+    const result = OPERATIONS[name].input.safeParse(input);
+    if (result.success) return result.data;
+    const description = result.error.issues
+      .map((issue) => `${issue.path.length > 0 ? `${issue.path.join(".")}: ` : ""}${issue.message}`)
+      .join("; ");
+    throw new SimlockError("BAD_REQUEST", "protocol", description, {});
+  }
+
+  #parseOutput<Name extends OperationName>(
+    name: Name,
+    payload: unknown,
+  ): z.infer<(typeof OPERATIONS)[Name]["output"]> {
+    const result = OPERATIONS[name].output.safeParse(payload);
+    if (result.success) return result.data;
+    throw new SimlockError(
+      "BAD_FRAME",
+      "protocol",
+      `Daemon's ${name} response did not match the contract output schema`,
+      {},
+    );
+  }
+
+  async #call<Name extends OperationName>(
+    name: Name,
+    input: z.infer<(typeof OPERATIONS)[Name]["input"]>,
+  ): Promise<z.infer<(typeof OPERATIONS)[Name]["output"]>> {
+    const payload = await this.#callRaw(name, input);
+    return this.#parseOutput(name, payload);
+  }
+
+  #callRaw(
+    name: OperationName,
+    input: unknown,
+    onProgress?: (progress: LeaseProgress) => void,
+  ): Promise<unknown> {
+    const parsed = this.#parseInput(name, input);
+    return this.#wire.call(name, parsed, onProgress).catch((error: unknown) => {
+      throw toSimlockError(error);
+    });
+  }
+}
+
+function cancelledError(): SimlockError<"CANCELLED"> {
+  return new SimlockError("CANCELLED", "domain", "Lease request was cancelled", {});
+}
+
+function toSimlockError(error: unknown): AnySimlockError {
+  if (isSimlockError(error)) return error;
+  if (error instanceof WireCallError)
+    return fromWireError(error.code, error.message, error.details);
+  return new SimlockError(
+    "DAEMON_CONNECTION_LOST",
+    "transport",
+    error instanceof Error ? error.message : String(error),
+    {},
+  );
+}

--- a/src/simlock-client/no-core-leak.test.ts
+++ b/src/simlock-client/no-core-leak.test.ts
@@ -1,0 +1,112 @@
+/**
+ * ADR 0003 §10/PR description: "the public surface must expose contract types only -- core
+ * domain records (`DeviceRecord`, `LeaseRecord`, `LeaseGrant`) stay private". This compiles
+ * `simlock/client`'s and `simlock/admin`'s entry points with declaration-only emit (via a
+ * throwaway `tsc -p` invocation restricted to just those two root files, so only their actual
+ * import closure gets emitted -- not a shelled-out `pnpm run build` of the whole package, and
+ * not dependent on one having already run) and asserts none of the emitted `.d.ts` files ever
+ * import from `src/core`, `src/daemon`, `src/drivers`, `src/http`, `src/cli`, or `src/mcp`.
+ * Mirrors `src/contract/boundary.test.ts`'s source-text approach, but checked at the compiled
+ * public-surface boundary instead of the contract module's own imports -- the actual guarantee
+ * this test exists to prove is about what a *consumer* of the published package sees, which is
+ * the emitted declarations, not the source.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..", "..");
+
+const FORBIDDEN_IMPORT_SUBSTRINGS = [
+  "/core/",
+  "/daemon/",
+  "/daemon.js",
+  "/drivers/",
+  "/http/",
+  "/cli/",
+  "/mcp/",
+];
+
+let outDir: string;
+let dtsFiles: Array<{ readonly path: string; readonly contents: string }>;
+
+describe("public package surface (simlock/client, simlock/admin)", () => {
+  let tmpTsconfigPath: string;
+
+  beforeAll(() => {
+    outDir = mkdtempSync(join(tmpdir(), "simlock-surface-"));
+    // Written inside the repo root (not the tmp outDir) so `"types": ["node"]` and everything
+    // else in the extended `tsconfig.json` still resolves against this project's own
+    // `node_modules` -- TS resolves package/type-root lookups relative to the config file's own
+    // directory, not the directory of the config it extends.
+    tmpTsconfigPath = join(repoRoot, ".simlock-surface-tsconfig.json");
+    writeFileSync(
+      tmpTsconfigPath,
+      JSON.stringify({
+        extends: "./tsconfig.json",
+        compilerOptions: { declaration: true, emitDeclarationOnly: true, outDir },
+        files: ["src/client/index.ts", "src/admin/index.ts"],
+        include: [],
+      }),
+    );
+    const tscBin = join(repoRoot, "node_modules", ".bin", "tsc");
+    execFileSync(tscBin, ["-p", tmpTsconfigPath], { cwd: repoRoot, stdio: "pipe" });
+    dtsFiles = collectDtsFiles(outDir).map((path) => ({
+      contents: readFileSync(path, "utf8"),
+      path,
+    }));
+  }, 60_000);
+
+  afterAll(() => {
+    rmSync(outDir, { force: true, recursive: true });
+    rmSync(tmpTsconfigPath, { force: true });
+  });
+
+  it("compiles both entry points and emits declarations for each", () => {
+    expect(dtsFiles.some((file) => file.path.endsWith(join("client", "index.d.ts")))).toBe(true);
+    expect(dtsFiles.some((file) => file.path.endsWith(join("admin", "index.d.ts")))).toBe(true);
+  });
+
+  it("never imports a core/daemon/drivers-private module from the compiled public surface", () => {
+    expect(dtsFiles.length).toBeGreaterThan(0);
+    for (const file of dtsFiles) {
+      for (const specifier of importSpecifiers(file.contents)) {
+        for (const forbidden of FORBIDDEN_IMPORT_SUBSTRINGS) {
+          expect(
+            specifier.includes(forbidden),
+            `${file.path} imports "${specifier}", which references forbidden "${forbidden}"`,
+          ).toBe(false);
+        }
+      }
+    }
+  });
+});
+
+/** Import/re-export specifiers only -- e.g. from `import("../core/index.js").Foo` or
+ * `export * from "./x.js"` -- deliberately not a plain substring scan of the whole file, which
+ * would false-positive on prose in a carried-over JSDoc comment (e.g. a `.d.ts` comment that
+ * merely *mentions* `src/http/errors.ts` in passing, as `errors.ts` does today). */
+function importSpecifiers(contents: string): string[] {
+  const specifiers: string[] = [];
+  const pattern = /(?:from\s+["']([^"']+)["']|import\(["']([^"']+)["']\))/g;
+  for (const match of contents.matchAll(pattern)) {
+    const specifier = match[1] ?? match[2];
+    if (specifier !== undefined) specifiers.push(specifier);
+  }
+  return specifiers;
+}
+
+function collectDtsFiles(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) results.push(...collectDtsFiles(full));
+    else if (entry.name.endsWith(".d.ts")) results.push(full);
+  }
+  return results;
+}

--- a/src/simlock-client/test-support.ts
+++ b/src/simlock-client/test-support.ts
@@ -1,0 +1,109 @@
+/**
+ * A scripted `IpcConnection` double for the typed client's unit tests (ADR §12: "client unit
+ * tests against a scripted connection"). Records every frame the client writes (so a test can
+ * assert exactly what was/wasn't sent -- the "zero requests after hello" and "mismatch rejected
+ * before any request" conditions need this) and lets a test script arbitrary success/error/push
+ * replies keyed by request id, or drive the connection dead on demand.
+ */
+import type { IpcConnection } from "../ports/index.js";
+
+export interface SentFrame {
+  readonly id: number | string;
+  readonly type: string;
+  readonly payload: unknown;
+}
+
+export class ScriptedConnection implements IpcConnection {
+  readonly sent: SentFrame[] = [];
+  #closed = false;
+  readonly #dataListeners = new Set<(chunk: string) => void>();
+  readonly #closeListeners = new Set<() => void>();
+  readonly #errorListeners = new Set<(error: Error) => void>();
+
+  get closed(): boolean {
+    return this.#closed;
+  }
+
+  onData(listener: (chunk: string) => void): () => void {
+    this.#dataListeners.add(listener);
+    return () => this.#dataListeners.delete(listener);
+  }
+
+  onClose(listener: () => void): () => void {
+    this.#closeListeners.add(listener);
+    return () => this.#closeListeners.delete(listener);
+  }
+
+  onError(listener: (error: Error) => void): () => void {
+    this.#errorListeners.add(listener);
+    return () => this.#errorListeners.delete(listener);
+  }
+
+  write(contents: string): Promise<void> {
+    for (const line of contents.split("\n")) {
+      if (line.trim() === "") continue;
+      const frame = JSON.parse(line) as { id: number | string; type: string; payload: unknown };
+      this.sent.push(frame);
+    }
+    return Promise.resolve();
+  }
+
+  close(): Promise<void> {
+    this.#simulateClose();
+    return Promise.resolve();
+  }
+
+  /** Feeds one JSON line to the client as if the daemon sent it. */
+  receive(frame: unknown): void {
+    for (const listener of this.#dataListeners) listener(`${JSON.stringify(frame)}\n`);
+  }
+
+  /** Replies success to the most recent (or a specific) sent frame id. */
+  reply(id: number | string, payload: unknown): void {
+    this.receive({ id, ok: true, payload });
+  }
+
+  fail(id: number | string, code: string, message = code, details?: unknown): void {
+    this.receive({ error: { code, details, message }, id, ok: false });
+  }
+
+  push(kind: string, payload: unknown): void {
+    this.receive({ payload, push: kind });
+  }
+
+  /** Finds the most recent sent frame of a given type, e.g. for auto-replying to `hello`. */
+  lastSentOf(type: string): SentFrame | undefined {
+    for (let index = this.sent.length - 1; index >= 0; index -= 1) {
+      const frame = this.sent[index];
+      if (frame !== undefined && frame.type === type) return frame;
+    }
+    return undefined;
+  }
+
+  /** Simulates the socket dying (not a graceful `close()`). */
+  simulateDeath(): void {
+    this.#simulateClose();
+  }
+
+  #simulateClose(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    for (const listener of this.#closeListeners) listener();
+  }
+}
+
+/** Replies to the connection's `hello` frame with a normal, matching-protocol, given-role
+ * response -- the common setup step for every test that needs a connected client. */
+export function completeHello(
+  connection: ScriptedConnection,
+  options: { readonly role?: "agent" | "admin"; readonly version?: string } = {},
+): void {
+  const hello = connection.lastSentOf("hello");
+  if (hello === undefined) throw new Error("Expected the client to have sent hello already");
+  connection.reply(hello.id, {
+    daemonProtocolRange: { max: 3, min: 3 },
+    protocolVersion: 3,
+    role: options.role ?? "agent",
+    version: options.version ?? "0.3.0",
+  });
+}

--- a/src/simlock-client/types.ts
+++ b/src/simlock-client/types.ts
@@ -1,0 +1,92 @@
+/**
+ * Public types for `simlock/client` and `simlock/admin` (ADR 0003 §10). Every type here is
+ * `z.infer`red from a contract schema (`src/contract/operations.ts`, `schemas.ts`, `pushes.ts`)
+ * rather than hand-declared, so a schema change is a compile-time type change here too, never a
+ * silent drift. Nothing in this file imports from `src/core`, `src/daemon`, or `src/drivers` --
+ * see `no-core-leak.test.ts`, which asserts the compiled `.d.ts` for these two entry points
+ * never mentions a core-private type name.
+ */
+import type { z } from "zod";
+
+import type { OPERATIONS, OperationName, PUSH_SCHEMAS } from "../contract/index.js";
+import type { leaseProgressSchema } from "../contract/schemas.js";
+
+type OpInput<Name extends OperationName> = z.infer<(typeof OPERATIONS)[Name]["input"]>;
+type OpOutput<Name extends OperationName> = z.infer<(typeof OPERATIONS)[Name]["output"]>;
+
+// ---- agent-visible operations -------------------------------------------------------------
+
+export type CatalogGetInput = OpInput<"catalog.get">;
+export type CatalogGetOutput = OpOutput<"catalog.get">;
+export type StatusGetOutput = OpOutput<"status.get">;
+export type LeaseRequestInput = OpInput<"lease.request">;
+/** `lease.request`'s output -- deliberately not named `LeaseRequestOutput` since it is the
+ * thing every frontend actually calls a "grant" (device + lease + timing estimates). */
+export type LeaseGrant = OpOutput<"lease.request">;
+export type LeaseCancelInput = OpInput<"lease.cancel">;
+export type LeaseCancelOutput = OpOutput<"lease.cancel">;
+export type LeaseRenewInput = OpInput<"lease.renew">;
+/** Also `lease.renew`'s output, and the element type of `lease.list`'s array -- one shape,
+ * reused wherever the contract reuses `leaseRecordSchema`. */
+export type LeaseRecord = OpOutput<"lease.renew">;
+export type LeaseReleaseInput = OpInput<"lease.release">;
+export type LeaseReleaseOutput = OpOutput<"lease.release">;
+export type LeaseListOutput = OpOutput<"lease.list">;
+export type LeaseHeartbeatOutput = OpOutput<"lease.heartbeat">;
+export type DoctorRunInput = OpInput<"doctor.run">;
+export type DoctorReport = OpOutput<"doctor.run">;
+
+// ---- admin-only operations ------------------------------------------------------------------
+
+export type LeaseReleaseAllOutput = OpOutput<"lease.release-all">;
+export type ListGetInput = OpInput<"list.get">;
+export type ListGetOutput = OpOutput<"list.get">;
+export type CleanupRunInput = OpInput<"cleanup.run">;
+export type CleanupRunOutput = OpOutput<"cleanup.run">;
+export type NukeRunInput = OpInput<"nuke.run">;
+export type NukeReport = OpOutput<"nuke.run">;
+export type SimlockConfig = OpOutput<"config.get">;
+export type DaemonStopOutput = OpOutput<"daemon.stop">;
+export type EventsReplayInput = OpInput<"events.replay">;
+export type EventsReplayOutput = OpOutput<"events.replay">;
+export type EventsSubscribeOutput = OpOutput<"events.subscribe">;
+export type EventsUnsubscribeOutput = OpOutput<"events.unsubscribe">;
+export type TokenCreateInput = OpInput<"token.create">;
+export type TokenCreateOutput = OpOutput<"token.create">;
+export type TokenListOutput = OpOutput<"token.list">;
+export type TokenRevokeInput = OpInput<"token.revoke">;
+export type TokenRevokeOutput = OpOutput<"token.revoke">;
+
+// ---- pushes ---------------------------------------------------------------------------------
+
+export type LeaseProgress = z.infer<typeof leaseProgressSchema>;
+export type EventPush = z.infer<(typeof PUSH_SCHEMAS)["event"]>;
+
+export interface LeaseLostPush {
+  readonly leaseId: string;
+  readonly deviceId: string;
+  /** A server-reported reason (`"expired"`, `"explicit"`, `"closed"`, ...) or, when this
+   * client's own connection died, the client-synthesized `"daemon-connection-lost"` (ADR
+   * §10). Not a closed enum on the wire, so kept as `string` here rather than invented. */
+  readonly reason: string;
+}
+
+export interface DeviceUnhealthyPush {
+  readonly leaseId: string;
+  readonly deviceId: string;
+}
+
+export interface DeviceRecoveredPush {
+  readonly leaseId: string;
+  readonly deviceId: string;
+  readonly attempts: number;
+}
+
+// ---- connect options --------------------------------------------------------------------------
+
+export interface RequestLeaseOptions {
+  /** ADR §10's one stateful client behaviour -- see `client.ts`'s `#requestLeaseWithAbort` for
+   * the four distinct behaviours this drives. */
+  readonly signal?: AbortSignal;
+  readonly onProgress?: (progress: LeaseProgress) => void;
+}

--- a/src/simlock-client/wire.ts
+++ b/src/simlock-client/wire.ts
@@ -1,0 +1,367 @@
+/**
+ * The typed client's wire layer (ADR 0003 §10). One connection, one frame-id space, no
+ * reconnect and no retry -- see the module comment on `client.ts` for the policy this
+ * implements. This file owns only framing, push routing, and connection-death handling; every
+ * typed method surface lives in `client.ts`.
+ */
+import type { IpcConnection } from "../ports/index.js";
+import {
+  fromWireError,
+  mapLegacyProtocolMismatch,
+  normalizeProtocolVersion,
+  PROTOCOL_VERSION_RANGE,
+  PUSH_SCHEMAS,
+  SimlockError,
+  helloReplySchema,
+  type AnySimlockError,
+  type ProtocolRange,
+  type Role,
+} from "../contract/index.js";
+import { parseDaemonResponse, serializeFrame } from "../daemon-protocol/index.js";
+import type { LeaseProgress } from "./types.js";
+
+/** The one legacy code a protocol-2 daemon answers `hello` with (see
+ * `src/daemon-client/startup-coordinator.ts`'s comment, the only place in this repo that names
+ * it -- there is no live protocol-2 daemon to negotiate with, so this constant documents a
+ * historical fact rather than something exercised against a real peer). */
+const LEGACY_MISMATCH_CODE = "PROTOCOL_VERSION_MISMATCH";
+
+export interface HelloOptions {
+  readonly principal?: string;
+  readonly credential?: string;
+  readonly capabilities?: { readonly heartbeat?: boolean };
+}
+
+export interface HelloResult {
+  readonly protocolVersion: number;
+  readonly daemonProtocolRange: ProtocolRange;
+  readonly daemonVersion: string;
+  readonly role: Role;
+}
+
+interface PendingCall {
+  readonly resolve: (payload: unknown) => void;
+  readonly reject: (error: Error) => void;
+  readonly onProgress?: ((progress: LeaseProgress) => void) | undefined;
+}
+
+export type LeaseScopedPush =
+  | {
+      readonly kind: "lease-lost";
+      readonly leaseId: string;
+      readonly deviceId: string;
+      readonly reason: string;
+    }
+  | { readonly kind: "device-unhealthy"; readonly leaseId: string; readonly deviceId: string }
+  | {
+      readonly kind: "device-recovered";
+      readonly leaseId: string;
+      readonly deviceId: string;
+      readonly attempts: number;
+    };
+
+/**
+ * Everything below `client.ts`'s typed method surface: frame ids, pending-call bookkeeping,
+ * push routing and de-duplication, and connection-death fan-out. Deliberately has no idea what
+ * a "lease" or a "grant" is beyond the push correlation keys the contract declares -- that
+ * vocabulary lives in `client.ts`.
+ */
+export class SimlockWire {
+  readonly #connection: IpcConnection;
+  readonly #pending = new Map<number, PendingCall>();
+  readonly #leaseScopedListeners = new Set<(push: LeaseScopedPush) => void>();
+  readonly #eventListeners = new Set<(payload: unknown) => void>();
+  readonly #closeListeners = new Set<(error: AnySimlockError) => void>();
+  /** Lease ids this client itself asked to release -- suppresses the matching `lease-lost`
+   * push exactly once (ADR §8: "never fires onLeaseLost for a release the same client asked
+   * for"), then is removed so a *later*, unrelated crash for a reused lease id is not silently
+   * eaten forever. */
+  readonly #selfInitiatedReleases = new Set<string>();
+  /** De-dup key (`${kind}:${leaseId}`) for lease-scoped pushes already delivered, so a
+   * redundant re-push (the owner-routed fan-out can in principle reach the same connection
+   * twice for one fact) does not fire a listener twice for the same fact. */
+  readonly #deliveredLeaseScoped = new Set<string>();
+  #buffer = "";
+  #nextId = 1;
+  #dead: AnySimlockError | undefined;
+
+  constructor(connection: IpcConnection) {
+    this.#connection = connection;
+    connection.onData((chunk) => this.#read(chunk));
+    connection.onError(() =>
+      this.#die(
+        new SimlockError("DAEMON_CONNECTION_LOST", "transport", "Daemon connection is closed", {}),
+      ),
+    );
+    connection.onClose(() =>
+      this.#die(
+        new SimlockError("DAEMON_CONNECTION_LOST", "transport", "Daemon connection closed", {}),
+      ),
+    );
+  }
+
+  /** Sends `hello` and returns its reply, or throws the contract's typed mismatch/auth error.
+   * Called exactly once, before any other frame -- see `client.ts`'s `connect*` functions. */
+  async hello(options: HelloOptions): Promise<HelloResult> {
+    let raw: unknown;
+    try {
+      raw = await this.#send("hello", {
+        clientVersion: "1.0.0",
+        protocolVersion: PROTOCOL_VERSION_RANGE.max,
+        protocolRange: PROTOCOL_VERSION_RANGE,
+        ...(options.principal === undefined ? {} : { principal: options.principal }),
+        ...(options.credential === undefined ? {} : { credential: options.credential }),
+        ...(options.capabilities === undefined ? {} : { capabilities: options.capabilities }),
+      });
+    } catch (error: unknown) {
+      throw this.#toHelloError(error);
+    }
+    const parsed = helloReplySchema.safeParse(raw);
+    if (!parsed.success) {
+      throw new SimlockError(
+        "BAD_FRAME",
+        "protocol",
+        "Daemon's hello reply did not match the protocol contract",
+        {},
+      );
+    }
+    return {
+      daemonProtocolRange: parsed.data.daemonProtocolRange,
+      daemonVersion: parsed.data.version,
+      protocolVersion: parsed.data.protocolVersion,
+      role: parsed.data.role,
+    };
+  }
+
+  #toHelloError(error: unknown): AnySimlockError {
+    if (!(error instanceof WireCallError)) {
+      return new SimlockError(
+        "DAEMON_CONNECTION_LOST",
+        "transport",
+        error instanceof Error ? error.message : String(error),
+        {},
+      );
+    }
+    if (error.code === LEGACY_MISMATCH_CODE) {
+      return mapLegacyProtocolMismatch(PROTOCOL_VERSION_RANGE, error.message);
+    }
+    if (error.code === "PROTOCOL_VERSION_UNSUPPORTED") {
+      const details = asRecord(error.details);
+      const client = asProtocolRange(details.client) ?? PROTOCOL_VERSION_RANGE;
+      const daemon = asProtocolRange(details.daemon);
+      if (daemon !== undefined) {
+        return new SimlockError("PROTOCOL_VERSION_UNSUPPORTED", "protocol", error.message, {
+          client,
+          daemon,
+          daemonVersion:
+            typeof details.daemonVersion === "string" ? details.daemonVersion : "unknown",
+        });
+      }
+    }
+    return fromWireError(error.code, error.message, error.details);
+  }
+
+  /** One request/response round trip for an already role/shape-agnostic operation name.
+   * `client.ts` is responsible for input/output schema validation; this only moves bytes and
+   * correlates frame ids. */
+  call(
+    type: string,
+    payload: unknown,
+    onProgress?: (progress: LeaseProgress) => void,
+  ): Promise<unknown> {
+    if (this.#dead !== undefined) return Promise.reject(this.#dead);
+    return this.#send(type, payload, onProgress);
+  }
+
+  onLeaseScopedPush(listener: (push: LeaseScopedPush) => void): () => void {
+    this.#leaseScopedListeners.add(listener);
+    return () => this.#leaseScopedListeners.delete(listener);
+  }
+
+  onEvent(listener: (payload: unknown) => void): () => void {
+    this.#eventListeners.add(listener);
+    return () => this.#eventListeners.delete(listener);
+  }
+
+  /** Fires exactly once, when this connection dies (socket close/error, or `close()`). */
+  onDeath(listener: (error: AnySimlockError) => void): () => void {
+    this.#closeListeners.add(listener);
+    return () => this.#closeListeners.delete(listener);
+  }
+
+  /** A lease this client itself is releasing: the next matching `lease-lost` push is
+   * swallowed rather than surfaced as a loss. */
+  markSelfInitiatedRelease(leaseId: string): void {
+    this.#selfInitiatedReleases.add(leaseId);
+  }
+
+  async close(): Promise<void> {
+    this.#die(
+      new SimlockError("DAEMON_CONNECTION_LOST", "transport", "Client closed the connection", {}),
+    );
+    await this.#connection.close();
+  }
+
+  #send(
+    type: string,
+    payload: unknown,
+    onProgress?: (progress: LeaseProgress) => void,
+  ): Promise<unknown> {
+    const id = this.#nextId++;
+    return new Promise((resolve, reject) => {
+      this.#pending.set(id, { onProgress, reject, resolve });
+      void this.#connection.write(serializeFrame({ id, payload, type })).catch((error: unknown) => {
+        this.#pending.delete(id);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      });
+    });
+  }
+
+  #read(chunk: string): void {
+    this.#buffer += chunk;
+    for (;;) {
+      const newline = this.#buffer.indexOf("\n");
+      if (newline < 0) return;
+      const line = this.#buffer.slice(0, newline);
+      this.#buffer = this.#buffer.slice(newline + 1);
+      if (line.trim() === "") continue;
+      let value: unknown;
+      try {
+        value = JSON.parse(line) as unknown;
+      } catch {
+        continue; // A malformed line from the daemon is not this client's problem to crash over.
+      }
+      this.#dispatch(value);
+    }
+  }
+
+  // fallow-ignore-next-line complexity -- one frame-kind switch, deliberately not split further.
+  #dispatch(value: unknown): void {
+    const frame = parseDaemonResponse(value);
+    if (frame === undefined) return;
+    if (frame.kind === "push") {
+      this.#dispatchPush(frame.push, frame.payload);
+      return;
+    }
+    const pending = this.#pending.get(frame.id);
+    if (pending === undefined) return; // ADR §8: drop pushes/replies for ids no longer tracked.
+    this.#pending.delete(frame.id);
+    if (frame.kind === "success") {
+      pending.resolve(frame.payload);
+    } else {
+      const details = asRecord(frame.error);
+      pending.reject(
+        new WireCallError(
+          typeof details.code === "string" ? details.code : "INTERNAL",
+          typeof details.message === "string" ? details.message : "Daemon request failed",
+          details.details,
+        ),
+      );
+    }
+  }
+
+  // fallow-ignore-next-line complexity -- one push-kind switch, deliberately not split further (matches DaemonServer/Dispatcher's own single-switch dispatch style elsewhere).
+  #dispatchPush(push: string, payload: unknown): void {
+    switch (push) {
+      case "progress": {
+        const parsed = PUSH_SCHEMAS.progress.safeParse(payload);
+        if (!parsed.success) return;
+        const requestId = parsed.data.requestId;
+        const id = typeof requestId === "number" ? requestId : Number(requestId);
+        const pending = this.#pending.get(id);
+        pending?.onProgress?.(parsed.data.progress);
+        return;
+      }
+      case "lease-lost": {
+        const parsed = PUSH_SCHEMAS["lease-lost"].safeParse(payload);
+        if (!parsed.success) return;
+        const suppressed = this.#selfInitiatedReleases.delete(parsed.data.leaseId);
+        if (suppressed) return;
+        this.#emitLeaseScoped({
+          deviceId: parsed.data.deviceId,
+          kind: "lease-lost",
+          leaseId: parsed.data.leaseId,
+          reason: parsed.data.reason,
+        });
+        return;
+      }
+      case "device-unhealthy": {
+        const parsed = PUSH_SCHEMAS["device-unhealthy"].safeParse(payload);
+        if (!parsed.success) return;
+        this.#emitLeaseScoped({
+          deviceId: parsed.data.deviceId,
+          kind: "device-unhealthy",
+          leaseId: parsed.data.leaseId,
+        });
+        return;
+      }
+      case "device-recovered": {
+        const parsed = PUSH_SCHEMAS["device-recovered"].safeParse(payload);
+        if (!parsed.success) return;
+        this.#emitLeaseScoped({
+          attempts: parsed.data.attempts,
+          deviceId: parsed.data.deviceId,
+          kind: "device-recovered",
+          leaseId: parsed.data.leaseId,
+        });
+        return;
+      }
+      case "lease.heartbeat": {
+        // Reactive pong, same behavior as today's `daemon-client/connection.ts`: answer with
+        // an ordinary request frame carrying the same payload (nonce), fire-and-forget.
+        void this.#send("lease.heartbeat", payload).catch(() => undefined);
+        return;
+      }
+      case "event": {
+        const parsed = PUSH_SCHEMAS.event.safeParse(payload);
+        if (!parsed.success) return;
+        for (const listener of this.#eventListeners) listener(parsed.data);
+        return;
+      }
+      default:
+        return;
+    }
+  }
+
+  #emitLeaseScoped(push: LeaseScopedPush): void {
+    const key = `${push.kind}:${push.leaseId}`;
+    if (this.#deliveredLeaseScoped.has(key)) return;
+    this.#deliveredLeaseScoped.add(key);
+    for (const listener of this.#leaseScopedListeners) listener(push);
+  }
+
+  #die(error: AnySimlockError): void {
+    if (this.#dead !== undefined) return;
+    this.#dead = error;
+    for (const pending of this.#pending.values()) pending.reject(error);
+    this.#pending.clear();
+    for (const listener of this.#closeListeners) listener(error);
+  }
+}
+
+/** Internal wire-level rejection: `{code, message, details}` straight off the wire, not yet
+ * mapped through the contract's error table. `client.ts`/`hello()` do that mapping -- kept
+ * separate from `SimlockError` so a mid-mapping bug cannot masquerade as a real contract error. */
+export class WireCallError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+    readonly details?: unknown,
+  ) {
+    super(message);
+    this.name = "WireCallError";
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asProtocolRange(value: unknown): ProtocolRange | undefined {
+  const record = asRecord(value);
+  return typeof record.min === "number" && typeof record.max === "number"
+    ? normalizeProtocolVersion({ max: record.max, min: record.min })
+    : undefined;
+}


### PR DESCRIPTION
**Stacked on #94.** PR 3 of 5 implementing ADR 0003 (§10, with §6/§7/§8).

`simlock/client` exports `connectSimlock`; `simlock/admin` exports `connectSimlockAdmin`, which extends it. **The split is by import path; the enforcement is the daemon's role check** — the client does not police roles locally. Method signatures and every public type are inferred from the contract schemas, never written beside them.

## The client owns nothing but its connection

When the connection dies, every in-flight call rejects with `DAEMON_CONNECTION_LOST`, `onLeaseLost` fires for each held lease with reason `daemon-connection-lost`, and the client is dead. **It does not reconnect and does not retry — not even for reads.** A shared retry is a trap the moment it touches a mutation, and "reconnecting never implicitly acquires a device" is trivially provable for a client that cannot reconnect. Reconnect policy stays a frontend concern: MCP keeps its lazy reconnect because its process outlives a connection, the CLI needs none, a host supervisor has its own.

## Pushes

A push can arrive **before** the response to the request that caused it, so the wire layer handles that ordering rather than assuming it away. `progress` is routed by the originating frame id and dropped for ids no longer tracked; lease-scoped pushes are de-duplicated by lease id; `onLeaseLost` never fires for a release this client asked for itself.

## Abort — the one stateful thing the client does

`requestLease` takes an `AbortSignal` with four distinct behaviours, each implemented and tested:

- **before send** — reject `CANCELLED`, nothing sent;
- **while queued** — send `lease.cancel`, wait for the original to reject, surface `CANCELLED`;
- **while device work is in flight** — `lease.cancel` answers not-cancellable, so the client waits for the outcome and **releases the grant immediately** before rejecting `CANCELLED`, so the caller never holds a lease it abandoned;
- **after the grant resolved** — ignored.

True cancellation during provisioning is deliberately out of scope and is recorded as a follow-up in `known-pitfalls.md` (PR 5).

## Package exports

`exports` entries for `./client` and `./admin` (additive — the package had no `exports`/`main`/`types` field). The published surface exposes **contract types only**: `no-core-leak.test.ts` compiles both entry points declaration-only and scans the emitted `.d.ts` import specifiers for anything under `core`, `daemon`, `drivers`, `http`, `cli`, or `mcp`. This is the payoff of the contract module's import boundary, now mechanically enforced.

## Notes for reviewers

- `CANCELLED` joins the closed error-code union; it is client-originated and never sent by the daemon.
- Lease-scoped push de-duplication is permanent per `(kind, leaseId)` for the connection's life, so a legitimate second `device-recovered` after a second crash would be swallowed. The ADR requires not double-firing but does not specify a dedup lifetime — flagging the interpretation.
- If the best-effort release after an in-flight abort itself fails, the caller still sees only `CANCELLED`; the secondary failure is not surfaced.
- The heartbeat capability defaults to `true` in both entry points — a judgment call, not specified.

Covers the four conditions ADR §12 names explicitly, against a scripted connection: invalid payload rejected, mismatch rejected before any request, agent cannot call admin methods, bad credential causes zero requests after `hello`. 1096 tests green.