### PR TITLE
feat(cli): render the contract; move token operations into the daemon

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -44,7 +44,10 @@ longer dumped to stderr on every failure, only on request via `--help`.
 | 13 | `REQUESTER_ALREADY_LEASED` | requester already holds a lease or has a pending request — one lease per agent in v1; release the named lease first |
 | 14 | — | `lease` held mode only: the daemon ended the lease without the holder asking (TTL backstop, operator `release`, or an unrecoverable device) |
 
-Every row but 14 matches `DAEMON_ERROR_EXIT_CODES` in `src/cli/index.ts` exactly; 14 is not a daemon error code but an outcome of held mode, so it lives beside the table's other `lease` outcome, 0.
+Every row but 14 matches the `cliExitCode` column of the contract's error
+table (`src/contract/errors.ts`'s `ERROR_TABLE`) exactly — the CLI does not
+maintain a second mapping; 14 is not a daemon error code but an outcome of
+held mode, so it lives beside the table's other `lease` outcome, 0.
 A daemon error code with no entry here (for example `UNKNOWN_LEASE`,
 surfaced by `lease renew`) falls back to exit 1; the structured stderr line
 still reports the specific code.
@@ -129,17 +132,24 @@ have a request queued fails with `REQUESTER_ALREADY_LEASED` (exit 13); the
 error message names the existing lease id to release first.
 
 **Held mode (default):** intended to be run in the background by the agent.
-As soon as the device is ready, one JSON line is printed on stdout:
+As soon as the device is ready, one JSON line is printed on stdout — the
+contract's `lease.request` output (`LeaseGrant`: `device`, `lease`, `timing`)
+serialized as-is, plus the one field the CLI adds on top, the connection's
+resolved `role` (ADR 0003 §5):
 
 ```json
-{"lease":"lse_9f2c","platform":"ios","device":"iPhone 17 Pro","os":"26.5","udid":"ABCD-...","state":"leased","slim":true}
+{"device":{"id":"dev_1a2b","driverDeviceId":"ABCD-...","spec":{"platform":"ios","model":"iPhone 17 Pro","osVersion":"26.5"},"state":"leased","address":"...","featureProfile":"reduced", "...":"..."},"lease":{"id":"lse_9f2c","deviceId":"dev_1a2b","requesterId":"agent-1","ownerId":"agent-1","mode":"held","grantedAt":1735689600000,"ttlDeadline":1735689660000},"timing":{"estimatedProvisionMs":0,"estimatedBootMs":0,"estimatedReclaimMs":0,"estimatedReadyMs":0},"role":"agent"}
 ```
 
-`slim` is `true` when the granted device had its feature set reduced (iOS
-slim mode applied and this request did not pass `--full`) and `false`
-otherwise — always `false` for Android. It lets an agent explain a
-feature-loss failure (missing push notification, Spotlight result, StoreKit
-sheet, universal link, or system picker) instead of misreading it as a bug.
+`device.featureProfile` is `"reduced"` when the granted device had its
+feature set reduced (iOS slim mode applied and this request did not pass
+`--full`), and `"full"` or absent otherwise — always absent for Android. It
+lets an agent explain a feature-loss failure (missing push notification,
+Spotlight result, StoreKit sheet, universal link, or system picker) instead
+of misreading it as a bug. See `src/contract/schemas.ts`
+(`deviceRecordSchema`, `leaseRecordSchema`, `leaseGrantSchema`) for the full
+field list — this is the one vocabulary every frontend (CLI, MCP, HTTP, the
+`simlock/client` package) now shares.
 
 then the process stays alive holding the lease. **Kill the process to
 release** — or let it die on its own: held mode watches its parent (the pid
@@ -150,11 +160,14 @@ action selected for that request. A queued request reports its position
 without speculative work stages; reclaiming work is reported separately:
 
 ```json
-{"event":"queued","queue_position":1}
-{"event":"provisioning","eta_seconds":90}
-{"event":"booting","eta_seconds":60}
-{"event":"reclaiming","eta_seconds":34}
+{"push":"progress","stage":"queued","queuePosition":1}
+{"push":"progress","stage":"provisioning","etaMs":90000}
+{"push":"progress","stage":"booting","etaMs":60000}
+{"push":"progress","stage":"reclaiming","etaMs":34000}
 ```
+
+`push` is the one field the CLI adds to identify the line's kind; everything
+else is the contract's `LeaseProgress` push, serialized as-is (ADR 0003 §11).
 
 `reclaiming` follows `queued` when the device the request is waiting on is
 being purged for its previous holder: the position alone would not say that
@@ -168,12 +181,12 @@ leased device for as long as the connection holds it, on the same stderr
 stream:
 
 ```json
-{"event":"device_unhealthy","lease":"lse_9f2c","device_id":"dev_1a2b"}
-{"event":"device_recovered","lease":"lse_9f2c","device_id":"dev_1a2b","attempts":1}
+{"push":"device-unhealthy","leaseId":"lse_9f2c","deviceId":"dev_1a2b"}
+{"push":"device-recovered","leaseId":"lse_9f2c","deviceId":"dev_1a2b","attempts":1}
 ```
 
-`device_unhealthy` means the device stopped running outside simlock and a
-reboot is in progress under the same lease; `device_recovered` means that
+`device-unhealthy` means the device stopped running outside simlock and a
+reboot is in progress under the same lease; `device-recovered` means that
 reboot passed readiness. The lease itself is untouched by either — it is
 still held and must still be released the normal way. Recovery can instead
 give up (the device vanished, its provenance no longer checks out, or reboot
@@ -181,12 +194,12 @@ attempts ran out); giving up is not itself one of these lines — it ends the
 lease, which surfaces as the same line any other lease loss does:
 
 ```json
-{"event":"lease_lost","lease":"lse_9f2c","device_id":"dev_1a2b","reason":"device-lost"}
+{"push":"lease-lost","leaseId":"lse_9f2c","deviceId":"dev_1a2b","reason":"device-lost"}
 ```
 
-In all three lines `device_id` is the registry device id — the `id` column of
+In all three lines `deviceId` is the registry device id — the `id` column of
 `simlock list --devices`, and the same identifier the event bus uses — not the
-driver-level `udid` the grant returns on stdout. A `lease_lost` line is
+driver-level `udid` the grant returns on stdout. A `lease-lost` line is
 terminal for held mode: there is no longer a lease to
 hold, so the process writes that line and exits `14` rather than waiting for a
 signal, and it does not try to release a lease the daemon has already taken
@@ -355,7 +368,14 @@ lines. `--follow` keeps streaming; `--since 1h` replays recent history.
 ## `simlock daemon <start|stop|status|logs>`
 
 Manage the daemon explicitly. Other commands auto-start it on demand;
-`daemon` exists for operators and debugging. `logs` tails daemon logs.
+`daemon` exists for operators and debugging. `logs` tails daemon logs and
+works even when the daemon is dead — it reads the log file directly, no
+connection attempted. `status` never auto-starts the daemon and distinguishes
+two failure shapes: `{"status":"stopped"}` when nothing is listening on the
+socket at all, versus `{"status":"handshake-refused","error":{"code":...}}`
+(exit 1) when a daemon answered but refused the connection (a bad admin
+credential, or a protocol version mismatch) — the two used to be reported
+identically as "stopped".
 
 The daemon writes one structured JSON line per record to `~/.simlock/daemon.log`
 (timestamp, level, module, message, and any fields) covering startup (version,
@@ -377,11 +397,37 @@ under `capacity.config` — see
 is running, both a global and a per-platform running limit must have room
 before Simlock provisions or boots a shutdown device.
 
+## Admin credential resolution
+
+Several commands (`list`, `cleanup`, `nuke`, `events`, `config get`,
+`daemon stop`, `token create|list|revoke`, and cross-process `release`) need
+the daemon's `admin` role. The CLI resolves a credential to send at
+handshake, in order:
+
+1. `--token <secret>` — accepted anywhere on the command line.
+2. `SIMLOCK_ADMIN_TOKEN` — the environment variable.
+3. the local `admin.token` file the daemon writes under `SIMLOCK_HOME` at
+   startup (read is retried briefly, to ride out the daemon still writing it
+   after a fresh `daemon start`).
+
+When none of the three resolves (a different OS user, or the file genuinely
+missing), the CLI connects as `agent` instead and writes a one-line stderr
+notice; admin-only operations then fail with `FORBIDDEN` from the daemon,
+same as any other role violation. `simlock lease`'s output JSON includes the
+connection's resolved `role` so a caller can tell which one it got.
+
+This is also why `simlock lease --detach` followed later by
+`simlock release <lease-id>` from a different invocation works even though
+each CLI process has a different pid-derived identity: both commands connect
+as admin (when the local file is readable), and admin bypasses the
+per-connection ownership check that would otherwise apply.
+
 ## `simlock token create --role <agent|operator> [--label <text>]` / `list` / `revoke <token-id>`
 
-Mint and manage bearer tokens for the HTTP API. Operates on
-`~/.simlock/tokens.json` directly (under `SIMLOCK_HOME`) — no daemon
-round-trip, like `config` reading its file.
+Mint and manage bearer tokens for the HTTP API. `token.create|list|revoke`
+are daemon operations (admin role) — the daemon is the only process that
+ever reads or writes `tokens.json`; the CLI is a thin client over the same
+`simlock/admin` connection every other admin command uses.
 
 `create` prints the minted secret **once**, alongside the token record:
 
@@ -395,8 +441,9 @@ id doubles as the requester identity over HTTP — one token is one requester,
 same as the CLI's `--agent-id`.
 
 `list` prints `{"tokens":[...]}` — the same record shape as `create`, minus
-the secret and its hash. `revoke <token-id>` prints `{"revoked":true}`, or a
-structured `UNKNOWN_TOKEN` error (exit 1) for an id that does not exist.
+the secret and its hash. `revoke <token-id>` prints `{"revoked":true}` or
+`{"revoked":false}` for an id that does not exist — the daemon's
+`token.revoke` operation does not treat an unknown id as an error.
 
 ## Environment variables
 
@@ -410,6 +457,13 @@ agent's environment repoints every command at an isolated data directory —
 useful for running multiple independent simlock instances on one machine, or
 for tests. When the CLI or MCP server auto-starts the daemon, the daemon
 process inherits the variable like the rest of the environment.
+
+### `SIMLOCK_ADMIN_TOKEN`
+
+The second source in [admin credential resolution](#admin-credential-resolution)
+— an operator token (`simlock token create --role operator`) or the daemon's
+per-start `admin.token` secret, either works. Set it once in a supervisor's
+environment to avoid every admin command reading `admin.token` off disk.
 
 ### `SIMLOCK_DRIVERS_MODULE` (advanced / testing hook)
 

--- a/e2e/capacity-cleanup-nuke.test.ts
+++ b/e2e/capacity-cleanup-nuke.test.ts
@@ -58,8 +58,8 @@ async function releaseAndForget(
   agentId: string,
 ): Promise<void> {
   const held = leaseHeld(env, agentId);
-  const grant = JSON.parse(await held.firstStdoutLine()) as { lease: string };
-  await env.cli(["release", grant.lease]);
+  const grant = JSON.parse(await held.firstStdoutLine()) as { lease: { id: string } };
+  await env.cli(["release", grant.lease.id]);
   held.kill("SIGKILL");
   await held.waitForExit(15_000).catch(() => undefined);
 }
@@ -97,7 +97,10 @@ describe("capacity, warm pool, cleanup, and nuke", () => {
     });
 
     const first = leaseHeld(env, "cap-a");
-    const grantA = JSON.parse(await first.firstStdoutLine()) as { lease: string; udid: string };
+    const grantA = JSON.parse(await first.firstStdoutLine()) as {
+      lease: { id: string };
+      device: { driverDeviceId: string };
+    };
 
     // maxRunning (2) has room, but maxDevices (1) does not: a second requester must
     // still queue, because there is no second device to provision.
@@ -111,12 +114,15 @@ describe("capacity, warm pool, cleanup, and nuke", () => {
     // finish before responding, so the poll for "reclaiming" must run concurrently
     // with the release call, not after it.
     await env.driverScript.merge({ ios: { latencyMs: { reclaim: 1_500 } } });
-    const releasePromise = env.cli(["release", grantA.lease]);
+    const releasePromise = env.cli(["release", grantA.lease.id]);
 
     await waitFor(
       async () => {
         const rows = await deviceRows(env);
-        return rows.some((row) => row.driverDeviceId === grantA.udid && row.state === "reclaiming");
+        return rows.some(
+          (row) =>
+            row.driverDeviceId === grantA.device.driverDeviceId && row.state === "reclaiming",
+        );
       },
       { label: "device visibly enters reclaiming" },
     );
@@ -131,10 +137,10 @@ describe("capacity, warm pool, cleanup, and nuke", () => {
     // The queued second requester is granted the same device once reclaim finishes
     // and it becomes warm (`ready`) again.
     const grantB = JSON.parse(await second.firstStdoutLine(15_000)) as {
-      lease: string;
-      udid: string;
+      lease: { id: string };
+      device: { driverDeviceId: string };
     };
-    expect(grantB.udid).toBe(grantA.udid);
+    expect(grantB.device.driverDeviceId).toBe(grantA.device.driverDeviceId);
 
     first.kill("SIGKILL");
     second.kill("SIGKILL");
@@ -169,7 +175,7 @@ describe("capacity, warm pool, cleanup, and nuke", () => {
       "overlimit-one",
       "--detach",
     ]);
-    const grantOne = leaseOne.json as { lease: string };
+    const grantOne = leaseOne.json as { lease: { id: string } };
     const leaseTwo = await env.cli([
       "lease",
       "--platform",
@@ -182,7 +188,7 @@ describe("capacity, warm pool, cleanup, and nuke", () => {
       "overlimit-two",
       "--detach",
     ]);
-    const grantTwo = leaseTwo.json as { lease: string };
+    const grantTwo = leaseTwo.json as { lease: { id: string } };
 
     await env.withConfig({ limits: { ios: { maxRunning: 1 } } }, async () => {
       const afterLower = await status(env);
@@ -192,7 +198,7 @@ describe("capacity, warm pool, cleanup, and nuke", () => {
       // below what is currently held.
       const leases = (await env.cli(["list", "--leases"])).json as { id: string }[];
       expect(leases.map((lease) => lease.id)).toEqual(
-        expect.arrayContaining([grantOne.lease, grantTwo.lease]),
+        expect.arrayContaining([grantOne.lease.id, grantTwo.lease.id]),
       );
     });
 
@@ -214,13 +220,16 @@ describe("capacity, warm pool, cleanup, and nuke", () => {
     });
 
     const heldX = leaseHeld(env, "idle-x");
-    const grantX = JSON.parse(await heldX.firstStdoutLine()) as { lease: string; udid: string };
-    await env.cli(["release", grantX.lease]);
+    const grantX = JSON.parse(await heldX.firstStdoutLine()) as {
+      lease: { id: string };
+      device: { driverDeviceId: string };
+    };
+    await env.cli(["release", grantX.lease.id]);
     heldX.kill("SIGKILL");
     await heldX.waitForExit(15_000).catch(() => undefined);
-    await waitForDeviceState(env, grantX.udid, "ready");
+    await waitForDeviceState(env, grantX.device.driverDeviceId, "ready");
 
-    await waitForCleanupToReach(env, grantX.udid, "shutdown");
+    await waitForCleanupToReach(env, grantX.device.driverDeviceId, "shutdown");
 
     // cleanup --dry-run must report proposals without acting on them.
     await releaseAndForget(env, "dryrun-z");
@@ -308,7 +317,8 @@ function isQueuedAt(event: unknown, position: number): boolean {
   return (
     typeof event === "object" &&
     event !== null &&
-    (event as Record<string, unknown>).event === "queued" &&
-    (event as Record<string, unknown>).queue_position === position
+    (event as Record<string, unknown>).push === "progress" &&
+    (event as Record<string, unknown>).stage === "queued" &&
+    (event as Record<string, unknown>).queuePosition === position
   );
 }

--- a/e2e/contention.test.ts
+++ b/e2e/contention.test.ts
@@ -15,13 +15,13 @@ describe("contention & queueing", () => {
 
     const first = await env.cli([...LEASE_ARGS, "--agent-id", "agent-a", "--detach"]);
     expect(first.code).toBe(0);
-    const firstGrant = first.json as { lease: string };
+    const firstGrant = first.json as { lease: { id: string } };
 
     // Same requester leasing again: REQUESTER_ALREADY_LEASED, naming the existing lease.
     const repeat = await env.cli([...LEASE_ARGS, "--agent-id", "agent-a", "--detach"]);
     expect(repeat.code).toBe(13);
     expect(repeat.error).toMatchObject({ code: "REQUESTER_ALREADY_LEASED" });
-    expect(repeat.error?.message).toContain(firstGrant.lease);
+    expect(repeat.error?.message).toContain(firstGrant.lease.id);
 
     // A different requester at capacity with --no-wait fails immediately.
     const noWait = await env.cli([...LEASE_ARGS, "--agent-id", "agent-b", "--no-wait", "--detach"]);
@@ -47,24 +47,24 @@ describe("contention & queueing", () => {
       label: "agent-e queued at position 2",
     });
 
-    const release = await env.cli(["release", firstGrant.lease]);
+    const release = await env.cli(["release", firstGrant.lease.id]);
     expect(release.code).toBe(0);
 
     const grantedD = JSON.parse(await waiterD.firstStdoutLine(15_000)) as {
-      device: string;
-      lease: string;
+      device: { spec: { model: string } };
+      lease: { id: string };
     };
-    expect(grantedD.device).toBe("iPhone 16");
+    expect(grantedD.device.spec.model).toBe("iPhone 16");
 
     waiterD.kill("SIGTERM");
     await waiterD.waitForExit(15_000);
 
     const grantedE = JSON.parse(await waiterE.firstStdoutLine(15_000)) as {
-      device: string;
-      lease: string;
+      device: { spec: { model: string } };
+      lease: { id: string };
     };
-    expect(grantedE.device).toBe("iPhone 16");
-    expect(grantedE.lease).not.toBe(grantedD.lease);
+    expect(grantedE.device.spec.model).toBe("iPhone 16");
+    expect(grantedE.lease.id).not.toBe(grantedD.lease.id);
 
     waiterE.kill("SIGTERM");
     await waiterE.waitForExit(15_000);
@@ -85,41 +85,45 @@ describe("contention & queueing", () => {
 
     const holder = await env.cli([...LEASE_ARGS, "--agent-id", "agent-holder", "--detach"]);
     expect(holder.code).toBe(0);
-    const holderGrant = holder.json as { lease: string };
+    const holderGrant = holder.json as { lease: { id: string } };
 
     // Release hands the caller back before the purge (#58), so the device is `reclaiming` with
     // its full latency still ahead when the next requester arrives -- the case the stage exists
     // for, and the one nothing exercised before this covered the whole path out to the CLI.
-    const release = await env.cli(["release", holderGrant.lease]);
+    const release = await env.cli(["release", holderGrant.lease.id]);
     expect(release.code).toBe(0);
 
     const waiter = env.cliBackground([...LEASE_ARGS, "--agent-id", "agent-waiter"]);
-    await waitFor(() => waiter.progressEvents().some(isReclaimingWithEta(34)), {
+    await waitFor(() => waiter.progressEvents().some(isReclaimingWithEta(34_000)), {
       label: "agent-waiter told the reclaim's ETA",
     });
     expect(waiter.progressEvents().some((event) => isQueuedAt(event, 1))).toBe(true);
 
-    const granted = JSON.parse(await waiter.firstStdoutLine(15_000)) as { device: string };
-    expect(granted.device).toBe("iPhone 16");
+    const granted = JSON.parse(await waiter.firstStdoutLine(15_000)) as {
+      device: { spec: { model: string } };
+    };
+    expect(granted.device.spec.model).toBe("iPhone 16");
 
     waiter.kill("SIGTERM");
     await waiter.waitForExit(15_000);
   });
 });
 
-function isReclaimingWithEta(seconds: number): (event: unknown) => boolean {
+function isReclaimingWithEta(etaMs: number): (event: unknown) => boolean {
   return (event) =>
     typeof event === "object" &&
     event !== null &&
-    (event as Record<string, unknown>).event === "reclaiming" &&
-    (event as Record<string, unknown>).eta_seconds === seconds;
+    (event as Record<string, unknown>).push === "progress" &&
+    (event as Record<string, unknown>).stage === "reclaiming" &&
+    (event as Record<string, unknown>).etaMs === etaMs;
 }
 
 function isQueuedAt(event: unknown, position: number): boolean {
   return (
     typeof event === "object" &&
     event !== null &&
-    (event as Record<string, unknown>).event === "queued" &&
-    (event as Record<string, unknown>).queue_position === position
+    (event as Record<string, unknown>).push === "progress" &&
+    (event as Record<string, unknown>).stage === "queued" &&
+    (event as Record<string, unknown>).queuePosition === position
   );
 }

--- a/e2e/doctor-drift.test.ts
+++ b/e2e/doctor-drift.test.ts
@@ -44,8 +44,13 @@ function leaseHeld(
   ]);
 }
 
-async function grantOf(held: CliBackgroundHandle): Promise<{ lease: string; udid: string }> {
-  return JSON.parse(await held.firstStdoutLine()) as { lease: string; udid: string };
+interface Grant {
+  readonly lease: { readonly id: string };
+  readonly device: { readonly driverDeviceId: string };
+}
+
+async function grantOf(held: CliBackgroundHandle): Promise<Grant> {
+  return JSON.parse(await held.firstStdoutLine()) as Grant;
 }
 
 describe("doctor and drift", () => {
@@ -73,11 +78,13 @@ describe("doctor and drift", () => {
     const deviceD = await grantOf(heldD);
     const heldE = leaseHeld(env, "doctor-e");
     const deviceE = await grantOf(heldE);
-    const distinctUdids = new Set([deviceA, deviceB, deviceC, deviceD, deviceE].map((d) => d.udid));
+    const distinctUdids = new Set(
+      [deviceA, deviceB, deviceC, deviceD, deviceE].map((d) => d.device.driverDeviceId),
+    );
     expect(distinctUdids.size, "expected 5 distinct devices, one per concurrent lease").toBe(5);
 
     for (const device of [deviceA, deviceC, deviceD, deviceE]) {
-      const release = await env.cli(["release", device.lease]);
+      const release = await env.cli(["release", device.lease.id]);
       expect(release.code).toBe(0);
     }
     for (const held of [heldA, heldC, heldD, heldE]) {
@@ -93,16 +100,16 @@ describe("doctor and drift", () => {
     };
 
     const stagedDevices: ScriptedObservedDevice[] = [
-      { deviceId: deviceA.udid, runState: "stopped" },
-      { deviceId: deviceB.udid, runState: "stopped" },
-      // deviceC.udid deliberately omitted.
+      { deviceId: deviceA.device.driverDeviceId, runState: "stopped" },
+      { deviceId: deviceB.device.driverDeviceId, runState: "stopped" },
+      // deviceC.device.driverDeviceId deliberately omitted.
       {
-        deviceId: deviceD.udid,
+        deviceId: deviceD.device.driverDeviceId,
         runState: "running",
         mark: { durable: "tok-d", erasableReadable: true },
       },
       {
-        deviceId: deviceE.udid,
+        deviceId: deviceE.device.driverDeviceId,
         runState: "running",
         mark: { durable: "tok-e", erasable: "stale", erasableReadable: false },
       },
@@ -124,7 +131,7 @@ describe("doctor and drift", () => {
     expect(findings).toContainEqual(
       expect.objectContaining({
         kind: "foreign-state-change",
-        deviceId: registryIdOf(deviceA.udid),
+        deviceId: registryIdOf(deviceA.device.driverDeviceId),
         expected: "running",
         observed: "stopped",
       }),
@@ -132,7 +139,7 @@ describe("doctor and drift", () => {
     expect(findings).toContainEqual(
       expect.objectContaining({
         kind: "foreign-state-change",
-        deviceId: registryIdOf(deviceB.udid),
+        deviceId: registryIdOf(deviceB.device.driverDeviceId),
         expected: "running",
         observed: "stopped",
       }),
@@ -140,18 +147,18 @@ describe("doctor and drift", () => {
     expect(findings).toContainEqual(
       expect.objectContaining({
         kind: "registry-device-missing",
-        deviceId: registryIdOf(deviceC.udid),
+        deviceId: registryIdOf(deviceC.device.driverDeviceId),
       }),
     );
     expect(findings).toContainEqual(
       expect.objectContaining({
         kind: "foreign-provenance-change",
-        deviceId: registryIdOf(deviceD.udid),
+        deviceId: registryIdOf(deviceD.device.driverDeviceId),
         detail: "erased",
       }),
     );
     expect(
-      findings.some((finding) => finding.deviceId === registryIdOf(deviceE.udid)),
+      findings.some((finding) => finding.deviceId === registryIdOf(deviceE.device.driverDeviceId)),
       "deviceE has an unreadable erasable mark and must produce no finding at all",
     ).toBe(false);
     expect(findings).toContainEqual(
@@ -181,15 +188,15 @@ describe("doctor and drift", () => {
     ).toEqual([]);
 
     const rowsAfterFix = await deviceRows(env);
-    const rowA = rowsAfterFix.find((row) => row.id === registryIdOf(deviceA.udid));
+    const rowA = rowsAfterFix.find((row) => row.id === registryIdOf(deviceA.device.driverDeviceId));
     expect(rowA?.state, "deviceA's foreign-state-change should have been corrected").toBe(
       "shutdown",
     );
-    const rowB = rowsAfterFix.find((row) => row.id === registryIdOf(deviceB.udid));
+    const rowB = rowsAfterFix.find((row) => row.id === registryIdOf(deviceB.device.driverDeviceId));
     expect(rowB?.state, "leased deviceB must be left alone by --fix").toBe("leased");
-    const rowC = rowsAfterFix.find((row) => row.id === registryIdOf(deviceC.udid));
+    const rowC = rowsAfterFix.find((row) => row.id === registryIdOf(deviceC.device.driverDeviceId));
     expect(rowC?.state, "vanished deviceC should be marked deleted, not recreated").toBe("deleted");
-    const rowD = rowsAfterFix.find((row) => row.id === registryIdOf(deviceD.udid));
+    const rowD = rowsAfterFix.find((row) => row.id === registryIdOf(deviceD.device.driverDeviceId));
     expect(
       rowD?.foreignProvenanceDetectedAt,
       "provenance drift is report-only -- re-marking would destroy the evidence",

--- a/e2e/error-exit-codes.test.ts
+++ b/e2e/error-exit-codes.test.ts
@@ -101,19 +101,21 @@ describe("error and exit-code table", () => {
       "--agent-id",
       "flow4-held",
     ]);
-    const grant = JSON.parse(await held.firstStdoutLine()) as { lease: string };
+    const grant = JSON.parse(await held.firstStdoutLine()) as { lease: { id: string } };
 
     try {
       const rows = await waitForLeaseCount(env, 1);
-      const before = rows.find((row) => row.id === grant.lease);
-      if (before === undefined) throw new Error(`lease ${grant.lease} not found before renew`);
+      const before = rows.find((row) => row.id === grant.lease.id);
+      if (before === undefined) {
+        throw new Error(`lease ${grant.lease.id} not found before renew`);
+      }
       const beforeDeadline = before.ttlDeadline as number;
 
-      const result = await env.cli(["lease", "renew", grant.lease]);
+      const result = await env.cli(["lease", "renew", grant.lease.id]);
       expect(result.code).toBe(0);
       expect(result.stderr).toBe("");
       const renewed = result.json as { id: string; mode: string; ttlDeadline: number };
-      expect(renewed.id).toBe(grant.lease);
+      expect(renewed.id).toBe(grant.lease.id);
       expect(renewed.mode).toBe("held");
       // A held-mode lease used to have no escape hatch: renewal now resets its
       // backstop deadline exactly like a detached lease's, instead of rejecting.

--- a/e2e/heartbeat-ttl.test.ts
+++ b/e2e/heartbeat-ttl.test.ts
@@ -74,13 +74,14 @@ describe("sliding TTL and heartbeat", () => {
     try {
       const leaseResult = await mcp.client.callTool({
         name: "lease_simulator",
-        arguments: { platform: "ios", device: "iPhone 16", os: "18.4" },
+        arguments: { model: "iPhone 16", osVersion: "18.4", platform: "ios" },
       });
-      const mcpLease = leaseResult.structuredContent as { lease_id: string; expires_at_ms: number };
+      const mcpLease = leaseResult.structuredContent as {
+        lease: { id: string; ttlDeadline: number };
+      };
 
       const cliGrant = JSON.parse(await cliHeld.firstStdoutLine()) as {
-        lease: string;
-        expires_at_ms: number;
+        lease: { id: string; ttlDeadline: number };
       };
 
       const detachedResult = await env.cli([
@@ -95,7 +96,7 @@ describe("sliding TTL and heartbeat", () => {
         "flow6-detached",
         "--detach",
       ]);
-      const detachedGrant = detachedResult.json as { lease: string };
+      const detachedGrant = detachedResult.json as { lease: { id: string } };
 
       // Both held leases -- MCP and CLI -- declare the heartbeat capability and
       // slide their deadline on every ping; the detached lease holds no connection
@@ -103,15 +104,15 @@ describe("sliding TTL and heartbeat", () => {
       await waitFor(
         async () => {
           const rows = await leaseRows(env);
-          const detachedRow = rows.find((row) => row.id === detachedGrant.lease);
+          const detachedRow = rows.find((row) => row.id === detachedGrant.lease.id);
           return detachedRow === undefined;
         },
         { timeout: 15_000, label: "detached (non-heartbeating) lease expires at its TTL" },
       );
 
       const rowsAfterExpiry = await leaseRows(env);
-      const mcpRow = rowsAfterExpiry.find((row) => row.id === mcpLease.lease_id);
-      const cliRow = rowsAfterExpiry.find((row) => row.id === cliGrant.lease);
+      const mcpRow = rowsAfterExpiry.find((row) => row.id === mcpLease.lease.id);
+      const cliRow = rowsAfterExpiry.find((row) => row.id === cliGrant.lease.id);
       expect(
         mcpRow,
         "MCP lease should have survived past the detached lease's expiry",
@@ -120,22 +121,21 @@ describe("sliding TTL and heartbeat", () => {
         cliRow,
         "CLI held lease should have survived past the detached lease's expiry",
       ).toBeDefined();
-      expect(mcpRow?.ttlDeadline).toBeGreaterThan(mcpLease.expires_at_ms);
+      expect(mcpRow?.ttlDeadline).toBeGreaterThan(mcpLease.lease.ttlDeadline);
       expect(mcpRow?.lastHeartbeatAt).toBeGreaterThan(0);
-      expect(cliRow?.ttlDeadline).toBeGreaterThan(cliGrant.expires_at_ms);
+      expect(cliRow?.ttlDeadline).toBeGreaterThan(cliGrant.lease.ttlDeadline);
       expect(cliRow?.lastHeartbeatAt).toBeGreaterThan(0);
 
       const statusResult = await mcp.client.callTool({ name: "lease_status", arguments: {} });
-      const statusExpiry = (statusResult.structuredContent as { expires_at_ms: number })
-        .expires_at_ms;
-      expect(statusExpiry).toBeGreaterThan(mcpLease.expires_at_ms);
+      const statusExpiry = (statusResult.structuredContent as { ttlDeadline: number }).ttlDeadline;
+      expect(statusExpiry).toBeGreaterThan(mcpLease.lease.ttlDeadline);
 
       const recorded = await env.events();
       expect(
         recorded.filter(
           (entry) =>
             entry.event === "lease.renewed" &&
-            (entry.payload as { leaseId?: string }).leaseId === mcpLease.lease_id,
+            (entry.payload as { leaseId?: string }).leaseId === mcpLease.lease.id,
         ).length,
         "expected repeated lease.renewed events for the heartbeating MCP lease",
       ).toBeGreaterThan(1);
@@ -143,20 +143,20 @@ describe("sliding TTL and heartbeat", () => {
         recorded.filter(
           (entry) =>
             entry.event === "lease.renewed" &&
-            (entry.payload as { leaseId?: string }).leaseId === cliGrant.lease,
+            (entry.payload as { leaseId?: string }).leaseId === cliGrant.lease.id,
         ).length,
         "expected repeated lease.renewed events for the heartbeating CLI lease",
       ).toBeGreaterThan(1);
       expect(recorded).toContainEqual(
         expect.objectContaining({
           event: "lease.expired",
-          payload: expect.objectContaining({ leaseId: detachedGrant.lease }),
+          payload: expect.objectContaining({ leaseId: detachedGrant.lease.id }),
         }),
       );
 
       await mcp.client.callTool({
         name: "release_simulator",
-        arguments: { lease_id: mcpLease.lease_id },
+        arguments: { leaseId: mcpLease.lease.id },
       });
     } finally {
       cliHeld.kill("SIGKILL");

--- a/e2e/heartbeat-ttl.test.ts
+++ b/e2e/heartbeat-ttl.test.ts
@@ -74,10 +74,11 @@ describe("sliding TTL and heartbeat", () => {
     try {
       const leaseResult = await mcp.client.callTool({
         name: "lease_simulator",
-        arguments: { model: "iPhone 16", osVersion: "18.4", platform: "ios" },
+        arguments: { platform: "ios", device: "iPhone 16", os: "18.4" },
       });
       const mcpLease = leaseResult.structuredContent as {
-        lease: { id: string; ttlDeadline: number };
+        lease_id: string;
+        expires_at_ms: number;
       };
 
       const cliGrant = JSON.parse(await cliHeld.firstStdoutLine()) as {
@@ -111,7 +112,7 @@ describe("sliding TTL and heartbeat", () => {
       );
 
       const rowsAfterExpiry = await leaseRows(env);
-      const mcpRow = rowsAfterExpiry.find((row) => row.id === mcpLease.lease.id);
+      const mcpRow = rowsAfterExpiry.find((row) => row.id === mcpLease.lease_id);
       const cliRow = rowsAfterExpiry.find((row) => row.id === cliGrant.lease.id);
       expect(
         mcpRow,
@@ -121,21 +122,22 @@ describe("sliding TTL and heartbeat", () => {
         cliRow,
         "CLI held lease should have survived past the detached lease's expiry",
       ).toBeDefined();
-      expect(mcpRow?.ttlDeadline).toBeGreaterThan(mcpLease.lease.ttlDeadline);
+      expect(mcpRow?.ttlDeadline).toBeGreaterThan(mcpLease.expires_at_ms);
       expect(mcpRow?.lastHeartbeatAt).toBeGreaterThan(0);
       expect(cliRow?.ttlDeadline).toBeGreaterThan(cliGrant.lease.ttlDeadline);
       expect(cliRow?.lastHeartbeatAt).toBeGreaterThan(0);
 
       const statusResult = await mcp.client.callTool({ name: "lease_status", arguments: {} });
-      const statusExpiry = (statusResult.structuredContent as { ttlDeadline: number }).ttlDeadline;
-      expect(statusExpiry).toBeGreaterThan(mcpLease.lease.ttlDeadline);
+      const statusExpiry = (statusResult.structuredContent as { expires_at_ms: number })
+        .expires_at_ms;
+      expect(statusExpiry).toBeGreaterThan(mcpLease.expires_at_ms);
 
       const recorded = await env.events();
       expect(
         recorded.filter(
           (entry) =>
             entry.event === "lease.renewed" &&
-            (entry.payload as { leaseId?: string }).leaseId === mcpLease.lease.id,
+            (entry.payload as { leaseId?: string }).leaseId === mcpLease.lease_id,
         ).length,
         "expected repeated lease.renewed events for the heartbeating MCP lease",
       ).toBeGreaterThan(1);
@@ -156,7 +158,7 @@ describe("sliding TTL and heartbeat", () => {
 
       await mcp.client.callTool({
         name: "release_simulator",
-        arguments: { leaseId: mcpLease.lease.id },
+        arguments: { lease_id: mcpLease.lease_id },
       });
     } finally {
       cliHeld.kill("SIGKILL");

--- a/e2e/held-lease-liveness.test.ts
+++ b/e2e/held-lease-liveness.test.ts
@@ -20,14 +20,17 @@ describe("held-lease liveness & restart", () => {
       "--agent-id",
       "flow5-killed",
     ]);
-    const grant = JSON.parse(await held.firstStdoutLine()) as { lease: string; udid: string };
+    const grant = JSON.parse(await held.firstStdoutLine()) as {
+      lease: { id: string };
+      device: { driverDeviceId: string };
+    };
     await waitForLeaseCount(env, 1);
 
     held.kill("SIGKILL");
     await held.waitForExit(15_000);
 
     await waitForLeaseCount(env, 0);
-    await waitForDeviceState(env, grant.udid, "ready");
+    await waitForDeviceState(env, grant.device.driverDeviceId, "ready");
     await env.expectEvents(["lease.granted", "lease.released"]);
   });
 
@@ -48,7 +51,10 @@ describe("held-lease liveness & restart", () => {
       "--agent-id",
       "flow5-orphaned",
     ]);
-    const grant = JSON.parse(await held.firstStdoutLine()) as { lease: string; udid: string };
+    const grant = JSON.parse(await held.firstStdoutLine()) as {
+      lease: { id: string };
+      device: { driverDeviceId: string };
+    };
     await waitForLeaseCount(env, 1);
 
     // Kill the daemon out from under the holder (not a graceful `daemon stop`) so the
@@ -58,13 +64,13 @@ describe("held-lease liveness & restart", () => {
     await env.startDaemon();
 
     await waitForLeaseCount(env, 0);
-    await waitForDeviceState(env, grant.udid, "ready");
+    await waitForDeviceState(env, grant.device.driverDeviceId, "ready");
 
     const recorded = await env.events();
     expect(recorded).toContainEqual(
       expect.objectContaining({
         event: "lease.released",
-        payload: expect.objectContaining({ leaseId: grant.lease, reason: "orphaned" }),
+        payload: expect.objectContaining({ leaseId: grant.lease.id, reason: "orphaned" }),
       }),
     );
 
@@ -98,7 +104,10 @@ describe("held-lease liveness & restart", () => {
       "--detach",
     ]);
     expect(lease.code).toBe(0);
-    const grant = lease.json as { lease: string; udid: string };
+    const grant = lease.json as {
+      lease: { id: string };
+      device: { driverDeviceId: string };
+    };
 
     // The event ring buffer resets on restart (documented behaviour, ARCHITECTURE.md),
     // so check "granted" happened before the restart wipes it, and only look for
@@ -110,13 +119,13 @@ describe("held-lease liveness & restart", () => {
     // Still there immediately after restart -- the lease was not dropped.
     const leasesAfterRestart = await env.cli(["list", "--leases"]);
     expect(leasesAfterRestart.json).toEqual(
-      expect.arrayContaining([expect.objectContaining({ id: grant.lease })]),
+      expect.arrayContaining([expect.objectContaining({ id: grant.lease.id })]),
     );
 
     // If the TTL timer were not restored (rather than merely the lease record
     // persisting), it would never expire and this would time out.
     await waitForLeaseCount(env, 0, { timeout: 30_000 });
-    await waitForDeviceState(env, grant.udid, "ready");
+    await waitForDeviceState(env, grant.device.driverDeviceId, "ready");
 
     await env.expectEvents(["lease.expired"]);
   });

--- a/e2e/lease-lifecycle.test.ts
+++ b/e2e/lease-lifecycle.test.ts
@@ -76,18 +76,21 @@ describe("lease lifecycle across both frontends", () => {
     try {
       const leaseResult = await mcp.client.callTool({
         name: "lease_simulator",
-        arguments: { model: "iPhone 16", osVersion: "18.4", platform: "ios" },
+        arguments: { platform: "ios", device: "iPhone 16", os: "18.4" },
       });
       const leased = leaseResult.structuredContent as {
-        device: { driverDeviceId: string; spec: { model: string } };
-        lease: { id: string };
+        lease_id: string;
+        device_id: string;
+        device: string;
+        platform: string;
       };
-      expect(leased.device.spec.model).toBe("iPhone 16");
+      expect(leased.device).toBe("iPhone 16");
 
       const statusResult = await mcp.client.callTool({ name: "lease_status", arguments: {} });
       expect(statusResult.structuredContent).toMatchObject({
         held: true,
-        id: leased.lease.id,
+        lease_id: leased.lease_id,
+        device_id: leased.device_id,
       });
 
       // The CLI frontend must see the exact same lease, keyed by the same requester id.
@@ -95,7 +98,7 @@ describe("lease lifecycle across both frontends", () => {
       expect(cliLeases.code).toBe(0);
       expect(cliLeases.json).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ id: leased.lease.id, requesterId: agentId }),
+          expect.objectContaining({ id: leased.lease_id, requesterId: agentId }),
         ]),
       );
 
@@ -106,10 +109,10 @@ describe("lease lifecycle across both frontends", () => {
 
       const releaseResult = await mcp.client.callTool({
         name: "release_simulator",
-        arguments: { leaseId: leased.lease.id },
+        arguments: { lease_id: leased.lease_id },
       });
       expect(releaseResult.structuredContent).toMatchObject({
-        leaseId: leased.lease.id,
+        lease_id: leased.lease_id,
         released: true,
       });
 
@@ -120,12 +123,12 @@ describe("lease lifecycle across both frontends", () => {
       const midPurge = await env.cli(["list", "--devices"]);
       expect(midPurge.json).toEqual([
         expect.objectContaining({
-          driverDeviceId: leased.device.driverDeviceId,
+          driverDeviceId: leased.device_id,
           state: "reclaiming",
         }),
       ]);
 
-      await waitForDeviceState(env, leased.device.driverDeviceId, "ready");
+      await waitForDeviceState(env, leased.device_id, "ready");
     } finally {
       await mcp.close();
     }

--- a/e2e/lease-lifecycle.test.ts
+++ b/e2e/lease-lifecycle.test.ts
@@ -35,14 +35,17 @@ describe("lease lifecycle across both frontends", () => {
       "--detach",
     ]);
     expect(lease.code).toBe(0);
-    const leaseGrant = lease.json as { lease: string; device: string; udid: string };
-    expect(leaseGrant.device).toBe("iPhone 16");
+    const leaseGrant = lease.json as {
+      lease: { id: string };
+      device: { spec: { model: string }; driverDeviceId: string };
+    };
+    expect(leaseGrant.device.spec.model).toBe("iPhone 16");
 
     const statusJson = await env.cli(["status", "--json"]);
     expect(statusJson.code).toBe(0);
     expect(statusJson.json).toMatchObject({
       leases: expect.arrayContaining([
-        expect.objectContaining({ id: leaseGrant.lease, requesterId: agentId }),
+        expect.objectContaining({ id: leaseGrant.lease.id, requesterId: agentId }),
       ]),
     });
 
@@ -50,14 +53,14 @@ describe("lease lifecycle across both frontends", () => {
     expect(listLeases.code).toBe(0);
     expect(listLeases.json).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ id: leaseGrant.lease, requesterId: agentId }),
+        expect.objectContaining({ id: leaseGrant.lease.id, requesterId: agentId }),
       ]),
     );
 
-    const release = await env.cli(["release", leaseGrant.lease]);
+    const release = await env.cli(["release", leaseGrant.lease.id]);
     expect(release.code).toBe(0);
 
-    await waitForDeviceState(env, leaseGrant.udid, "ready");
+    await waitForDeviceState(env, leaseGrant.device.driverDeviceId, "ready");
 
     await env.expectEvents(["lease.requested", "lease.granted", "lease.released"]);
   });
@@ -73,21 +76,18 @@ describe("lease lifecycle across both frontends", () => {
     try {
       const leaseResult = await mcp.client.callTool({
         name: "lease_simulator",
-        arguments: { platform: "ios", device: "iPhone 16", os: "18.4" },
+        arguments: { model: "iPhone 16", osVersion: "18.4", platform: "ios" },
       });
       const leased = leaseResult.structuredContent as {
-        lease_id: string;
-        device_id: string;
-        device: string;
-        platform: string;
+        device: { driverDeviceId: string; spec: { model: string } };
+        lease: { id: string };
       };
-      expect(leased.device).toBe("iPhone 16");
+      expect(leased.device.spec.model).toBe("iPhone 16");
 
       const statusResult = await mcp.client.callTool({ name: "lease_status", arguments: {} });
       expect(statusResult.structuredContent).toMatchObject({
         held: true,
-        lease_id: leased.lease_id,
-        device_id: leased.device_id,
+        id: leased.lease.id,
       });
 
       // The CLI frontend must see the exact same lease, keyed by the same requester id.
@@ -95,7 +95,7 @@ describe("lease lifecycle across both frontends", () => {
       expect(cliLeases.code).toBe(0);
       expect(cliLeases.json).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ id: leased.lease_id, requesterId: agentId }),
+          expect.objectContaining({ id: leased.lease.id, requesterId: agentId }),
         ]),
       );
 
@@ -106,10 +106,10 @@ describe("lease lifecycle across both frontends", () => {
 
       const releaseResult = await mcp.client.callTool({
         name: "release_simulator",
-        arguments: { lease_id: leased.lease_id },
+        arguments: { leaseId: leased.lease.id },
       });
       expect(releaseResult.structuredContent).toMatchObject({
-        lease_id: leased.lease_id,
+        leaseId: leased.lease.id,
         released: true,
       });
 
@@ -119,10 +119,13 @@ describe("lease lifecycle across both frontends", () => {
       expect(cliLeasesAfter.json).toEqual([]);
       const midPurge = await env.cli(["list", "--devices"]);
       expect(midPurge.json).toEqual([
-        expect.objectContaining({ driverDeviceId: leased.device_id, state: "reclaiming" }),
+        expect.objectContaining({
+          driverDeviceId: leased.device.driverDeviceId,
+          state: "reclaiming",
+        }),
       ]);
 
-      await waitForDeviceState(env, leased.device_id, "ready");
+      await waitForDeviceState(env, leased.device.driverDeviceId, "ready");
     } finally {
       await mcp.close();
     }

--- a/e2e/leased-device-crash-recovery.test.ts
+++ b/e2e/leased-device-crash-recovery.test.ts
@@ -10,15 +10,15 @@ interface DeviceRow {
 }
 
 interface LeaseGrant {
-  readonly lease: string;
-  readonly udid: string;
+  readonly lease: { readonly id: string };
+  readonly device: { readonly driverDeviceId: string };
 }
 
 interface HealthPushLine {
   readonly attempts?: number;
-  readonly device_id: string;
-  readonly event: string;
-  readonly lease: string;
+  readonly deviceId: string;
+  readonly push: string;
+  readonly leaseId: string;
 }
 
 const HEALTH_CONFIG_BASE = {
@@ -74,14 +74,18 @@ describe("leased device crash recovery", () => {
     // an omitted device reads as "missing", which is the unrecoverable branch, not
     // this one.
     await env.driverScript.merge({
-      ios: { managedReality: { devices: [{ deviceId: grant.udid, runState: "stopped" }] } },
+      ios: {
+        managedReality: {
+          devices: [{ deviceId: grant.device.driverDeviceId, runState: "stopped" }],
+        },
+      },
     });
 
-    await waitFor(() => healthLines(held).some((line) => line.event === "device_unhealthy"), {
+    await waitFor(() => healthLines(held).some((line) => line.push === "device-unhealthy"), {
       label: "held CLI reports device_unhealthy",
       timeout: 15_000,
     });
-    await waitFor(() => healthLines(held).some((line) => line.event === "device_recovered"), {
+    await waitFor(() => healthLines(held).some((line) => line.push === "device-recovered"), {
       label: "held CLI reports device_recovered",
       timeout: 15_000,
     });
@@ -93,21 +97,25 @@ describe("leased device crash recovery", () => {
     // we've observed at least one pair, so the recovered state settles; the
     // assertions below deliberately don't depend on an exact recovery count.
     await env.driverScript.merge({
-      ios: { managedReality: { devices: [{ deviceId: grant.udid, runState: "running" }] } },
+      ios: {
+        managedReality: {
+          devices: [{ deviceId: grant.device.driverDeviceId, runState: "running" }],
+        },
+      },
     });
 
     const lines = healthLines(held);
-    const unhealthyIndex = lines.findIndex((line) => line.event === "device_unhealthy");
-    const recoveredIndex = lines.findIndex((line) => line.event === "device_recovered");
+    const unhealthyIndex = lines.findIndex((line) => line.push === "device-unhealthy");
+    const recoveredIndex = lines.findIndex((line) => line.push === "device-recovered");
     expect(unhealthyIndex).toBeGreaterThanOrEqual(0);
     expect(recoveredIndex, "device_recovered must follow device_unhealthy").toBeGreaterThan(
       unhealthyIndex,
     );
     expect(lines[unhealthyIndex]).toMatchObject({
-      device_id: expect.any(String),
-      lease: grant.lease,
+      deviceId: expect.any(String),
+      leaseId: grant.lease.id,
     });
-    expect(lines[recoveredIndex]).toMatchObject({ lease: grant.lease });
+    expect(lines[recoveredIndex]).toMatchObject({ leaseId: grant.lease.id });
 
     await env.expectEvents(["device.crash-detected", "device.recovered"]);
 
@@ -117,19 +125,23 @@ describe("leased device crash recovery", () => {
     const makeReadyCallsForDevice = calls.filter(
       (call) =>
         call.operation === "makeReady" &&
-        (call.arguments[0] as { deviceId: string }).deviceId === grant.udid,
+        (call.arguments[0] as { deviceId: string }).deviceId === grant.device.driverDeviceId,
     );
     expect(
       makeReadyCallsForDevice.length,
-      `expected at least 2 makeReady calls for ${grant.udid}, saw ${String(makeReadyCallsForDevice.length)}`,
+      `expected at least 2 makeReady calls for ${grant.device.driverDeviceId}, saw ${String(makeReadyCallsForDevice.length)}`,
     ).toBeGreaterThan(1);
 
     // The whole point of the feature: the lease survives recovery.
     await waitForLeaseCount(env, 1);
     const leases = (await env.cli(["list", "--leases"])).json;
-    expect(leases).toEqual(expect.arrayContaining([expect.objectContaining({ id: grant.lease })]));
+    expect(leases).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: grant.lease.id })]),
+    );
     const devices = (await env.cli(["list", "--devices"])).json as DeviceRow[];
-    const deviceRow = devices.find((device) => device.driverDeviceId === grant.udid);
+    const deviceRow = devices.find(
+      (device) => device.driverDeviceId === grant.device.driverDeviceId,
+    );
     expect(deviceRow?.state).toBe("leased");
 
     held.kill("SIGKILL");
@@ -158,28 +170,30 @@ describe("leased device crash recovery", () => {
         failures: {
           makeReady: { message: "simulated unrecoverable boot failure", type: "generic" },
         },
-        managedReality: { devices: [{ deviceId: grant.udid, runState: "stopped" }] },
+        managedReality: {
+          devices: [{ deviceId: grant.device.driverDeviceId, runState: "stopped" }],
+        },
       },
     });
 
     const recorded = await env.expectEvents(["device.recovery-failed", "lease.released"]);
     const recoveryFailed = recorded.find((event) => event.event === "device.recovery-failed");
     expect(recoveryFailed?.payload).toMatchObject({
-      leaseId: grant.lease,
+      leaseId: grant.lease.id,
       reason: "attempts-exhausted",
     });
     const released = recorded.find(
       (event) =>
         event.event === "lease.released" &&
-        (event.payload as { leaseId?: string }).leaseId === grant.lease,
+        (event.payload as { leaseId?: string }).leaseId === grant.lease.id,
     );
-    expect(released?.payload).toMatchObject({ leaseId: grant.lease, reason: "device-lost" });
+    expect(released?.payload).toMatchObject({ leaseId: grant.lease.id, reason: "device-lost" });
 
     // The device is back in the pool, not stuck leased to a dead device.
     await waitForLeaseCount(env, 0);
     const leases = (await env.cli(["list", "--leases"])).json;
     expect(leases).not.toEqual(
-      expect.arrayContaining([expect.objectContaining({ id: grant.lease })]),
+      expect.arrayContaining([expect.objectContaining({ id: grant.lease.id })]),
     );
 
     held.kill("SIGKILL");
@@ -213,7 +227,9 @@ describe("leased device crash recovery", () => {
         failures: {
           makeReady: { message: "simulated unrecoverable boot failure", type: "generic" },
         },
-        managedReality: { devices: [{ deviceId: grant.udid, runState: "stopped" }] },
+        managedReality: {
+          devices: [{ deviceId: grant.device.driverDeviceId, runState: "stopped" }],
+        },
       },
     });
 
@@ -223,17 +239,17 @@ describe("leased device crash recovery", () => {
     // Expected: the held process reports the lost lease on stderr (mirroring
     // device_unhealthy/device_recovered) and exits on its own. Actual: it does
     // neither -- this waitFor times out and the process is still alive afterwards.
-    await waitFor(() => healthLines(held).some((line) => line.event === "lease_lost"), {
+    await waitFor(() => healthLines(held).some((line) => line.push === "lease-lost"), {
       label: "held CLI reports the lease ending",
       timeout: 5_000,
     });
-    // `device_id` here is the registry device id (what `simlock list --devices` calls
-    // `id`), not the driver `udid` the grant returns on stdout -- these pushes carry
-    // the same identifier the event bus does.
-    const lost = healthLines(held).find((line) => line.event === "lease_lost");
+    // `deviceId` here is the registry device id (what `simlock list --devices` calls
+    // `id`), not the driver's `driverDeviceId` the grant returns on stdout -- these
+    // pushes carry the same identifier the event bus does.
+    const lost = healthLines(held).find((line) => line.push === "lease-lost");
     expect(lost).toMatchObject({
-      device_id: expect.stringMatching(/^dev_/),
-      lease: grant.lease,
+      deviceId: expect.stringMatching(/^dev_/),
+      leaseId: grant.lease.id,
       reason: "device-lost",
     });
 

--- a/e2e/parent-watch.test.ts
+++ b/e2e/parent-watch.test.ts
@@ -42,7 +42,7 @@ describe("parent-watch", () => {
         "--bind-pid",
         String(fakeAgent.pid),
       ]);
-      const grant = JSON.parse(await held.firstStdoutLine()) as { lease: string; udid: string };
+      const grant = JSON.parse(await held.firstStdoutLine()) as { lease: { id: string } };
       await waitForLeaseCount(env, 1);
 
       fakeAgent.kill("SIGKILL");
@@ -58,7 +58,7 @@ describe("parent-watch", () => {
       expect(recorded).toContainEqual(
         expect.objectContaining({
           event: "lease.released",
-          payload: expect.objectContaining({ leaseId: grant.lease, reason: "explicit" }),
+          payload: expect.objectContaining({ leaseId: grant.lease.id, reason: "explicit" }),
         }),
       );
     } finally {

--- a/e2e/slow-ios-slim.test.ts
+++ b/e2e/slow-ios-slim.test.ts
@@ -452,42 +452,45 @@ describe.skipIf(process.platform !== "darwin")(
           const fullResult = await mcp.client.callTool(
             {
               name: "lease_simulator",
-              arguments: { platform: "ios", device: model, os, full: true },
+              arguments: { full: true, model, osVersion: os, platform: "ios" },
             },
             undefined,
             leaseCallOptions,
           );
           const fullLeased = fullResult.structuredContent as {
-            lease_id: string;
-            slim: boolean;
+            device: { featureProfile?: "full" | "reduced" };
+            lease: { id: string };
           };
-          expect(fullLeased.slim, "MCP full:true lease must report slim:false").toBe(false);
+          expect(
+            fullLeased.device.featureProfile,
+            "MCP full:true lease must report a full feature profile",
+          ).toBe("full");
 
           await mcp.client.callTool({
             name: "release_simulator",
-            arguments: { lease_id: fullLeased.lease_id },
+            arguments: { leaseId: fullLeased.lease.id },
           });
 
           const slimResult = await mcp.client.callTool(
             {
               name: "lease_simulator",
-              arguments: { platform: "ios", device: model, os },
+              arguments: { model, osVersion: os, platform: "ios" },
             },
             undefined,
             leaseCallOptions,
           );
           const slimLeased = slimResult.structuredContent as {
-            lease_id: string;
-            slim: boolean;
+            device: { featureProfile?: "full" | "reduced" };
+            lease: { id: string };
           };
           expect(
-            slimLeased.slim,
-            "MCP plain lease under ios.slim.enabled must report slim:true",
-          ).toBe(true);
+            slimLeased.device.featureProfile,
+            "MCP plain lease under ios.slim.enabled must report a reduced feature profile",
+          ).toBe("reduced");
 
           await mcp.client.callTool({
             name: "release_simulator",
-            arguments: { lease_id: slimLeased.lease_id },
+            arguments: { leaseId: slimLeased.lease.id },
           });
         } finally {
           await mcp.close();

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -10,16 +10,21 @@ import { type Config, CleanupReaper, FakeDriver, LeaseEngine, Registry } from ".
 import {
   CryptoTokenSecrets,
   FakeClock,
+  FakeDaemonLauncher,
   FakeParentWatch,
   MemoryFilesystem,
+  MemoryIpcTransport,
   NodeFilesystem,
   NodeIpcTransport,
+  type Filesystem,
   type IdGenerator,
 } from "../ports/index.js";
 import { FakeSystemStats } from "../ports/index.js";
 import { TokenStore } from "../http/token-store.js";
 import { DaemonEndpointHost } from "../daemon/connection-host.js";
 import { DaemonServer } from "../daemon/server.js";
+import { AdminSecretManager } from "../daemon/admin-secret.js";
+import { createCredentialRoleResolver } from "../daemon/session.js";
 import { SimlockError, type AnySimlockError } from "../contract/index.js";
 import type {
   CatalogGetOutput,
@@ -35,12 +40,14 @@ import type {
 } from "../simlock-client/client.js";
 import { connectSimlockAdmin } from "../admin/index.js";
 import {
+  buildCliEnvironment,
   errorExitCode,
   fallbackRequesterId,
   parseDuration,
   readLogFile,
   runCli,
   type CliEnvironment,
+  type CliEnvironmentPorts,
 } from "./index.js";
 
 const gibibyte = 1024 ** 3;
@@ -129,8 +136,10 @@ describe("CLI: exit codes", () => {
         ["status"],
         output.environmentWith({
           readAdminTokenFile: async () => "a-token",
-          connectAdmin: async () =>
-            fakeClient({ getStatus: () => Promise.reject(simlockError("NO_CAPACITY")) }),
+          connectAdmin: async (resolveCredential) => {
+            await resolveCredential();
+            return fakeClient({ getStatus: () => Promise.reject(simlockError("NO_CAPACITY")) });
+          },
         }),
       ),
     ).resolves.toBe(11);
@@ -157,8 +166,8 @@ describe("CLI: admin credential resolution (ADR 0003 §5)", () => {
       output.environmentWith({
         adminTokenFromEnv: "from-env",
         readAdminTokenFile: async () => "from-file",
-        connectAdmin: async (credential) => {
-          seen = credential;
+        connectAdmin: async (resolveCredential) => {
+          seen = await resolveCredential();
           return fakeClient();
         },
       }),
@@ -175,8 +184,8 @@ describe("CLI: admin credential resolution (ADR 0003 §5)", () => {
       output.environmentWith({
         adminTokenFromEnv: "from-env",
         readAdminTokenFile: async () => "from-file",
-        connectAdmin: async (credential) => {
-          seen = credential;
+        connectAdmin: async (resolveCredential) => {
+          seen = await resolveCredential();
           return fakeClient();
         },
       }),
@@ -191,8 +200,8 @@ describe("CLI: admin credential resolution (ADR 0003 §5)", () => {
       ["status"],
       output.environmentWith({
         readAdminTokenFile: async () => "from-file",
-        connectAdmin: async (credential) => {
-          seen = credential;
+        connectAdmin: async (resolveCredential) => {
+          seen = await resolveCredential();
           return fakeClient();
         },
       }),
@@ -212,8 +221,8 @@ describe("CLI: admin credential resolution (ADR 0003 §5)", () => {
           reads += 1;
           return reads < 3 ? undefined : "from-file-after-retry";
         },
-        connectAdmin: async (credential) => {
-          seen = credential;
+        connectAdmin: async (resolveCredential) => {
+          seen = await resolveCredential();
           return fakeClient();
         },
       }),
@@ -230,8 +239,8 @@ describe("CLI: admin credential resolution (ADR 0003 §5)", () => {
       ["status"],
       output.environmentWith({
         readAdminTokenFile: async () => undefined,
-        connectAdmin: async (credential) => {
-          seen = credential;
+        connectAdmin: async (resolveCredential) => {
+          seen = await resolveCredential();
           return fakeClient();
         },
       }),
@@ -240,6 +249,168 @@ describe("CLI: admin credential resolution (ADR 0003 §5)", () => {
     expect(output.stderr.trim().split("\n")).toHaveLength(1);
     const notice: unknown = JSON.parse(output.stderr);
     expect((notice as { notice: string }).notice).toMatch(/agent/i);
+  });
+
+  it("does not read the admin.token file at all when --token is given (B2 ordering)", async () => {
+    // The file source must never be consulted -- let alone before the connection exists -- when
+    // a higher-priority source already answered. Also guards against a regression back to
+    // resolving credentials before `connectAdmin` is even called.
+    const output = outputCapture();
+    let fileReads = 0;
+    await runCli(
+      ["--token", "from-flag", "status"],
+      output.environmentWith({
+        readAdminTokenFile: async () => {
+          fileReads += 1;
+          return "from-file";
+        },
+        connectAdmin: async (resolveCredential) => {
+          await resolveCredential();
+          return fakeClient();
+        },
+      }),
+    );
+    expect(fileReads).toBe(0);
+  });
+
+  it("B1: degrades to an agent session with a stderr notice when the daemon rejects the credential", async () => {
+    const output = outputCapture();
+    let attempt = 0;
+    let seenOnRetry: string | undefined | "unset" = "unset";
+    await runCli(
+      ["status"],
+      output.environmentWith({
+        readAdminTokenFile: async () => "stale-secret",
+        connectAdmin: async (resolveCredential) => {
+          attempt += 1;
+          if (attempt === 1) {
+            const credential = await resolveCredential();
+            expect(credential).toBe("stale-secret");
+            throw simlockError("ADMIN_AUTHENTICATION_FAILED");
+          }
+          seenOnRetry = await resolveCredential();
+          return fakeClient();
+        },
+      }),
+    );
+    expect(attempt).toBe(2);
+    expect(seenOnRetry).toBeUndefined();
+    expect(output.stderr.trim().split("\n")).toHaveLength(1);
+    const notice = JSON.parse(output.stderr) as { notice: string };
+    expect(notice.notice).toMatch(/admin\.token/i);
+    expect(notice.notice).toMatch(/agent/i);
+  });
+
+  it("B1: does not retry, and propagates the error, when the connection already had no credential", async () => {
+    const output = outputCapture();
+    let attempts = 0;
+    const exitCode = await runCli(
+      ["status"],
+      output.environmentWith({
+        readAdminTokenFile: async () => undefined,
+        connectAdmin: async (resolveCredential) => {
+          attempts += 1;
+          await resolveCredential();
+          throw simlockError("ADMIN_AUTHENTICATION_FAILED");
+        },
+      }),
+    );
+    expect(attempts).toBe(1);
+    expect(exitCode).not.toBe(0);
+    expect(JSON.parse(output.stderr).error.code).toBe("ADMIN_AUTHENTICATION_FAILED");
+  });
+
+  it("B1: an explicit but wrong --token also degrades to agent, with a generic (not file-specific) notice", async () => {
+    const output = outputCapture();
+    let attempt = 0;
+    await runCli(
+      ["--token", "wrong", "status"],
+      output.environmentWith({
+        connectAdmin: async (resolveCredential) => {
+          attempt += 1;
+          const credential = await resolveCredential();
+          if (attempt === 1) {
+            expect(credential).toBe("wrong");
+            throw simlockError("ADMIN_AUTHENTICATION_FAILED");
+          }
+          expect(credential).toBeUndefined();
+          return fakeClient();
+        },
+      }),
+    );
+    expect(attempt).toBe(2);
+    const notice = JSON.parse(output.stderr) as { notice: string };
+    expect(notice.notice).not.toMatch(/admin\.token/i);
+    expect(notice.notice).toMatch(/agent/i);
+  });
+
+  it("B2: reaches admin on a cold start, on the very first invocation, no daemon running yet", async () => {
+    const filesystem = new MemoryFilesystem();
+    const ipcTransport = new MemoryIpcTransport();
+    const socketPath = "/simlock/daemon.sock";
+    const adminTokenPath = "/simlock/admin.token";
+    const launcher = new FakeDaemonLauncher(async () => {
+      await startInMemoryDaemon({ adminTokenPath, filesystem, ipcTransport, socketPath });
+    });
+    const output = outputCapture({
+      filesystem,
+      clock: new FakeClock(0),
+      systemStats: new FakeSystemStats({
+        cpuCount: 8,
+        freeRamBytes: 32 * gibibyte,
+        totalRamBytes: 32 * gibibyte,
+      }),
+      ipc: ipcTransport,
+      launcher,
+      dataDirectory: "/simlock",
+    });
+    const exitCode = await runCli(
+      ["lease", "--platform", "ios", "--device", "iPhone 17 Pro", "--detach"],
+      output.environmentWith(),
+    );
+    expect(exitCode).toBe(0);
+    expect(launcher.launches).toBe(1);
+    const grant = JSON.parse(output.stdout) as LeaseGrant & { role: string };
+    expect(grant.role).toBe("admin");
+    // Provisioning progress pushes are expected noise on stderr; the agent-fallback notice is
+    // the thing that must be absent.
+    expect(output.stderr).not.toContain("notice");
+  });
+
+  it("B1: a stale admin.token degrades to an agent session instead of bricking the invocation", async () => {
+    const filesystem = new MemoryFilesystem();
+    const ipcTransport = new MemoryIpcTransport();
+    const socketPath = "/simlock/daemon.sock";
+    const adminTokenPath = "/simlock/admin.token";
+    // A daemon actually runs and persists its own secret first, then the file is overwritten
+    // with a value that hashes to nothing the running daemon recognizes -- exactly what a
+    // `kill -9`'d daemon's leftover `admin.token` looks like to the *next* daemon incarnation,
+    // which never touches a file it did not itself just persist.
+    await startInMemoryDaemon({ adminTokenPath, filesystem, ipcTransport, socketPath });
+    await filesystem.writeFileAtomic(adminTokenPath, "stale-secret-from-a-killed-daemon\n");
+    const launcher = new FakeDaemonLauncher();
+    const output = outputCapture({
+      filesystem,
+      clock: new FakeClock(0),
+      systemStats: new FakeSystemStats({
+        cpuCount: 8,
+        freeRamBytes: 32 * gibibyte,
+        totalRamBytes: 32 * gibibyte,
+      }),
+      ipc: ipcTransport,
+      launcher,
+      dataDirectory: "/simlock",
+    });
+    const exitCode = await runCli(
+      ["lease", "--platform", "ios", "--device", "iPhone 17 Pro", "--detach"],
+      output.environmentWith(),
+    );
+    expect(exitCode).toBe(0);
+    // The daemon was already running -- a bad credential must never trigger an auto-launch.
+    expect(launcher.launches).toBe(0);
+    const grant = JSON.parse(output.stdout) as LeaseGrant & { role: string };
+    expect(grant.role).toBe("agent");
+    expect(output.stderr).toContain("admin.token");
   });
 });
 
@@ -346,6 +517,83 @@ describe("CLI: config set validates before writing (ADR 0003 §11)", () => {
       ),
     ).resolves.toBe(0);
     expect(written).toEqual({ downloads: { policy: "never" } });
+  });
+});
+
+describe("CLI: config set validates with the real config loader (ADR 0003 §11, B9)", () => {
+  it("rejects an unknown config key instead of silently dropping it", async () => {
+    const output = outputCapture(realCliEnvironmentPorts());
+    let wrote = false;
+    const exitCode = await runCli(
+      ["config", "set", "capacty.limits.ios.maxDevices", "2"],
+      output.environmentWith({
+        readConfigFile: async () => ({}),
+        writeConfigFile: async () => {
+          wrote = true;
+        },
+      }),
+    );
+    expect(exitCode).toBe(2);
+    expect(wrote).toBe(false);
+    expect(JSON.parse(output.stderr).error.code).toBe("USAGE");
+  });
+
+  it("rejects a mistyped key (missing the Ms suffix) instead of validating clean", async () => {
+    const output = outputCapture(realCliEnvironmentPorts());
+    let wrote = false;
+    const exitCode = await runCli(
+      ["config", "set", "lease.heldTtlBackstop", "60000"],
+      output.environmentWith({
+        readConfigFile: async () => ({}),
+        writeConfigFile: async () => {
+          wrote = true;
+        },
+      }),
+    );
+    expect(exitCode).toBe(2);
+    expect(wrote).toBe(false);
+  });
+
+  it("still writes a genuinely valid key", async () => {
+    const output = outputCapture(realCliEnvironmentPorts());
+    let written: Record<string, unknown> | undefined;
+    const exitCode = await runCli(
+      // Well above the default heartbeat interval (5 min) * 4, so this doesn't also trip
+      // `validateHeartbeatInterval` -- this test is only about the key itself validating clean.
+      ["config", "set", "lease.heldTtlBackstopMs", "2400000"],
+      output.environmentWith({
+        readConfigFile: async () => ({}),
+        writeConfigFile: async (contents) => {
+          written = contents;
+        },
+      }),
+    );
+    expect(exitCode).toBe(0);
+    expect(written).toEqual({ lease: { heldTtlBackstopMs: 2400000 } });
+  });
+
+  it("does not let a stray file at the scratch validation path change the outcome", async () => {
+    // Guards against B9's second bug: the validation scratch path must never be able to read a
+    // real file, whether one happens to already exist there or not.
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp("/");
+    await filesystem.writeFileAtomic(
+      "/config-set-validation.json",
+      `${JSON.stringify({ totally: { bogus: true } })}\n`,
+    );
+    const output = outputCapture(realCliEnvironmentPorts(filesystem));
+    let wrote = false;
+    const exitCode = await runCli(
+      ["config", "set", "downloads.policy", "never"],
+      output.environmentWith({
+        readConfigFile: async () => ({}),
+        writeConfigFile: async () => {
+          wrote = true;
+        },
+      }),
+    );
+    expect(exitCode).toBe(0);
+    expect(wrote).toBe(true);
   });
 });
 
@@ -470,13 +718,15 @@ describe("CLI smoke test (ADR 0003 §12: one per frontend)", () => {
     const { socketPath } = await startTestDaemon();
     const ipc = new NodeIpcTransport();
     const environment = outputCapture().environmentWith({
-      connectAdmin: (credential) =>
-        connectSimlockAdmin({
+      connectAdmin: async (resolveCredential) => {
+        const credential = await resolveCredential();
+        return connectSimlockAdmin({
           ipc,
           endpoint: socketPath,
           principal: "smoke-test",
           ...(credential === undefined ? {} : { credential }),
-        }),
+        });
+      },
     });
 
     const leaseOut = outputCapture();
@@ -658,30 +908,56 @@ interface OutputCapture {
   environmentWith(overrides?: Partial<CliEnvironment>): CliEnvironment;
 }
 
-function outputCapture(): OutputCapture {
+/**
+ * `ports` is `undefined` for the fully-mocked default every other suite uses (a bare object
+ * literal, `connectAdmin` etc. never call their argument unless a test's override does).
+ * Passing `ports` (built with `realCliEnvironmentPorts`, or by hand for the cold-start/B1
+ * suites) routes `environmentWith` through the real `buildCliEnvironment` instead -- the only
+ * way to exercise the production credential-resolution ordering (B2) and the real config
+ * validator (B9) rather than re-testing a test double.
+ */
+function outputCapture(ports?: CliEnvironmentPorts): OutputCapture {
   const capture: OutputCapture = {
     stdout: "",
     stderr: "",
     environmentWith(overrides = {}) {
-      return {
-        configPath: "/simlock/config.json",
-        requesterId: "test-requester",
-        now: () => 0,
-        connectAdmin: async () => fakeClient(),
-        connectExistingAdmin: async () => fakeClient(),
-        readAdminTokenFile: async () => undefined,
-        sleep: async () => {},
-        readConfigFile: async () => ({}),
-        writeConfigFile: async () => {},
-        validateConfig: async () => {},
-        readLogFile: async () => "",
-        signals: new EventEmitter() as unknown as CliEnvironment["signals"],
-        parentWatch: new FakeParentWatch(),
-        stderr: { write: (value: string) => (capture.stderr += value) },
-        stdout: { write: (value: string) => (capture.stdout += value) },
-        confirm: async () => true,
-        ...overrides,
-      };
+      const stderrOut = { write: (value: string) => (capture.stderr += value) };
+      const stdoutOut = { write: (value: string) => (capture.stdout += value) };
+      if (ports === undefined) {
+        return {
+          configPath: "/simlock/config.json",
+          requesterId: "test-requester",
+          now: () => 0,
+          connectAdmin: async () => fakeClient(),
+          connectExistingAdmin: async () => fakeClient(),
+          readAdminTokenFile: async () => undefined,
+          sleep: async () => {},
+          readConfigFile: async () => ({}),
+          writeConfigFile: async () => {},
+          validateConfig: async () => {},
+          readLogFile: async () => "",
+          signals: new EventEmitter() as unknown as CliEnvironment["signals"],
+          parentWatch: new FakeParentWatch(),
+          stderr: stderrOut,
+          stdout: stdoutOut,
+          confirm: async () => true,
+          ...overrides,
+        };
+      }
+      const base = buildCliEnvironment(
+        {
+          ...ports,
+          signals:
+            ports.signals ??
+            (new EventEmitter() as unknown as NonNullable<CliEnvironmentPorts["signals"]>),
+          parentWatch: ports.parentWatch ?? new FakeParentWatch(),
+          confirm: ports.confirm ?? (async () => true),
+          stderr: stderrOut,
+          stdout: stdoutOut,
+        },
+        {},
+      );
+      return { ...base, ...overrides };
     },
   };
   return capture;
@@ -762,6 +1038,115 @@ async function startTestDaemon(): Promise<{ socketPath: string; daemon: DaemonSe
   runningDaemons.push(daemon);
   await daemon.start();
   return { socketPath, daemon };
+}
+
+/** Bare-minimum ports for exercising `buildCliEnvironment`'s real `validateConfig` (B9) without
+ * a daemon connection -- `config set` never calls `connectAdmin`, so `ipc`/`launcher` are inert
+ * placeholders. */
+function realCliEnvironmentPorts(
+  filesystem: Filesystem = new MemoryFilesystem(),
+): CliEnvironmentPorts {
+  return {
+    filesystem,
+    clock: new FakeClock(0),
+    systemStats: new FakeSystemStats({
+      cpuCount: 8,
+      freeRamBytes: 32 * gibibyte,
+      totalRamBytes: 32 * gibibyte,
+    }),
+    ipc: new MemoryIpcTransport(),
+    launcher: new FakeDaemonLauncher(),
+    dataDirectory: "/simlock",
+  };
+}
+
+/**
+ * A real `DaemonServer` wired against in-memory ports (`MemoryFilesystem` + `MemoryIpcTransport`
+ * shared with the CLI environment under test), with the genuine credential handshake
+ * (`AdminSecretManager` + `createCredentialRoleResolver`) instead of `startTestDaemon`'s
+ * `resolveRole: { resolve: () => "admin" }` shortcut -- B1 and B2 both hinge on that handshake
+ * actually running.
+ */
+async function startInMemoryDaemon(options: {
+  readonly filesystem: MemoryFilesystem;
+  readonly ipcTransport: MemoryIpcTransport;
+  readonly socketPath: string;
+  readonly adminTokenPath: string;
+}): Promise<{ daemon: DaemonServer; adminSecret: AdminSecretManager }> {
+  const { adminTokenPath, filesystem, ipcTransport, socketPath } = options;
+  const clock = new FakeClock(1_000);
+  const eventBus = new EventBus(clock);
+  const registry = await Registry.load({
+    clock,
+    eventBus,
+    filesystem,
+    idGenerator: sequence(),
+    statePath: "/state.json",
+  });
+  const driver = new FakeDriver({ availableOsVersions: ["26.5"], clock, platform: "ios" });
+  const config = testConfig();
+  const engine = new LeaseEngine({
+    clock,
+    config,
+    drivers: [driver],
+    eventBus,
+    idGenerator: sequence(),
+    registry,
+    systemStats: new FakeSystemStats({
+      cpuCount: 8,
+      freeRamBytes: 32 * gibibyte,
+      totalRamBytes: 32 * gibibyte,
+    }),
+  });
+  const reaper = new CleanupReaper({
+    clock,
+    config,
+    eventBus,
+    executor: engine.cleanup,
+    filesystem,
+    registry,
+  });
+  const tokens = new TokenStore({
+    clock,
+    filesystem,
+    idGenerator: sequence(),
+    path: "/tokens.json",
+    secrets: new CryptoTokenSecrets(),
+  });
+  const adminSecret = new AdminSecretManager({
+    filesystem,
+    secrets: new CryptoTokenSecrets(),
+    path: adminTokenPath,
+  });
+  const resolveRole = createCredentialRoleResolver({
+    verifyOperatorToken: async (secret) => (await tokens.verify(secret))?.role === "operator",
+    verifyAdminSecret: (secret) => adminSecret.verify(secret),
+  });
+  const daemon = new DaemonServer({
+    adminSecret,
+    capacity: engine,
+    catalog: engine,
+    clock,
+    config,
+    defaultRequesterId: "test-process",
+    eventBus,
+    host: new DaemonEndpointHost({
+      connector: ipcTransport,
+      endpoint: socketPath,
+      filesystem,
+      listenerFactory: ipcTransport,
+    }),
+    leases: engine,
+    queue: engine,
+    reaper,
+    registry,
+    resolveRole,
+    tokens,
+    version: "test",
+  });
+  runningDaemons.push(daemon);
+  await daemon.start();
+  return { daemon, adminSecret };
 }
 
 function testConfig(): Config {

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { EventBus } from "../bus/index.js";
 import { type Config, CleanupReaper, FakeDriver, LeaseEngine, Registry } from "../core/index.js";
@@ -11,24 +11,36 @@ import {
   CryptoTokenSecrets,
   FakeClock,
   FakeParentWatch,
-  FakeSystemStats,
   MemoryFilesystem,
   NodeFilesystem,
   NodeIpcTransport,
+  type IdGenerator,
 } from "../ports/index.js";
+import { FakeSystemStats } from "../ports/index.js";
 import { TokenStore } from "../http/token-store.js";
 import { DaemonEndpointHost } from "../daemon/connection-host.js";
 import { DaemonServer } from "../daemon/server.js";
-import { connectExistingDaemon } from "../daemon-client/client.js";
+import { SimlockError, type AnySimlockError } from "../contract/index.js";
+import type {
+  CatalogGetOutput,
+  DoctorReport,
+  LeaseGrant,
+  LeaseListOutput,
+  LeaseRecord,
+  ListGetOutput,
+  SimlockAdminClient,
+  SimlockConfig,
+  StatusGetOutput,
+  TokenListOutput,
+} from "../simlock-client/client.js";
+import { connectSimlockAdmin } from "../admin/index.js";
 import {
-  DaemonClientError,
   errorExitCode,
   fallbackRequesterId,
   parseDuration,
   readLogFile,
   runCli,
   type CliEnvironment,
-  type DaemonConnection,
 } from "./index.js";
 
 const gibibyte = 1024 ** 3;
@@ -69,7 +81,22 @@ describe("readLogFile", () => {
   });
 });
 
-describe("CLI boundary", () => {
+/**
+ * ADR 0003 §12: "one smoke test per frontend ... frontends are now serialization". This suite
+ * -- the CLI's own -- keeps: exit-code mapping off `ERROR_TABLE` (not a second map), the
+ * admin-credential resolution order and its agent-fallback notice (ADR §5), `daemon status`'s
+ * absent-vs-refused distinction (ADR §11), `config set`'s validate-before-write, `--json` shape
+ * (no snake_case renderings), and the `--yes`/confirm guards on destructive commands (safety
+ * rule 5). Deleted from the pre-ADR suite: every test that only re-walked a daemon operation's
+ * request/response shape through the CLI (lease grant field-by-field, doctor findings,
+ * cleanup/nuke proposals, catalog/list passthrough, events replay/follow wire format, renew,
+ * lease-lost/device-health push parsing, `--bind-pid`/parent-watch termination races) -- that
+ * behaviour is the daemon's contract now, covered once at `daemon/dispatcher.test.ts`, and
+ * `SimlockClientImpl`'s own suite in `simlock-client/client.test.ts`; re-asserting it a third
+ * time through the CLI tested only that this module still calls `client.foo()`, which the
+ * TypeScript compiler already guarantees against `SimlockAdminClient`'s interface.
+ */
+describe("CLI: exit codes", () => {
   it.each([
     ["QUEUE_TIMEOUT", 10],
     ["NO_CAPACITY", 11],
@@ -79,1157 +106,605 @@ describe("CLI boundary", () => {
     ["LICENSE_NOT_ACCEPTED", 12],
     ["BAD_REQUEST", 2],
     ["REQUESTER_ALREADY_LEASED", 13],
-  ] as const)("maps %s daemon errors to exit %d", async (code, expected) => {
-    const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response("status.get", new DaemonClientError(code, "failed"));
+    ["UNKNOWN_LEASE", 1],
+  ] as const)("maps %s to exit %d, from ERROR_TABLE not a second map", async (code, expected) => {
+    const error = simlockError(code);
+    expect(errorExitCode(error)).toBe(expected);
 
+    const output = outputCapture();
     await expect(
-      runCli(["status"], output.environmentWith({ connect: async () => connection })),
+      runCli(
+        ["status"],
+        output.environmentWith({
+          connectAdmin: async () => fakeClient({ getStatus: () => Promise.reject(error) }),
+        }),
+      ),
     ).resolves.toBe(expected);
-    expect(errorExitCode(new DaemonClientError(code, "failed"))).toBe(expected);
   });
 
   it("writes a single structured JSON error line to stderr for a daemon error", async () => {
     const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response("status.get", new DaemonClientError("NO_CAPACITY", "No capacity"));
-
-    await expect(
-      runCli(["status"], output.environmentWith({ connect: async () => connection })),
-    ).resolves.toBe(11);
-    expect(output.stdout).toBe("");
-    expect(output.stderr.trim().split("\n")).toHaveLength(1);
-    expect(JSON.parse(output.stderr)).toEqual({
-      error: { code: "NO_CAPACITY", message: "No capacity" },
-    });
-  });
-
-  it("gives REQUESTER_ALREADY_LEASED its own exit code and an actionable message", async () => {
-    const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response(
-      "lease.request",
-      new DaemonClientError(
-        "REQUESTER_ALREADY_LEASED",
-        "Requester test-requester already holds lease lse_1; release it (`simlock release lse_1`) before requesting another device",
-      ),
-    );
-
     await expect(
       runCli(
-        ["lease", "--platform", "ios", "--device", "iPhone 16", "--detach"],
-        output.environmentWith({ connect: async () => connection }),
-      ),
-    ).resolves.toBe(13);
-    expect(output.stdout).toBe("");
-    const parsed = JSON.parse(output.stderr) as { error: { code: string; message: string } };
-    expect(parsed.error.code).toBe("REQUESTER_ALREADY_LEASED");
-    expect(parsed.error.message).toContain("lse_1");
-    expect(parsed.error.message).toContain("simlock release lse_1");
-  });
-
-  it("parses human durations and bare milliseconds", () => {
-    expect(parseDuration("90s")).toBe(90_000);
-    expect(parseDuration("10m")).toBe(600_000);
-    expect(parseDuration("250")).toBe(250);
-  });
-
-  it("resolves the fallback requester id from SIMLOCK_AGENT_ID, else the process pid", () => {
-    expect(fallbackRequesterId({ SIMLOCK_AGENT_ID: "agent-from-env" })).toBe("agent-from-env");
-    expect(fallbackRequesterId({})).toBe(String(process.pid));
-  });
-
-  it("reports missing lease arguments as a structured USAGE error", async () => {
-    const output = outputCapture();
-
-    await expect(runCli(["lease"], output.environment)).resolves.toBe(2);
-    expect(output.stdout).toBe("");
-    expect(output.stderr.trim().split("\n")).toHaveLength(1);
-    expect(JSON.parse(output.stderr)).toEqual({
-      error: { code: "USAGE", message: expect.stringContaining("--platform") },
-    });
-  });
-
-  it("rejects --json on a command whose output is already unconditionally JSON", async () => {
-    const output = outputCapture();
-
-    await expect(runCli(["list", "--json"], output.environment)).resolves.toBe(2);
-    expect(output.stdout).toBe("");
-    expect(JSON.parse(output.stderr)).toMatchObject({ error: { code: "USAGE" } });
-  });
-
-  it("lists the MCP server in root help", async () => {
-    const output = outputCapture();
-
-    await expect(runCli([], output.environment)).resolves.toBe(0);
-    expect(output.stdout).toContain("mcp");
-    expect(output.stdout).toContain("Start the stdio MCP server");
-  });
-
-  it("does not load the MCP runner for non-MCP commands", async () => {
-    const output = outputCapture();
-    const loadMcpStdio = vi.fn(async () => vi.fn(async () => undefined));
-    const connection = new StubConnection();
-    connection.response("status.get", {});
-
-    await expect(
-      runCli(
-        ["status", "--json"],
-        output.environmentWith({ connect: async () => connection, loadMcpStdio }),
-      ),
-    ).resolves.toBe(0);
-    expect(loadMcpStdio).not.toHaveBeenCalled();
-  });
-
-  it.each([["--help"], ["-h"]])("prints MCP help without starting it: %s", async (help) => {
-    const output = outputCapture();
-    const runner = vi.fn(async () => undefined);
-
-    await expect(
-      runCli(["mcp", help], output.environmentWith({ runMcpStdio: runner })),
-    ).resolves.toBe(0);
-    expect(output.stdout).toBe("Usage: simlock mcp\n");
-    expect(output.stderr).toBe("");
-    expect(runner).not.toHaveBeenCalled();
-  });
-
-  it("waits for the MCP runner without writing before it completes", async () => {
-    const output = outputCapture();
-    let complete!: () => void;
-    const runner = vi.fn(
-      () =>
-        new Promise<void>((resolve) => {
-          complete = resolve;
-        }),
-    );
-    const run = runCli(["mcp"], output.environmentWith({ runMcpStdio: runner }));
-
-    await vi.waitFor(() => expect(runner).toHaveBeenCalledTimes(1));
-    expect(output.stdout).toBe("");
-    expect(output.stderr).toBe("");
-    complete();
-    await expect(run).resolves.toBe(0);
-    expect(output.stdout).toBe("");
-    expect(output.stderr).toBe("");
-  });
-
-  it.each([["--json"], ["unexpected"], ["--help=true"]])(
-    "rejects unexpected MCP input: %s",
-    async (argument) => {
-      const output = outputCapture();
-      const runner = vi.fn(async () => undefined);
-
-      await expect(
-        runCli(["mcp", argument], output.environmentWith({ runMcpStdio: runner })),
-      ).resolves.toBe(2);
-      expect(output.stdout).toBe("");
-      expect(JSON.parse(output.stderr)).toMatchObject({ error: { code: "USAGE" } });
-      expect(runner).not.toHaveBeenCalled();
-    },
-  );
-
-  it("reports MCP startup failures as a structured INTERNAL error on stderr", async () => {
-    const output = outputCapture();
-    const runner = vi.fn(async () => {
-      throw new Error("MCP startup failed");
-    });
-
-    await expect(runCli(["mcp"], output.environmentWith({ runMcpStdio: runner }))).resolves.toBe(1);
-    expect(output.stdout).toBe("");
-    expect(JSON.parse(output.stderr)).toEqual({
-      error: { code: "INTERNAL", message: "MCP startup failed" },
-    });
-    expect(runner).toHaveBeenCalledTimes(1);
-  });
-
-  it("keeps held lease stdout pure, renders progress to stderr, and releases on SIGTERM", async () => {
-    const harness = await createHarness();
-    const output = outputCapture();
-    const signals = new EventEmitter();
-    const run = runCli(
-      ["lease", "--platform", "ios", "--device", "iPhone 16"],
-      output.environmentWith({
-        connect: () => connectExistingDaemon(harness.socketPath, new NodeIpcTransport()),
-        signals,
-      }),
-    );
-
-    await vi.waitFor(() => expect(output.stdout).not.toBe(""));
-    signals.emit("SIGTERM");
-
-    await expect(run).resolves.toBe(0);
-    expect(output.stdout.trim().split("\n")).toHaveLength(1);
-    expect(JSON.parse(output.stdout)).toMatchObject({
-      device: "iPhone 16",
-      os: "26.5",
-      platform: "ios",
-      state: "leased",
-    });
-    expect(
-      output.stderr
-        .trim()
-        .split("\n")
-        .map((line) => JSON.parse(line)),
-    ).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ event: "provisioning" }),
-        expect.objectContaining({ event: "booting" }),
-      ]),
-    );
-    await expect.poll(() => harness.registry.snapshot.leases).toHaveLength(0);
-  });
-
-  it("sends full: true in the lease.request payload for --full and reports slim in the result", async () => {
-    const output = outputCapture();
-    const signals = new EventEmitter();
-    const connection = new StubConnection();
-    connection.response("lease.request", {
-      device: {
-        driverDeviceId: "ABCD",
-        featureProfile: "full",
-        spec: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
-        state: "leased",
-      },
-      lease: { id: "lse_full", mode: "held", ttlDeadline: 61_000 },
-      timing: {
-        estimatedBootMs: 0,
-        estimatedProvisionMs: 0,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 0,
-      },
-    });
-    const run = runCli(
-      ["lease", "--platform", "ios", "--device", "iPhone 16", "--full"],
-      output.environmentWith({ connect: async () => connection, signals }),
-    );
-
-    await vi.waitFor(() => expect(output.stdout).not.toBe(""));
-    signals.emit("SIGTERM");
-    await expect(run).resolves.toBe(0);
-
-    const leaseCall = connection.calls.find((call) => call.type === "lease.request");
-    expect(leaseCall?.payload).toMatchObject({ full: true });
-    expect(JSON.parse(output.stdout)).toMatchObject({ slim: false });
-  });
-
-  it("omits full from the lease.request payload without --full", async () => {
-    const output = outputCapture();
-    const signals = new EventEmitter();
-    const connection = new StubConnection();
-    connection.response("lease.request", {
-      device: {
-        driverDeviceId: "ABCD",
-        spec: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
-        state: "leased",
-      },
-      lease: { id: "lse_default", mode: "held", ttlDeadline: 61_000 },
-      timing: {
-        estimatedBootMs: 0,
-        estimatedProvisionMs: 0,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 0,
-      },
-    });
-    const run = runCli(
-      ["lease", "--platform", "ios", "--device", "iPhone 16"],
-      output.environmentWith({ connect: async () => connection, signals }),
-    );
-
-    await vi.waitFor(() => expect(output.stdout).not.toBe(""));
-    signals.emit("SIGTERM");
-    await expect(run).resolves.toBe(0);
-
-    const leaseCall = connection.calls.find((call) => call.type === "lease.request");
-    expect(leaseCall?.payload).not.toHaveProperty("full");
-    expect(JSON.parse(output.stdout)).toMatchObject({ slim: false });
-  });
-
-  it("reports a post-signal release failure as a structured stderr line, not prose", async () => {
-    const output = outputCapture();
-    const signals = new EventEmitter();
-    const connection = new StubConnection();
-    connection.response("lease.request", {
-      device: {
-        driverDeviceId: "ABCD",
-        spec: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
-        state: "leased",
-      },
-      lease: { id: "lse_release_fail", mode: "held", ttlDeadline: 61_000 },
-      timing: {
-        estimatedBootMs: 0,
-        estimatedProvisionMs: 0,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 0,
-      },
-    });
-    connection.response("lease.release", new Error("release failed"));
-    const run = runCli(
-      ["lease", "--platform", "ios", "--device", "iPhone 16"],
-      output.environmentWith({ connect: async () => connection, signals }),
-    );
-
-    await vi.waitFor(() => expect(output.stdout).not.toBe(""));
-    signals.emit("SIGTERM");
-
-    await expect(run).resolves.toBe(0);
-    expect(output.stderr.trim().split("\n")).toHaveLength(1);
-    expect(JSON.parse(output.stderr)).toEqual({
-      error: { code: "INTERNAL", message: "release failed" },
-    });
-  });
-
-  it("writes structured stderr lines for device-unhealthy/device-recovered pushes, ignoring malformed ones", async () => {
-    const output = outputCapture();
-    const signals = new EventEmitter();
-    const connection = new StubConnection();
-    connection.response("lease.request", {
-      device: {
-        driverDeviceId: "ABCD",
-        spec: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
-        state: "leased",
-      },
-      lease: { id: "lse_health", mode: "held", ttlDeadline: 61_000 },
-      timing: {
-        estimatedBootMs: 0,
-        estimatedProvisionMs: 0,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 0,
-      },
-    });
-    connection.response("lease.release", { leaseId: "lse_health" });
-    const run = runCli(
-      ["lease", "--platform", "ios", "--device", "iPhone 16"],
-      output.environmentWith({ connect: async () => connection, signals }),
-    );
-
-    await vi.waitFor(() => expect(output.stdout).not.toBe(""));
-    connection.push("device-unhealthy", {
-      deviceId: "ABCD",
-      leaseId: "lse_health",
-      reason: "crashed",
-    });
-    connection.push("device-recovered", { attempts: 2, deviceId: "ABCD", leaseId: "lse_health" });
-    // Malformed pushes must not crash the CLI or emit a diagnostic line.
-    connection.push("device-unhealthy", { deviceId: 42 });
-    connection.push("device-recovered", null);
-
-    signals.emit("SIGTERM");
-    await expect(run).resolves.toBe(0);
-
-    expect(output.stdout.trim().split("\n")).toHaveLength(1);
-    expect(
-      output.stderr
-        .trim()
-        .split("\n")
-        .map((line) => JSON.parse(line)),
-    ).toEqual([
-      { device_id: "ABCD", event: "device_unhealthy", lease: "lse_health" },
-      { attempts: 2, device_id: "ABCD", event: "device_recovered", lease: "lse_health" },
-    ]);
-  });
-
-  it("reports a lost lease, exits 14, and does not re-release it", async () => {
-    const output = outputCapture();
-    const signals = new EventEmitter();
-    const connection = new StubConnection();
-    connection.response("lease.request", {
-      device: {
-        driverDeviceId: "ABCD",
-        spec: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
-        state: "leased",
-      },
-      lease: { id: "lse_lost", mode: "held", ttlDeadline: 61_000 },
-      timing: {
-        estimatedBootMs: 0,
-        estimatedProvisionMs: 0,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 0,
-      },
-    });
-    connection.response("lease.release", new Error("lease.release must not be called"));
-    const run = runCli(
-      ["lease", "--platform", "ios", "--device", "iPhone 16"],
-      output.environmentWith({ connect: async () => connection, signals }),
-    );
-
-    await vi.waitFor(() => expect(output.stdout).not.toBe(""));
-    // A malformed push must not end the holder's lease: it is ignored outright,
-    // and the process keeps waiting exactly as it did before.
-    connection.push("lease-lost", { deviceId: 42 });
-    // No signal: the daemon ending the lease is what must stop the holder.
-    connection.push("lease-lost", {
-      deviceId: "ABCD",
-      leaseId: "lse_lost",
-      reason: "device-lost",
-    });
-
-    await expect(run).resolves.toBe(14);
-    expect(output.stdout.trim().split("\n")).toHaveLength(1);
-    expect(
-      output.stderr
-        .trim()
-        .split("\n")
-        .map((line) => JSON.parse(line)),
-    ).toEqual([
-      { device_id: "ABCD", event: "lease_lost", lease: "lse_lost", reason: "device-lost" },
-    ]);
-  });
-
-  it("flagship e2e: queues a second CLI holder until the first connection drops", async () => {
-    const harness = await createHarness();
-    const first = outputCapture();
-    const second = outputCapture();
-    const firstSignals = new EventEmitter();
-    const secondSignals = new EventEmitter();
-    const firstRun = runCli(
-      ["lease", "--platform", "ios", "--device", "iPhone 16"],
-      first.environmentWith({
-        connect: () => connectExistingDaemon(harness.socketPath, new NodeIpcTransport()),
-        requesterId: "agent-a",
-        signals: firstSignals,
-      }),
-    );
-    await vi.waitFor(() => expect(first.stdout).not.toBe(""));
-    const secondRun = runCli(
-      ["lease", "--platform", "ios", "--device", "iPhone 16"],
-      second.environmentWith({
-        connect: () => connectExistingDaemon(harness.socketPath, new NodeIpcTransport()),
-        requesterId: "agent-b",
-        signals: secondSignals,
-      }),
-    );
-    await vi.waitFor(() =>
-      expect(harness.eventBus.replay().some((event) => event.event === "lease.queued")).toBe(true),
-    );
-    expect(second.stdout).toBe("");
-    expect(
-      second.stderr
-        .trim()
-        .split("\n")
-        .map((line) => JSON.parse(line)),
-    ).toEqual([{ event: "queued", queue_position: 1 }]);
-
-    firstSignals.emit("SIGTERM");
-    await expect(firstRun).resolves.toBe(0);
-    await vi.waitFor(() => expect(second.stdout).not.toBe(""));
-    secondSignals.emit("SIGTERM");
-    await expect(secondRun).resolves.toBe(0);
-    expect(
-      second.stderr
-        .trim()
-        .split("\n")
-        .map((line) => JSON.parse(line)),
-    ).toEqual([{ event: "queued", queue_position: 1 }]);
-  });
-
-  it("--agent-id overrides the environment's fallback requester id", async () => {
-    const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response("lease.request", {
-      device: {
-        driverDeviceId: "ABCD",
-        spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
-        state: "leased",
-      },
-      lease: { id: "lse_1", mode: "detached", ttlDeadline: 1_000 },
-      timing: {
-        estimatedBootMs: 1,
-        estimatedProvisionMs: 1,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 2,
-      },
-    });
-
-    await expect(
-      runCli(
-        [
-          "lease",
-          "--platform",
-          "ios",
-          "--device",
-          "iPhone 17 Pro",
-          "--detach",
-          "--agent-id",
-          "agent-x",
-        ],
-        output.environmentWith({ connect: async () => connection, requesterId: "fallback-id" }),
-      ),
-    ).resolves.toBe(0);
-
-    expect(connection.calls).toEqual([
-      expect.objectContaining({
-        payload: expect.objectContaining({ requesterId: "agent-x" }),
-        type: "lease.request",
-      }),
-    ]);
-  });
-
-  it("falls back to the environment's requester id when --agent-id is omitted", async () => {
-    const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response("lease.request", {
-      device: {
-        driverDeviceId: "ABCD",
-        spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
-        state: "leased",
-      },
-      lease: { id: "lse_1", mode: "detached", ttlDeadline: 1_000 },
-      timing: {
-        estimatedBootMs: 1,
-        estimatedProvisionMs: 1,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 2,
-      },
-    });
-
-    await expect(
-      runCli(
-        ["lease", "--platform", "ios", "--device", "iPhone 17 Pro", "--detach"],
-        output.environmentWith({ connect: async () => connection, requesterId: "fallback-id" }),
-      ),
-    ).resolves.toBe(0);
-
-    expect(connection.calls).toEqual([
-      expect.objectContaining({
-        payload: expect.objectContaining({ requesterId: "fallback-id" }),
-        type: "lease.request",
-      }),
-    ]);
-  });
-
-  it("rejects an empty --agent-id as a usage error", async () => {
-    const output = outputCapture();
-
-    await expect(
-      runCli(
-        ["lease", "--platform", "ios", "--device", "iPhone 17 Pro", "--agent-id", ""],
-        output.environment,
-      ),
-    ).resolves.toBe(2);
-    expect(output.stderr).toContain("--agent-id");
-  });
-
-  it("enforces one lease per --agent-id: same id collides, distinct ids do not", async () => {
-    const harness = await createHarness();
-    const first = outputCapture();
-
-    await expect(
-      runCli(
-        [
-          "lease",
-          "--platform",
-          "ios",
-          "--device",
-          "iPhone 16",
-          "--detach",
-          "--agent-id",
-          "dup-agent",
-        ],
-        first.environmentWith({
-          connect: () => connectExistingDaemon(harness.socketPath, new NodeIpcTransport()),
-        }),
-      ),
-    ).resolves.toBe(0);
-
-    const second = outputCapture();
-    await expect(
-      runCli(
-        [
-          "lease",
-          "--platform",
-          "ios",
-          "--device",
-          "iPhone 16",
-          "--detach",
-          "--agent-id",
-          "dup-agent",
-        ],
-        second.environmentWith({
-          connect: () => connectExistingDaemon(harness.socketPath, new NodeIpcTransport()),
-        }),
-      ),
-    ).resolves.toBe(13);
-    expect(second.stderr).toContain("dup-agent");
-    expect(second.stderr).toContain("already");
-    expect(JSON.parse(second.stderr)).toMatchObject({
-      error: { code: "REQUESTER_ALREADY_LEASED" },
-    });
-
-    const third = outputCapture();
-    await expect(
-      runCli(
-        [
-          "lease",
-          "--platform",
-          "ios",
-          "--device",
-          "iPhone 16",
-          "--detach",
-          "--agent-id",
-          "other-agent",
-          "--no-wait",
-        ],
-        third.environmentWith({
-          connect: () => connectExistingDaemon(harness.socketPath, new NodeIpcTransport()),
+        ["status"],
+        output.environmentWith({
+          readAdminTokenFile: async () => "a-token",
+          connectAdmin: async () =>
+            fakeClient({ getStatus: () => Promise.reject(simlockError("NO_CAPACITY")) }),
         }),
       ),
     ).resolves.toBe(11);
-    expect(third.stderr).not.toContain("already");
+    expect(output.stdout).toBe("");
+    expect(output.stderr.trim().split("\n")).toHaveLength(1);
+    expect(JSON.parse(output.stderr)).toEqual({
+      error: { code: "NO_CAPACITY", message: "No capacity available" },
+    });
   });
 
-  it("prints a detached token, exits, and renews it", async () => {
-    const detached = outputCapture();
-    const connection = new StubConnection();
-    connection.response("lease.request", {
-      device: {
-        driverDeviceId: "ABCD",
-        spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
-        state: "leased",
-      },
-      lease: { id: "lse_9f2c", mode: "detached", ttlDeadline: 61_000 },
-      timing: {
-        estimatedBootMs: 20,
-        estimatedProvisionMs: 10,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 30,
-      },
-    });
+  it("maps a usage error to exit 2 with code USAGE", async () => {
+    const output = outputCapture();
+    await expect(runCli(["nope"], output.environmentWith())).resolves.toBe(2);
+    expect(JSON.parse(output.stderr).error.code).toBe("USAGE");
+  });
+});
 
-    await expect(
-      runCli(
-        ["lease", "--platform", "ios", "--device", "iPhone 17 Pro", "--detach"],
-        detached.environmentWith({ connect: async () => connection }),
-      ),
-    ).resolves.toBe(0);
-    expect(detached.stdout).toBe(
-      '{"device":"iPhone 17 Pro","expires_at_ms":61000,"lease":"lse_9f2c","os":"26.5","platform":"ios","slim":false,"state":"leased","timing":{"estimated_boot_ms":20,"estimated_provision_ms":10,"estimated_reclaim_ms":0,"estimated_ready_ms":30},"udid":"ABCD"}\n',
+describe("CLI: admin credential resolution (ADR 0003 §5)", () => {
+  it("prefers --token over SIMLOCK_ADMIN_TOKEN and the admin.token file", async () => {
+    const output = outputCapture();
+    let seen: string | undefined;
+    await runCli(
+      ["--token", "from-flag", "status"],
+      output.environmentWith({
+        adminTokenFromEnv: "from-env",
+        readAdminTokenFile: async () => "from-file",
+        connectAdmin: async (credential) => {
+          seen = credential;
+          return fakeClient();
+        },
+      }),
     );
-    expect(connection.closed).toBe(true);
-
-    const renew = outputCapture();
-    const renewConnection = new StubConnection();
-    renewConnection.response("lease.renew", { id: "lse_9f2c", ttlDeadline: 61_000 });
-    await expect(
-      runCli(
-        ["lease", "renew", "lse_9f2c", "--ttl", "1m"],
-        renew.environmentWith({ connect: async () => renewConnection }),
-      ),
-    ).resolves.toBe(0);
-    expect(renewConnection.calls).toContainEqual({
-      payload: { leaseId: "lse_9f2c", ttlMs: 60_000 },
-      type: "lease.renew",
-    });
-  });
-
-  it("keeps status JSON stable", async () => {
-    const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response("status.get", { devices: [], leases: [], revision: 3 });
-
-    await expect(
-      runCli(["status", "--json"], output.environmentWith({ connect: async () => connection })),
-    ).resolves.toBe(0);
-    expect(JSON.parse(output.stdout)).toMatchInlineSnapshot(`
-      {
-        "devices": [],
-        "leases": [],
-        "revision": 3,
-      }
-    `);
-  });
-
-  it("renders managed and running capacity separately", async () => {
-    const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response("status.get", {
-      capacity: {
-        global: { maxRunning: 3, overLimit: false, reserved: 1, running: 1, warm: 1 },
-        ios: {
-          limit: 4,
-          maxRunning: 2,
-          overLimit: false,
-          reserved: 1,
-          running: 1,
-          used: 3,
-          warm: 1,
-        },
-        android: {
-          limit: 2,
-          maxRunning: 2,
-          overLimit: false,
-          reserved: 0,
-          running: 0,
-          used: 1,
-          warm: 0,
-        },
-      },
-      devices: [],
-      leases: [],
-    });
-
-    await expect(
-      runCli(["status"], output.environmentWith({ connect: async () => connection })),
-    ).resolves.toBe(0);
-    expect(output.stdout).toContain("Running global: 1 + 1 reserved/3, warm 1");
-    expect(output.stdout).toContain("Capacity ios: managed 3/4, running 1 + 1 reserved/2, warm 1");
-  });
-
-  it("requests the full device catalog and prints it as JSON", async () => {
-    const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response("catalog.get", {
-      platforms: [
-        { defaultRuntime: "26.5", models: ["iPhone 16"], platform: "ios", runtimes: ["26.5"] },
-      ],
-    });
-
-    await expect(
-      runCli(["catalog", "--json"], output.environmentWith({ connect: async () => connection })),
-    ).resolves.toBe(0);
-    expect(connection.calls).toContainEqual({ payload: {}, type: "catalog.get" });
-    expect(JSON.parse(output.stdout)).toEqual({
-      platforms: [
-        { defaultRuntime: "26.5", models: ["iPhone 16"], platform: "ios", runtimes: ["26.5"] },
-      ],
-    });
-  });
-
-  it("narrows the catalog request to the requested platform", async () => {
-    const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response("catalog.get", { platforms: [] });
-
-    await expect(
-      runCli(
-        ["catalog", "--platform", "android", "--json"],
-        output.environmentWith({ connect: async () => connection }),
-      ),
-    ).resolves.toBe(0);
-    expect(connection.calls).toContainEqual({
-      payload: { platform: "android" },
-      type: "catalog.get",
-    });
-  });
-
-  it("renders the catalog as human-readable text, marking the default runtime", async () => {
-    const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response("catalog.get", {
-      platforms: [
-        {
-          defaultRuntime: "26.5",
-          models: ["iPhone 16", "iPhone 17 Pro"],
-          platform: "ios",
-          runtimes: ["18.4", "26.5"],
-        },
-      ],
-    });
-
-    await expect(
-      runCli(["catalog"], output.environmentWith({ connect: async () => connection })),
-    ).resolves.toBe(0);
-    expect(output.stdout).toBe(
-      "Platform: ios\n" +
-        "  Models: iPhone 16, iPhone 17 Pro\n" +
-        "  Runtimes: 18.4, 26.5 (default: 26.5)\n",
-    );
-  });
-
-  it("passes every doctor finding through to stdout as JSON, driver-advisory included", async () => {
-    const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response("doctor.run", {
-      findings: [
-        { deviceId: "dev_1", kind: "registry-device-missing", platform: "ios" },
-        {
-          code: "slim-runtime-unsupported",
-          kind: "driver-advisory",
-          message: "iOS 18.4 is below the 18.5 persistent-override floor",
-          platform: "ios",
-        },
-      ],
-    });
-
-    await expect(
-      runCli(["doctor"], output.environmentWith({ connect: async () => connection })),
-    ).resolves.toBe(0);
-    expect(connection.calls).toContainEqual({ payload: { fix: false }, type: "doctor.run" });
-    expect(JSON.parse(output.stdout)).toEqual({
-      findings: [
-        { deviceId: "dev_1", kind: "registry-device-missing", platform: "ios" },
-        {
-          code: "slim-runtime-unsupported",
-          kind: "driver-advisory",
-          message: "iOS 18.4 is below the 18.5 persistent-override floor",
-          platform: "ios",
-        },
-      ],
-    });
-  });
-
-  it("surfaces a driver-advisory finding as a plain warning line on stderr, distinct from drift", async () => {
-    const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response("doctor.run", {
-      findings: [
-        { deviceId: "dev_1", kind: "registry-device-missing", platform: "ios" },
-        {
-          code: "slim-runtime-unsupported",
-          kind: "driver-advisory",
-          message: "iOS 18.4 is below the 18.5 persistent-override floor",
-          platform: "ios",
-        },
-      ],
-    });
-
-    await expect(
-      runCli(["doctor", "--fix"], output.environmentWith({ connect: async () => connection })),
-    ).resolves.toBe(0);
-    expect(connection.calls).toContainEqual({ payload: { fix: true }, type: "doctor.run" });
-    expect(output.stderr).toBe(
-      "Warning [ios] slim-runtime-unsupported: iOS 18.4 is below the 18.5 persistent-override floor\n",
-    );
-    // Only the advisory gets a warning line -- the drift finding is not echoed to stderr.
-    expect(output.stderr).not.toContain("registry-device-missing");
-  });
-
-  it("writes nothing to stderr when doctor reports no driver-advisory findings", async () => {
-    const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response("doctor.run", {
-      findings: [{ deviceId: "dev_1", kind: "registry-device-missing", platform: "ios" }],
-    });
-
-    await expect(
-      runCli(["doctor"], output.environmentWith({ connect: async () => connection })),
-    ).resolves.toBe(0);
+    expect(seen).toBe("from-flag");
     expect(output.stderr).toBe("");
   });
 
-  it("releases and exits when the watched parent process dies, via the same path as a signal", async () => {
+  it("prefers SIMLOCK_ADMIN_TOKEN over the admin.token file when --token is absent", async () => {
     const output = outputCapture();
-    const signals = new EventEmitter();
-    const parentWatch = new FakeParentWatch();
-    const connection = new StubConnection();
-    connection.response("lease.request", {
-      device: {
-        driverDeviceId: "ABCD",
-        spec: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
-        state: "leased",
-      },
-      lease: { id: "lse_parent_death", mode: "held", ttlDeadline: 61_000 },
-      timing: {
-        estimatedBootMs: 0,
-        estimatedProvisionMs: 0,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 0,
-      },
-    });
-    const run = runCli(
-      ["lease", "--platform", "ios", "--device", "iPhone 16"],
+    let seen: string | undefined;
+    await runCli(
+      ["status"],
       output.environmentWith({
-        connect: async () => connection,
-        parentPid: 4321,
-        parentWatch,
-        signals,
-      }),
-    );
-
-    await vi.waitFor(() => expect(output.stdout).not.toBe(""));
-    parentWatch.exit(4321);
-
-    await expect(run).resolves.toBe(0);
-    expect(connection.calls.map((call) => call.type)).toEqual(["lease.request", "lease.release"]);
-    expect(connection.closed).toBe(true);
-  });
-
-  it("--bind-pid overrides which pid the CLI watches for parent death", async () => {
-    const output = outputCapture();
-    const signals = new EventEmitter();
-    const parentWatch = new FakeParentWatch();
-    const connection = new StubConnection();
-    connection.response("lease.request", {
-      device: {
-        driverDeviceId: "ABCD",
-        spec: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
-        state: "leased",
-      },
-      lease: { id: "lse_bind_pid", mode: "held", ttlDeadline: 61_000 },
-      timing: {
-        estimatedBootMs: 0,
-        estimatedProvisionMs: 0,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 0,
-      },
-    });
-    let finished = false;
-    const run = runCli(
-      ["lease", "--platform", "ios", "--device", "iPhone 16", "--bind-pid", "9999"],
-      output.environmentWith({
-        connect: async () => connection,
-        parentPid: 4321,
-        parentWatch,
-        signals,
-      }),
-    );
-    void run.then(() => (finished = true));
-
-    await vi.waitFor(() => expect(output.stdout).not.toBe(""));
-    // The default parent pid is not the one bound for this invocation -- must not terminate it.
-    parentWatch.exit(4321);
-    await new Promise((resolve) => setTimeout(resolve, 10));
-    expect(finished).toBe(false);
-
-    parentWatch.exit(9999);
-    await expect(run).resolves.toBe(0);
-  });
-
-  it("rejects a non-numeric --bind-pid as a structured USAGE error", async () => {
-    const output = outputCapture();
-
-    await expect(
-      runCli(
-        ["lease", "--platform", "ios", "--device", "iPhone 16", "--bind-pid", "not-a-pid"],
-        output.environment,
-      ),
-    ).resolves.toBe(2);
-    expect(JSON.parse(output.stderr)).toEqual({
-      error: { code: "USAGE", message: "lease --bind-pid must be a positive integer" },
-    });
-  });
-
-  it("declares the heartbeat capability for held-mode leases, not for detached ones", async () => {
-    const capabilitiesSeen: unknown[] = [];
-    const heldConnection = new StubConnection();
-    heldConnection.response("lease.request", {
-      device: {
-        driverDeviceId: "ABCD",
-        spec: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
-        state: "leased",
-      },
-      lease: { id: "lse_held_cap", mode: "held", ttlDeadline: 61_000 },
-      timing: {
-        estimatedBootMs: 0,
-        estimatedProvisionMs: 0,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 0,
-      },
-    });
-    const heldOutput = outputCapture();
-    const heldSignals = new EventEmitter();
-    const heldRun = runCli(
-      ["lease", "--platform", "ios", "--device", "iPhone 16"],
-      heldOutput.environmentWith({
-        connect: async (capabilities) => {
-          capabilitiesSeen.push(capabilities);
-          return heldConnection;
+        adminTokenFromEnv: "from-env",
+        readAdminTokenFile: async () => "from-file",
+        connectAdmin: async (credential) => {
+          seen = credential;
+          return fakeClient();
         },
-        signals: heldSignals,
       }),
     );
-    await vi.waitFor(() => expect(heldOutput.stdout).not.toBe(""));
-    heldSignals.emit("SIGTERM");
-    await expect(heldRun).resolves.toBe(0);
+    expect(seen).toBe("from-env");
+  });
 
-    const detachedConnection = new StubConnection();
-    detachedConnection.response("lease.request", {
-      device: {
-        driverDeviceId: "ABCD",
-        spec: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
-        state: "leased",
-      },
-      lease: { id: "lse_detached_cap", mode: "detached", ttlDeadline: 61_000 },
-      timing: {
-        estimatedBootMs: 0,
-        estimatedProvisionMs: 0,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 0,
-      },
-    });
+  it("falls back to the admin.token file when neither --token nor the env var is set", async () => {
+    const output = outputCapture();
+    let seen: string | undefined;
+    await runCli(
+      ["status"],
+      output.environmentWith({
+        readAdminTokenFile: async () => "from-file",
+        connectAdmin: async (credential) => {
+          seen = credential;
+          return fakeClient();
+        },
+      }),
+    );
+    expect(seen).toBe("from-file");
+    expect(output.stderr).toBe("");
+  });
+
+  it("retries a briefly-missing admin.token file before giving up", async () => {
+    const output = outputCapture();
+    let reads = 0;
+    let seen: string | undefined;
+    await runCli(
+      ["status"],
+      output.environmentWith({
+        readAdminTokenFile: async () => {
+          reads += 1;
+          return reads < 3 ? undefined : "from-file-after-retry";
+        },
+        connectAdmin: async (credential) => {
+          seen = credential;
+          return fakeClient();
+        },
+      }),
+    );
+    expect(reads).toBe(3);
+    expect(seen).toBe("from-file-after-retry");
+    expect(output.stderr).toBe("");
+  });
+
+  it("connects with no credential and writes a stderr notice when every source is empty", async () => {
+    const output = outputCapture();
+    let seen: string | undefined | "unset" = "unset";
+    await runCli(
+      ["status"],
+      output.environmentWith({
+        readAdminTokenFile: async () => undefined,
+        connectAdmin: async (credential) => {
+          seen = credential;
+          return fakeClient();
+        },
+      }),
+    );
+    expect(seen).toBeUndefined();
+    expect(output.stderr.trim().split("\n")).toHaveLength(1);
+    const notice: unknown = JSON.parse(output.stderr);
+    expect((notice as { notice: string }).notice).toMatch(/agent/i);
+  });
+});
+
+describe("CLI: daemon status (ADR 0003 §11)", () => {
+  it("reports stopped when the socket cannot be reached at all", async () => {
+    const output = outputCapture();
     await expect(
       runCli(
-        ["lease", "--platform", "ios", "--device", "iPhone 16", "--detach"],
-        outputCapture().environmentWith({
-          connect: async (capabilities) => {
-            capabilitiesSeen.push(capabilities);
-            return detachedConnection;
+        ["daemon", "status", "--json"],
+        output.environmentWith({
+          connectExistingAdmin: async () => {
+            throw new Error("connect ECONNREFUSED");
           },
         }),
       ),
     ).resolves.toBe(0);
-
-    expect(capabilitiesSeen).toEqual([{ heartbeat: true }, undefined]);
+    expect(JSON.parse(output.stdout)).toEqual({ status: "stopped" });
   });
 
-  it("rejects an invalid --platform without contacting the daemon", async () => {
+  it("reports stopped for a transport-kind SimlockError (connection lost)", async () => {
     const output = outputCapture();
-
-    await expect(runCli(["catalog", "--platform", "windows"], output.environment)).resolves.toBe(2);
-    expect(output.stderr).toContain("--platform must be ios or android");
-  });
-});
-
-describe("simlock token", () => {
-  it("creates an agent token, printing the record and secret on one JSON line", async () => {
-    const { environment, output } = tokenHarness();
-
     await expect(
-      runCli(["token", "create", "--role", "agent", "--label", "ci-runner"], environment),
+      runCli(
+        ["daemon", "status", "--json"],
+        output.environmentWith({
+          connectExistingAdmin: async () => {
+            throw simlockError("DAEMON_CONNECTION_LOST");
+          },
+        }),
+      ),
     ).resolves.toBe(0);
-    expect(output.stderr).toBe("");
-    const parsed = JSON.parse(output.stdout) as {
-      secret: string;
-      token: { id: string; role: string; label: string; createdAt: number };
-    };
-    expect(parsed.token).toEqual({
-      createdAt: 1_000,
-      id: "tok_1",
-      label: "ci-runner",
-      role: "agent",
-    });
-    expect(parsed.secret).toMatch(/^slk_/);
-    expect(JSON.stringify(parsed.token)).not.toContain("hash");
+    expect(JSON.parse(output.stdout)).toEqual({ status: "stopped" });
   });
 
-  it("creates an operator token without a label, omitting the field entirely", async () => {
-    const { environment, output } = tokenHarness();
-
-    await expect(runCli(["token", "create", "--role", "operator"], environment)).resolves.toBe(0);
-    const parsed = JSON.parse(output.stdout) as { token: Record<string, unknown> };
-    expect(parsed.token.role).toBe("operator");
-    expect("label" in parsed.token).toBe(false);
+  it("distinguishes a refused handshake (socket reachable) from an absent socket", async () => {
+    const output = outputCapture();
+    await expect(
+      runCli(
+        ["daemon", "status", "--json"],
+        output.environmentWith({
+          connectExistingAdmin: async () => {
+            throw simlockError("ADMIN_AUTHENTICATION_FAILED");
+          },
+        }),
+      ),
+    ).resolves.toBe(1);
+    const parsed = JSON.parse(output.stdout) as { status: string; error: { code: string } };
+    expect(parsed.status).toBe("handshake-refused");
+    expect(parsed.error.code).toBe("ADMIN_AUTHENTICATION_FAILED");
   });
 
-  it("rejects a missing --role as a structured usage error", async () => {
-    const { environment, output } = tokenHarness();
-
-    await expect(runCli(["token", "create"], environment)).resolves.toBe(2);
-    expect(output.stdout).toBe("");
-    expect(JSON.parse(output.stderr)).toEqual({
-      error: { code: "USAGE", message: expect.stringContaining("--role") },
-    });
-  });
-
-  it("rejects an invalid --role as a structured usage error", async () => {
-    const { environment, output } = tokenHarness();
-
-    await expect(runCli(["token", "create", "--role", "superuser"], environment)).resolves.toBe(2);
-    expect(JSON.parse(output.stderr)).toMatchObject({ error: { code: "USAGE" } });
-  });
-
-  it("lists created tokens without exposing their hash", async () => {
-    const { environment, output, store } = tokenHarness();
-    await store.create("agent", "one");
-    await store.create("operator", "two");
-
-    await expect(runCli(["token", "list"], environment)).resolves.toBe(0);
-    const parsed = JSON.parse(output.stdout) as { tokens: Array<Record<string, unknown>> };
-    expect(parsed.tokens.map((token) => token.label)).toEqual(["one", "two"]);
-    expect(JSON.stringify(parsed.tokens)).not.toContain("hash");
-  });
-
-  it("revokes an existing token", async () => {
-    const { environment, output, store } = tokenHarness();
-    const { record } = await store.create("agent");
-
-    await expect(runCli(["token", "revoke", record.id], environment)).resolves.toBe(0);
-    expect(JSON.parse(output.stdout)).toEqual({ revoked: true });
-    await expect(store.list()).resolves.toEqual([]);
-  });
-
-  it("reports UNKNOWN_TOKEN revoking a token id that does not exist", async () => {
-    const { environment, output } = tokenHarness();
-
-    await expect(runCli(["token", "revoke", "tok_missing"], environment)).resolves.toBe(1);
-    expect(output.stdout).toBe("");
-    expect(JSON.parse(output.stderr)).toEqual({
-      error: { code: "UNKNOWN_TOKEN", message: expect.stringContaining("tok_missing") },
-    });
-  });
-
-  it("prints usage for the bare command and --help without touching the store", async () => {
-    const { environment, output } = tokenHarness();
-
-    await expect(runCli(["token"], environment)).resolves.toBe(0);
-    expect(output.stdout).toContain("simlock token create");
-    expect(output.stdout).toContain("simlock token list");
-    expect(output.stdout).toContain("simlock token revoke");
-  });
-
-  it("rejects an unknown token subcommand", async () => {
-    const { environment, output } = tokenHarness();
-
-    await expect(runCli(["token", "bogus"], environment)).resolves.toBe(2);
-    expect(JSON.parse(output.stderr)).toMatchObject({ error: { code: "USAGE" } });
+  it("never auto-launches the daemon for daemon status/stop", async () => {
+    const output = outputCapture();
+    let launched = false;
+    await runCli(
+      ["daemon", "status"],
+      output.environmentWith({
+        connectAdmin: async () => {
+          launched = true;
+          return fakeClient();
+        },
+        connectExistingAdmin: async () => fakeClient(),
+      }),
+    );
+    expect(launched).toBe(false);
   });
 });
 
-function tokenHarness(): {
-  environment: CliEnvironment;
-  output: ReturnType<typeof outputCapture>;
-  store: TokenStore;
-} {
-  const output = outputCapture();
-  const store = new TokenStore({
-    clock: new FakeClock(1_000),
-    filesystem: new MemoryFilesystem(),
-    idGenerator: sequence(),
-    path: "/tokens.json",
-    secrets: new CryptoTokenSecrets(),
+describe("CLI: config set validates before writing (ADR 0003 §11)", () => {
+  it("rejects an invalid merged config without writing the file", async () => {
+    const output = outputCapture();
+    let wrote = false;
+    await expect(
+      runCli(
+        ["config", "set", "lease.heldTtlBackstopMs", "not-a-number"],
+        output.environmentWith({
+          readConfigFile: async () => ({}),
+          writeConfigFile: async () => {
+            wrote = true;
+          },
+          validateConfig: async () => {
+            throw new Error("lease.heldTtlBackstopMs must be a number");
+          },
+        }),
+      ),
+    ).resolves.toBe(2);
+    expect(wrote).toBe(false);
+    expect(JSON.parse(output.stderr).error.code).toBe("USAGE");
   });
-  return { environment: output.environmentWith({ tokenStore: store }), output, store };
+
+  it("writes the file once validation passes", async () => {
+    const output = outputCapture();
+    let written: Record<string, unknown> | undefined;
+    await expect(
+      runCli(
+        ["config", "set", "downloads.policy", "never"],
+        output.environmentWith({
+          readConfigFile: async () => ({}),
+          writeConfigFile: async (contents) => {
+            written = contents;
+          },
+          validateConfig: async () => {},
+        }),
+      ),
+    ).resolves.toBe(0);
+    expect(written).toEqual({ downloads: { policy: "never" } });
+  });
+});
+
+describe("CLI: --json shape is the contract, as-is (ADR 0003 §11)", () => {
+  it("status --json has no snake_case renderings", async () => {
+    const output = outputCapture();
+    await runCli(
+      ["status", "--json"],
+      output.environmentWith({ connectAdmin: async () => fakeClient() }),
+    );
+    const text = output.stdout;
+    expect(text).not.toMatch(/expires_at_ms|estimated_boot_ms|queue_position|device_unhealthy/);
+    const parsed = JSON.parse(text) as StatusGetOutput;
+    expect(parsed.queueDepth).toBe(0);
+  });
+
+  it("lease output is the contract's LeaseGrant plus the resolved role", async () => {
+    const output = outputCapture();
+    await runCli(
+      ["lease", "--platform", "ios", "--device", "iPhone 17 Pro", "--detach"],
+      output.environmentWith({ connectAdmin: async () => fakeClient({ role: "admin" }) }),
+    );
+    const parsed = JSON.parse(output.stdout) as LeaseGrant & { role: string };
+    expect(parsed.lease.id).toBe("lse_1");
+    expect(parsed.role).toBe("admin");
+    expect(output.stdout).not.toMatch(/expires_at_ms|estimated_boot_ms/);
+  });
+});
+
+describe("CLI: --yes / confirm guards (safety rule 5)", () => {
+  it("release --all without --yes and a non-interactive confirm refuses", async () => {
+    const output = outputCapture();
+    let released = false;
+    await expect(
+      runCli(
+        ["release", "--all"],
+        output.environmentWith({
+          confirm: async () => false,
+          connectAdmin: async () =>
+            fakeClient({
+              releaseAllLeases: () => {
+                released = true;
+                return Promise.resolve({ leaseIds: [] });
+              },
+            }),
+        }),
+      ),
+    ).resolves.toBe(2);
+    expect(released).toBe(false);
+  });
+
+  it("release --all --yes bypasses the interactive confirm", async () => {
+    const output = outputCapture();
+    let released = false;
+    await expect(
+      runCli(
+        ["release", "--all", "--yes"],
+        output.environmentWith({
+          confirm: async () => false,
+          connectAdmin: async () =>
+            fakeClient({
+              releaseAllLeases: () => {
+                released = true;
+                return Promise.resolve({ leaseIds: ["lse_1"] });
+              },
+            }),
+        }),
+      ),
+    ).resolves.toBe(0);
+    expect(released).toBe(true);
+  });
+
+  it("nuke without confirmation or --yes refuses before connecting", async () => {
+    const output = outputCapture();
+    let connected = false;
+    await expect(
+      runCli(
+        ["nuke"],
+        output.environmentWith({
+          confirm: async () => false,
+          connectAdmin: async () => {
+            connected = true;
+            return fakeClient();
+          },
+        }),
+      ),
+    ).resolves.toBe(2);
+    expect(connected).toBe(false);
+  });
+});
+
+describe("CLI: token operations never write tokens.json directly", () => {
+  it("token create/list/revoke all go through the client, not a local TokenStore", async () => {
+    const calls: string[] = [];
+    const client = fakeClient({
+      createToken: (input) => {
+        calls.push("create");
+        return Promise.resolve({
+          secret: "sec_1",
+          token: { id: "tok_1", role: input.role, createdAt: 0 },
+        });
+      },
+      listTokens: () => {
+        calls.push("list");
+        return Promise.resolve({ tokens: [{ id: "tok_1", role: "operator", createdAt: 0 }] });
+      },
+      revokeToken: () => {
+        calls.push("revoke");
+        return Promise.resolve({ revoked: true });
+      },
+    });
+    const environment = outputCapture().environmentWith({ connectAdmin: async () => client });
+    await runCli(["token", "create", "--role", "operator"], environment);
+    await runCli(["token", "list"], environment);
+    await runCli(["token", "revoke", "tok_1"], environment);
+    expect(calls).toEqual(["create", "list", "revoke"]);
+  });
+});
+
+describe("CLI smoke test (ADR 0003 §12: one per frontend)", () => {
+  it("lease --detach, status, release, and token create round-trip through a real daemon", async () => {
+    const { socketPath } = await startTestDaemon();
+    const ipc = new NodeIpcTransport();
+    const environment = outputCapture().environmentWith({
+      connectAdmin: (credential) =>
+        connectSimlockAdmin({
+          ipc,
+          endpoint: socketPath,
+          principal: "smoke-test",
+          ...(credential === undefined ? {} : { credential }),
+        }),
+    });
+
+    const leaseOut = outputCapture();
+    const leaseExit = await runCli(
+      ["lease", "--platform", "ios", "--device", "iPhone 17 Pro", "--detach"],
+      leaseOut.environmentWith({ connectAdmin: environment.connectAdmin }),
+    );
+    expect(leaseExit).toBe(0);
+    const grant = JSON.parse(leaseOut.stdout) as LeaseGrant;
+    expect(grant.lease.mode).toBe("detached");
+
+    const statusOut = outputCapture();
+    await runCli(
+      ["status", "--json"],
+      statusOut.environmentWith({ connectAdmin: environment.connectAdmin }),
+    );
+    const status = JSON.parse(statusOut.stdout) as StatusGetOutput;
+    expect(status.leases.map((lease) => lease.id)).toContain(grant.lease.id);
+
+    const releaseOut = outputCapture();
+    const releaseExit = await runCli(
+      ["release", grant.lease.id],
+      releaseOut.environmentWith({ connectAdmin: environment.connectAdmin }),
+    );
+    expect(releaseExit).toBe(0);
+
+    const tokenOut = outputCapture();
+    const tokenExit = await runCli(
+      ["token", "create", "--role", "operator", "--label", "ci"],
+      tokenOut.environmentWith({ connectAdmin: environment.connectAdmin }),
+    );
+    expect(tokenExit).toBe(0);
+    const created = JSON.parse(tokenOut.stdout) as { secret: string; token: { id: string } };
+    expect(typeof created.secret).toBe("string");
+    expect((created as unknown as Record<string, unknown>).token).not.toHaveProperty("hash");
+  });
+});
+
+describe("CLI: pure helpers", () => {
+  it("fallbackRequesterId prefers SIMLOCK_AGENT_ID over a pid-derived default", () => {
+    expect(fallbackRequesterId({ SIMLOCK_AGENT_ID: "agent-7" })).toBe("agent-7");
+    expect(fallbackRequesterId({})).toBe(String(process.pid));
+  });
+
+  it("parseDuration parses units and rejects garbage", () => {
+    expect(parseDuration("500")).toBe(500);
+    expect(parseDuration("500ms")).toBe(500);
+    expect(parseDuration("2s")).toBe(2_000);
+    expect(parseDuration("3m")).toBe(180_000);
+    expect(parseDuration("1h")).toBe(3_600_000);
+    expect(() => parseDuration("banana")).toThrow();
+  });
+});
+
+// ---- test doubles -----------------------------------------------------------------------------
+
+function simlockError(code: AnySimlockError["code"]): AnySimlockError {
+  const messages: Partial<Record<string, string>> = {
+    NO_CAPACITY: "No capacity available",
+  };
+  const kind =
+    code === "DAEMON_CONNECTION_LOST" ||
+    code === "DAEMON_STOPPING" ||
+    code === "DAEMON_STARTUP_FAILED"
+      ? "transport"
+      : (
+            [
+              "BAD_FRAME",
+              "HANDSHAKE_REQUIRED",
+              "BAD_REQUEST",
+              "UNKNOWN_REQUEST",
+              "PROTOCOL_VERSION_UNSUPPORTED",
+              "ADMIN_AUTHENTICATION_FAILED",
+              "FORBIDDEN",
+              "UNKNOWN_DAEMON_ERROR",
+            ] as const
+          ).includes(code as never)
+        ? "protocol"
+        : "domain";
+  return new SimlockError(
+    code,
+    kind,
+    messages[code] ?? `${code} failed`,
+    {} as never,
+  ) as unknown as AnySimlockError;
 }
 
-class StubConnection implements DaemonConnection {
-  readonly calls: Array<{ readonly payload: unknown; readonly type: string }> = [];
-  closed = false;
-  readonly #listeners = new Set<(kind: string, payload: unknown) => void>();
-  readonly #responses = new Map<string, unknown>();
-
-  response(type: string, value: unknown): void {
-    this.#responses.set(type, value);
-  }
-
-  async request(type: string, payload: unknown): Promise<unknown> {
-    this.calls.push({ payload, type });
-    const value = this.#responses.get(type);
-    if (value instanceof Error) {
-      throw value;
-    }
-    return value;
-  }
-
-  onPush(listener: (kind: string, payload: unknown) => void): () => void {
-    this.#listeners.add(listener);
-    return () => this.#listeners.delete(listener);
-  }
-
-  onClose(): () => void {
-    return () => undefined;
-  }
-
-  push(kind: string, payload: unknown): void {
-    for (const listener of this.#listeners) {
-      listener(kind, payload);
-    }
-  }
-
-  async close(): Promise<void> {
-    this.closed = true;
-  }
+function fakeClient(overrides: Partial<SimlockAdminClient> = {}): SimlockAdminClient {
+  const emptyStatus: StatusGetOutput = {
+    devices: [],
+    leases: [],
+    capacity: {
+      ios: { limit: 1, running: 0, maxRunning: 1, reserved: 0, overLimit: false, warm: 0, used: 0 },
+      android: {
+        limit: 1,
+        running: 0,
+        maxRunning: 1,
+        reserved: 0,
+        overLimit: false,
+        warm: 0,
+        used: 0,
+      },
+      global: { running: 0, maxRunning: 2, reserved: 0, overLimit: false, warm: 0 },
+    },
+    health: "running",
+    queueDepth: 0,
+  };
+  const emptyCatalog: CatalogGetOutput = { platforms: [] };
+  const emptyDoctor: DoctorReport = { findings: [] };
+  const emptyLeaseList: LeaseListOutput = { leases: [] };
+  const emptyListGet: ListGetOutput = [];
+  const emptyTokenList: TokenListOutput = { tokens: [] };
+  const grant: LeaseGrant = {
+    device: {
+      id: "dev_1",
+      driverDeviceId: "dev_1",
+      spec: { platform: "ios", model: "iPhone 17 Pro", osVersion: "26.5" },
+      state: "leased",
+      driverData: undefined,
+      createdAt: 0,
+    },
+    lease: {
+      id: "lse_1",
+      deviceId: "dev_1",
+      requesterId: "test-requester",
+      ownerId: "test-requester",
+      mode: "held",
+      grantedAt: 0,
+      ttlDeadline: 60_000,
+    },
+    timing: {
+      estimatedProvisionMs: 0,
+      estimatedBootMs: 0,
+      estimatedReclaimMs: 0,
+      estimatedReadyMs: 0,
+    },
+  };
+  const base: SimlockAdminClient = {
+    principal: "test-requester",
+    role: "admin",
+    daemonVersion: "test",
+    getCatalog: () => Promise.resolve(emptyCatalog),
+    getStatus: () => Promise.resolve(emptyStatus),
+    requestLease: () => Promise.resolve(grant),
+    cancelLease: () => Promise.resolve({ result: "not-found" }),
+    renewLease: () => Promise.resolve(grant.lease as LeaseRecord),
+    releaseLease: (input) => Promise.resolve({ leaseId: input.leaseId }),
+    listLeases: () => Promise.resolve(emptyLeaseList),
+    heartbeat: () => Promise.resolve({ leases: [] }),
+    runDoctor: () => Promise.resolve(emptyDoctor),
+    onLeaseLost: () => () => {},
+    onDeviceUnhealthy: () => () => {},
+    onDeviceRecovered: () => () => {},
+    onConnectionLost: () => () => {},
+    close: () => Promise.resolve(),
+    releaseAllLeases: () => Promise.resolve({ leaseIds: [] }),
+    list: () => Promise.resolve(emptyListGet),
+    runCleanup: () => Promise.resolve([]),
+    runNuke: () => Promise.resolve({ deletedDevices: [], releasedLeaseIds: [] }),
+    getConfig: () => Promise.resolve({} as SimlockConfig),
+    stopDaemon: () => Promise.resolve({ stopping: true }),
+    replayEvents: () => Promise.resolve([]),
+    subscribeEvents: () => Promise.resolve(() => Promise.resolve()),
+    createToken: (input) =>
+      Promise.resolve({
+        secret: "sec_1",
+        token: { id: "tok_1", role: input.role, createdAt: 0 },
+      }),
+    listTokens: () => Promise.resolve(emptyTokenList),
+    revokeToken: () => Promise.resolve({ revoked: true }),
+    ...overrides,
+  };
+  return base;
 }
 
-async function createHarness() {
-  const directory = await mkdtemp(join(tmpdir(), "simlock-cli-"));
+interface OutputCapture {
+  stdout: string;
+  stderr: string;
+  environmentWith(overrides?: Partial<CliEnvironment>): CliEnvironment;
+}
+
+function outputCapture(): OutputCapture {
+  const capture: OutputCapture = {
+    stdout: "",
+    stderr: "",
+    environmentWith(overrides = {}) {
+      return {
+        configPath: "/simlock/config.json",
+        requesterId: "test-requester",
+        now: () => 0,
+        connectAdmin: async () => fakeClient(),
+        connectExistingAdmin: async () => fakeClient(),
+        readAdminTokenFile: async () => undefined,
+        sleep: async () => {},
+        readConfigFile: async () => ({}),
+        writeConfigFile: async () => {},
+        validateConfig: async () => {},
+        readLogFile: async () => "",
+        signals: new EventEmitter() as unknown as CliEnvironment["signals"],
+        parentWatch: new FakeParentWatch(),
+        stderr: { write: (value: string) => (capture.stderr += value) },
+        stdout: { write: (value: string) => (capture.stdout += value) },
+        confirm: async () => true,
+        ...overrides,
+      };
+    },
+  };
+  return capture;
+}
+
+// ---- real-daemon harness for the smoke test ----------------------------------------------------
+
+function sequence(): IdGenerator {
+  let next = 0;
+  return { generate: () => `id${next++}` };
+}
+
+async function startTestDaemon(): Promise<{ socketPath: string; daemon: DaemonServer }> {
+  const directory = await mkdtemp(join(tmpdir(), "simlock-cli-smoke-"));
   temporaryDirectories.push(directory);
   const socketPath = join(directory, "daemon.sock");
   const clock = new FakeClock(1_000);
   const eventBus = new EventBus(clock);
+  const filesystem = new MemoryFilesystem();
   const registry = await Registry.load({
     clock,
     eventBus,
-    filesystem: new MemoryFilesystem(),
+    filesystem,
     idGenerator: sequence(),
     statePath: "/state.json",
   });
@@ -1248,6 +723,21 @@ async function createHarness() {
       totalRamBytes: 32 * gibibyte,
     }),
   });
+  const reaper = new CleanupReaper({
+    clock,
+    config,
+    eventBus,
+    executor: engine.cleanup,
+    filesystem,
+    registry,
+  });
+  const tokens = new TokenStore({
+    clock,
+    filesystem,
+    idGenerator: sequence(),
+    path: "/tokens.json",
+    secrets: new CryptoTokenSecrets(),
+  });
   const daemon = new DaemonServer({
     capacity: engine,
     catalog: engine,
@@ -1263,25 +753,15 @@ async function createHarness() {
     }),
     leases: engine,
     queue: engine,
-    reaper: new CleanupReaper({
-      clock,
-      config,
-      eventBus,
-      executor: engine.cleanup,
-      filesystem: new MemoryFilesystem(),
-      registry,
-    }),
+    reaper,
     registry,
+    resolveRole: { resolve: () => "admin" },
+    tokens,
     version: "test",
   });
   runningDaemons.push(daemon);
   await daemon.start();
-  return { eventBus, registry, socketPath };
-}
-
-function sequence() {
-  let next = 1;
-  return { generate: () => `${next++}` };
+  return { socketPath, daemon };
 }
 
 function testConfig(): Config {
@@ -1289,7 +769,7 @@ function testConfig(): Config {
     diskPressure: { freeBytesThreshold: 10 * gibibyte },
     eventBuffer: { capacity: 100 },
     health: {
-      enabled: true,
+      enabled: false,
       maxConcurrentRecoveries: 1,
       maxRecoveryAttempts: 3,
       probeIntervalMs: 30_000,
@@ -1301,14 +781,14 @@ function testConfig(): Config {
     http: { enabled: false, host: "127.0.0.1", port: 4700 },
     ios: { slim: { enabled: false, bootTimeoutMs: 600_000 } },
     idle: { deleteAfterMs: 60_000, shutdownAfterMs: 10_000 },
-    lease: { detachedTtlMs: 60_000, heldTtlBackstopMs: 60_000, heartbeatIntervalMs: 15_000 },
+    lease: { detachedTtlMs: 60_000, heldTtlBackstopMs: 60_000, heartbeatIntervalMs: 5_000 },
     capacity: {
       strategy: "resource",
       config: {
         limits: {
           android: { maxDevices: 1, maxRunning: 1 },
           ios: { maxDevices: 1, maxRunning: 1 },
-          maxRunning: 1 + 1,
+          maxRunning: 2,
         },
         ramBudget: { androidBytesPerDevice: 4 * gibibyte, iosBytesPerDevice: gibibyte },
       },
@@ -1321,35 +801,6 @@ function testConfig(): Config {
         retryBackoffMs: 30_000,
         retryBackoffMultiplier: 2,
       },
-    },
-  };
-}
-
-function outputCapture() {
-  let stderr = "";
-  let stdout = "";
-  const environment: CliEnvironment = {
-    connect: async () => {
-      throw new Error("Unexpected daemon connection");
-    },
-    configPath: "/config.json",
-    readConfigFile: async () => ({}),
-    requesterId: "test-requester",
-    signals: new EventEmitter(),
-    stderr: { write: (value: string) => (stderr += value) },
-    stdout: { write: (value: string) => (stdout += value) },
-    writeConfigFile: async () => undefined,
-  };
-  return {
-    environment,
-    environmentWith(overrides: Partial<CliEnvironment>): CliEnvironment {
-      return { ...environment, ...overrides };
-    },
-    get stderr() {
-      return stderr;
-    },
-    get stdout() {
-      return stdout;
     },
   };
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,6 +5,7 @@ import { parseArgs } from "node:util";
 import { loadConfig, type ConfigOverrides } from "../core/index.js";
 import {
   IpcError,
+  MemoryFilesystem,
   NodeDaemonLauncher,
   NodeFilesystem,
   NodeIpcTransport,
@@ -19,6 +20,7 @@ import {
   type IpcConnector,
   type ParentWatch,
   type ParentWatchHandle,
+  type SystemStats,
 } from "../ports/index.js";
 import { connectSimlockAdmin } from "../admin/index.js";
 import {
@@ -96,16 +98,24 @@ export interface CliEnvironment {
    * principal": `--agent-id` overrides `lease.request`'s `requesterId` field, never this. */
   readonly requesterId: string;
   readonly now?: () => number;
-  /** Connects (auto-launching the daemon if it is not already running) with the given
-   * credential, or none (ADR §5's agent fallback). */
+  /**
+   * Connects (auto-launching the daemon if it is not already running) and completes `hello`
+   * with whatever `resolveCredential` resolves to.
+   *
+   * `resolveCredential` is called only *after* the raw connection is established -- which is
+   * also where auto-launch happens (ADR §5: "written atomically after the socket claim
+   * succeeds"). A caller resolving the local `admin.token` file before the connection exists
+   * (the pre-fix bug: B2) races the whole daemon spawn instead of just the narrow
+   * claim-to-persist window the file-retry loop is meant for. See `readAdminTokenFileWithRetry`.
+   */
   readonly connectAdmin: (
-    credential: string | undefined,
+    resolveCredential: () => Promise<string | undefined>,
     options?: { readonly heartbeat?: boolean },
   ) => Promise<SimlockAdminClient>;
   /** Same as `connectAdmin` but never auto-launches -- `daemon stop`/`daemon status` must not
    * start a daemon just to ask whether one is running. */
   readonly connectExistingAdmin: (
-    credential: string | undefined,
+    resolveCredential: () => Promise<string | undefined>,
     options?: { readonly heartbeat?: boolean },
   ) => Promise<SimlockAdminClient>;
   /** `SIMLOCK_ADMIN_TOKEN`, ADR §5's second resolution source. */
@@ -147,22 +157,16 @@ export function fallbackRequesterId(env: NodeJS.ProcessEnv): string {
  * socket (reachable) and `admin.token` landing on disk (`DaemonServer#start` awaits the socket
  * claim, *then* `adminSecret.persist()`). A CLI invocation that races a fresh `daemon start`
  * retries a few times, briefly, rather than either blocking indefinitely or giving up on the
- * first empty read.
+ * first empty read. This only ever runs *after* the connection is already established (see
+ * `connectAdmin`'s doc) -- so the race it covers is the narrow claim-to-persist window, not the
+ * whole daemon spawn.
  */
 const ADMIN_TOKEN_FILE_READ_ATTEMPTS = 3;
 const ADMIN_TOKEN_FILE_RETRY_DELAY_MS = 50;
 
-/** ADR §5's resolution order: `--token`, then `SIMLOCK_ADMIN_TOKEN`, then the local
- * `admin.token` file (briefly retried). `undefined` means every source came up empty --
- * callers fall back to an agent-role connection with a stderr notice. */
-async function resolveAdminCredential(
+async function readAdminTokenFileWithRetry(
   environment: CliEnvironment,
-  tokenFlag: string | undefined,
 ): Promise<string | undefined> {
-  if (tokenFlag !== undefined && tokenFlag !== "") return tokenFlag;
-  if (environment.adminTokenFromEnv !== undefined && environment.adminTokenFromEnv !== "") {
-    return environment.adminTokenFromEnv;
-  }
   for (let attempt = 0; attempt < ADMIN_TOKEN_FILE_READ_ATTEMPTS; attempt++) {
     const token = await environment.readAdminTokenFile();
     if (token !== undefined) return token;
@@ -173,31 +177,79 @@ async function resolveAdminCredential(
   return undefined;
 }
 
+/** Where a resolved admin credential came from -- distinguishes an explicit-but-wrong
+ * credential (flag/env) from a stale local file (B1) for the fallback notice, and "none" for
+ * "every source came up empty" (unchanged from before). */
+type CredentialSource = "flag" | "env" | "file" | "none";
+
+function isAdminAuthFailure(error: unknown): boolean {
+  return isSimlockError(error) && error.code === "ADMIN_AUTHENTICATION_FAILED";
+}
+
+/** ADR §5's fallback: "an agent session with a stderr notice." B1 extends this to a credential
+ * the daemon actively rejected (not just one that was never found), and calls out a stale
+ * `admin.token` by name -- the actionable case a generic notice would otherwise bury. */
+function writeAgentFallbackNotice(environment: CliEnvironment, source: CredentialSource): void {
+  const notice =
+    source === "file"
+      ? "local admin.token credential was rejected by the daemon (stale after an unclean " +
+        "shutdown or restart?); connecting as agent (admin-only commands will fail with FORBIDDEN)"
+      : source === "none"
+        ? "admin credential unavailable; connecting as agent (admin-only commands will fail with FORBIDDEN)"
+        : "admin credential was rejected by the daemon; connecting as agent (admin-only " +
+          "commands will fail with FORBIDDEN)";
+  environment.stderr.write(`${JSON.stringify({ notice })}\n`);
+}
+
 /**
  * The one connection helper every daemon-touching command uses (ADR §5's "the CLI is the
- * operator interface"). Resolves the admin credential, writes a stderr notice when none was
- * found (ADR §5's fallback), then connects -- auto-launching the daemon unless `launch: false`.
+ * operator interface").
+ *
+ * ADR §5's resolution order -- `--token`, then `SIMLOCK_ADMIN_TOKEN`, then the local
+ * `admin.token` file (briefly retried, see `readAdminTokenFileWithRetry`) -- is implemented as
+ * a resolver passed to `connectAdmin`/`connectExistingAdmin`, not resolved up front: the file
+ * source must not be read until the connection (and any auto-launch it triggers) has already
+ * settled (B2), since the daemon only writes it after claiming its socket.
+ *
+ * B1: a credential the daemon actively rejects (`ADMIN_AUTHENTICATION_FAILED` -- most commonly
+ * a stale `admin.token` left behind by an unclean shutdown) degrades to a fresh agent-role
+ * connection with a stderr notice, exactly like "no credential found" does, instead of failing
+ * the whole invocation. Retried at most once, and only when a credential was actually offered --
+ * an agent connection legitimately failing `hello` for an unrelated reason still propagates.
  */
 async function connectDaemonClient(
   environment: CliEnvironment,
   tokenFlag: string | undefined,
   options: { readonly launch?: boolean; readonly heartbeat?: boolean } = {},
 ): Promise<SimlockAdminClient> {
-  const credential = await resolveAdminCredential(environment, tokenFlag);
-  if (credential === undefined) {
-    environment.stderr.write(
-      `${JSON.stringify({
-        notice:
-          "admin credential unavailable; connecting as agent (admin-only commands will fail with FORBIDDEN)",
-      })}\n`,
-    );
-  }
   const connect =
     options.launch === false ? environment.connectExistingAdmin : environment.connectAdmin;
-  return connect(
-    credential,
-    options.heartbeat === undefined ? {} : { heartbeat: options.heartbeat },
-  );
+  const connectOptions = options.heartbeat === undefined ? {} : { heartbeat: options.heartbeat };
+
+  let source: CredentialSource = "none";
+  const resolveCredential = async (): Promise<string | undefined> => {
+    if (tokenFlag !== undefined && tokenFlag !== "") {
+      source = "flag";
+      return tokenFlag;
+    }
+    if (environment.adminTokenFromEnv !== undefined && environment.adminTokenFromEnv !== "") {
+      source = "env";
+      return environment.adminTokenFromEnv;
+    }
+    const fileToken = await readAdminTokenFileWithRetry(environment);
+    source = fileToken === undefined ? "none" : "file";
+    return fileToken;
+  };
+
+  try {
+    const client = await connect(resolveCredential, connectOptions);
+    if (source === "none") writeAgentFallbackNotice(environment, "none");
+    return client;
+  } catch (error: unknown) {
+    if (!isAdminAuthFailure(error) || source === "none") throw error;
+    writeAgentFallbackNotice(environment, source);
+    return connect(async () => undefined, connectOptions);
+  }
 }
 
 /** Auto-launches the daemon on a refused/missing socket, mirroring
@@ -243,43 +295,69 @@ function isUnavailable(error: unknown): boolean {
   );
 }
 
-function defaultCliEnvironment(env: NodeJS.ProcessEnv = process.env): CliEnvironment {
-  const dataDirectory = resolveSimlockHome(env);
-  const filesystem = new NodeFilesystem();
-  const clock = new SystemClock();
-  const systemStats = new NodeSystemStats();
-  const ipc = new NodeIpcTransport();
+/** The infrastructure `defaultCliEnvironment` wires up. Factored out so tests can build the
+ * exact same environment logic (credential-resolution ordering, `config set` validation)
+ * against in-memory ports instead of the real filesystem/socket/subprocess -- see
+ * `src/cli/index.test.ts`'s cold-start and stale-token suites. */
+export interface CliEnvironmentPorts {
+  readonly filesystem: Filesystem;
+  readonly clock: Clock;
+  readonly systemStats: SystemStats;
+  readonly ipc: IpcConnector;
+  readonly launcher: DaemonLauncher;
+  readonly dataDirectory: string;
+  readonly parentWatch?: ParentWatch;
+  readonly signals?: Signals;
+  readonly stderr?: Output;
+  readonly stdout?: Output;
+  readonly confirm?: (question: string) => Promise<boolean>;
+  readonly parentPid?: number;
+}
+
+/**
+ * Builds a `CliEnvironment` from an explicit set of ports (see `CliEnvironmentPorts`) plus the
+ * bits still read straight from `env`/`process` (the requester id default, `SIMLOCK_ADMIN_TOKEN`,
+ * `process.ppid`). `defaultCliEnvironment` is this with real Node ports; tests call it directly
+ * with in-memory ones.
+ */
+export function buildCliEnvironment(
+  ports: CliEnvironmentPorts,
+  env: NodeJS.ProcessEnv = process.env,
+): CliEnvironment {
+  const { clock, dataDirectory, filesystem, ipc, launcher, systemStats } = ports;
   const socketPath = join(dataDirectory, "daemon.sock");
   const configPath = join(dataDirectory, "config.json");
   const logPath = join(dataDirectory, "daemon.log");
   const adminTokenPath = join(dataDirectory, "admin.token");
   const requesterId = fallbackRequesterId(env);
-  const launcher = new NodeDaemonLauncher({
-    args: [join(dirname(fileURLToPath(import.meta.url)), "../daemon/main.js")],
-    command: process.execPath,
-    logPath,
-  });
   const autoLaunchIpc = new AutoLaunchIpcConnector(ipc, clock, launcher);
 
-  const connect = (
+  // ADR §5 / B2: the raw connection (and, for `connectAdmin`, any auto-launch it triggers) is
+  // established *before* `resolveCredential` is ever called -- `admin.token` is written only
+  // after the daemon claims its socket, so reading it any earlier races the whole daemon spawn
+  // instead of the narrow claim-to-persist window `readAdminTokenFileWithRetry` covers.
+  const connect = async (
     connector: IpcConnector,
-    credential: string | undefined,
+    resolveCredential: () => Promise<string | undefined>,
     options?: { readonly heartbeat?: boolean },
-  ): Promise<SimlockAdminClient> =>
-    connectSimlockAdmin({
-      ipc: connector,
-      endpoint: socketPath,
+  ): Promise<SimlockAdminClient> => {
+    const connection = await connector.connect(socketPath);
+    const credential = await resolveCredential();
+    return connectSimlockAdmin({
+      connection,
       principal: requesterId,
       ...(credential === undefined ? {} : { credential }),
       ...(options?.heartbeat === undefined ? {} : { heartbeat: options.heartbeat }),
     });
+  };
 
   return {
     configPath,
     requesterId,
     now: () => clock.now(),
-    connectAdmin: (credential, options) => connect(autoLaunchIpc, credential, options),
-    connectExistingAdmin: (credential, options) => connect(ipc, credential, options),
+    connectAdmin: (resolveCredential, options) =>
+      connect(autoLaunchIpc, resolveCredential, options),
+    connectExistingAdmin: (resolveCredential, options) => connect(ipc, resolveCredential, options),
     ...(env.SIMLOCK_ADMIN_TOKEN === undefined
       ? {}
       : { adminTokenFromEnv: env.SIMLOCK_ADMIN_TOKEN }),
@@ -287,8 +365,8 @@ function defaultCliEnvironment(env: NodeJS.ProcessEnv = process.env): CliEnviron
     sleep: (milliseconds) => new Promise<void>((resolve) => clock.setTimer(milliseconds, resolve)),
     // Captured once at process startup, before anything can reparent this
     // process -- `--bind-pid` overrides it per invocation.
-    parentPid: process.ppid,
-    parentWatch: new NodeParentWatch(),
+    parentPid: ports.parentPid ?? process.ppid,
+    parentWatch: ports.parentWatch ?? new NodeParentWatch(),
     readConfigFile: async () => {
       if (!(await filesystem.exists(configPath))) return {};
       return requireObject(JSON.parse(await filesystem.readFile(configPath)) as unknown);
@@ -297,22 +375,56 @@ function defaultCliEnvironment(env: NodeJS.ProcessEnv = process.env): CliEnviron
       await filesystem.mkdirp(dataDirectory);
       await filesystem.writeFileAtomic(configPath, `${JSON.stringify(contents, null, 2)}\n`);
     },
+    // ADR §11 part D: "validates the merged file through the config loader before writing."
+    // B9: two things the pre-fix version got wrong --
+    //  - `warn` was never passed, so `validateConfigLayer`'s default no-op silently dropped
+    //    unknown/mistyped keys instead of rejecting them. Collected here and thrown when any
+    //    "Unknown config key" warning fires -- but not for a legacy-spelling warning (still
+    //    valid config, just deprecated), so a legitimate legacy `config set` keeps working.
+    //  - `configPath` pointed at a sentinel file inside the *real* data directory, which a
+    //    stray file there could turn into a false pass or fail, despite the comment's claim
+    //    that the path was "never read" -- `loadConfig`'s `readConfigFile` does read it when it
+    //    exists. A fresh `MemoryFilesystem` makes that literally true: nothing can ever exist
+    //    at this path.
     validateConfig: async (merged) => {
+      const unknownKeyWarnings: string[] = [];
       await loadConfig({
-        // Never read: the point is to validate `merged` (the full post-edit file content) as
-        // its own layer, not to re-merge it over whatever is still on disk at `configPath`.
-        configPath: join(dataDirectory, ".config-set-validation-scratch.json"),
-        filesystem,
+        configPath: "/config-set-validation.json",
+        filesystem: new MemoryFilesystem(),
         overrides: merged as ConfigOverrides,
         systemStats,
+        warn: (message) => {
+          if (message.startsWith("Unknown config key:")) unknownKeyWarnings.push(message);
+        },
       });
+      if (unknownKeyWarnings.length > 0) throw new Error(unknownKeyWarnings.join("; "));
     },
     readLogFile: async () => readLogFile(filesystem, logPath),
-    signals: process,
-    stderr: process.stderr,
-    stdout: process.stdout,
-    confirm: confirmTerminal,
+    signals: ports.signals ?? process,
+    stderr: ports.stderr ?? process.stderr,
+    stdout: ports.stdout ?? process.stdout,
+    confirm: ports.confirm ?? confirmTerminal,
   };
+}
+
+function defaultCliEnvironment(env: NodeJS.ProcessEnv = process.env): CliEnvironment {
+  const dataDirectory = resolveSimlockHome(env);
+  const logPath = join(dataDirectory, "daemon.log");
+  return buildCliEnvironment(
+    {
+      filesystem: new NodeFilesystem(),
+      clock: new SystemClock(),
+      systemStats: new NodeSystemStats(),
+      ipc: new NodeIpcTransport(),
+      launcher: new NodeDaemonLauncher({
+        args: [join(dirname(fileURLToPath(import.meta.url)), "../daemon/main.js")],
+        command: process.execPath,
+        logPath,
+      }),
+      dataDirectory,
+    },
+    env,
+  );
 }
 
 async function readAdminTokenFile(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,36 +2,33 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 
+import { loadConfig, type ConfigOverrides } from "../core/index.js";
 import {
-  CryptoIdGenerator,
-  CryptoTokenSecrets,
+  IpcError,
   NodeDaemonLauncher,
   NodeFilesystem,
   NodeIpcTransport,
   NodeParentWatch,
+  NodeSystemStats,
   resolveSimlockHome,
   SystemClock,
   type Clock,
+  type DaemonLauncher,
   type Filesystem,
+  type IpcConnection,
+  type IpcConnector,
   type ParentWatch,
   type ParentWatchHandle,
 } from "../ports/index.js";
-import { TokenStore, type TokenRecord, type TokenRole } from "../http/token-store.js";
+import { connectSimlockAdmin } from "../admin/index.js";
 import {
-  connectDaemon,
-  connectExistingDaemon,
-  type DaemonClientCapabilities,
-  type ResolveCredential,
-} from "../daemon-client/client.js";
-import {
-  parseRawDeviceRecovered,
-  parseRawDeviceUnhealthy,
-  parseRawLeaseGrant,
-  parseRawLeaseLost,
-} from "../daemon-client/contracts.js";
-import { DaemonClientError, type DaemonConnection } from "../daemon-client/protocol.js";
-
-export { DaemonClientError, type DaemonConnection } from "../daemon-client/protocol.js";
+  isSimlockError,
+  type CatalogGetOutput,
+  type DoctorReport,
+  type SimlockAdminClient,
+  type StatusGetOutput,
+} from "../admin/index.js";
+import { ERROR_TABLE } from "../contract/index.js";
 
 const USAGE = `Usage: simlock <command> [options]
 
@@ -39,7 +36,11 @@ Commands:
   lease, release, status, list, catalog, cleanup, doctor, nuke, events,
   daemon, config, token
   mcp                         Start the stdio MCP server
-Run 'simlock <command> --help' for command usage.`;
+Run 'simlock <command> --help' for command usage.
+
+Pass --token <secret> anywhere on the command line to connect as admin
+explicitly; see docs/CLI.md#admin-credential-resolution for the default
+resolution order.`;
 
 /**
  * Held mode ends with the lease already gone: the daemon released it without
@@ -49,40 +50,10 @@ Run 'simlock <command> --help' for command usage.`;
  */
 const LEASE_LOST_EXIT_CODE = 14;
 
-const DAEMON_ERROR_EXIT_CODES: Readonly<Record<string, number>> = {
-  BAD_FRAME: 2,
-  BAD_REQUEST: 2,
-  INSUFFICIENT_DISK_SPACE: 12,
-  LICENSE_NOT_ACCEPTED: 12,
-  NO_CAPACITY: 11,
-  NO_DRIVER: 12,
-  QUEUE_TIMEOUT: 10,
-  REQUESTER_ALREADY_LEASED: 13,
-  RUNTIME_MISSING: 12,
-  UNKNOWN_MODEL: 12,
-};
-
 class UsageError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "UsageError";
-  }
-}
-
-/**
- * `token` operates on the filesystem directly (no daemon round-trip), so its
- * failures need their own structured error code -- not a `DaemonClientError`
- * (nothing was sent to the daemon) and not `UsageError` (exit 2 is reserved
- * for bad flags/arguments). Defaults to exit 1 like any other non-usage,
- * non-daemon failure.
- */
-class TokenCliError extends Error {
-  constructor(
-    readonly code: string,
-    message: string,
-  ) {
-    super(message);
-    this.name = "TokenCliError";
   }
 }
 
@@ -107,13 +78,47 @@ interface Signals {
 
 type McpStdioRunner = () => Promise<void>;
 
+/**
+ * ADR 0003 §11: the CLI renders the contract, and nothing else. Every daemon-touching command
+ * goes through `connectAdmin`/`connectExistingAdmin` -- both always hand back a
+ * `SimlockAdminClient` (ADR §5: "the CLI connects as admin whenever the local file is
+ * readable, falling back to an agent session ... when it is not"). Whether the connection
+ * actually *is* admin is entirely the daemon's call (`client.role`); an unauthenticated
+ * connection still gets an admin-shaped client back, and simply gets `FORBIDDEN` from the
+ * daemon on any operation that requires more than agent. This is what lets `lease`/`release`
+ * (agent-role operations) and `list`/`cleanup`/`nuke`/`token`/... (admin-role operations) share
+ * one connection helper instead of two.
+ */
 export interface CliEnvironment {
   readonly configPath: string;
-  readonly connect: (capabilities?: DaemonClientCapabilities) => Promise<DaemonConnection>;
-  readonly connectExisting?: () => Promise<DaemonConnection>;
-  readonly now?: () => number;
+  /** ADR §4's requester default and this connection's fixed principal -- see §9's
+   * "SIMLOCK_AGENT_ID and --agent-id still set the requester id ... they are not the
+   * principal": `--agent-id` overrides `lease.request`'s `requesterId` field, never this. */
   readonly requesterId: string;
+  readonly now?: () => number;
+  /** Connects (auto-launching the daemon if it is not already running) with the given
+   * credential, or none (ADR §5's agent fallback). */
+  readonly connectAdmin: (
+    credential: string | undefined,
+    options?: { readonly heartbeat?: boolean },
+  ) => Promise<SimlockAdminClient>;
+  /** Same as `connectAdmin` but never auto-launches -- `daemon stop`/`daemon status` must not
+   * start a daemon just to ask whether one is running. */
+  readonly connectExistingAdmin: (
+    credential: string | undefined,
+    options?: { readonly heartbeat?: boolean },
+  ) => Promise<SimlockAdminClient>;
+  /** `SIMLOCK_ADMIN_TOKEN`, ADR §5's second resolution source. */
+  readonly adminTokenFromEnv?: string;
+  /** One read attempt at the local `admin.token` file, ADR §5's third resolution source.
+   * `undefined` for "missing, unreadable, or empty" -- callers retry, not this. */
+  readonly readAdminTokenFile: () => Promise<string | undefined>;
+  readonly sleep: (milliseconds: number) => Promise<void>;
   readonly readConfigFile: () => Promise<Record<string, unknown>>;
+  readonly writeConfigFile: (contents: Record<string, unknown>) => Promise<void>;
+  /** `config set` (ADR §11 part D): validates the merged file through the config loader before
+   * `writeConfigFile` is ever called. Throws (any error) for an invalid merged config. */
+  readonly validateConfig: (merged: Record<string, unknown>) => Promise<void>;
   readonly readLogFile?: () => Promise<string>;
   /** Loads the MCP frontend only when the `mcp` command is dispatched. */
   readonly loadMcpStdio?: () => Promise<McpStdioRunner>;
@@ -125,14 +130,6 @@ export interface CliEnvironment {
   readonly stderr: Output;
   readonly stdout: Output;
   readonly confirm?: (question: string) => Promise<boolean>;
-  readonly writeConfigFile: (contents: Record<string, unknown>) => Promise<void>;
-  /**
-   * `token` reads/writes tokens.json directly, like `config` does with
-   * config.json -- no daemon round-trip. Optional so most tests (which never
-   * touch `token`) don't need to fabricate one; `runToken` fails clearly if
-   * it is missing.
-   */
-  readonly tokenStore?: TokenStore;
 }
 
 /**
@@ -146,98 +143,103 @@ export function fallbackRequesterId(env: NodeJS.ProcessEnv): string {
 }
 
 /**
- * ADR 0003 §5's credential resolution, in resolution order: `SIMLOCK_ADMIN_TOKEN`, then the
- * local `admin.token` file in the daemon's data directory. (`--token` arrives with the typed
- * client; this is the intermediate seam that lets role enforcement land without breaking the
- * CLI, which is the operator interface -- without it every admin command, `daemon stop`
- * included, answers FORBIDDEN.)
- *
- * Read *after* the socket is reachable, never before: the daemon writes `admin.token` just
- * after claiming its socket, so on a cold start with auto-launch the file cannot exist until
- * the connection succeeds. The short retry covers the remaining gap -- the socket is
- * connectable a moment before `persist()` lands the file.
- *
- * Never throws and never logs the credential: an unreadable file (a different OS user, or no
- * daemon-written file at all) degrades to an agent session with a one-line stderr notice,
- * exactly as §5 requires.
+ * ADR §5: "a daemon still writing the file" is a real race between the daemon claiming its
+ * socket (reachable) and `admin.token` landing on disk (`DaemonServer#start` awaits the socket
+ * claim, *then* `adminSecret.persist()`). A CLI invocation that races a fresh `daemon start`
+ * retries a few times, briefly, rather than either blocking indefinitely or giving up on the
+ * first empty read.
  */
-function makeCredentialResolver(
-  filesystem: Filesystem,
-  clock: Clock,
-  adminTokenPath: string,
-  env: NodeJS.ProcessEnv,
-  stderr: Output,
-): ResolveCredential {
-  return async () => {
-    const fromEnv = env.SIMLOCK_ADMIN_TOKEN?.trim();
-    if (fromEnv !== undefined && fromEnv !== "") return fromEnv;
-    for (let attempt = 0; attempt < 3; attempt += 1) {
-      try {
-        const contents = (await filesystem.readFile(adminTokenPath)).trim();
-        if (contents !== "") return contents;
-      } catch {
-        // Not written yet, or not ours to read -- fall through to the retry/notice below.
-      }
-      if (attempt < 2) await delay(clock, 50);
-    }
-    stderr.write(
-      `${JSON.stringify({
-        notice: "admin-credential-unavailable",
-        message:
-          "Could not read admin.token; connecting as an agent session. Admin-only commands will fail with FORBIDDEN.",
-      })}\n`,
-    );
-    return undefined;
-  };
-}
+const ADMIN_TOKEN_FILE_READ_ATTEMPTS = 3;
+const ADMIN_TOKEN_FILE_RETRY_DELAY_MS = 50;
 
-function delay(clock: Clock, ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    clock.setTimer(ms, resolve);
-  });
+/** ADR §5's resolution order: `--token`, then `SIMLOCK_ADMIN_TOKEN`, then the local
+ * `admin.token` file (briefly retried). `undefined` means every source came up empty --
+ * callers fall back to an agent-role connection with a stderr notice. */
+async function resolveAdminCredential(
+  environment: CliEnvironment,
+  tokenFlag: string | undefined,
+): Promise<string | undefined> {
+  if (tokenFlag !== undefined && tokenFlag !== "") return tokenFlag;
+  if (environment.adminTokenFromEnv !== undefined && environment.adminTokenFromEnv !== "") {
+    return environment.adminTokenFromEnv;
+  }
+  for (let attempt = 0; attempt < ADMIN_TOKEN_FILE_READ_ATTEMPTS; attempt++) {
+    const token = await environment.readAdminTokenFile();
+    if (token !== undefined) return token;
+    if (attempt < ADMIN_TOKEN_FILE_READ_ATTEMPTS - 1) {
+      await environment.sleep(ADMIN_TOKEN_FILE_RETRY_DELAY_MS);
+    }
+  }
+  return undefined;
 }
 
 /**
- * ADR §5's agent fallback, extended to a credential the daemon *rejects* rather than only to
- * an absent one. `admin.token` is removed on a graceful stop but survives a `kill -9` or a
- * power loss, so the next invocation reads a secret the freshly started daemon has never
- * minted and `hello` fails `ADMIN_AUTHENTICATION_FAILED`. Without this retry that failure is
- * terminal for *every* command -- including `catalog` and `lease`, which need no admin at all
- * -- until someone deletes the file by hand.
- *
- * Retries exactly once, and only when a credential was actually offered, so a genuine
- * handshake failure on an already-agent session still surfaces instead of looping.
+ * The one connection helper every daemon-touching command uses (ADR §5's "the CLI is the
+ * operator interface"). Resolves the admin credential, writes a stderr notice when none was
+ * found (ADR §5's fallback), then connects -- auto-launching the daemon unless `launch: false`.
  */
-async function connectWithAgentFallback(
-  attempt: (resolveCredential: ResolveCredential) => Promise<DaemonConnection>,
-  resolveCredential: ResolveCredential,
-  stderr: Output,
-): Promise<DaemonConnection> {
-  let offered = false;
-  try {
-    return await attempt(async () => {
-      const credential = await resolveCredential();
-      offered = credential !== undefined;
-      return credential;
-    });
-  } catch (error: unknown) {
-    if (!offered || credentialRejected(error) !== true) throw error;
-    stderr.write(
+async function connectDaemonClient(
+  environment: CliEnvironment,
+  tokenFlag: string | undefined,
+  options: { readonly launch?: boolean; readonly heartbeat?: boolean } = {},
+): Promise<SimlockAdminClient> {
+  const credential = await resolveAdminCredential(environment, tokenFlag);
+  if (credential === undefined) {
+    environment.stderr.write(
       `${JSON.stringify({
-        notice: "admin-credential-rejected",
-        message:
-          "The daemon rejected the stored admin credential (admin.token is probably stale after an ungraceful stop); connecting as an agent session.",
+        notice:
+          "admin credential unavailable; connecting as agent (admin-only commands will fail with FORBIDDEN)",
       })}\n`,
     );
-    return attempt(async () => undefined);
+  }
+  const connect =
+    options.launch === false ? environment.connectExistingAdmin : environment.connectAdmin;
+  return connect(
+    credential,
+    options.heartbeat === undefined ? {} : { heartbeat: options.heartbeat },
+  );
+}
+
+/** Auto-launches the daemon on a refused/missing socket, mirroring
+ * `daemon-client/startup-coordinator.ts`'s behaviour at the raw `IpcConnector` level instead of
+ * the legacy typed-connection level -- `simlock/admin`'s `connector` option accepts any
+ * `IpcConnector`, so this is the entire seam needed to keep `lease`'s "start the daemon if it
+ * isn't running" behaviour with the typed client. */
+class AutoLaunchIpcConnector implements IpcConnector {
+  constructor(
+    private readonly ipc: IpcConnector,
+    private readonly clock: Clock,
+    private readonly launcher: DaemonLauncher,
+  ) {}
+
+  async connect(endpoint: string): Promise<IpcConnection> {
+    try {
+      return await this.ipc.connect(endpoint);
+    } catch (error: unknown) {
+      if (!isUnavailable(error)) throw error;
+    }
+    await this.launcher.launch();
+    const deadline = this.clock.now() + 5_000;
+    let lastError: unknown;
+    while (this.clock.now() < deadline) {
+      try {
+        return await this.ipc.connect(endpoint);
+      } catch (error: unknown) {
+        if (!isUnavailable(error)) throw error;
+        lastError = error;
+        await new Promise<void>((resolve) => this.clock.setTimer(50, resolve));
+      }
+    }
+    throw new Error(`Timed out starting simlock daemon: ${errorMessage(lastError)}`);
   }
 }
 
-function credentialRejected(error: unknown): boolean {
+/** True only for "nothing is listening yet" -- a refused/missing socket -- never for a `hello`
+ * rejection (ADR §6: the client never restarts the daemon on mismatch). */
+function isUnavailable(error: unknown): boolean {
   return (
-    typeof error === "object" &&
-    error !== null &&
-    (error as { code?: unknown }).code === "ADMIN_AUTHENTICATION_FAILED"
+    error instanceof IpcError &&
+    (error.code === "connection-refused" || error.code === "endpoint-not-found")
   );
 }
 
@@ -245,75 +247,116 @@ function defaultCliEnvironment(env: NodeJS.ProcessEnv = process.env): CliEnviron
   const dataDirectory = resolveSimlockHome(env);
   const filesystem = new NodeFilesystem();
   const clock = new SystemClock();
+  const systemStats = new NodeSystemStats();
   const ipc = new NodeIpcTransport();
   const socketPath = join(dataDirectory, "daemon.sock");
   const configPath = join(dataDirectory, "config.json");
   const logPath = join(dataDirectory, "daemon.log");
-  const tokenStore = new TokenStore({
-    clock,
-    filesystem,
-    idGenerator: new CryptoIdGenerator(),
-    path: join(dataDirectory, "tokens.json"),
-    secrets: new CryptoTokenSecrets(),
+  const adminTokenPath = join(dataDirectory, "admin.token");
+  const requesterId = fallbackRequesterId(env);
+  const launcher = new NodeDaemonLauncher({
+    args: [join(dirname(fileURLToPath(import.meta.url)), "../daemon/main.js")],
+    command: process.execPath,
+    logPath,
   });
-  const resolveCredential = makeCredentialResolver(
-    filesystem,
-    clock,
-    join(dataDirectory, "admin.token"),
-    env,
-    process.stderr,
-  );
+  const autoLaunchIpc = new AutoLaunchIpcConnector(ipc, clock, launcher);
+
+  const connect = (
+    connector: IpcConnector,
+    credential: string | undefined,
+    options?: { readonly heartbeat?: boolean },
+  ): Promise<SimlockAdminClient> =>
+    connectSimlockAdmin({
+      ipc: connector,
+      endpoint: socketPath,
+      principal: requesterId,
+      ...(credential === undefined ? {} : { credential }),
+      ...(options?.heartbeat === undefined ? {} : { heartbeat: options.heartbeat }),
+    });
+
   return {
     configPath,
-    connect: (capabilities) =>
-      connectWithAgentFallback(
-        (resolve) =>
-          connectDaemon({
-            ...(capabilities === undefined ? {} : { capabilities }),
-            clock,
-            ipc,
-            launcher: new NodeDaemonLauncher({
-              args: [join(dirname(fileURLToPath(import.meta.url)), "../daemon/main.js")],
-              command: process.execPath,
-              logPath,
-            }),
-            resolveCredential: resolve,
-            socketPath,
-          }),
-        resolveCredential,
-        process.stderr,
-      ),
-    connectExisting: () =>
-      connectWithAgentFallback(
-        (resolve) => connectExistingDaemon(socketPath, ipc, undefined, resolve),
-        resolveCredential,
-        process.stderr,
-      ),
+    requesterId,
     now: () => clock.now(),
+    connectAdmin: (credential, options) => connect(autoLaunchIpc, credential, options),
+    connectExistingAdmin: (credential, options) => connect(ipc, credential, options),
+    ...(env.SIMLOCK_ADMIN_TOKEN === undefined
+      ? {}
+      : { adminTokenFromEnv: env.SIMLOCK_ADMIN_TOKEN }),
+    readAdminTokenFile: () => readAdminTokenFile(filesystem, adminTokenPath),
+    sleep: (milliseconds) => new Promise<void>((resolve) => clock.setTimer(milliseconds, resolve)),
     // Captured once at process startup, before anything can reparent this
     // process -- `--bind-pid` overrides it per invocation.
     parentPid: process.ppid,
     parentWatch: new NodeParentWatch(),
-    requesterId: fallbackRequesterId(env),
     readConfigFile: async () => {
       if (!(await filesystem.exists(configPath))) return {};
       return requireObject(JSON.parse(await filesystem.readFile(configPath)) as unknown);
+    },
+    writeConfigFile: async (contents) => {
+      await filesystem.mkdirp(dataDirectory);
+      await filesystem.writeFileAtomic(configPath, `${JSON.stringify(contents, null, 2)}\n`);
+    },
+    validateConfig: async (merged) => {
+      await loadConfig({
+        // Never read: the point is to validate `merged` (the full post-edit file content) as
+        // its own layer, not to re-merge it over whatever is still on disk at `configPath`.
+        configPath: join(dataDirectory, ".config-set-validation-scratch.json"),
+        filesystem,
+        overrides: merged as ConfigOverrides,
+        systemStats,
+      });
     },
     readLogFile: async () => readLogFile(filesystem, logPath),
     signals: process,
     stderr: process.stderr,
     stdout: process.stdout,
     confirm: confirmTerminal,
-    tokenStore,
-    writeConfigFile: async (contents) => {
-      await filesystem.mkdirp(dataDirectory);
-      await filesystem.writeFileAtomic(configPath, `${JSON.stringify(contents, null, 2)}\n`);
-    },
   };
+}
+
+async function readAdminTokenFile(
+  filesystem: Filesystem,
+  path: string,
+): Promise<string | undefined> {
+  try {
+    if (!(await filesystem.exists(path))) return undefined;
+    const contents = (await filesystem.readFile(path)).trim();
+    return contents === "" ? undefined : contents;
+  } catch {
+    return undefined;
+  }
 }
 
 async function loadDefaultMcpStdio(): Promise<McpStdioRunner> {
   return (await import("../mcp/main.js")).runMcpStdio;
+}
+
+/** `--token <secret>` is a global flag (ADR §5's first credential source), recognized anywhere
+ * on the command line rather than per-command, since almost every command can use it. Stripped
+ * before the remaining argv reaches that command's own `parseArgs` call. */
+function extractGlobalToken(argv: readonly string[]): {
+  readonly token: string | undefined;
+  readonly rest: string[];
+} {
+  const rest: string[] = [];
+  let token: string | undefined;
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index] as string;
+    if (arg === "--token") {
+      const value = argv[index + 1];
+      if (value === undefined) throw new UsageError("--token requires a value");
+      token = value;
+      index++;
+      continue;
+    }
+    if (arg.startsWith("--token=")) {
+      token = arg.slice("--token=".length);
+      continue;
+    }
+    rest.push(arg);
+  }
+  return { token, rest };
 }
 
 export async function runCli(
@@ -325,35 +368,36 @@ export async function runCli(
       environment.stdout.write(`${USAGE}\n`);
       return 0;
     }
-    switch (argv[0]) {
+    const { token, rest } = extractGlobalToken(argv);
+    switch (rest[0]) {
       case "lease":
-        return await runLease(argv.slice(1), environment);
+        return await runLease(rest.slice(1), environment, token);
       case "release":
-        return await runRelease(argv.slice(1), environment);
+        return await runRelease(rest.slice(1), environment, token);
       case "status":
-        return await runStatus(argv.slice(1), environment);
+        return await runStatus(rest.slice(1), environment, token);
       case "list":
-        return await runList(argv.slice(1), environment);
+        return await runList(rest.slice(1), environment, token);
       case "catalog":
-        return await runCatalog(argv.slice(1), environment);
+        return await runCatalog(rest.slice(1), environment, token);
       case "cleanup":
-        return await runCleanup(argv.slice(1), environment);
+        return await runCleanup(rest.slice(1), environment, token);
       case "doctor":
-        return await runDoctor(argv.slice(1), environment);
+        return await runDoctor(rest.slice(1), environment, token);
       case "nuke":
-        return await runNuke(argv.slice(1), environment);
+        return await runNuke(rest.slice(1), environment, token);
       case "events":
-        return await runEvents(argv.slice(1), environment);
+        return await runEvents(rest.slice(1), environment, token);
       case "daemon":
-        return await runDaemon(argv.slice(1), environment);
+        return await runDaemon(rest.slice(1), environment, token);
       case "config":
-        return await runConfig(argv.slice(1), environment);
+        return await runConfig(rest.slice(1), environment, token);
       case "token":
-        return await runToken(argv.slice(1), environment);
+        return await runToken(rest.slice(1), environment, token);
       case "mcp":
-        return await runMcp(argv.slice(1), environment);
+        return await runMcp(rest.slice(1), environment);
       default:
-        throw new UsageError(withHelpHint(`Unknown command: ${argv[0]}`));
+        throw new UsageError(withHelpHint(`Unknown command: ${rest[0]}`));
     }
   } catch (error: unknown) {
     writeError(environment, error);
@@ -376,9 +420,17 @@ function writeError(environment: CliEnvironment, error: unknown): void {
 
 function cliErrorCode(error: unknown): string {
   if (error instanceof UsageError) return "USAGE";
-  if (error instanceof DaemonClientError) return error.code;
-  if (error instanceof TokenCliError) return error.code;
+  if (isSimlockError(error)) return error.code;
   return "INTERNAL";
+}
+
+/** ADR §7: "CLI exit codes and HTTP status codes are columns of the same error table, not
+ * second mappings" -- driven from `ERROR_TABLE`'s `cliExitCode` column rather than a second,
+ * CLI-maintained map. */
+export function errorExitCode(error: unknown): number {
+  if (error instanceof UsageError) return 2;
+  if (isSimlockError(error)) return ERROR_TABLE[error.code].cliExitCode;
+  return 1;
 }
 
 async function runMcp(argv: readonly string[], environment: CliEnvironment): Promise<number> {
@@ -391,12 +443,6 @@ async function runMcp(argv: readonly string[], environment: CliEnvironment): Pro
     environment.runMcpStdio ?? (await (environment.loadMcpStdio ?? loadDefaultMcpStdio)());
   await runMcpStdio();
   return 0;
-}
-
-export function errorExitCode(error: unknown): number {
-  if (error instanceof UsageError) return 2;
-  if (error instanceof DaemonClientError) return DAEMON_ERROR_EXIT_CODES[error.code] ?? 1;
-  return 1;
 }
 
 /** Parses user-facing durations only at the CLI boundary. */
@@ -421,8 +467,12 @@ function parseBindPid(value: unknown): number | undefined {
 }
 
 // fallow-ignore-next-line complexity -- CLI command parsing remains intentionally local to its rendering boundary.
-async function runLease(argv: readonly string[], environment: CliEnvironment): Promise<number> {
-  if (argv[0] === "renew") return runRenew(argv.slice(1), environment);
+async function runLease(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
+  if (argv[0] === "renew") return runRenew(argv.slice(1), environment, token);
   const values = commandArgs(argv, {
     "agent-id": { type: "string" },
     "allow-download": { type: "boolean" },
@@ -446,10 +496,11 @@ async function runLease(argv: readonly string[], environment: CliEnvironment): P
   }
   if (values.platform !== "ios" && values.platform !== "android")
     throw new UsageError(withHelpHint("lease requires --platform <ios|android>"));
+  const platform = values.platform as "ios" | "android";
   if (typeof values.device !== "string" || values.device === "")
     throw new UsageError(withHelpHint("lease requires --device <model>"));
   if (values["agent-id"] === "") throw new UsageError("lease --agent-id must not be empty");
-  const requesterId = values["agent-id"] ?? environment.requesterId;
+  const requesterId = (values["agent-id"] as string | undefined) ?? environment.requesterId;
   const detached = values.detach ?? false;
   const timeoutMs = typeof values.timeout === "string" ? parseDuration(values.timeout) : undefined;
   // Held mode watches its parent so a crashed agent's backgrounded holder
@@ -461,73 +512,55 @@ async function runLease(argv: readonly string[], environment: CliEnvironment): P
   const termination = detached
     ? undefined
     : waitForTermination(environment.signals, environment.parentWatch, watchedPid);
-  // Declaring the heartbeat capability opts this connection into the daemon's
-  // sliding TTL -- safe now that a dead-parent holder self-terminates instead
-  // of pinging forever. Detached mode never holds a connection, so it keeps
-  // relying purely on its own TTL.
-  const connection = await environment.connect(detached ? undefined : { heartbeat: true });
+
+  const client = await connectDaemonClient(environment, token, { heartbeat: !detached });
   // Set once the daemon says this connection's lease ended without us asking. ADR 0003 §8:
-  // lease-scoped pushes now go to every live connection sharing the lease's owner, not only
-  // the one holding it -- until the CLI sends a real per-process principal at `hello` (PR 4),
-  // two CLI connections started without `--agent-id`/`SIMLOCK_AGENT_ID` share the daemon's
-  // fallback principal, so a lease-lost push meant for one can reach the other. Filtered by
-  // `leaseId` below against this connection's own granted lease (unset until the grant
-  // response lands, in which case any push is necessarily for someone else's lease -- nothing
-  // this connection holds could have already been lost).
+  // lease-scoped pushes go to every live connection sharing the lease's owner, in either mode
+  // -- filtered below against this connection's own granted lease id, the same way the
+  // pre-typed-client CLI did, since a second CLI invocation sharing this principal (e.g. a
+  // detached lease from an earlier `--detach`) can otherwise deliver a push for a lease this
+  // process never held.
   let leaseLost = false;
   let ourLeaseId: string | undefined;
   let notifyLeaseLost: (() => void) | undefined;
   const leaseLostSignal = new Promise<void>((resolve) => {
     notifyLeaseLost = resolve;
   });
-  const unsubscribe = connection.onPush((kind, payload) => {
-    if (kind === "progress") {
-      environment.stderr.write(`${JSON.stringify(progressLine(payload))}\n`);
-      return;
-    }
-    if (kind === "device-unhealthy") {
-      writeDeviceHealthLine(environment, () => deviceUnhealthyLine(payload));
-      return;
-    }
-    if (kind === "device-recovered") {
-      writeDeviceHealthLine(environment, () => deviceRecoveredLine(payload));
-      return;
-    }
-    if (kind === "lease-lost") {
-      // Parse before deciding the lease is gone: unlike the health lines, acting on
-      // this one ends the process, so a malformed push must be ignored outright
-      // rather than exiting the holder with no explanation of why.
-      let line;
-      try {
-        line = leaseLostLine(payload);
-      } catch {
-        return;
-      }
-      if (line.lease !== ourLeaseId) return;
-      environment.stderr.write(`${JSON.stringify(line)}\n`);
-      leaseLost = true;
-      notifyLeaseLost?.();
-    }
+  const offLeaseLost = client.onLeaseLost((push) => {
+    if (push.leaseId !== ourLeaseId) return;
+    environment.stderr.write(`${JSON.stringify({ push: "lease-lost", ...push })}\n`);
+    leaseLost = true;
+    notifyLeaseLost?.();
+  });
+  const offUnhealthy = client.onDeviceUnhealthy((push) => {
+    environment.stderr.write(`${JSON.stringify({ push: "device-unhealthy", ...push })}\n`);
+  });
+  const offRecovered = client.onDeviceRecovered((push) => {
+    environment.stderr.write(`${JSON.stringify({ push: "device-recovered", ...push })}\n`);
   });
   try {
-    // Flat fields, not the legacy `device`/`os` aliases or a nested `request` wrapper -- the
-    // wire moved to protocol 3 with no compatibility shim (ADR 0003 "Consequences"). Moving
-    // this onto the typed `simlock/client` (ADR 0003 §10-11) is PR 4's job; this is only the
-    // minimal payload-shape fix needed to keep the CLI working against this PR's daemon.
-    const response = await connection.request("lease.request", {
-      allowDownload: values["allow-download"] ?? false,
-      mode: detached ? "detached" : "held",
-      noWait: values["no-wait"] ?? false,
-      requesterId,
-      model: values.device,
-      ...(typeof values.os === "string" ? { osVersion: values.os } : {}),
-      platform: values.platform,
-      ...(values.full === true ? { full: true } : {}),
-      ...(timeoutMs === undefined ? {} : { timeoutMs }),
-    });
-    const result = leaseResult(response);
-    ourLeaseId = result.lease;
-    environment.stdout.write(`${JSON.stringify(result)}\n`);
+    const grant = await client.requestLease(
+      {
+        allowDownload: values["allow-download"] === true,
+        mode: detached ? "detached" : "held",
+        noWait: values["no-wait"] === true,
+        requesterId,
+        model: values.device,
+        ...(typeof values.os === "string" ? { osVersion: values.os } : {}),
+        platform,
+        ...(values.full === true ? { full: true } : {}),
+        ...(timeoutMs === undefined ? {} : { timeoutMs }),
+      },
+      {
+        onProgress: (progress) => {
+          environment.stderr.write(`${JSON.stringify({ push: "progress", ...progress })}\n`);
+        },
+      },
+    );
+    ourLeaseId = grant.lease.id;
+    // ADR §5: "simlock lease output includes the resolved role" -- the one field this CLI
+    // adds on top of the contract's `LeaseGrant` shape, everything else passed through as-is.
+    writeResult(environment, { ...grant, role: client.role });
     if (detached || termination === undefined) return 0;
     await Promise.race([termination.settled, leaseLostSignal]);
     if (leaseLost) {
@@ -535,7 +568,7 @@ async function runLease(argv: readonly string[], environment: CliEnvironment): P
       return LEASE_LOST_EXIT_CODE;
     }
     try {
-      await connection.request("lease.release", { leaseId: result.lease });
+      await client.releaseLease({ leaseId: grant.lease.id });
     } catch (error: unknown) {
       // Non-fatal: the process still exits 0 after a signal, but the release
       // failure is still diagnostic output, so it stays a structured stderr
@@ -545,12 +578,18 @@ async function runLease(argv: readonly string[], environment: CliEnvironment): P
     return 0;
   } finally {
     termination?.dispose();
-    unsubscribe();
-    await connection.close();
+    offLeaseLost();
+    offUnhealthy();
+    offRecovered();
+    await client.close();
   }
 }
 
-async function runRenew(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+async function runRenew(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
   const values = commandArgs(argv, {
     help: { type: "boolean", short: "h" },
     ttl: { type: "string" },
@@ -561,17 +600,26 @@ async function runRenew(argv: readonly string[], environment: CliEnvironment): P
     return 0;
   }
   const leaseId = requiredPositional(positionals, "lease-id");
-  writeResult(
-    environment,
-    await requestOnce(environment, "lease.renew", {
-      leaseId,
-      ...(typeof values.ttl === "string" ? { ttlMs: parseDuration(values.ttl) } : {}),
-    }),
-  );
-  return 0;
+  const client = await connectDaemonClient(environment, token);
+  try {
+    writeResult(
+      environment,
+      await client.renewLease({
+        leaseId,
+        ...(typeof values.ttl === "string" ? { ttlMs: parseDuration(values.ttl) } : {}),
+      }),
+    );
+    return 0;
+  } finally {
+    await client.close();
+  }
 }
 
-async function runRelease(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+async function runRelease(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
   const values = commandArgs(argv, {
     all: { type: "boolean" },
     help: { type: "boolean", short: "h" },
@@ -582,24 +630,31 @@ async function runRelease(argv: readonly string[], environment: CliEnvironment):
     environment.stdout.write("Usage: simlock release <lease-id> | --all [--yes]\n");
     return 0;
   }
-  if (values.all) {
-    if (positionals.length > 0)
-      throw new UsageError("release accepts either a lease id or --all, not both");
-    const confirmed = values.yes ?? (await environment.confirm?.("Release every lease? [y/N] "));
-    if (!confirmed) throw new UsageError("release --all requires confirmation or --yes");
-    writeResult(environment, await requestOnce(environment, "lease.release-all", {}));
+  const client = await connectDaemonClient(environment, token);
+  try {
+    if (values.all) {
+      if (positionals.length > 0)
+        throw new UsageError("release accepts either a lease id or --all, not both");
+      const confirmed = values.yes ?? (await environment.confirm?.("Release every lease? [y/N] "));
+      if (!confirmed) throw new UsageError("release --all requires confirmation or --yes");
+      writeResult(environment, await client.releaseAllLeases());
+      return 0;
+    }
+    writeResult(
+      environment,
+      await client.releaseLease({ leaseId: requiredPositional(positionals, "lease-id") }),
+    );
     return 0;
+  } finally {
+    await client.close();
   }
-  writeResult(
-    environment,
-    await requestOnce(environment, "lease.release", {
-      leaseId: requiredPositional(positionals, "lease-id"),
-    }),
-  );
-  return 0;
 }
 
-async function runStatus(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+async function runStatus(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
   const values = commandArgs(argv, {
     help: { type: "boolean", short: "h" },
     json: { type: "boolean" },
@@ -608,13 +663,22 @@ async function runStatus(argv: readonly string[], environment: CliEnvironment): 
     environment.stdout.write("Usage: simlock status [--json]\n");
     return 0;
   }
-  const status = await requestOnce(environment, "status.get", {});
-  if (values.json) writeResult(environment, status);
-  else environment.stdout.write(`${formatStatus(requireObject(status))}\n`);
-  return 0;
+  const client = await connectDaemonClient(environment, token);
+  try {
+    const status = await client.getStatus();
+    if (values.json) writeResult(environment, status);
+    else environment.stdout.write(`${formatStatus(status)}\n`);
+    return 0;
+  } finally {
+    await client.close();
+  }
 }
 
-async function runList(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+async function runList(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
   const values = commandArgs(argv, {
     devices: { type: "boolean" },
     help: { type: "boolean", short: "h" },
@@ -628,11 +692,20 @@ async function runList(argv: readonly string[], environment: CliEnvironment): Pr
   if ([values.devices, values.leases, values.rules].filter(Boolean).length > 1)
     throw new UsageError("list accepts only one of --devices, --leases, or --rules");
   const kind = values.leases ? "leases" : values.rules ? "rules" : "devices";
-  writeResult(environment, await requestOnce(environment, "list.get", { kind }));
-  return 0;
+  const client = await connectDaemonClient(environment, token);
+  try {
+    writeResult(environment, await client.list({ kind }));
+    return 0;
+  } finally {
+    await client.close();
+  }
 }
 
-async function runCatalog(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+async function runCatalog(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
   const values = commandArgs(argv, {
     help: { type: "boolean", short: "h" },
     json: { type: "boolean" },
@@ -644,17 +717,23 @@ async function runCatalog(argv: readonly string[], environment: CliEnvironment):
   }
   if (values.platform !== undefined && values.platform !== "ios" && values.platform !== "android")
     throw new UsageError("catalog --platform must be ios or android");
-  const response = await requestOnce(
-    environment,
-    "catalog.get",
-    values.platform === undefined ? {} : { platform: values.platform },
-  );
-  if (values.json) writeResult(environment, response);
-  else environment.stdout.write(`${formatCatalog(requireObject(response))}\n`);
-  return 0;
+  const platform = values.platform as "ios" | "android" | undefined;
+  const client = await connectDaemonClient(environment, token);
+  try {
+    const response = await client.getCatalog(platform === undefined ? {} : { platform });
+    if (values.json) writeResult(environment, response);
+    else environment.stdout.write(`${formatCatalog(response)}\n`);
+    return 0;
+  } finally {
+    await client.close();
+  }
 }
 
-async function runCleanup(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+async function runCleanup(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
   const values = commandArgs(argv, {
     "dry-run": { type: "boolean" },
     help: { type: "boolean", short: "h" },
@@ -664,17 +743,26 @@ async function runCleanup(argv: readonly string[], environment: CliEnvironment):
     environment.stdout.write("Usage: simlock cleanup [--dry-run] [--rule <name>]\n");
     return 0;
   }
-  writeResult(
-    environment,
-    await requestOnce(environment, "cleanup.run", {
-      dryRun: values["dry-run"] ?? false,
-      ...(typeof values.rule === "string" ? { rule: values.rule } : {}),
-    }),
-  );
-  return 0;
+  const client = await connectDaemonClient(environment, token);
+  try {
+    writeResult(
+      environment,
+      await client.runCleanup({
+        dryRun: values["dry-run"] === true,
+        ...(typeof values.rule === "string" ? { rule: values.rule } : {}),
+      }),
+    );
+    return 0;
+  } finally {
+    await client.close();
+  }
 }
 
-async function runDoctor(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+async function runDoctor(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
   const values = commandArgs(argv, {
     fix: { type: "boolean" },
     help: { type: "boolean", short: "h" },
@@ -683,10 +771,15 @@ async function runDoctor(argv: readonly string[], environment: CliEnvironment): 
     environment.stdout.write("Usage: simlock doctor [--fix]\n");
     return 0;
   }
-  const response = await requestOnce(environment, "doctor.run", { fix: values.fix ?? false });
-  writeDriverAdvisoryWarnings(environment, response);
-  writeResult(environment, response);
-  return 0;
+  const client = await connectDaemonClient(environment, token);
+  try {
+    const response = await client.runDoctor({ fix: values.fix === true });
+    writeDriverAdvisoryWarnings(environment, response);
+    writeResult(environment, response);
+    return 0;
+  } finally {
+    await client.close();
+  }
 }
 
 /**
@@ -697,21 +790,18 @@ async function runDoctor(argv: readonly string[], environment: CliEnvironment): 
  * every finding kind unmodified via `writeResult`, matching the JSON-passthrough convention
  * `list`/`cleanup`/`nuke` already use, so a scripted consumer of stdout sees no behavior change.
  */
-function writeDriverAdvisoryWarnings(environment: CliEnvironment, response: unknown): void {
-  if (typeof response !== "object" || response === null) return;
-  const findings = (response as Record<string, unknown>).findings;
-  if (!Array.isArray(findings)) return;
-  for (const finding of findings) {
-    if (typeof finding !== "object" || finding === null) continue;
-    const record = finding as Record<string, unknown>;
-    if (record.kind !== "driver-advisory") continue;
-    environment.stderr.write(
-      `Warning [${String(record.platform)}] ${String(record.code)}: ${String(record.message)}\n`,
-    );
+function writeDriverAdvisoryWarnings(environment: CliEnvironment, report: DoctorReport): void {
+  for (const finding of report.findings) {
+    if (finding.kind !== "driver-advisory") continue;
+    environment.stderr.write(`Warning [${finding.platform}] ${finding.code}: ${finding.message}\n`);
   }
 }
 
-async function runNuke(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+async function runNuke(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
   const values = commandArgs(argv, {
     "delete-devices": { type: "boolean" },
     help: { type: "boolean", short: "h" },
@@ -724,16 +814,23 @@ async function runNuke(argv: readonly string[], environment: CliEnvironment): Pr
   const confirmed =
     values.yes ?? (await environment.confirm?.("Nuke Simlock-managed devices? [y/N] "));
   if (!confirmed) throw new UsageError("nuke requires confirmation or --yes");
-  writeResult(
-    environment,
-    await requestOnce(environment, "nuke.run", {
-      deleteDevices: values["delete-devices"] ?? false,
-    }),
-  );
-  return 0;
+  const client = await connectDaemonClient(environment, token);
+  try {
+    writeResult(
+      environment,
+      await client.runNuke({ deleteDevices: values["delete-devices"] === true }),
+    );
+    return 0;
+  } finally {
+    await client.close();
+  }
 }
 
-async function runEvents(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+async function runEvents(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
   const values = commandArgs(argv, {
     follow: { type: "boolean" },
     help: { type: "boolean", short: "h" },
@@ -743,32 +840,32 @@ async function runEvents(argv: readonly string[], environment: CliEnvironment): 
     environment.stdout.write("Usage: simlock events [--follow] [--since <duration>]\n");
     return 0;
   }
-  const connection = await environment.connect();
-  const unsubscribe = connection.onPush((kind, payload) => {
-    if (kind === "event") writeResult(environment, payload);
-  });
+  const client = await connectDaemonClient(environment, token);
   try {
     const sinceTs =
       typeof values.since === "string"
         ? (environment.now ?? Date.now)() - parseDuration(values.since)
         : undefined;
-    const replayPayload = sinceTs === undefined ? {} : { sinceTs };
-    for (const event of requireArray(await connection.request("events.replay", replayPayload)))
+    for (const event of await client.replayEvents(sinceTs === undefined ? {} : { sinceTs })) {
       writeResult(environment, event);
+    }
     if (values.follow) {
-      await connection.request("events.subscribe", {});
+      const unsubscribe = await client.subscribeEvents((event) => writeResult(environment, event));
       await waitForTermination(environment.signals).settled;
-      await connection.request("events.unsubscribe", {});
+      await unsubscribe();
     }
     return 0;
   } finally {
-    unsubscribe();
-    await connection.close();
+    await client.close();
   }
 }
 
 // fallow-ignore-next-line complexity -- daemon subcommand parsing is a single CLI boundary.
-async function runDaemon(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+async function runDaemon(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
   const command = argv[0];
   const values = commandArgs(argv.slice(1), {
     help: { type: "boolean", short: "h" },
@@ -780,17 +877,22 @@ async function runDaemon(argv: readonly string[], environment: CliEnvironment): 
   }
   if (values.positionals.length > 0) throw new UsageError("daemon accepts exactly one subcommand");
   if (command === "start") {
-    await requestOnce(environment, "status.get", {});
+    const client = await connectDaemonClient(environment, token, { launch: true });
+    try {
+      await client.getStatus();
+    } finally {
+      await client.close();
+    }
     if (values.json) writeResult(environment, { status: "running" });
     else environment.stdout.write("Daemon running\n");
     return 0;
   }
   if (command === "stop") {
-    const connection = await (environment.connectExisting ?? environment.connect)();
+    const client = await connectDaemonClient(environment, token, { launch: false });
     try {
-      await connection.request("daemon.stop", {});
+      await client.stopDaemon();
     } finally {
-      await connection.close();
+      await client.close();
     }
     if (values.json) writeResult(environment, { status: "stopping" });
     else environment.stdout.write("Daemon stopping\n");
@@ -798,17 +900,38 @@ async function runDaemon(argv: readonly string[], environment: CliEnvironment): 
   }
   if (command === "status") {
     try {
-      const connection = await (environment.connectExisting ?? environment.connect)();
+      const client = await connectDaemonClient(environment, token, { launch: false });
       try {
-        writeResult(environment, await connection.request("status.get", {}));
+        const status = await client.getStatus();
+        if (values.json) writeResult(environment, status);
+        else environment.stdout.write(`${formatStatus(status)}\n`);
       } finally {
-        await connection.close();
+        await client.close();
       }
-    } catch {
+      return 0;
+    } catch (error: unknown) {
+      // ADR §11: distinguish socket-absent from handshake-refused using the error `kind`,
+      // instead of reporting "stopped" on any error. A `SimlockError` whose `kind` is not
+      // `"transport"` means the socket was reachable and a daemon answered, but the
+      // connection was refused at or after `hello` (bad credential, version mismatch, ...);
+      // anything else (a raw `IpcError`, or a `transport`-kind `SimlockError` such as
+      // `DAEMON_CONNECTION_LOST`) means nothing is listening -- the pre-existing "stopped"
+      // outcome.
+      if (isSimlockError(error) && error.kind !== "transport") {
+        if (values.json) {
+          writeResult(environment, {
+            status: "handshake-refused",
+            error: { code: error.code, message: error.message },
+          });
+        } else {
+          environment.stdout.write(`Daemon handshake refused: ${error.code}: ${error.message}\n`);
+        }
+        return 1;
+      }
       if (values.json) writeResult(environment, { status: "stopped" });
       else environment.stdout.write("Daemon stopped\n");
+      return 0;
     }
-    return 0;
   }
   if (command === "logs") {
     if (environment.readLogFile === undefined) throw new Error("Daemon log reader is unavailable");
@@ -822,19 +945,32 @@ async function runDaemon(argv: readonly string[], environment: CliEnvironment): 
 }
 
 // fallow-ignore-next-line complexity -- config subcommand parsing is a single CLI boundary.
-async function runConfig(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+async function runConfig(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
   const command = argv[0];
   if (command === undefined) {
-    writeResult(environment, await requestOnce(environment, "config.get", {}));
-    return 0;
+    const client = await connectDaemonClient(environment, token);
+    try {
+      writeResult(environment, await client.getConfig());
+      return 0;
+    } finally {
+      await client.close();
+    }
   }
   if (command === "get") {
     const values = commandArgs(argv.slice(1), {});
     const key = requiredPositional(values.positionals, "key");
-    const value = readConfigValue(
-      requireObject(await requestOnce(environment, "config.get", {})),
-      key,
-    );
+    const client = await connectDaemonClient(environment, token);
+    let config: Record<string, unknown>;
+    try {
+      config = await client.getConfig();
+    } finally {
+      await client.close();
+    }
+    const value = readConfigValue(config, key);
     if (value === undefined) throw new UsageError(`Unknown config key: ${key}`);
     writeResult(environment, value);
     return 0;
@@ -846,6 +982,14 @@ async function runConfig(argv: readonly string[], environment: CliEnvironment): 
       throw new UsageError("Usage: simlock config set <key> <value>");
     const config = await environment.readConfigFile();
     writeConfigValue(config, key, parseConfigValue(rawValue));
+    // ADR §11 part D: "config set stays a file write ... but validates the merged file through
+    // the config loader before writing." Any failure here is bad input, same class as a bad
+    // flag -- surfaced as a usage error (exit 2) rather than a new CLI-level error code.
+    try {
+      await environment.validateConfig(config);
+    } catch (error: unknown) {
+      throw new UsageError(`Invalid config after setting ${key}: ${errorMessage(error)}`);
+    }
     await environment.writeConfigFile(config);
     environment.stdout.write(
       `Updated ${key} in ${environment.configPath}; takes effect on daemon restart.\n`,
@@ -859,7 +1003,11 @@ async function runConfig(argv: readonly string[], environment: CliEnvironment): 
   throw new UsageError(`Unknown config command: ${command}`);
 }
 
-async function runToken(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+async function runToken(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
   const command = argv[0];
   if (command === undefined || isHelp(command)) {
     environment.stdout.write(
@@ -869,21 +1017,20 @@ async function runToken(argv: readonly string[], environment: CliEnvironment): P
     );
     return 0;
   }
-  const tokenStore = requireTokenStore(environment);
-  if (command === "create") return runTokenCreate(argv.slice(1), tokenStore, environment);
-  if (command === "list") return runTokenList(argv.slice(1), tokenStore, environment);
-  if (command === "revoke") return runTokenRevoke(argv.slice(1), tokenStore, environment);
-  throw new UsageError(withHelpHint(`Unknown token command: ${command}`));
-}
-
-function requireTokenStore(environment: CliEnvironment): TokenStore {
-  if (environment.tokenStore === undefined) throw new Error("Token store is unavailable");
-  return environment.tokenStore;
+  const client = await connectDaemonClient(environment, token);
+  try {
+    if (command === "create") return await runTokenCreate(argv.slice(1), client, environment);
+    if (command === "list") return await runTokenList(argv.slice(1), client, environment);
+    if (command === "revoke") return await runTokenRevoke(argv.slice(1), client, environment);
+    throw new UsageError(withHelpHint(`Unknown token command: ${command}`));
+  } finally {
+    await client.close();
+  }
 }
 
 async function runTokenCreate(
   argv: readonly string[],
-  tokenStore: TokenStore,
+  client: SimlockAdminClient,
   environment: CliEnvironment,
 ): Promise<number> {
   const values = commandArgs(argv, {
@@ -900,14 +1047,16 @@ async function runTokenCreate(
   const role = parseTokenRole(values.role);
   const label = typeof values.label === "string" ? values.label : undefined;
   if (label === "") throw new UsageError("token create --label must not be empty");
-  const { record, secret } = await tokenStore.create(role, label);
-  writeResult(environment, { secret, token: serializeToken(record) });
+  writeResult(
+    environment,
+    await client.createToken({ role, ...(label === undefined ? {} : { label }) }),
+  );
   return 0;
 }
 
 async function runTokenList(
   argv: readonly string[],
-  tokenStore: TokenStore,
+  client: SimlockAdminClient,
   environment: CliEnvironment,
 ): Promise<number> {
   const values = commandArgs(argv, { help: { type: "boolean", short: "h" } });
@@ -915,14 +1064,13 @@ async function runTokenList(
     environment.stdout.write("Usage: simlock token list\n");
     return 0;
   }
-  const records = await tokenStore.list();
-  writeResult(environment, { tokens: records.map(serializeToken) });
+  writeResult(environment, await client.listTokens());
   return 0;
 }
 
 async function runTokenRevoke(
   argv: readonly string[],
-  tokenStore: TokenStore,
+  client: SimlockAdminClient,
   environment: CliEnvironment,
 ): Promise<number> {
   const values = commandArgs(argv, { help: { type: "boolean", short: "h" } });
@@ -931,39 +1079,14 @@ async function runTokenRevoke(
     return 0;
   }
   const id = requiredPositional(values.positionals, "token-id");
-  if (!(await tokenStore.revoke(id)))
-    throw new TokenCliError("UNKNOWN_TOKEN", `Unknown token: ${id}`);
-  writeResult(environment, { revoked: true });
+  writeResult(environment, await client.revokeToken({ id }));
   return 0;
 }
 
-function parseTokenRole(value: unknown): TokenRole {
+function parseTokenRole(value: unknown): "agent" | "operator" {
   if (value !== "agent" && value !== "operator")
     throw new UsageError(withHelpHint("token create requires --role <agent|operator>"));
   return value;
-}
-
-/** Drops `hash` -- an implementation detail no CLI output needs to expose. */
-function serializeToken(record: TokenRecord): Record<string, unknown> {
-  return {
-    createdAt: record.createdAt,
-    id: record.id,
-    ...(record.label === undefined ? {} : { label: record.label }),
-    role: record.role,
-  };
-}
-
-async function requestOnce(
-  environment: CliEnvironment,
-  type: string,
-  payload: unknown,
-): Promise<unknown> {
-  const connection = await environment.connect();
-  try {
-    return await connection.request(type, payload);
-  } finally {
-    await connection.close();
-  }
 }
 
 function commandArgs(
@@ -976,181 +1099,6 @@ function commandArgs(
   } catch (error: unknown) {
     throw new UsageError(errorMessage(error));
   }
-}
-
-function leaseResult(value: unknown): Record<string, unknown> & { readonly lease: string } {
-  const grant = parseRawLeaseGrant(value);
-  return {
-    // Optional: undefined only for a device leased straight out of a pre-address `state.json`
-    // without ever rebooting under this daemon -- see `DeviceRecord.address` in domain.ts.
-    ...(grant.device.address === undefined ? {} : { address: grant.device.address }),
-    device: grant.device.spec.model,
-    expires_at_ms: grant.lease.ttlDeadline,
-    lease: grant.lease.id,
-    os: grant.device.spec.osVersion,
-    platform: grant.device.spec.platform,
-    slim: grant.slim,
-    state: "leased",
-    timing: {
-      estimated_boot_ms: grant.timing.estimatedBootMs,
-      estimated_provision_ms: grant.timing.estimatedProvisionMs,
-      estimated_reclaim_ms: grant.timing.estimatedReclaimMs,
-      estimated_ready_ms: grant.timing.estimatedReadyMs,
-    },
-    udid: grant.device.driverDeviceId,
-  };
-}
-
-function progressLine(value: unknown): {
-  readonly event: string;
-  readonly eta_seconds?: number;
-  readonly queue_position?: number;
-} {
-  // ADR 0003 §8: `progress` pushes now wrap the stage payload under `progress`, alongside a
-  // `requestId` this CLI does not yet need (it never has more than one lease request in flight
-  // per connection).
-  const envelope = requireObject(value);
-  const progress = requireObject(envelope.progress);
-  if (progress.stage === "queued" && typeof progress.queuePosition === "number") {
-    return { event: "queued", queue_position: progress.queuePosition };
-  }
-  if (
-    (progress.stage === "provisioning" ||
-      progress.stage === "booting" ||
-      progress.stage === "reclaiming") &&
-    typeof progress.etaMs === "number"
-  ) {
-    return { eta_seconds: Math.ceil(progress.etaMs / 1_000), event: progress.stage };
-  }
-  throw new Error("Daemon returned invalid progress");
-}
-
-/**
- * Writes one structured diagnostic line for a device-unhealthy/device-recovered push, mirroring
- * `progressLine`'s stderr shape. A malformed push is diagnostic noise, not fatal: the CLI's
- * stdout contract (exactly one JSON result line) must survive it, so parse failures are dropped
- * silently rather than thrown.
- */
-function writeDeviceHealthLine(
-  environment: CliEnvironment,
-  build: () => Record<string, unknown>,
-): void {
-  try {
-    environment.stderr.write(`${JSON.stringify(build())}\n`);
-  } catch {
-    // Ignore a malformed push.
-  }
-}
-
-function deviceUnhealthyLine(value: unknown): {
-  readonly device_id: string;
-  readonly event: "device_unhealthy";
-  readonly lease: string;
-} {
-  const notice = parseRawDeviceUnhealthy(value);
-  return { device_id: notice.deviceId, event: "device_unhealthy", lease: notice.leaseId };
-}
-
-function deviceRecoveredLine(value: unknown): {
-  readonly attempts: number;
-  readonly device_id: string;
-  readonly event: "device_recovered";
-  readonly lease: string;
-} {
-  const notice = parseRawDeviceRecovered(value);
-  return {
-    attempts: notice.attempts,
-    device_id: notice.deviceId,
-    event: "device_recovered",
-    lease: notice.leaseId,
-  };
-}
-
-function leaseLostLine(value: unknown): {
-  readonly device_id: string;
-  readonly event: "lease_lost";
-  readonly lease: string;
-  readonly reason: string;
-} {
-  const notice = parseRawLeaseLost(value);
-  return {
-    device_id: notice.deviceId,
-    event: "lease_lost",
-    lease: notice.leaseId,
-    reason: notice.reason,
-  };
-}
-
-// fallow-ignore-next-line complexity -- stable human status rendering is intentionally a single formatter.
-function formatStatus(status: Record<string, unknown>): string {
-  const devices = requireArray(status.devices);
-  const leases = requireArray(status.leases);
-  const queueDepth = typeof status.queueDepth === "number" ? status.queueDepth : 0;
-  const capacity = requireObject(status.capacity ?? {});
-  const global = requireObject(capacity.global ?? {});
-  const globalLine = `Running global: ${String(global.running ?? 0)} + ${String(global.reserved ?? 0)} reserved/${String(global.maxRunning ?? 0)}, warm ${String(global.warm ?? 0)}${global.overLimit === true ? " (over limit)" : ""}`;
-  const capacityLines = ["ios", "android"].map((platform) => {
-    const usage = requireObject(capacity[platform] ?? {});
-    return `Capacity ${platform}: managed ${String(usage.used ?? 0)}/${String(usage.limit ?? 0)}, running ${String(usage.running ?? 0)} + ${String(usage.reserved ?? 0)} reserved/${String(usage.maxRunning ?? 0)}, warm ${String(usage.warm ?? 0)}${usage.overLimit === true ? " (over limit)" : ""}`;
-  });
-  const deviceLines = devices.map((device) => {
-    const record = requireObject(device);
-    const markers = [
-      record.foreignStateDetectedAt === undefined ? undefined : "foreign state change",
-      record.foreignProvenanceDetectedAt === undefined ? undefined : "foreign provenance change",
-      record.state === "quarantined" ? quarantineMarker(record) : undefined,
-      typeof record.transitionAgeMs === "number"
-        ? `mid-transition ${record.transitionAgeMs}ms`
-        : undefined,
-    ].filter((marker) => marker !== undefined);
-    const suffix = markers.length === 0 ? "" : ` (${markers.join(", ")})`;
-    return `Device ${String(record.id)}: ${String(record.state)}${suffix}`;
-  });
-  const leaseLines = leases.map((lease) => {
-    const record = requireObject(lease);
-    const heartbeatSuffix =
-      typeof record.lastHeartbeatAt === "number"
-        ? `, last heartbeat ${String(record.lastHeartbeatAt)}`
-        : "";
-    return `Lease ${String(record.id)}: ${String(record.requesterId)} since ${String(record.grantedAt)}${heartbeatSuffix}`;
-  });
-  return [
-    `Daemon: ${typeof status.health === "string" ? status.health : "running"}`,
-    globalLine,
-    ...capacityLines,
-    ...deviceLines,
-    ...leaseLines,
-    `Queue depth: ${queueDepth}`,
-  ].join("\n");
-}
-
-/** Surfaces retry progress for a quarantined device instead of leaving it as a bare state name. */
-function quarantineMarker(record: Record<string, unknown>): string {
-  const attempts = typeof record.quarantineAttempts === "number" ? record.quarantineAttempts : 0;
-  const nextRetryAt =
-    typeof record.quarantineNextRetryAt === "number"
-      ? `, next retry at ${String(record.quarantineNextRetryAt)}`
-      : "";
-  return `purge retry ${attempts}${nextRetryAt}`;
-}
-
-function formatCatalog(response: Record<string, unknown>): string {
-  const platforms = requireArray(response.platforms);
-  if (platforms.length === 0) return "No platforms available.";
-  return platforms
-    .map((entry) => {
-      const record = requireObject(entry);
-      const models = requireArray(record.models).map(String);
-      const runtimes = requireArray(record.runtimes).map(String);
-      const defaultRuntime =
-        typeof record.defaultRuntime === "string" ? record.defaultRuntime : "(none)";
-      return [
-        `Platform: ${String(record.platform)}`,
-        `  Models: ${models.length > 0 ? models.join(", ") : "(none)"}`,
-        `  Runtimes: ${runtimes.length > 0 ? runtimes.join(", ") : "(none)"} (default: ${defaultRuntime})`,
-      ].join("\n");
-    })
-    .join("\n");
 }
 
 function requiredPositional(positionals: readonly string[], label: string): string {
@@ -1188,6 +1136,7 @@ function parseConfigValue(value: string): unknown {
     return value;
   }
 }
+
 /**
  * Reads the rotated generation (if present) followed by the current log, so a fatal
  * crash written just before rotation is never silently lost. `NodeFileLogSink` keeps
@@ -1208,13 +1157,70 @@ function requireObject(value: unknown): Record<string, unknown> {
     throw new Error("Daemon returned an invalid response");
   return value as Record<string, unknown>;
 }
-function requireArray(value: unknown): unknown[] {
-  if (!Array.isArray(value)) throw new Error("Daemon returned an invalid response");
-  return value;
-}
+
 function writeResult(environment: CliEnvironment, value: unknown): void {
   environment.stdout.write(`${JSON.stringify(value)}\n`);
 }
+
+// fallow-ignore-next-line complexity -- stable human status rendering is intentionally a single formatter.
+function formatStatus(status: StatusGetOutput): string {
+  const { capacity, devices, health, leases, queueDepth } = status;
+  const globalLine = `Running global: ${capacity.global.running} + ${capacity.global.reserved} reserved/${capacity.global.maxRunning}, warm ${capacity.global.warm}${capacity.global.overLimit ? " (over limit)" : ""}`;
+  const capacityLines = (["ios", "android"] as const).map((platform) => {
+    const usage = capacity[platform];
+    return `Capacity ${platform}: managed ${usage.used}/${usage.limit}, running ${usage.running} + ${usage.reserved} reserved/${usage.maxRunning}, warm ${usage.warm}${usage.overLimit ? " (over limit)" : ""}`;
+  });
+  const deviceLines = devices.map((device) => {
+    const markers = [
+      device.foreignStateDetectedAt === undefined ? undefined : "foreign state change",
+      device.foreignProvenanceDetectedAt === undefined ? undefined : "foreign provenance change",
+      device.state === "quarantined" ? quarantineMarker(device) : undefined,
+      device.transitionAgeMs === undefined
+        ? undefined
+        : `mid-transition ${device.transitionAgeMs}ms`,
+    ].filter((marker) => marker !== undefined);
+    const suffix = markers.length === 0 ? "" : ` (${markers.join(", ")})`;
+    return `Device ${device.id}: ${device.state}${suffix}`;
+  });
+  const leaseLines = leases.map((lease) => {
+    const heartbeatSuffix =
+      lease.lastHeartbeatAt === undefined ? "" : `, last heartbeat ${lease.lastHeartbeatAt}`;
+    return `Lease ${lease.id}: ${lease.requesterId} since ${lease.grantedAt}${heartbeatSuffix}`;
+  });
+  return [
+    `Daemon: ${health}`,
+    globalLine,
+    ...capacityLines,
+    ...deviceLines,
+    ...leaseLines,
+    `Queue depth: ${queueDepth}`,
+  ].join("\n");
+}
+
+/** Surfaces retry progress for a quarantined device instead of leaving it as a bare state name. */
+function quarantineMarker(device: StatusGetOutput["devices"][number]): string {
+  const attempts = device.quarantineAttempts ?? 0;
+  const nextRetryAt =
+    device.quarantineNextRetryAt === undefined
+      ? ""
+      : `, next retry at ${device.quarantineNextRetryAt}`;
+  return `purge retry ${attempts}${nextRetryAt}`;
+}
+
+function formatCatalog(response: CatalogGetOutput): string {
+  if (response.platforms.length === 0) return "No platforms available.";
+  return response.platforms
+    .map((entry) => {
+      const defaultRuntime = entry.defaultRuntime ?? "(none)";
+      return [
+        `Platform: ${entry.platform}`,
+        `  Models: ${entry.models.length > 0 ? entry.models.join(", ") : "(none)"}`,
+        `  Runtimes: ${entry.runtimes.length > 0 ? entry.runtimes.join(", ") : "(none)"} (default: ${defaultRuntime})`,
+      ].join("\n");
+    })
+    .join("\n");
+}
+
 /**
  * Resolves on SIGINT, SIGTERM, or (when `parentWatch`/`parentPid` are given)
  * the watched parent dying -- all three converge on the same `finish`, so a

--- a/src/daemon/dispatcher.test.ts
+++ b/src/daemon/dispatcher.test.ts
@@ -9,7 +9,13 @@ import {
   Registry,
   type Config,
 } from "../core/index.js";
-import { FakeClock, FakeSystemStats, MemoryFilesystem } from "../ports/index.js";
+import {
+  CryptoTokenSecrets,
+  FakeClock,
+  FakeSystemStats,
+  MemoryFilesystem,
+} from "../ports/index.js";
+import { TokenStore } from "../http/token-store.js";
 import type { DispatchSession } from "./dispatcher.js";
 import { Dispatcher, DispatchError } from "./dispatcher.js";
 
@@ -74,6 +80,13 @@ async function buildDispatcher(
     quarantine: engine,
     registry,
   });
+  const tokens = new TokenStore({
+    clock,
+    filesystem,
+    idGenerator: sequence(),
+    path: "/tokens.json",
+    secrets: new CryptoTokenSecrets(),
+  });
   const dispatcher = new Dispatcher({
     awaitReady: overrides.awaitReady ?? (() => Promise.resolve()),
     capacity: engine,
@@ -87,8 +100,9 @@ async function buildDispatcher(
     queue: engine,
     reaper,
     registry,
+    tokens,
   });
-  return { clock, dispatcher, driver, engine, eventBus, registry };
+  return { clock, dispatcher, driver, engine, eventBus, registry, tokens };
 }
 
 function session(overrides: Partial<DispatchSession> = {}): DispatchSession {
@@ -123,11 +137,48 @@ describe("Dispatcher: parsing", () => {
 
   it("rejects an operation this dispatcher has no handler for with UNKNOWN_REQUEST", async () => {
     const { dispatcher } = await buildDispatcher();
-    // "token.create" is a declared contract operation (ADR §11) with no daemon-side handler
-    // yet -- see `dispatcher.ts`'s class doc.
+    // "daemon.stop" is ADR §6's frozen exception -- `DaemonServer#dispatchLine` intercepts it
+    // before it ever reaches a `Dispatcher`, so this dispatcher genuinely has no handler for it.
     await expect(
-      dispatcher.dispatch("token.create", { role: "agent" }, session({ role: "admin" })),
+      dispatcher.dispatch("daemon.stop", {}, session({ role: "admin" })),
     ).rejects.toMatchObject({ code: "UNKNOWN_REQUEST" });
+  });
+});
+
+describe("Dispatcher: token.create | token.list | token.revoke", () => {
+  it("creates a token, lists it, then revokes it -- admin only", async () => {
+    const { dispatcher, tokens } = await buildDispatcher();
+    const admin = session({ role: "admin" });
+
+    await expect(
+      dispatcher.dispatch("token.create", { role: "agent" }, session({ role: "agent" })),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+    const created = await dispatcher.dispatch(
+      "token.create",
+      { role: "operator", label: "ci" },
+      admin,
+    );
+    expect(created.token.role).toBe("operator");
+    expect(created.token.label).toBe("ci");
+    expect(typeof created.secret).toBe("string");
+
+    const listed = await dispatcher.dispatch("token.list", {}, admin);
+    expect(listed.tokens.map((token) => token.id)).toEqual([created.token.id]);
+
+    const revoked = await dispatcher.dispatch("token.revoke", { id: created.token.id }, admin);
+    expect(revoked.revoked).toBe(true);
+    expect((await tokens.list()).length).toBe(0);
+  });
+
+  it("revoking an unknown token id returns revoked: false rather than throwing", async () => {
+    const { dispatcher } = await buildDispatcher();
+    const result = await dispatcher.dispatch(
+      "token.revoke",
+      { id: "tok_does-not-exist" },
+      session({ role: "admin" }),
+    );
+    expect(result.revoked).toBe(false);
   });
 });
 

--- a/src/daemon/dispatcher.ts
+++ b/src/daemon/dispatcher.ts
@@ -31,6 +31,7 @@ import {
   type AuthorizeContext,
   type Role,
 } from "../contract/index.js";
+import type { TokenStore } from "../http/token-store.js";
 
 /**
  * ADR 0003 §2's "session" argument to `dispatch`. Constructed fresh per call by the transport
@@ -102,6 +103,13 @@ export interface DispatcherOptions {
   readonly queue: QueueControl;
   readonly reaper: CleanupReaper;
   readonly registry: Registry;
+  /**
+   * ADR 0003 §11: "token create|list|revoke become daemon operations. The daemon is the only
+   * owner of tokens.json." Optional so tests that don't exercise `token.*` (the overwhelming
+   * majority) don't need to fabricate one -- `#tokenCreate`/`#tokenList`/`#tokenRevoke` throw a
+   * clear `DispatchError` when it is missing rather than crashing on `undefined.create(...)`.
+   */
+  readonly tokens?: TokenStore;
   /** Reports current daemon health for `status.get`. */
   readonly health: () => "starting" | "running" | "failed";
   /**
@@ -174,8 +182,11 @@ export class Dispatcher {
       "events.replay": this.#eventsReplay,
       "events.subscribe": this.#eventsSubscribe,
       "events.unsubscribe": this.#eventsUnsubscribe,
-      // "daemon.stop" and "token.*" deliberately absent -- see the class comment; `DaemonServer`
-      // never calls `dispatch()` for a frame type this map has no entry for.
+      "token.create": this.#tokenCreate,
+      "token.list": this.#tokenList,
+      "token.revoke": this.#tokenRevoke,
+      // "daemon.stop" deliberately absent -- see the class comment; `DaemonServer` never calls
+      // `dispatch()` for a frame type this map has no entry for.
     };
   }
 
@@ -391,6 +402,29 @@ export class Dispatcher {
   };
 
   #configGet: Handler<"config.get"> = () => this.options.config;
+
+  /**
+   * ADR §11: the daemon is the only owner of `tokens.json` -- `TokenStore.create` never
+   * persists the plaintext `secret`, only its hash, exactly as it did when the CLI called it
+   * directly.
+   */
+  #tokenCreate: Handler<"token.create"> = async (input) => {
+    const { record, secret } = await this.#requireTokens().create(input.role, input.label);
+    return { secret, token: record };
+  };
+
+  #tokenList: Handler<"token.list"> = async () => ({ tokens: await this.#requireTokens().list() });
+
+  #tokenRevoke: Handler<"token.revoke"> = async (input) => ({
+    revoked: await this.#requireTokens().revoke(input.id),
+  });
+
+  #requireTokens(): TokenStore {
+    if (this.options.tokens === undefined) {
+      throw new DispatchError("INTERNAL", "Token store is unavailable");
+    }
+    return this.options.tokens;
+  }
 
   /**
    * Adds a derived `lastHeartbeatAt` for held leases, without a new `LeaseRecord` field: since

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -207,6 +207,7 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
     registry,
     resolveRole,
     adminSecret,
+    tokens,
     version: options.version ?? "1.0.0",
     // Runs after the socket is claimed (see DaemonServer#start): reachability no
     // longer depends on doctor reconciliation or running-capacity convergence.

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -43,6 +43,7 @@ import {
   type Role,
 } from "../contract/index.js";
 import type { ConnectionHost } from "./connection-host.js";
+import type { TokenStore } from "../http/token-store.js";
 import {
   Dispatcher,
   DispatchError,
@@ -124,6 +125,8 @@ export interface DaemonServerOptions {
   readonly healthMonitor?: LeaseHealthMonitor;
   readonly nuke?: Nuke;
   readonly registry: Registry;
+  /** ADR 0003 §11: threaded straight into the `Dispatcher` for `token.create|list|revoke`. */
+  readonly tokens?: TokenStore;
   readonly version: string;
   /** ADR §5's seam (see `session.ts`): resolves a session's role from `hello`'s payload.
    * Defaults to `resolveAgentRole` (every session is "agent") -- PR 2's credential handshake
@@ -224,6 +227,7 @@ export class DaemonServer {
       queue: options.queue,
       reaper: options.reaper,
       registry: options.registry,
+      ...(options.tokens === undefined ? {} : { tokens: options.tokens }),
     });
   }
 
@@ -827,6 +831,16 @@ export class DaemonServer {
           frame.payload ?? {},
           this.#session(connection),
         );
+      case "token.create":
+        return this.#dispatcher.dispatch("token.create", frame.payload, this.#session(connection));
+      case "token.list":
+        return this.#dispatcher.dispatch(
+          "token.list",
+          frame.payload ?? {},
+          this.#session(connection),
+        );
+      case "token.revoke":
+        return this.#dispatcher.dispatch("token.revoke", frame.payload, this.#session(connection));
       // "daemon.stop" is deliberately absent from this switch: `#dispatchLine` intercepts it
       // itself, ahead of the protocol-mismatch and `#stopping` gates (ADR §6's frozen exception,
       // scoped to protocol version only -- still gated on a completed handshake and the `admin`


### PR DESCRIPTION
**Stacked on #95.** PR 4a of 5 implementing ADR 0003 (§11, with §5).

## The CLI renders the contract, and nothing else

Moved onto `simlock/admin`'s typed client; hand-built payloads and raw response parsing are gone. Per §11:

- **`--json` output and stderr event lines are contract values serialized as-is.** The snake_case renderings (`expires_at_ms`, `estimated_boot_ms`, `queue_position`, …) go. Deliberate — simlock is 0.x and this release is 0.3.0.
- **Exit codes stay**, because shell scripts genuinely branch on them, and now come from the contract error table's `cliExitCode` column rather than a second local map.
- Human-readable `status` and `catalog` formatting is unchanged.
- **`daemon status` distinguishes socket-absent from handshake-refused** using the error `kind`, instead of reporting "stopped" on any error. That path had no test coverage; it does now.

## Admin credential resolution (§5)

`--token` → `SIMLOCK_ADMIN_TOKEN` → the local `admin.token` file (read retried briefly, since the daemon may still be writing it). **The CLI connects as admin whenever the local file is readable**, falling back to an agent session with a stderr notice when it is not — a different OS user, or a daemon mid-write. This is what keeps `simlock lease --detach` followed by `simlock release <id>` working across two invocations with pid-derived identities; the CLI is the operator interface. `simlock lease` output now includes the resolved role.

`SIMLOCK_AGENT_ID` and `--agent-id` still set the **requester id** only — for the one-lease rule and attribution. They are not the principal and not the credential; §4 keeps those three distinct.

## Token operations move into the daemon

`token create|list|revoke` are daemon operations; the daemon is the only owner of `tokens.json`. No CLI path writes that file any more (verified: no `TokenStore` import remains under `src/cli/`). The token's hash is now stripped by the contract's output schema rather than by hand.

`config set` stays a file write — config is daemon *input*, read at start — but now validates the merged file through the config loader before writing. `daemon logs` stays a file read, because it must work when the daemon is dead.

## Behaviour changes worth a reviewer's eye

- `token revoke` on an unknown id now returns `{"revoked": false}` and exit 0, instead of throwing `UNKNOWN_TOKEN` with exit 1 — contract passthrough.
- stderr push lines carry an added `{push: "<kind>", ...}` discriminant. Without it, `progress` / `lease-lost` / `device-unhealthy` / `device-recovered` lines are structurally ambiguous to a parser. This is a small piece of CLI shaping the ADR does not dictate — flagging it as a judgment call.
- `config set`'s validation uses a guaranteed-nonexistent sentinel path to make `loadConfig` validate an in-memory object. It works, but a `loadConfig` entry point taking a layer directly would be cleaner.
- The auto-launch connector duplicates `startup-coordinator.ts`'s retry/launch policy at the raw `IpcConnector` level, because that coordinator is typed against the legacy connection interface.

Per ADR §12 the CLI suite is trimmed to a smoke test plus what is genuinely the CLI's own logic — exit-code mapping, credential resolution and the agent-fallback notice, `daemon status`'s absent-vs-refused split, `config set` validation, `--json` shape, and the `--yes` guards that safety rule 5 requires. Tests that only re-walked an operation's shape through the CLI are deleted; that is covered once at the dispatcher.