### PR TITLE
feat(mcp): derive tool schemas from the contract, delete the session cache

### DIFF
--- a/e2e/heartbeat-ttl.test.ts
+++ b/e2e/heartbeat-ttl.test.ts
@@ -81,8 +81,7 @@ describe("sliding TTL and heartbeat", () => {
       };
 
       const cliGrant = JSON.parse(await cliHeld.firstStdoutLine()) as {
-        lease: string;
-        expires_at_ms: number;
+        lease: { id: string; ttlDeadline: number };
       };
 
       const detachedResult = await env.cli([
@@ -97,7 +96,7 @@ describe("sliding TTL and heartbeat", () => {
         "flow6-detached",
         "--detach",
       ]);
-      const detachedGrant = detachedResult.json as { lease: string };
+      const detachedGrant = detachedResult.json as { lease: { id: string } };
 
       // Both held leases -- MCP and CLI -- declare the heartbeat capability and
       // slide their deadline on every ping; the detached lease holds no connection
@@ -105,7 +104,7 @@ describe("sliding TTL and heartbeat", () => {
       await waitFor(
         async () => {
           const rows = await leaseRows(env);
-          const detachedRow = rows.find((row) => row.id === detachedGrant.lease);
+          const detachedRow = rows.find((row) => row.id === detachedGrant.lease.id);
           return detachedRow === undefined;
         },
         { timeout: 15_000, label: "detached (non-heartbeating) lease expires at its TTL" },
@@ -113,7 +112,7 @@ describe("sliding TTL and heartbeat", () => {
 
       const rowsAfterExpiry = await leaseRows(env);
       const mcpRow = rowsAfterExpiry.find((row) => row.id === mcpLease.lease.id);
-      const cliRow = rowsAfterExpiry.find((row) => row.id === cliGrant.lease);
+      const cliRow = rowsAfterExpiry.find((row) => row.id === cliGrant.lease.id);
       expect(
         mcpRow,
         "MCP lease should have survived past the detached lease's expiry",
@@ -124,7 +123,7 @@ describe("sliding TTL and heartbeat", () => {
       ).toBeDefined();
       expect(mcpRow?.ttlDeadline).toBeGreaterThan(mcpLease.lease.ttlDeadline);
       expect(mcpRow?.lastHeartbeatAt).toBeGreaterThan(0);
-      expect(cliRow?.ttlDeadline).toBeGreaterThan(cliGrant.expires_at_ms);
+      expect(cliRow?.ttlDeadline).toBeGreaterThan(cliGrant.lease.ttlDeadline);
       expect(cliRow?.lastHeartbeatAt).toBeGreaterThan(0);
 
       const statusResult = await mcp.client.callTool({ name: "lease_status", arguments: {} });
@@ -144,14 +143,14 @@ describe("sliding TTL and heartbeat", () => {
         recorded.filter(
           (entry) =>
             entry.event === "lease.renewed" &&
-            (entry.payload as { leaseId?: string }).leaseId === cliGrant.lease,
+            (entry.payload as { leaseId?: string }).leaseId === cliGrant.lease.id,
         ).length,
         "expected repeated lease.renewed events for the heartbeating CLI lease",
       ).toBeGreaterThan(1);
       expect(recorded).toContainEqual(
         expect.objectContaining({
           event: "lease.expired",
-          payload: expect.objectContaining({ leaseId: detachedGrant.lease }),
+          payload: expect.objectContaining({ leaseId: detachedGrant.lease.id }),
         }),
       );
 

--- a/e2e/heartbeat-ttl.test.ts
+++ b/e2e/heartbeat-ttl.test.ts
@@ -74,15 +74,15 @@ describe("sliding TTL and heartbeat", () => {
     try {
       const leaseResult = await mcp.client.callTool({
         name: "lease_simulator",
-        arguments: { platform: "ios", device: "iPhone 16", os: "18.4" },
+        arguments: { model: "iPhone 16", osVersion: "18.4", platform: "ios" },
       });
       const mcpLease = leaseResult.structuredContent as {
-        lease_id: string;
-        expires_at_ms: number;
+        lease: { id: string; ttlDeadline: number };
       };
 
       const cliGrant = JSON.parse(await cliHeld.firstStdoutLine()) as {
-        lease: { id: string; ttlDeadline: number };
+        lease: string;
+        expires_at_ms: number;
       };
 
       const detachedResult = await env.cli([
@@ -97,7 +97,7 @@ describe("sliding TTL and heartbeat", () => {
         "flow6-detached",
         "--detach",
       ]);
-      const detachedGrant = detachedResult.json as { lease: { id: string } };
+      const detachedGrant = detachedResult.json as { lease: string };
 
       // Both held leases -- MCP and CLI -- declare the heartbeat capability and
       // slide their deadline on every ping; the detached lease holds no connection
@@ -105,15 +105,15 @@ describe("sliding TTL and heartbeat", () => {
       await waitFor(
         async () => {
           const rows = await leaseRows(env);
-          const detachedRow = rows.find((row) => row.id === detachedGrant.lease.id);
+          const detachedRow = rows.find((row) => row.id === detachedGrant.lease);
           return detachedRow === undefined;
         },
         { timeout: 15_000, label: "detached (non-heartbeating) lease expires at its TTL" },
       );
 
       const rowsAfterExpiry = await leaseRows(env);
-      const mcpRow = rowsAfterExpiry.find((row) => row.id === mcpLease.lease_id);
-      const cliRow = rowsAfterExpiry.find((row) => row.id === cliGrant.lease.id);
+      const mcpRow = rowsAfterExpiry.find((row) => row.id === mcpLease.lease.id);
+      const cliRow = rowsAfterExpiry.find((row) => row.id === cliGrant.lease);
       expect(
         mcpRow,
         "MCP lease should have survived past the detached lease's expiry",
@@ -122,22 +122,21 @@ describe("sliding TTL and heartbeat", () => {
         cliRow,
         "CLI held lease should have survived past the detached lease's expiry",
       ).toBeDefined();
-      expect(mcpRow?.ttlDeadline).toBeGreaterThan(mcpLease.expires_at_ms);
+      expect(mcpRow?.ttlDeadline).toBeGreaterThan(mcpLease.lease.ttlDeadline);
       expect(mcpRow?.lastHeartbeatAt).toBeGreaterThan(0);
-      expect(cliRow?.ttlDeadline).toBeGreaterThan(cliGrant.lease.ttlDeadline);
+      expect(cliRow?.ttlDeadline).toBeGreaterThan(cliGrant.expires_at_ms);
       expect(cliRow?.lastHeartbeatAt).toBeGreaterThan(0);
 
       const statusResult = await mcp.client.callTool({ name: "lease_status", arguments: {} });
-      const statusExpiry = (statusResult.structuredContent as { expires_at_ms: number })
-        .expires_at_ms;
-      expect(statusExpiry).toBeGreaterThan(mcpLease.expires_at_ms);
+      const statusExpiry = (statusResult.structuredContent as { ttlDeadline: number }).ttlDeadline;
+      expect(statusExpiry).toBeGreaterThan(mcpLease.lease.ttlDeadline);
 
       const recorded = await env.events();
       expect(
         recorded.filter(
           (entry) =>
             entry.event === "lease.renewed" &&
-            (entry.payload as { leaseId?: string }).leaseId === mcpLease.lease_id,
+            (entry.payload as { leaseId?: string }).leaseId === mcpLease.lease.id,
         ).length,
         "expected repeated lease.renewed events for the heartbeating MCP lease",
       ).toBeGreaterThan(1);
@@ -145,20 +144,20 @@ describe("sliding TTL and heartbeat", () => {
         recorded.filter(
           (entry) =>
             entry.event === "lease.renewed" &&
-            (entry.payload as { leaseId?: string }).leaseId === cliGrant.lease.id,
+            (entry.payload as { leaseId?: string }).leaseId === cliGrant.lease,
         ).length,
         "expected repeated lease.renewed events for the heartbeating CLI lease",
       ).toBeGreaterThan(1);
       expect(recorded).toContainEqual(
         expect.objectContaining({
           event: "lease.expired",
-          payload: expect.objectContaining({ leaseId: detachedGrant.lease.id }),
+          payload: expect.objectContaining({ leaseId: detachedGrant.lease }),
         }),
       );
 
       await mcp.client.callTool({
         name: "release_simulator",
-        arguments: { lease_id: mcpLease.lease_id },
+        arguments: { leaseId: mcpLease.lease.id },
       });
     } finally {
       cliHeld.kill("SIGKILL");

--- a/e2e/lease-lifecycle.test.ts
+++ b/e2e/lease-lifecycle.test.ts
@@ -35,14 +35,17 @@ describe("lease lifecycle across both frontends", () => {
       "--detach",
     ]);
     expect(lease.code).toBe(0);
-    const leaseGrant = lease.json as { lease: string; device: string; udid: string };
-    expect(leaseGrant.device).toBe("iPhone 16");
+    const leaseGrant = lease.json as {
+      lease: { id: string };
+      device: { spec: { model: string }; driverDeviceId: string };
+    };
+    expect(leaseGrant.device.spec.model).toBe("iPhone 16");
 
     const statusJson = await env.cli(["status", "--json"]);
     expect(statusJson.code).toBe(0);
     expect(statusJson.json).toMatchObject({
       leases: expect.arrayContaining([
-        expect.objectContaining({ id: leaseGrant.lease, requesterId: agentId }),
+        expect.objectContaining({ id: leaseGrant.lease.id, requesterId: agentId }),
       ]),
     });
 
@@ -50,14 +53,14 @@ describe("lease lifecycle across both frontends", () => {
     expect(listLeases.code).toBe(0);
     expect(listLeases.json).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ id: leaseGrant.lease, requesterId: agentId }),
+        expect.objectContaining({ id: leaseGrant.lease.id, requesterId: agentId }),
       ]),
     );
 
-    const release = await env.cli(["release", leaseGrant.lease]);
+    const release = await env.cli(["release", leaseGrant.lease.id]);
     expect(release.code).toBe(0);
 
-    await waitForDeviceState(env, leaseGrant.udid, "ready");
+    await waitForDeviceState(env, leaseGrant.device.driverDeviceId, "ready");
 
     await env.expectEvents(["lease.requested", "lease.granted", "lease.released"]);
   });

--- a/e2e/lease-lifecycle.test.ts
+++ b/e2e/lease-lifecycle.test.ts
@@ -35,17 +35,14 @@ describe("lease lifecycle across both frontends", () => {
       "--detach",
     ]);
     expect(lease.code).toBe(0);
-    const leaseGrant = lease.json as {
-      lease: { id: string };
-      device: { spec: { model: string }; driverDeviceId: string };
-    };
-    expect(leaseGrant.device.spec.model).toBe("iPhone 16");
+    const leaseGrant = lease.json as { lease: string; device: string; udid: string };
+    expect(leaseGrant.device).toBe("iPhone 16");
 
     const statusJson = await env.cli(["status", "--json"]);
     expect(statusJson.code).toBe(0);
     expect(statusJson.json).toMatchObject({
       leases: expect.arrayContaining([
-        expect.objectContaining({ id: leaseGrant.lease.id, requesterId: agentId }),
+        expect.objectContaining({ id: leaseGrant.lease, requesterId: agentId }),
       ]),
     });
 
@@ -53,14 +50,14 @@ describe("lease lifecycle across both frontends", () => {
     expect(listLeases.code).toBe(0);
     expect(listLeases.json).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ id: leaseGrant.lease.id, requesterId: agentId }),
+        expect.objectContaining({ id: leaseGrant.lease, requesterId: agentId }),
       ]),
     );
 
-    const release = await env.cli(["release", leaseGrant.lease.id]);
+    const release = await env.cli(["release", leaseGrant.lease]);
     expect(release.code).toBe(0);
 
-    await waitForDeviceState(env, leaseGrant.device.driverDeviceId, "ready");
+    await waitForDeviceState(env, leaseGrant.udid, "ready");
 
     await env.expectEvents(["lease.requested", "lease.granted", "lease.released"]);
   });
@@ -76,21 +73,18 @@ describe("lease lifecycle across both frontends", () => {
     try {
       const leaseResult = await mcp.client.callTool({
         name: "lease_simulator",
-        arguments: { platform: "ios", device: "iPhone 16", os: "18.4" },
+        arguments: { model: "iPhone 16", osVersion: "18.4", platform: "ios" },
       });
       const leased = leaseResult.structuredContent as {
-        lease_id: string;
-        device_id: string;
-        device: string;
-        platform: string;
+        device: { driverDeviceId: string; spec: { model: string } };
+        lease: { id: string };
       };
-      expect(leased.device).toBe("iPhone 16");
+      expect(leased.device.spec.model).toBe("iPhone 16");
 
       const statusResult = await mcp.client.callTool({ name: "lease_status", arguments: {} });
       expect(statusResult.structuredContent).toMatchObject({
         held: true,
-        lease_id: leased.lease_id,
-        device_id: leased.device_id,
+        id: leased.lease.id,
       });
 
       // The CLI frontend must see the exact same lease, keyed by the same requester id.
@@ -98,7 +92,7 @@ describe("lease lifecycle across both frontends", () => {
       expect(cliLeases.code).toBe(0);
       expect(cliLeases.json).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ id: leased.lease_id, requesterId: agentId }),
+          expect.objectContaining({ id: leased.lease.id, requesterId: agentId }),
         ]),
       );
 
@@ -109,10 +103,10 @@ describe("lease lifecycle across both frontends", () => {
 
       const releaseResult = await mcp.client.callTool({
         name: "release_simulator",
-        arguments: { lease_id: leased.lease_id },
+        arguments: { leaseId: leased.lease.id },
       });
       expect(releaseResult.structuredContent).toMatchObject({
-        lease_id: leased.lease_id,
+        leaseId: leased.lease.id,
         released: true,
       });
 
@@ -123,12 +117,12 @@ describe("lease lifecycle across both frontends", () => {
       const midPurge = await env.cli(["list", "--devices"]);
       expect(midPurge.json).toEqual([
         expect.objectContaining({
-          driverDeviceId: leased.device_id,
+          driverDeviceId: leased.device.driverDeviceId,
           state: "reclaiming",
         }),
       ]);
 
-      await waitForDeviceState(env, leased.device_id, "ready");
+      await waitForDeviceState(env, leased.device.driverDeviceId, "ready");
     } finally {
       await mcp.close();
     }

--- a/e2e/mcp-session.test.ts
+++ b/e2e/mcp-session.test.ts
@@ -29,10 +29,10 @@ describe("MCP session semantics", () => {
 
       const leaseResult = await mcp.client.callTool({
         name: "lease_simulator",
-        arguments: { platform: "ios", device: "iPhone 16", os: "18.4" },
+        arguments: { model: "iPhone 16", osVersion: "18.4", platform: "ios" },
         _meta: { progressToken: "flow7-token" },
       });
-      const leased = leaseResult.structuredContent as { lease_id: string; device_id: string };
+      const leased = leaseResult.structuredContent as { lease: { id: string } };
 
       const progress = mcp.progressNotifications();
       expect(progress.length, "expected at least one notifications/progress frame").toBeGreaterThan(
@@ -50,20 +50,23 @@ describe("MCP session semantics", () => {
       const statusAfter = await mcp.client.callTool({ name: "lease_status", arguments: {} });
       expect(statusAfter.structuredContent).toMatchObject({
         held: true,
-        lease_id: leased.lease_id,
+        id: leased.lease.id,
       });
 
       const released = await mcp.client.callTool({
         name: "release_simulator",
-        arguments: { lease_id: leased.lease_id },
+        arguments: { leaseId: leased.lease.id },
       });
-      expect(released.structuredContent).toEqual({ lease_id: leased.lease_id, released: true });
+      expect(released.structuredContent).toEqual({
+        leaseId: leased.lease.id,
+        released: true,
+      });
     } finally {
       await mcp.close();
     }
   });
 
-  it("relays a force-release from the CLI as a logging warning, then LEASE_NOT_OWNED is a clean tool error, and the server stays usable", async () => {
+  it("relays a force-release from the CLI as a logging warning, then FORBIDDEN is a clean tool error, and the server stays usable", async () => {
     const env = await withDaemon();
     await env.driverScript.set({
       ios: { knownModels: ["iPhone 16"], availableOsVersions: ["18.4"] },
@@ -73,9 +76,9 @@ describe("MCP session semantics", () => {
     try {
       const leaseResult = await mcp.client.callTool({
         name: "lease_simulator",
-        arguments: { platform: "ios", device: "iPhone 16", os: "18.4" },
+        arguments: { model: "iPhone 16", osVersion: "18.4", platform: "ios" },
       });
-      const leased = leaseResult.structuredContent as { lease_id: string; device_id: string };
+      const leased = leaseResult.structuredContent as { lease: { id: string } };
 
       const forceRelease = await env.cli(["release", "--all", "--yes"]);
       expect(forceRelease.code).toBe(0);
@@ -83,33 +86,33 @@ describe("MCP session semantics", () => {
       const warning = await mcp.waitForNotification((notification) => {
         if (notification.kind !== "logging") return undefined;
         const data = notification.params.data as
-          | { lease_id?: string; device_id?: string; reason?: string }
+          | { deviceId?: string; leaseId?: string; reason?: string }
           | undefined;
-        return data?.lease_id === leased.lease_id ? notification.params : undefined;
+        return data?.leaseId === leased.lease.id ? notification.params : undefined;
       });
       expect(warning.logger).toBe("simlock");
       expect(warning.level).toBe("warning");
-      // The daemon push carries its own internal registry device id, not the
-      // driver-opaque `device_id` (udid) the MCP lease result reports -- only assert
-      // it names *a* device, plus the lease id and reason, which do match exactly.
       expect(warning.data).toMatchObject({
-        lease_id: leased.lease_id,
-        device_id: expect.any(String),
+        deviceId: expect.any(String),
+        leaseId: leased.lease.id,
         reason: "explicit",
       });
 
       const statusAfter = await mcp.client.callTool({ name: "lease_status", arguments: {} });
       expect(statusAfter.structuredContent).toEqual({ held: false });
 
+      // The daemon's own ownership rule now answers, not a client-side pre-check (ADR
+      // 0003 §11): a stale release for a lease this session no longer owns/holds is
+      // FORBIDDEN, exactly the same as it would be for a lease this session never held.
       const staleRelease = await mcp.client.callTool({
         name: "release_simulator",
-        arguments: { lease_id: leased.lease_id },
+        arguments: { leaseId: leased.lease.id },
       });
       expect(staleRelease.isError).toBe(true);
       const errorPayload = JSON.parse(
         (staleRelease.content as { text: string }[])[0]?.text ?? "{}",
       ) as McpErrorPayload;
-      expect(errorPayload.code).toBe("LEASE_NOT_OWNED");
+      expect(errorPayload.code).toBe("FORBIDDEN");
 
       // Still usable: a clean tool error must not have wedged the session/transport.
       const devices = await mcp.client.callTool({ name: "list_devices", arguments: {} });
@@ -133,14 +136,14 @@ describe("MCP session semantics", () => {
     try {
       const leaseResult = await mcp.client.callTool({
         name: "lease_simulator",
-        arguments: { platform: "ios", device: "iPhone 16", os: "18.4" },
+        arguments: { model: "iPhone 16", osVersion: "18.4", platform: "ios" },
       });
-      const leased = leaseResult.structuredContent as { lease_id: string };
+      const leased = leaseResult.structuredContent as { lease: { id: string } };
 
       const lostNotice = mcp.waitForNotification((notification) => {
         if (notification.kind !== "logging") return undefined;
-        const data = notification.params.data as { lease_id?: string; reason?: string } | undefined;
-        return data?.lease_id === leased.lease_id ? data.reason : undefined;
+        const data = notification.params.data as { leaseId?: string; reason?: string } | undefined;
+        return data?.leaseId === leased.lease.id ? data.reason : undefined;
       });
 
       await env.restartDaemon();

--- a/e2e/mcp-session.test.ts
+++ b/e2e/mcp-session.test.ts
@@ -102,8 +102,12 @@ describe("MCP session semantics", () => {
       expect(statusAfter.structuredContent).toEqual({ held: false });
 
       // The daemon's own ownership rule now answers, not a client-side pre-check (ADR
-      // 0003 §11): a stale release for a lease this session no longer owns/holds is
-      // FORBIDDEN, exactly the same as it would be for a lease this session never held.
+      // 0003 §11) -- but `ownsLease` (src/contract/roles.ts) treats an id its registry
+      // lookup does not recognize as authorized on purpose, precisely so the handler's own
+      // "unknown resource" error surfaces instead of a misleading FORBIDDEN. A force-release
+      // fully removes the lease from the registry (`LeaseCommands#releaseAll`), so a stale
+      // release for it is UNKNOWN_LEASE, not FORBIDDEN -- FORBIDDEN is reserved for a lease
+      // that still exists but is owned by someone else.
       const staleRelease = await mcp.client.callTool({
         name: "release_simulator",
         arguments: { leaseId: leased.lease.id },
@@ -112,7 +116,7 @@ describe("MCP session semantics", () => {
       const errorPayload = JSON.parse(
         (staleRelease.content as { text: string }[])[0]?.text ?? "{}",
       ) as McpErrorPayload;
-      expect(errorPayload.code).toBe("FORBIDDEN");
+      expect(errorPayload.code).toBe("UNKNOWN_LEASE");
 
       // Still usable: a clean tool error must not have wedged the session/transport.
       const devices = await mcp.client.callTool({ name: "list_devices", arguments: {} });

--- a/src/mcp/connect.ts
+++ b/src/mcp/connect.ts
@@ -1,0 +1,91 @@
+/**
+ * MCP's connection-lifecycle-only auto-launch (ADR 0003 §11: MCP keeps "connection lifecycle
+ * (lazy reconnect, tool-call serialization)"). `simlock/client`'s `connectSimlock` deliberately
+ * does not start the daemon itself -- it only ever connects to an already-listening socket
+ * (ADR §10: the client "does not reconnect and does not retry"). MCP is the one frontend spawned
+ * with no separate "start the daemon first" step, so it is the frontend that needs this, the
+ * same way `src/daemon-client/startup-coordinator.ts`'s `DaemonStartupCoordinator` gives the
+ * (now superseded, daemon-client-based) old MCP client this behaviour. That coordinator is not
+ * reused directly -- it is typed against `daemon-client`'s `DaemonConnector`/`DaemonConnection`,
+ * not `simlock-client`'s connection-less `connectSimlock` -- so the same launch-then-retry
+ * policy is re-implemented here, against the typed client, instead.
+ */
+import {
+  connectSimlock,
+  isSimlockError,
+  SimlockError,
+  type SimlockClient,
+} from "../client/index.js";
+import { IpcError, type Clock, type DaemonLauncher, type IpcConnector } from "../ports/index.js";
+
+export interface ConnectWithAutoLaunchOptions {
+  readonly clock: Clock;
+  readonly heartbeat?: boolean;
+  readonly ipc: IpcConnector;
+  readonly launcher: DaemonLauncher;
+  readonly principal: string;
+  readonly retryIntervalMs?: number;
+  readonly socketPath: string;
+  readonly startupTimeoutMs?: number;
+}
+
+/**
+ * Connects to the daemon, launching it first if nothing is listening yet. Never launches on
+ * any other failure -- a version mismatch or a refused handshake is not "nothing is running",
+ * and launching there would risk starting a second daemon instance or masking a real
+ * incompatibility (mirrors `DaemonStartupCoordinator#isUnavailable`'s reasoning: "the client
+ * never restarts the daemon on mismatch", ADR §6).
+ */
+export async function connectWithAutoLaunch(
+  options: ConnectWithAutoLaunchOptions,
+): Promise<SimlockClient> {
+  try {
+    return await attempt(options);
+  } catch (error: unknown) {
+    if (!isUnavailable(error)) throw error;
+  }
+  await options.launcher.launch();
+  const deadline = options.clock.now() + (options.startupTimeoutMs ?? 5_000);
+  let lastError: unknown;
+  while (options.clock.now() < deadline) {
+    try {
+      return await attempt(options);
+    } catch (error: unknown) {
+      if (!isUnavailable(error)) throw error;
+      lastError = error;
+      await delay(options.clock, options.retryIntervalMs ?? 50);
+    }
+  }
+  throw new SimlockError(
+    "DAEMON_STARTUP_FAILED",
+    "transport",
+    `Timed out starting simlock daemon: ${errorMessage(lastError)}`,
+    {},
+  );
+}
+
+function attempt(options: ConnectWithAutoLaunchOptions): Promise<SimlockClient> {
+  return connectSimlock({
+    endpoint: options.socketPath,
+    heartbeat: options.heartbeat ?? true,
+    ipc: options.ipc,
+    principal: options.principal,
+  });
+}
+
+/** True only for "nothing is listening yet" -- a refused/missing socket. */
+function isUnavailable(error: unknown): boolean {
+  return (
+    error instanceof IpcError &&
+    (error.code === "connection-refused" || error.code === "endpoint-not-found")
+  );
+}
+
+function delay(clock: Clock, milliseconds: number): Promise<void> {
+  return new Promise((resolve) => clock.setTimer(milliseconds, resolve));
+}
+
+function errorMessage(error: unknown): string {
+  if (isSimlockError(error)) return error.message;
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/mcp/contracts.test.ts
+++ b/src/mcp/contracts.test.ts
@@ -1,66 +1,75 @@
 import { describe, expect, it } from "vitest";
 
+import { OPERATIONS } from "../contract/index.js";
 import {
   leaseSimulatorInputSchema,
   leaseSimulatorOutputSchema,
-  MAX_TIMEOUT_SECONDS,
+  leaseStatusOutputSchema,
   releaseSimulatorInputSchema,
   releaseSimulatorOutputSchema,
 } from "./contracts.js";
 
 describe("MCP contracts", () => {
-  it("applies safe lease input defaults", () => {
-    expect(leaseSimulatorInputSchema.parse({ device: "iPhone 17 Pro", platform: "ios" })).toEqual({
-      allow_download: false,
-      device: "iPhone 17 Pro",
-      full: false,
-      no_wait: false,
+  it("accepts a minimal lease input and omits the session-controlled fields", () => {
+    expect(leaseSimulatorInputSchema.parse({ model: "iPhone 17 Pro", platform: "ios" })).toEqual({
+      model: "iPhone 17 Pro",
       platform: "ios",
     });
   });
 
-  it("accepts an explicit full: true lease input", () => {
-    expect(
-      leaseSimulatorInputSchema.parse({ device: "iPhone 17 Pro", full: true, platform: "ios" }),
-    ).toMatchObject({ full: true });
+  it("rejects requesterId, mode, and ttlMs -- those are the session's job, not the caller's", () => {
+    for (const extra of [{ requesterId: "someone-else" }, { mode: "detached" }, { ttlMs: 1_000 }]) {
+      expect(() =>
+        leaseSimulatorInputSchema.parse({ model: "iPhone 17 Pro", platform: "ios", ...extra }),
+      ).toThrow();
+    }
   });
 
-  it.each([
-    [{ device: "", platform: "ios" }],
-    [{ device: "Pixel", os: "", platform: "android" }],
-    [{ device: "Pixel", platform: "android", timeout_seconds: -1 }],
-    [{ device: "Pixel", platform: "android", timeout_seconds: Number.POSITIVE_INFINITY }],
-    [{ device: "Pixel", platform: "android", timeout_seconds: MAX_TIMEOUT_SECONDS + 1 }],
-  ])("rejects invalid lease inputs", (input) => {
-    expect(() => leaseSimulatorInputSchema.parse(input)).toThrow();
+  it("is the same schema the contract validates lease.request input against, minus those fields", () => {
+    const full = OPERATIONS["lease.request"].input.innerType();
+    expect(Object.keys(leaseSimulatorInputSchema.shape).sort()).toEqual(
+      Object.keys(full.shape)
+        .filter((key) => !["mode", "requesterId", "ttlMs"].includes(key))
+        .sort(),
+    );
   });
 
-  it("validates public success results", () => {
-    expect(
-      leaseSimulatorOutputSchema.parse({
-        device: "iPhone 17 Pro",
-        device_id: "ABCD",
-        expires_at_ms: 61_000,
-        lease_id: "lse_9f2c",
-        mode: "held",
-        os: "26.5",
-        platform: "ios",
-        slim: false,
+  it("validates a lease grant, release, and lease-status shape using contract field names", () => {
+    const grant = leaseSimulatorOutputSchema.parse({
+      device: {
+        createdAt: 0,
+        driverData: null,
+        driverDeviceId: "SIM-1",
+        id: "device-1",
+        spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
         state: "leased",
-        timing: {
-          estimated_boot_ms: 20,
-          estimated_provision_ms: 10,
-          estimated_reclaim_ms: 0,
-          estimated_ready_ms: 30,
-        },
-      }),
-    ).toMatchObject({ lease_id: "lse_9f2c", slim: false, state: "leased" });
-    expect(releaseSimulatorInputSchema.parse({ lease_id: "lse_9f2c" })).toEqual({
-      lease_id: "lse_9f2c",
+      },
+      lease: {
+        deviceId: "device-1",
+        grantedAt: 0,
+        id: "lease-1",
+        mode: "held",
+        ownerId: "mcp:1",
+        requesterId: "mcp:1",
+        ttlDeadline: 61_000,
+      },
+      timing: {
+        estimatedBootMs: 20,
+        estimatedProvisionMs: 10,
+        estimatedReadyMs: 30,
+        estimatedReclaimMs: 0,
+      },
     });
-    expect(releaseSimulatorOutputSchema.parse({ lease_id: "lse_9f2c", released: true })).toEqual({
-      lease_id: "lse_9f2c",
+    expect(grant.lease.id).toBe("lease-1");
+
+    expect(releaseSimulatorInputSchema.parse({ leaseId: "lease-1" })).toEqual({
+      leaseId: "lease-1",
+    });
+    expect(releaseSimulatorOutputSchema.parse({ leaseId: "lease-1", released: true })).toEqual({
+      leaseId: "lease-1",
       released: true,
     });
+
+    expect(leaseStatusOutputSchema.parse({ held: false })).toEqual({ held: false });
   });
 });

--- a/src/mcp/contracts.ts
+++ b/src/mcp/contracts.ts
@@ -1,106 +1,69 @@
+/**
+ * MCP tool schemas, derived from the contract's operation schemas (ADR 0003 §11: "MCP tool
+ * schemas are derived from the contract schemas. Tool names stay."). Nothing here hand-declares
+ * a field the contract already declares -- each schema below is the contract's own zod object
+ * for that operation, or a small `.omit()`/`.extend()`/`.partial()` composition of it. A
+ * contract schema change is a compile-time (or, for a structurally-compatible-but-different
+ * shape, a test) change here too, not a silent drift.
+ *
+ * Field names follow the contract's own vocabulary (camelCase: `leaseId`, `deviceId`,
+ * `allowDownload`, ...), not the snake_case this module used before PR 4. This is a deliberate
+ * break (0.x, ADR "Alternatives considered": "one vocabulary everywhere is the point") -- see
+ * the PR report for the tradeoffs.
+ */
 import { z } from "zod";
 
-const nonEmptyString = z.string().min(1);
-const finiteNumber = z.number().finite();
-export const MAX_TIMEOUT_SECONDS = Number.MAX_SAFE_INTEGER / 1_000;
+import { leaseRecordSchema, OPERATIONS } from "../contract/index.js";
 
-export const leaseSimulatorInputSchema = z.object({
-  allow_download: z.boolean().default(false),
-  device: nonEmptyString,
-  // Platform-neutral: "give me a device with no driver-side resource reduction". The iOS
-  // driver implements this as "do not slim"; other drivers ignore it.
-  full: z.boolean().default(false),
-  no_wait: z.boolean().default(false),
-  os: nonEmptyString.optional(),
-  platform: z.enum(["ios", "android"]),
-  timeout_seconds: finiteNumber
-    .nonnegative()
-    .max(MAX_TIMEOUT_SECONDS, "timeout_seconds is too large to convert safely to milliseconds")
-    .optional(),
-});
+// ---- lease_simulator ---------------------------------------------------------------------
 
-export const leaseSimulatorOutputSchema = z.object({
-  // Optional: undefined only for a device leased straight out of a pre-address `state.json`
-  // without ever rebooting under this daemon -- see `DeviceRecord.address` in domain.ts.
-  address: nonEmptyString.optional(),
-  device: nonEmptyString,
-  device_id: nonEmptyString,
-  expires_at_ms: finiteNumber,
-  lease_id: nonEmptyString,
-  mode: z.literal("held"),
-  os: nonEmptyString,
-  platform: z.enum(["ios", "android"]),
-  /** Whether the granted device had its feature set reduced -- see `RawLeaseGrant.slim`. */
-  slim: z.boolean(),
-  state: z.literal("leased"),
-  timing: z.object({
-    estimated_boot_ms: finiteNumber,
-    estimated_provision_ms: finiteNumber,
-    estimated_reclaim_ms: finiteNumber,
-    estimated_ready_ms: finiteNumber,
-  }),
-});
+/**
+ * `lease.request`'s input, minus the three fields this tool never lets the caller set:
+ * `requesterId` (session-controlled -- see `session.ts`'s `#requesterId`, never caller-supplied,
+ * for the same reason the daemon never lets a request rename its own principal), `mode` (this
+ * tool always leases `"held"`), and `ttlMs` (only meaningful for a detached lease, which this
+ * tool never requests -- and is `BAD_REQUEST` for a held one per the contract's own
+ * `superRefine`). `.innerType()` unwraps the contract schema's `superRefine` wrapper down to
+ * the plain (still `.strict()`) object so `.omit()` is available -- see zod's `ZodEffects`.
+ */
+export const leaseSimulatorInputSchema = OPERATIONS["lease.request"].input
+  .innerType()
+  .omit({ mode: true, requesterId: true, ttlMs: true });
 
-export const releaseSimulatorInputSchema = z.object({
-  lease_id: nonEmptyString,
-});
+/** `lease.request`'s output verbatim -- the device/lease/timing grant. */
+export const leaseSimulatorOutputSchema = OPERATIONS["lease.request"].output;
 
-export const releaseSimulatorOutputSchema = z.object({
-  lease_id: nonEmptyString,
+// ---- list_devices -------------------------------------------------------------------------
+
+export const listDevicesInputSchema = OPERATIONS["catalog.get"].input;
+export const listDevicesOutputSchema = OPERATIONS["catalog.get"].output;
+
+// ---- release_simulator ---------------------------------------------------------------------
+
+export const releaseSimulatorInputSchema = OPERATIONS["lease.release"].input;
+/** `lease.release`'s output (`{leaseId}`) plus a friendly `released: true` literal -- an
+ * addition on top of the contract shape, not a hand duplicate of it. */
+export const releaseSimulatorOutputSchema = OPERATIONS["lease.release"].output.extend({
   released: z.literal(true),
 });
 
-export const listDevicesInputSchema = z.object({
-  platform: z.enum(["ios", "android"]).optional(),
-});
+// ---- lease_status -------------------------------------------------------------------------
 
-export const listDevicesOutputSchema = z.object({
-  platforms: z.array(
-    z.object({
-      default_runtime: nonEmptyString.optional(),
-      models: z.array(nonEmptyString),
-      platform: z.enum(["ios", "android"]),
-      runtimes: z.array(nonEmptyString),
-    }),
-  ),
-});
+/** `lease_status` is one `lease.list` call (ADR §9), not a session-local cache read. */
+export const leaseStatusInputSchema = OPERATIONS["lease.list"].input;
 
-export const leaseStatusInputSchema = z.object({});
-
-// Flat and all-optional (rather than a discriminated union) because the MCP SDK
-// validates structuredContent against outputSchema as a plain object shape.
-export const leaseStatusOutputSchema = z.object({
-  device: nonEmptyString.optional(),
-  device_id: nonEmptyString.optional(),
-  expires_at_ms: finiteNumber.optional(),
-  held: z.boolean(),
-  lease_id: nonEmptyString.optional(),
-  os: nonEmptyString.optional(),
-  platform: z.enum(["ios", "android"]).optional(),
-  state: z.literal("leased").optional(),
-});
+/**
+ * `lease.list` returns `{leases: LeaseRecord[]}`; this session ever holds at most one lease (one
+ * requester id, always `mode: "held"`), so the tool flattens that array's first entry (or none)
+ * onto a `held` discriminant. Flat and all-optional -- not a discriminated union -- because the
+ * MCP SDK validates `structuredContent` against `outputSchema` as a plain object shape.
+ */
+export const leaseStatusOutputSchema = leaseRecordSchema.partial().extend({ held: z.boolean() });
 
 export type LeaseSimulatorInput = z.infer<typeof leaseSimulatorInputSchema>;
 export type LeaseSimulatorOutput = z.infer<typeof leaseSimulatorOutputSchema>;
-export type ReleaseSimulatorInput = z.infer<typeof releaseSimulatorInputSchema>;
-export type ReleaseSimulatorOutput = z.infer<typeof releaseSimulatorOutputSchema>;
 export type ListDevicesInput = z.infer<typeof listDevicesInputSchema>;
 export type ListDevicesOutput = z.infer<typeof listDevicesOutputSchema>;
+export type ReleaseSimulatorInput = z.infer<typeof releaseSimulatorInputSchema>;
+export type ReleaseSimulatorOutput = z.infer<typeof releaseSimulatorOutputSchema>;
 export type LeaseStatusOutput = z.infer<typeof leaseStatusOutputSchema>;
-
-/** The `lease_status` result when this session currently holds a lease. */
-export interface HeldLeaseStatus {
-  readonly device: string;
-  readonly device_id: string;
-  readonly expires_at_ms: number;
-  readonly held: true;
-  readonly lease_id: string;
-  readonly os: string;
-  readonly platform: "android" | "ios";
-  readonly state: "leased";
-}
-
-/** The `lease_status` result when this session holds nothing. */
-export interface NoLeaseStatus {
-  readonly held: false;
-}

--- a/src/mcp/main.test.ts
+++ b/src/mcp/main.test.ts
@@ -2,10 +2,13 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import type { DaemonConnection } from "../daemon-client/protocol.js";
+import { FakeSimlockClient, sampleGrant } from "./test-support.js";
 import { startMcpStdio, type McpTransport } from "./main.js";
+
+const { connectWithAutoLaunch } = vi.hoisted(() => ({ connectWithAutoLaunch: vi.fn() }));
+vi.mock("./connect.js", () => ({ connectWithAutoLaunch }));
 
 describe("MCP stdio lifecycle", () => {
   it.each(["transport", "SIGINT", "SIGTERM"])("closes once on %s", async (cause) => {
@@ -66,78 +69,79 @@ describe("MCP stdio lifecycle", () => {
     expect(transport.closeCalls).toBe(1);
   });
 
-  it("closes the lease-owning session when its transport ends", async () => {
-    const connection = new LeaseConnection();
+  it("closes the lease-owning session's client when its transport ends", async () => {
+    const client = new FakeSimlockClient();
+    client.requestLeaseImpl = () => Promise.resolve(sampleGrant());
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     const runner = await startMcpStdio({
-      connect: async () => connection,
+      connect: async () => client,
       createTransport: () => serverTransport,
       requesterId: "mcp-test",
       signals: new FakeSignals(),
     });
-    const client = new Client({ name: "test", version: "1.0.0" });
-    await client.connect(clientTransport);
-    await client.request(
+    const mcpClient = new Client({ name: "test", version: "1.0.0" });
+    await mcpClient.connect(clientTransport);
+    await mcpClient.request(
       {
         method: "tools/call",
-        params: { arguments: { device: "iPhone", platform: "ios" }, name: "lease_simulator" },
+        params: { arguments: { model: "iPhone", platform: "ios" }, name: "lease_simulator" },
       },
       CallToolResultSchema,
     );
 
     serverTransport.onclose?.();
     await runner.finished;
-    expect(connection.closeCalls).toBe(1);
-    await client.close();
+    expect(client.closeCalls).toBe(1);
+    await mcpClient.close();
   });
 
-  it("sources the requester id from SIMLOCK_AGENT_ID when none is given explicitly", async () => {
-    const connection = new LeaseConnection();
+  it("sources the connection principal from SIMLOCK_AGENT_ID when no requesterId is given explicitly", async () => {
+    connectWithAutoLaunch.mockReset().mockResolvedValue(new FakeSimlockClient());
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     const runner = await startMcpStdio({
-      connect: async () => connection,
       createTransport: () => serverTransport,
       env: { SIMLOCK_AGENT_ID: "agent-from-env" },
       signals: new FakeSignals(),
     });
-    const client = new Client({ name: "test", version: "1.0.0" });
-    await client.connect(clientTransport);
-    await client.request(
-      {
-        method: "tools/call",
-        params: { arguments: { device: "iPhone", platform: "ios" }, name: "lease_simulator" },
-      },
-      CallToolResultSchema,
-    );
+    const mcpClient = new Client({ name: "test", version: "1.0.0" });
+    await mcpClient.connect(clientTransport);
+    await mcpClient
+      .request(
+        { method: "tools/call", params: { arguments: {}, name: "lease_status" } },
+        CallToolResultSchema,
+      )
+      .catch(() => undefined);
 
-    expect(connection.lastRequesterId).toBe("agent-from-env");
+    expect(connectWithAutoLaunch).toHaveBeenCalledWith(
+      expect.objectContaining({ principal: "agent-from-env" }),
+    );
+    await mcpClient.close();
     await runner.shutdown();
-    await client.close();
   });
 
   it("prefers an explicit requesterId over SIMLOCK_AGENT_ID", async () => {
-    const connection = new LeaseConnection();
+    connectWithAutoLaunch.mockReset().mockResolvedValue(new FakeSimlockClient());
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     const runner = await startMcpStdio({
-      connect: async () => connection,
       createTransport: () => serverTransport,
       env: { SIMLOCK_AGENT_ID: "agent-from-env" },
       requesterId: "explicit-agent",
       signals: new FakeSignals(),
     });
-    const client = new Client({ name: "test", version: "1.0.0" });
-    await client.connect(clientTransport);
-    await client.request(
-      {
-        method: "tools/call",
-        params: { arguments: { device: "iPhone", platform: "ios" }, name: "lease_simulator" },
-      },
-      CallToolResultSchema,
-    );
+    const mcpClient = new Client({ name: "test", version: "1.0.0" });
+    await mcpClient.connect(clientTransport);
+    await mcpClient
+      .request(
+        { method: "tools/call", params: { arguments: {}, name: "lease_status" } },
+        CallToolResultSchema,
+      )
+      .catch(() => undefined);
 
-    expect(connection.lastRequesterId).toBe("explicit-agent");
+    expect(connectWithAutoLaunch).toHaveBeenCalledWith(
+      expect.objectContaining({ principal: "explicit-agent" }),
+    );
+    await mcpClient.close();
     await runner.shutdown();
-    await client.close();
   });
 
   it("closes once when stdin reaches EOF", async () => {
@@ -239,37 +243,6 @@ class FakeSignals {
   }
   emit(signal: string): void {
     this.listeners.get(signal)?.();
-  }
-}
-
-class LeaseConnection implements DaemonConnection {
-  closeCalls = 0;
-  lastRequesterId: unknown;
-  async close(): Promise<void> {
-    this.closeCalls += 1;
-  }
-  onPush(): () => void {
-    return () => undefined;
-  }
-
-  onClose(): () => void {
-    return () => undefined;
-  }
-  async request(_type: string, payload: unknown): Promise<unknown> {
-    this.lastRequesterId = (payload as { readonly requesterId?: unknown }).requesterId;
-    return {
-      device: {
-        driverDeviceId: "SIM-1",
-        spec: { model: "iPhone", osVersion: "26", platform: "ios" },
-      },
-      lease: { id: "lease-1", mode: "held", ttlDeadline: 10 },
-      timing: {
-        estimatedBootMs: 1,
-        estimatedProvisionMs: 1,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 2,
-      },
-    };
   }
 }
 

--- a/src/mcp/main.ts
+++ b/src/mcp/main.ts
@@ -3,14 +3,14 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import type { SimlockClient } from "../client/index.js";
 import {
   NodeDaemonLauncher,
   NodeIpcTransport,
   resolveSimlockHome,
   SystemClock,
 } from "../ports/index.js";
-import { connectDaemon } from "../daemon-client/client.js";
-import type { DaemonConnection } from "../daemon-client/protocol.js";
+import { connectWithAutoLaunch } from "./connect.js";
 import { McpSession } from "./session.js";
 import { createMcpServer } from "./server.js";
 
@@ -32,7 +32,7 @@ export interface McpTransport {
 }
 
 export interface McpStdioEnvironment {
-  readonly connect?: () => Promise<DaemonConnection>;
+  readonly connect?: () => Promise<SimlockClient>;
   readonly createServer?: (session: McpSession) => McpServer;
   readonly createTransport?: () => McpTransport;
   /** Source for `SIMLOCK_AGENT_ID` when `requesterId` is not given explicitly. */
@@ -62,11 +62,11 @@ export async function runMcpStdio(environment: McpStdioEnvironment = {}): Promis
 export async function startMcpStdio(
   environment: McpStdioEnvironment = {},
 ): Promise<McpStdioRunner> {
-  const defaults = defaultEnvironment();
   const env = environment.env ?? process.env;
+  const requesterId = environment.requesterId ?? env.SIMLOCK_AGENT_ID ?? `mcp:${process.pid}`;
+  const defaults = defaultEnvironment(requesterId);
   const session = new McpSession({
     connect: environment.connect ?? defaults.connect,
-    requesterId: environment.requesterId ?? env.SIMLOCK_AGENT_ID ?? `mcp:${process.pid}`,
   });
   const server = (environment.createServer ?? createMcpServer)(session);
   const transport = (environment.createTransport ?? defaults.createTransport)();
@@ -137,7 +137,9 @@ export async function startMcpStdio(
   return { finished, shutdown };
 }
 
-function defaultEnvironment(): Required<Pick<McpStdioEnvironment, "connect" | "createTransport">> {
+function defaultEnvironment(
+  requesterId: string,
+): Required<Pick<McpStdioEnvironment, "connect" | "createTransport">> {
   const dataDirectory = resolveSimlockHome();
   const clock = new SystemClock();
   const ipc = new NodeIpcTransport();
@@ -145,18 +147,19 @@ function defaultEnvironment(): Required<Pick<McpStdioEnvironment, "connect" | "c
   const logPath = join(dataDirectory, "daemon.log");
   return {
     connect: () =>
-      connectDaemon({
+      connectWithAutoLaunch({
+        clock,
         // MCP's holder process dies with its agent (stdin EOF -> session.close()), so a
         // sliding TTL is safe here. CLI held mode declares the same capability now that
         // it self-terminates on parent death too — see docs/known-pitfalls.md.
-        capabilities: { heartbeat: true },
-        clock,
+        heartbeat: true,
         ipc,
         launcher: new NodeDaemonLauncher({
           args: [join(dirname(fileURLToPath(import.meta.url)), "../daemon/main.js")],
           command: process.execPath,
           logPath,
         }),
+        principal: requesterId,
         socketPath,
       }),
     createTransport: () => new StdioServerTransport(),

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -8,139 +8,168 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { describe, expect, it } from "vitest";
 
-import { DaemonClientError, type DaemonConnection } from "../daemon-client/protocol.js";
-import {
-  leaseSimulatorOutputSchema,
-  leaseStatusOutputSchema,
-  listDevicesOutputSchema,
-  releaseSimulatorOutputSchema,
-} from "./contracts.js";
+import { SimlockError } from "../client/index.js";
+import { FakeSimlockClient, sampleGrant } from "./test-support.js";
 import { McpSession } from "./session.js";
 import { createMcpServer } from "./server.js";
 
-const grant = {
-  device: {
-    driverDeviceId: "SIM-1",
-    spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" as const },
-  },
-  lease: { id: "lease-1", mode: "held" as const, ttlDeadline: 12_345 },
-  timing: {
-    estimatedBootMs: 3,
-    estimatedProvisionMs: 2,
-    estimatedReclaimMs: 1,
-    estimatedReadyMs: 6,
-  },
-};
-
-const catalog = {
-  platforms: [
-    {
-      defaultRuntime: "26.5",
-      models: ["iPhone 17 Pro"],
-      platform: "ios" as const,
-      runtimes: ["26.5"],
-    },
-  ],
-};
-
-describe("MCP server", () => {
-  it("advertises exactly the lease, catalog, and status tools and returns dual schema-valid results", async () => {
-    const connection = new StubConnection([grant, catalog, { leaseId: "lease-1" }]);
-    const { client, close } = await connectedServer(connection);
-    try {
-      const listed = await client.request({ method: "tools/list" }, ListToolsResultSchema);
-      expect(listed.tools.map((tool) => tool.name)).toEqual([
-        "lease_simulator",
-        "list_devices",
-        "release_simulator",
-        "lease_status",
-      ]);
-      for (const tool of listed.tools) {
-        expect(tool.title).toEqual(expect.any(String));
-        expect(tool.description).toEqual(expect.any(String));
-        expect(tool.inputSchema).toEqual(expect.any(Object));
-        expect(tool.outputSchema).toEqual(expect.any(Object));
-      }
-
-      const noLease = await call(client, "lease_status", {});
-      expect(noLease.isError).not.toBe(true);
-      leaseStatusOutputSchema.parse(noLease.structuredContent);
-      expect(noLease.structuredContent).toEqual({ held: false });
-
-      const lease = await call(client, "lease_simulator", {
-        device: "iPhone 17 Pro",
-        platform: "ios",
-      });
-      expect(lease.isError).not.toBe(true);
-      leaseSimulatorOutputSchema.parse(lease.structuredContent);
-      expect(lease.structuredContent).toMatchObject({ lease_id: "lease-1", mode: "held" });
-      expect(JSON.parse(text(lease))).toEqual(lease.structuredContent);
-
-      const devices = await call(client, "list_devices", {});
-      expect(devices.isError).not.toBe(true);
-      listDevicesOutputSchema.parse(devices.structuredContent);
-      expect(devices.structuredContent).toEqual({
+describe("MCP server (smoke)", () => {
+  it("advertises exactly the lease, catalog, and status tools, and walks lease -> list -> status -> release", async () => {
+    const client = new FakeSimlockClient();
+    const grant = sampleGrant();
+    client.requestLeaseImpl = () => Promise.resolve(grant);
+    client.getCatalogImpl = () =>
+      Promise.resolve({
         platforms: [
           {
-            default_runtime: "26.5",
+            defaultRuntime: "26.5",
             models: ["iPhone 17 Pro"],
             platform: "ios",
             runtimes: ["26.5"],
           },
         ],
       });
-      expect(JSON.parse(text(devices))).toEqual(devices.structuredContent);
+    client.releaseLeaseImpl = (input) => Promise.resolve({ leaseId: input.leaseId });
+    let listed = false;
+    client.listLeasesImpl = () => {
+      const wasListed = listed;
+      listed = true;
+      return Promise.resolve({
+        leases: wasListed
+          ? []
+          : [
+              {
+                deviceId: grant.device.id,
+                grantedAt: grant.lease.grantedAt,
+                id: grant.lease.id,
+                mode: grant.lease.mode,
+                ownerId: grant.lease.ownerId,
+                requesterId: grant.lease.requesterId,
+                ttlDeadline: grant.lease.ttlDeadline,
+              },
+            ],
+      });
+    };
+    const { mcpClient, close } = await connectedServer(client);
+    try {
+      const tools = await mcpClient.request({ method: "tools/list" }, ListToolsResultSchema);
+      expect(tools.tools.map((tool) => tool.name)).toEqual([
+        "lease_simulator",
+        "list_devices",
+        "release_simulator",
+        "lease_status",
+      ]);
+      for (const tool of tools.tools) {
+        expect(tool.inputSchema).toEqual(expect.any(Object));
+        expect(tool.outputSchema).toEqual(expect.any(Object));
+      }
 
-      const held = await call(client, "lease_status", {});
-      expect(held.isError).not.toBe(true);
-      leaseStatusOutputSchema.parse(held.structuredContent);
-      expect(held.structuredContent).toEqual({
-        device: "iPhone 17 Pro",
-        device_id: "SIM-1",
-        expires_at_ms: 12_345,
-        held: true,
-        lease_id: "lease-1",
-        os: "26.5",
+      const lease = await call(mcpClient, "lease_simulator", {
+        model: "iPhone 17 Pro",
         platform: "ios",
-        state: "leased",
+      });
+      expect(lease.isError).not.toBe(true);
+      expect(lease.structuredContent).toMatchObject({ lease: { id: "lease-1", mode: "held" } });
+
+      const devices = await call(mcpClient, "list_devices", {});
+      expect(devices.isError).not.toBe(true);
+      expect(devices.structuredContent).toEqual({
+        platforms: [
+          {
+            defaultRuntime: "26.5",
+            models: ["iPhone 17 Pro"],
+            platform: "ios",
+            runtimes: ["26.5"],
+          },
+        ],
       });
 
-      const release = await call(client, "release_simulator", { lease_id: "lease-1" });
-      expect(release.isError).not.toBe(true);
-      releaseSimulatorOutputSchema.parse(release.structuredContent);
-      expect(release.structuredContent).toEqual({ lease_id: "lease-1", released: true });
-      expect(JSON.parse(text(release))).toEqual(release.structuredContent);
+      const status = await call(mcpClient, "lease_status", {});
+      expect(status.isError).not.toBe(true);
+      expect(status.structuredContent).toMatchObject({ held: true, id: "lease-1" });
 
-      const afterRelease = await call(client, "lease_status", {});
+      const release = await call(mcpClient, "release_simulator", { leaseId: "lease-1" });
+      expect(release.isError).not.toBe(true);
+      expect(release.structuredContent).toEqual({ leaseId: "lease-1", released: true });
+
+      const afterRelease = await call(mcpClient, "lease_status", {});
       expect(afterRelease.structuredContent).toEqual({ held: false });
     } finally {
       await close();
     }
   });
 
-  it("relays a daemon lease-lost push as an MCP logging notification and forgets the lease", async () => {
-    const connection = new StubConnection([grant]);
-    const { client, close, session } = await connectedServer(connection);
+  it("surfaces a daemon FORBIDDEN as-is when releasing a lease this session does not own -- no client-side pre-check", async () => {
+    const client = new FakeSimlockClient();
+    client.releaseLeaseImpl = () =>
+      Promise.reject(new SimlockError("FORBIDDEN", "protocol", "not your lease", {}));
+    const { mcpClient, close } = await connectedServer(client);
+    try {
+      const result = await call(mcpClient, "release_simulator", { leaseId: "not-mine" });
+      expect(result.isError).toBe(true);
+      expect(JSON.parse(text(result))).toEqual({ code: "FORBIDDEN", message: "not your lease" });
+    } finally {
+      await close();
+    }
+  });
+
+  it("sanitizes an unexpected error without leaking its message", async () => {
+    const client = new FakeSimlockClient();
+    client.requestLeaseImpl = () => Promise.reject(new Error("/private/secret-stack-path"));
+    const { mcpClient, close } = await connectedServer(client);
+    try {
+      const result = await call(mcpClient, "lease_simulator", {
+        model: "iPhone 17 Pro",
+        platform: "ios",
+      });
+      expect(result.isError).toBe(true);
+      expect(JSON.parse(text(result))).toEqual({
+        code: "INTERNAL",
+        message: "Simlock could not complete the request",
+      });
+      expect(text(result)).not.toContain("private");
+    } finally {
+      await close();
+    }
+  });
+
+  it("rejects invalid tool arguments through the registered schema before touching the client", async () => {
+    const client = new FakeSimlockClient();
+    const { mcpClient, close } = await connectedServer(client);
+    try {
+      const result = await call(mcpClient, "lease_simulator", { model: "", platform: "desktop" });
+      expect(result.isError).toBe(true);
+      expect(text(result)).toContain("Input validation error");
+      expect(client.calls).toEqual([]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("relays a lease-lost push as an MCP logging notification (MCP-only relay)", async () => {
+    const client = new FakeSimlockClient();
+    client.requestLeaseImpl = () => Promise.resolve(sampleGrant());
+    const { mcpClient, close } = await connectedServer(client);
     try {
       const notifications: unknown[] = [];
-      client.setNotificationHandler(LoggingMessageNotificationSchema, (notification) => {
+      mcpClient.setNotificationHandler(LoggingMessageNotificationSchema, (notification) => {
         notifications.push(notification.params);
       });
 
-      const lease = await call(client, "lease_simulator", {
-        device: "iPhone 17 Pro",
+      const lease = await call(mcpClient, "lease_simulator", {
+        model: "iPhone 17 Pro",
         platform: "ios",
       });
       expect(lease.isError).not.toBe(true);
 
-      connection.pushLeaseLost({ deviceId: "SIM-1", leaseId: "lease-1", reason: "expired" });
+      client.emitLeaseLost({ deviceId: "SIM-1", leaseId: "lease-1", reason: "expired" });
       await expect
         .poll(() => notifications)
         .toEqual([
           {
             data: {
-              device_id: "SIM-1",
-              lease_id: "lease-1",
+              deviceId: "SIM-1",
+              leaseId: "lease-1",
               message: "Simlock lease ended; this session no longer holds the device.",
               reason: "expired",
             },
@@ -148,88 +177,77 @@ describe("MCP server", () => {
             logger: "simlock",
           },
         ]);
-
-      expect(session.status()).toEqual({ held: false });
-      const releaseAfterLost = await call(client, "release_simulator", { lease_id: "lease-1" });
-      expect(releaseAfterLost.isError).toBe(true);
-      expect(JSON.parse(text(releaseAfterLost))).toEqual({
-        code: "LEASE_NOT_OWNED",
-        message: "This session does not own that lease",
-      });
     } finally {
       await close();
     }
   });
 
-  it("relays device-unhealthy and device-recovered pushes as MCP logging notifications, keeping the lease held", async () => {
-    const connection = new StubConnection([grant]);
-    const { client, close, session } = await connectedServer(connection);
+  it("relays device-unhealthy and device-recovered pushes as MCP logging notifications (MCP-only relay)", async () => {
+    const client = new FakeSimlockClient();
+    client.requestLeaseImpl = () => Promise.resolve(sampleGrant());
+    const { mcpClient, close } = await connectedServer(client);
     try {
       const notifications: unknown[] = [];
-      client.setNotificationHandler(LoggingMessageNotificationSchema, (notification) => {
+      mcpClient.setNotificationHandler(LoggingMessageNotificationSchema, (notification) => {
         notifications.push(notification.params);
       });
 
-      const lease = await call(client, "lease_simulator", {
-        device: "iPhone 17 Pro",
+      const lease = await call(mcpClient, "lease_simulator", {
+        model: "iPhone 17 Pro",
         platform: "ios",
       });
       expect(lease.isError).not.toBe(true);
 
-      connection.pushDeviceUnhealthy({ deviceId: "SIM-1", leaseId: "lease-1", reason: "crashed" });
-      connection.pushDeviceRecovered({ attempts: 2, deviceId: "SIM-1", leaseId: "lease-1" });
+      client.emitDeviceUnhealthy({ deviceId: "SIM-1", leaseId: "lease-1" });
+      client.emitDeviceRecovered({ attempts: 2, deviceId: "SIM-1", leaseId: "lease-1" });
       await expect.poll(() => notifications).toHaveLength(2);
 
       expect(notifications).toEqual([
         expect.objectContaining({
-          data: expect.objectContaining({
-            device_id: "SIM-1",
-            lease_id: "lease-1",
-            reason: "crashed",
-          }),
+          data: expect.objectContaining({ deviceId: "SIM-1", leaseId: "lease-1" }),
           level: "warning",
         }),
         expect.objectContaining({
-          data: expect.objectContaining({
-            attempts: 2,
-            device_id: "SIM-1",
-            lease_id: "lease-1",
-          }),
+          data: expect.objectContaining({ attempts: 2, deviceId: "SIM-1", leaseId: "lease-1" }),
           level: "info",
         }),
       ]);
-
-      // The lease is still owned: unlike a lease-lost push, device health notices never
-      // clear it.
-      expect(session.status()).toMatchObject({ held: true, lease_id: "lease-1" });
     } finally {
       await close();
     }
   });
 
-  it("relays queued/provisioning/booting/reclaiming progress as notifications/progress when a token is supplied", async () => {
-    const deferredGrant = deferredResponse();
-    const connection = new StubConnection([deferredGrant.promise]);
-    const { client, close } = await connectedServer(connection);
+  it("relays queued/provisioning/booting/reclaiming progress as notifications/progress when a token is supplied (MCP-only relay)", async () => {
+    const client = new FakeSimlockClient();
+    let onProgress: ((progress: unknown) => void) | undefined;
+    let resolveGrant!: (grant: ReturnType<typeof sampleGrant>) => void;
+    const grantPromise = new Promise<ReturnType<typeof sampleGrant>>((resolve) => {
+      resolveGrant = resolve;
+    });
+    client.requestLeaseImpl = (_input, options) => {
+      onProgress = options.onProgress as ((progress: unknown) => void) | undefined;
+      return grantPromise;
+    };
+    const { mcpClient, close } = await connectedServer(client);
     try {
       const progressEvents: unknown[] = [];
-      const leaseCall = client.request(
+      const leaseCall = mcpClient.request(
         {
           method: "tools/call",
           params: {
-            arguments: { device: "iPhone 17 Pro", platform: "ios" },
+            arguments: { model: "iPhone 17 Pro", platform: "ios" },
             name: "lease_simulator",
           },
         },
         CallToolResultSchema,
         { onprogress: (progress) => progressEvents.push(progress) },
       );
-      await waitFor(() => connection.calls.length === 1);
+      await waitFor(() => onProgress !== undefined);
 
-      connection.pushProgress({ queuePosition: 2, stage: "queued" });
-      connection.pushProgress({ etaMs: 9_000, stage: "provisioning" });
-      connection.pushProgress({ etaMs: 4_000, stage: "booting" });
-      connection.pushProgress({ etaMs: 1_000, stage: "reclaiming" });
+      onProgress!({ queuePosition: 2, stage: "queued" });
+      onProgress!({ etaMs: 9_000, stage: "provisioning" });
+      onProgress!({ etaMs: 4_000, stage: "booting" });
+      onProgress!({ etaMs: 1_000, stage: "reclaiming" });
       await waitFor(() => progressEvents.length === 4);
 
       expect(progressEvents).toEqual([
@@ -242,7 +260,7 @@ describe("MCP server", () => {
       expect(values).toEqual([...values].sort((a, b) => a - b));
       expect(new Set(values).size).toBe(values.length);
 
-      deferredGrant.resolve(grant);
+      resolveGrant(sampleGrant());
       const lease = await leaseCall;
       expect(lease.isError).not.toBe(true);
     } finally {
@@ -250,102 +268,40 @@ describe("MCP server", () => {
     }
   });
 
-  it("emits nothing when the client supplied no progress token", async () => {
-    const deferredGrant = deferredResponse();
-    const connection = new StubConnection([deferredGrant.promise]);
-    const { client, close } = await connectedServer(connection);
+  it("emits nothing when the client supplied no progress token (MCP-only relay)", async () => {
+    const client = new FakeSimlockClient();
+    let onProgress: ((progress: unknown) => void) | undefined;
+    client.requestLeaseImpl = (_input, options) => {
+      onProgress = options.onProgress as ((progress: unknown) => void) | undefined;
+      return Promise.resolve(sampleGrant());
+    };
+    const { mcpClient, close } = await connectedServer(client);
     try {
       const progressEvents: unknown[] = [];
-      client.setNotificationHandler(ProgressNotificationSchema, (notification) => {
+      mcpClient.setNotificationHandler(ProgressNotificationSchema, (notification) => {
         progressEvents.push(notification.params);
       });
 
-      const leaseCall = call(client, "lease_simulator", {
-        device: "iPhone 17 Pro",
-        platform: "ios",
-      });
-      await waitFor(() => connection.calls.length === 1);
-
-      connection.pushProgress({ queuePosition: 1, stage: "queued" });
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      await call(mcpClient, "lease_simulator", { model: "iPhone 17 Pro", platform: "ios" });
+      expect(onProgress).toBeUndefined();
       expect(progressEvents).toEqual([]);
-
-      deferredGrant.resolve(grant);
-      await leaseCall;
-      expect(progressEvents).toEqual([]);
-    } finally {
-      await close();
-    }
-  });
-
-  it("forwards the platform filter for list_devices and never triggers a lease request", async () => {
-    const connection = new StubConnection([catalog]);
-    const { client, close } = await connectedServer(connection);
-    try {
-      const devices = await call(client, "list_devices", { platform: "ios" });
-      expect(devices.isError).not.toBe(true);
-      expect(connection.calls).toEqual([{ payload: { platform: "ios" }, type: "catalog.get" }]);
-    } finally {
-      await close();
-    }
-  });
-
-  it("returns stable, sanitized errors without invalid structured output", async () => {
-    const connection = new StubConnection([
-      new DaemonClientError("NO_CAPACITY", "No matching devices are available"),
-      new Error("/private/secret-stack-path"),
-    ]);
-    const { client, close } = await connectedServer(connection);
-    try {
-      const expected = await call(client, "lease_simulator", {
-        device: "iPhone 17 Pro",
-        platform: "ios",
-      });
-      expect(expected).toMatchObject({ isError: true });
-      expect(JSON.parse(text(expected))).toEqual({
-        code: "NO_CAPACITY",
-        message: "No matching devices are available",
-      });
-      expect(expected.structuredContent).toBeUndefined();
-
-      const unexpected = await call(client, "lease_simulator", {
-        device: "iPhone 17 Pro",
-        platform: "ios",
-      });
-      expect(JSON.parse(text(unexpected))).toEqual({
-        code: "INTERNAL",
-        message: "Simlock could not complete the request",
-      });
-      expect(text(unexpected)).not.toContain("private");
-    } finally {
-      await close();
-    }
-  });
-
-  it("rejects invalid tool arguments through the registered schema", async () => {
-    const { client, close } = await connectedServer(new StubConnection([]));
-    try {
-      const result = await call(client, "lease_simulator", { device: "", platform: "desktop" });
-      expect(result.isError).toBe(true);
-      expect(text(result)).toContain("Input validation error");
     } finally {
       await close();
     }
   });
 });
 
-async function connectedServer(connection: StubConnection) {
-  const session = new McpSession({ connect: async () => connection, requesterId: "mcp-test" });
+async function connectedServer(client: FakeSimlockClient) {
+  const session = new McpSession({ connect: async () => client });
   const server = createMcpServer(session);
-  const client = new Client({ name: "mcp-test-client", version: "1.0.0" });
+  const mcpClient = new Client({ name: "mcp-test-client", version: "1.0.0" });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+  await Promise.all([mcpClient.connect(clientTransport), server.connect(serverTransport)]);
   return {
-    client,
     close: async () => {
-      await Promise.all([client.close(), server.close(), session.close()]);
+      await Promise.all([mcpClient.close(), server.close(), session.close()]);
     },
-    session,
+    mcpClient,
   };
 }
 
@@ -362,60 +318,6 @@ function text(result: { content: Array<{ type: string; text?: string }> }): stri
   return first.text;
 }
 
-function deferredResponse(): { promise: Promise<unknown>; resolve: (value: unknown) => void } {
-  let resolve!: (value: unknown) => void;
-  const promise = new Promise<unknown>((next) => {
-    resolve = next;
-  });
-  return { promise, resolve };
-}
-
 async function waitFor(predicate: () => boolean): Promise<void> {
   while (!predicate()) await new Promise((resolve) => setTimeout(resolve, 0));
-}
-
-class StubConnection implements DaemonConnection {
-  closeCalls = 0;
-  readonly calls: Array<{ readonly payload: unknown; readonly type: string }> = [];
-  readonly #listeners = new Set<(kind: string, payload: unknown) => void>();
-  constructor(private readonly responses: unknown[]) {}
-  async close(): Promise<void> {
-    this.closeCalls += 1;
-  }
-  onPush(listener: (kind: string, payload: unknown) => void): () => void {
-    this.#listeners.add(listener);
-    return () => this.#listeners.delete(listener);
-  }
-
-  onClose(): () => void {
-    return () => undefined;
-  }
-  pushLeaseLost(payload: {
-    readonly deviceId: string;
-    readonly leaseId: string;
-    readonly reason: string;
-  }): void {
-    for (const listener of this.#listeners) listener("lease-lost", payload);
-  }
-
-  /** Wraps the given stage payload under `{requestId, progress}` -- ADR 0003 §8's push
-   * correlation shape -- so callers can keep passing the bare stage object. */
-  pushProgress(payload: unknown): void {
-    for (const listener of this.#listeners)
-      listener("progress", { progress: payload, requestId: "test-request" });
-  }
-
-  pushDeviceUnhealthy(payload: unknown): void {
-    for (const listener of this.#listeners) listener("device-unhealthy", payload);
-  }
-
-  pushDeviceRecovered(payload: unknown): void {
-    for (const listener of this.#listeners) listener("device-recovered", payload);
-  }
-  async request(type: string, payload: unknown): Promise<unknown> {
-    this.calls.push({ payload, type });
-    const response = this.responses.shift();
-    if (response instanceof Error) throw response;
-    return response;
-  }
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -166,9 +166,9 @@ export function createMcpServer(session: McpSession): McpServer {
       inputSchema: leaseStatusInputSchema,
       outputSchema: leaseStatusOutputSchema,
     },
-    () => {
+    async () => {
       try {
-        return success(session.status());
+        return success(await session.status());
       } catch (error: unknown) {
         return failure(error);
       }
@@ -178,8 +178,8 @@ export function createMcpServer(session: McpSession): McpServer {
   session.onLeaseLost((notice) => {
     void server.server.sendLoggingMessage({
       data: {
-        device_id: notice.deviceId,
-        lease_id: notice.leaseId,
+        deviceId: notice.deviceId,
+        leaseId: notice.leaseId,
         message: "Simlock lease ended; this session no longer holds the device.",
         reason: notice.reason,
       },
@@ -208,8 +208,8 @@ function deviceHealthLoggingMessage(notice: DeviceHealthNotice): {
   if (notice.kind === "unhealthy") {
     return {
       data: {
-        device_id: notice.deviceId,
-        lease_id: notice.leaseId,
+        deviceId: notice.deviceId,
+        leaseId: notice.leaseId,
         message:
           "Simlock's device crashed outside simlock; anything running inside it (apps, log streams, automation sessions, port forwards) is gone. Recovery is in progress under the same lease.",
         reason: notice.reason,
@@ -221,8 +221,8 @@ function deviceHealthLoggingMessage(notice: DeviceHealthNotice): {
   return {
     data: {
       attempts: notice.attempts,
-      device_id: notice.deviceId,
-      lease_id: notice.leaseId,
+      deviceId: notice.deviceId,
+      leaseId: notice.leaseId,
       message: "Simlock's device was rebooted and is ready again under the same lease.",
     },
     level: "info",

--- a/src/mcp/session.test.ts
+++ b/src/mcp/session.test.ts
@@ -1,1096 +1,229 @@
 import { describe, expect, it } from "vitest";
 
-import { DaemonClientError, type DaemonConnection } from "../daemon-client/protocol.js";
-import { leaseSimulatorInputSchema } from "./contracts.js";
+import { SimlockError } from "../client/index.js";
+import { FakeSimlockClient, sampleGrant } from "./test-support.js";
 import { McpSession, toMcpErrorResult } from "./session.js";
 
-const input = leaseSimulatorInputSchema.parse({ device: "iPhone 17 Pro", platform: "ios" });
-const rawGrant = {
-  device: {
-    driverDeviceId: "ABCD",
-    spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" as const },
-  },
-  lease: { id: "lse_9f2c", mode: "held" as const, ttlDeadline: 61_000 },
-  timing: {
-    estimatedBootMs: 20,
-    estimatedProvisionMs: 10,
-    estimatedReclaimMs: 0,
-    estimatedReadyMs: 30,
-  },
-};
-
 describe("McpSession", () => {
-  it("maps safe defaults and grants to the public result", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
+  it("requests a held lease with the tool input as-is, and returns the grant unchanged", async () => {
+    const client = new FakeSimlockClient();
+    let seenInput: unknown;
+    let seenOptions: unknown;
+    const grant = sampleGrant();
+    client.requestLeaseImpl = (input, options) => {
+      seenInput = input;
+      seenOptions = options;
+      return Promise.resolve(grant);
+    };
+    const session = new McpSession({ connect: async () => client });
 
-    await expect(session.lease(input)).resolves.toEqual({
-      device: "iPhone 17 Pro",
-      device_id: "ABCD",
-      expires_at_ms: 61_000,
-      lease_id: "lse_9f2c",
-      mode: "held",
-      os: "26.5",
-      platform: "ios",
-      slim: false,
-      state: "leased",
-      timing: {
-        estimated_boot_ms: 20,
-        estimated_provision_ms: 10,
-        estimated_reclaim_ms: 0,
-        estimated_ready_ms: 30,
-      },
+    const signal = new AbortController().signal;
+    const onProgress = () => undefined;
+    const result = await session.lease(
+      { model: "iPhone 17 Pro", platform: "ios" },
+      signal,
+      onProgress,
+    );
+
+    expect(result).toBe(grant);
+    expect(seenInput).toEqual({ model: "iPhone 17 Pro", mode: "held", platform: "ios" });
+    expect(seenOptions).toEqual({ onProgress, signal });
+  });
+
+  it("releases without any client-side ownership check -- a FORBIDDEN from the daemon passes straight through", async () => {
+    const client = new FakeSimlockClient();
+    client.releaseLeaseImpl = () =>
+      Promise.reject(new SimlockError("FORBIDDEN", "protocol", "not your lease", {}));
+    const session = new McpSession({ connect: async () => client });
+
+    await expect(session.release({ leaseId: "someone-elses-lease" })).rejects.toMatchObject({
+      code: "FORBIDDEN",
     });
-    expect(connection.requests).toEqual([
-      {
-        payload: {
-          allowDownload: false,
-          mode: "held",
-          model: "iPhone 17 Pro",
-          noWait: false,
-          platform: "ios",
-          requesterId: "mcp-session-1",
-        },
-        type: "lease.request",
-      },
+    expect(client.calls).toEqual([
+      { input: { leaseId: "someone-elses-lease" }, method: "releaseLease" },
     ]);
   });
 
-  it("sends full: true on the request when full is set, and slim: true when the grant reports a reduced feature profile", async () => {
-    const connection = new StubConnection();
-    connection.responses.push({
-      ...rawGrant,
-      device: { ...rawGrant.device, featureProfile: "reduced" },
-    });
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
+  it("adds released: true to a successful release without otherwise reshaping the result", async () => {
+    const client = new FakeSimlockClient();
+    client.releaseLeaseImpl = (input) => Promise.resolve({ leaseId: input.leaseId });
+    const session = new McpSession({ connect: async () => client });
 
-    await expect(
-      session.lease(leaseSimulatorInputSchema.parse({ ...input, full: true })),
-    ).resolves.toMatchObject({ slim: true });
-    expect(connection.requests).toEqual([
-      {
-        payload: {
-          allowDownload: false,
-          full: true,
-          mode: "held",
-          model: "iPhone 17 Pro",
-          noWait: false,
-          platform: "ios",
-          requesterId: "mcp-session-1",
-        },
-        type: "lease.request",
-      },
+    await expect(session.release({ leaseId: "lease-1" })).resolves.toEqual({
+      leaseId: "lease-1",
+      released: true,
+    });
+  });
+
+  it("forwards list_devices straight to getCatalog", async () => {
+    const client = new FakeSimlockClient();
+    client.getCatalogImpl = () => Promise.resolve({ platforms: [] });
+    const session = new McpSession({ connect: async () => client });
+
+    await session.listDevices({ platform: "ios" });
+    expect(client.calls).toEqual([{ input: { platform: "ios" }, method: "getCatalog" }]);
+  });
+
+  it("answers lease_status with one lease.list call each time, not a cache", async () => {
+    const client = new FakeSimlockClient();
+    let call = 0;
+    client.listLeasesImpl = () => {
+      call += 1;
+      return Promise.resolve(
+        call === 1
+          ? { leases: [] }
+          : {
+              leases: [
+                {
+                  deviceId: "device-1",
+                  grantedAt: 0,
+                  id: "lease-1",
+                  mode: "held" as const,
+                  ownerId: "mcp-test",
+                  requesterId: "mcp-test",
+                  ttlDeadline: 5_000,
+                },
+              ],
+            },
+      );
+    };
+    const session = new McpSession({ connect: async () => client });
+
+    await expect(session.status()).resolves.toEqual({ held: false });
+    await expect(session.status()).resolves.toEqual({
+      deviceId: "device-1",
+      grantedAt: 0,
+      held: true,
+      id: "lease-1",
+      mode: "held",
+      ownerId: "mcp-test",
+      requesterId: "mcp-test",
+      ttlDeadline: 5_000,
+    });
+    expect(client.calls.filter((c) => c.method === "listLeases")).toHaveLength(2);
+  });
+
+  it("reconnects lazily: builds a new client only after the current one's connection is lost", async () => {
+    const clients: FakeSimlockClient[] = [];
+    let connectCalls = 0;
+    const connect = async () => {
+      connectCalls += 1;
+      const client = new FakeSimlockClient();
+      client.getCatalogImpl = () => Promise.resolve({ platforms: [] });
+      clients.push(client);
+      return client;
+    };
+    const session = new McpSession({ connect });
+
+    await session.listDevices({});
+    await session.listDevices({});
+    expect(connectCalls).toBe(1);
+
+    clients[0]!.emitConnectionLost();
+    await session.listDevices({});
+    expect(connectCalls).toBe(2);
+    expect(clients[1]).not.toBe(clients[0]);
+  });
+
+  it("serializes tool calls: a slower lease still completes before a release issued after it", async () => {
+    const client = new FakeSimlockClient();
+    const order: string[] = [];
+    let releaseGrant: (() => void) | undefined;
+    client.requestLeaseImpl = () =>
+      new Promise((resolve) => {
+        releaseGrant = () => {
+          order.push("lease");
+          resolve(sampleGrant());
+        };
+      });
+    client.releaseLeaseImpl = (input) => {
+      order.push("release");
+      return Promise.resolve({ leaseId: input.leaseId });
+    };
+    const session = new McpSession({ connect: async () => client });
+
+    const leaseCall = session.lease({ model: "iPhone 17 Pro", platform: "ios" });
+    const releaseCall = session.release({ leaseId: "lease-1" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(order).toEqual([]); // release is queued behind the still-pending lease
+    releaseGrant?.();
+    await Promise.all([leaseCall, releaseCall]);
+
+    expect(order).toEqual(["lease", "release"]);
+  });
+
+  it("closes the current client exactly once, and closes a client that finishes connecting after close", async () => {
+    let resolveConnect!: (client: FakeSimlockClient) => void;
+    const pendingClient = new Promise<FakeSimlockClient>((resolve) => {
+      resolveConnect = resolve;
+    });
+    const session = new McpSession({ connect: () => pendingClient });
+
+    const listDevicesCall = session.listDevices({});
+    await Promise.resolve(); // let the queued mutation reach #clientForUse() and start connecting
+    const closeCall = session.close();
+    const client = new FakeSimlockClient();
+    client.getCatalogImpl = () => Promise.resolve({ platforms: [] });
+    resolveConnect(client);
+
+    await closeCall;
+    await expect(listDevicesCall).rejects.toBeTruthy();
+    expect(client.closeCalls).toBe(1);
+
+    await session.close();
+    expect(client.closeCalls).toBe(1);
+  });
+
+  it("rejects every tool call with SESSION_CLOSED, without contacting the client, once closed", async () => {
+    const client = new FakeSimlockClient();
+    const session = new McpSession({ connect: async () => client });
+    await session.close();
+
+    await expect(session.lease({ model: "x", platform: "ios" })).rejects.toMatchObject({
+      code: "SESSION_CLOSED",
+    });
+    await expect(session.release({ leaseId: "l" })).rejects.toMatchObject({
+      code: "SESSION_CLOSED",
+    });
+    await expect(session.listDevices({})).rejects.toMatchObject({ code: "SESSION_CLOSED" });
+    await expect(session.status()).rejects.toMatchObject({ code: "SESSION_CLOSED" });
+    expect(client.calls).toEqual([]);
+  });
+
+  it("relays the client's lease-lost, device-unhealthy, and device-recovered pushes to session listeners", async () => {
+    const client = new FakeSimlockClient();
+    client.getCatalogImpl = () => Promise.resolve({ platforms: [] });
+    const session = new McpSession({ connect: async () => client });
+    await session.listDevices({}); // forces the client to connect and wire up push relays
+
+    const leaseLost: unknown[] = [];
+    const deviceHealth: unknown[] = [];
+    session.onLeaseLost((notice) => leaseLost.push(notice));
+    session.onDeviceHealth((notice) => deviceHealth.push(notice));
+
+    client.emitLeaseLost({ deviceId: "SIM-1", leaseId: "lease-1", reason: "expired" });
+    client.emitDeviceUnhealthy({ deviceId: "SIM-1", leaseId: "lease-1" });
+    client.emitDeviceRecovered({ attempts: 2, deviceId: "SIM-1", leaseId: "lease-1" });
+
+    expect(leaseLost).toEqual([{ deviceId: "SIM-1", leaseId: "lease-1", reason: "expired" }]);
+    expect(deviceHealth).toEqual([
+      { deviceId: "SIM-1", kind: "unhealthy", leaseId: "lease-1", reason: "crashed" },
+      { attempts: 2, deviceId: "SIM-1", kind: "recovered", leaseId: "lease-1" },
     ]);
   });
+});
 
-  it("converts timeout seconds and optional fields for the daemon", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(
-      leaseSimulatorInputSchema.parse({
-        allow_download: true,
-        device: "iPhone 17 Pro",
-        no_wait: true,
-        os: "26.5",
-        platform: "ios",
-        timeout_seconds: 1.25,
-      }),
-    );
-    expect(connection.requests[0]?.payload).toEqual({
-      allowDownload: true,
-      mode: "held",
-      model: "iPhone 17 Pro",
-      noWait: true,
-      osVersion: "26.5",
-      platform: "ios",
-      requesterId: "mcp-session-1",
-      timeoutMs: 1_250,
-    });
-  });
-
-  it("rejects timeout values that would overflow milliseconds before requesting the daemon", async () => {
-    const connection = new StubConnection();
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-
-    await expect(
-      session.lease({ ...input, timeout_seconds: Number.MAX_VALUE }),
-    ).rejects.toMatchObject({ code: "INVALID_TIMEOUT" });
-    expect(connection.requests).toEqual([]);
-  });
-
-  it("rejects releases that this session does not own without calling the daemon", async () => {
-    const connection = new StubConnection();
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await expect(session.release({ lease_id: "other" })).rejects.toMatchObject({
-      code: "LEASE_NOT_OWNED",
-    });
-    expect(connection.requests).toEqual([]);
-  });
-
-  it("preserves expected daemon errors and sanitizes unexpected ones", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(
-      new DaemonClientError("NO_CAPACITY", "No matching devices are available"),
-    );
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await expect(session.lease(input)).rejects.toBeInstanceOf(DaemonClientError);
+describe("toMcpErrorResult", () => {
+  it("maps a SimlockError to its code and message", () => {
     expect(
-      toMcpErrorResult(new DaemonClientError("NO_CAPACITY", "No matching devices are available")),
-    ).toEqual({
-      code: "NO_CAPACITY",
-      message: "No matching devices are available",
-    });
-    expect(toMcpErrorResult(new Error("/private/secret"))).toEqual({
+      toMcpErrorResult(new SimlockError("NO_CAPACITY", "domain", "No matching devices", {})),
+    ).toEqual({ code: "NO_CAPACITY", message: "No matching devices" });
+  });
+
+  it("sanitizes any other error to a generic INTERNAL result", () => {
+    expect(toMcpErrorResult(new Error("/private/secret-stack-path"))).toEqual({
       code: "INTERNAL",
       message: "Simlock could not complete the request",
     });
   });
-
-  it("defers repeat lease ownership decisions to the daemon and replaces stale local ownership", async () => {
-    const connection = new StubConnection();
-    const activeError = new DaemonClientError("REQUESTER_ALREADY_LEASED", "Lease is active");
-    const replacementGrant = {
-      ...rawGrant,
-      lease: { ...rawGrant.lease, id: "lse_replacement" },
-    };
-    connection.responses.push(rawGrant, activeError, replacementGrant, {
-      leaseId: "lse_replacement",
-    });
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-
-    await session.lease(input);
-    await expect(session.lease(input)).rejects.toBe(activeError);
-    await expect(session.lease(input)).resolves.toMatchObject({ lease_id: "lse_replacement" });
-    await session.release({ lease_id: "lse_replacement" });
-    expect(connection.requests.map((request) => request.type)).toEqual([
-      "lease.request",
-      "lease.request",
-      "lease.request",
-      "lease.release",
-    ]);
-  });
-
-  it("rejects malformed and non-held daemon grants", async () => {
-    const malformed = new StubConnection();
-    malformed.responses.push({ nope: true });
-    await expect(
-      new McpSession({ connect: async () => malformed, requesterId: "mcp-session-1" }).lease(input),
-    ).rejects.toThrow("Daemon returned an invalid lease grant");
-    expect(malformed.closeCalls).toBe(1);
-
-    const detached = new StubConnection();
-    detached.responses.push(
-      { ...rawGrant, lease: { ...rawGrant.lease, mode: "detached" } },
-      new DaemonClientError("UNKNOWN_LEASE", "Lease was already gone"),
-    );
-    await expect(
-      new McpSession({ connect: async () => detached, requesterId: "mcp-session-1" }).lease(input),
-    ).rejects.toMatchObject({ code: "INVALID_LEASE_GRANT" });
-    expect(detached.requests).toEqual([
-      expect.objectContaining({ type: "lease.request" }),
-      { payload: { leaseId: "lse_9f2c" }, type: "lease.release" },
-    ]);
-    expect(detached.closeCalls).toBe(1);
-  });
-
-  it("closes the active connection when cancelled so a late grant cannot be orphaned", async () => {
-    const connection = new StubConnection();
-    const lateGrant = deferred<unknown>();
-    connection.responses.push(lateGrant.promise);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    const controller = new AbortController();
-    const unhandled: unknown[] = [];
-    const recordUnhandled = (reason: unknown) => unhandled.push(reason);
-    process.on("unhandledRejection", recordUnhandled);
-    try {
-      const lease = session.lease(input, controller.signal);
-      await waitFor(() => connection.requests.length === 1);
-      controller.abort();
-      await expect(lease).rejects.toMatchObject({ code: "CANCELLED" });
-      expect(connection.closeCalls).toBe(1);
-      lateGrant.resolve(rawGrant);
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      expect(connection.closeCalls).toBe(1);
-      expect(unhandled).toEqual([]);
-    } finally {
-      process.off("unhandledRejection", recordUnhandled);
-    }
-  });
-
-  it("closes promptly during a pending lease and makes the session terminal", async () => {
-    const connection = new StubConnection();
-    const lateGrant = deferred<unknown>();
-    connection.responses.push(lateGrant.promise);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    const unhandled: unknown[] = [];
-    const recordUnhandled = (reason: unknown) => unhandled.push(reason);
-    process.on("unhandledRejection", recordUnhandled);
-    try {
-      const lease = session.lease(input);
-      await waitFor(() => connection.requests.length === 1);
-      await session.close();
-      expect(connection.closeCalls).toBe(1);
-      await expect(lease).rejects.toMatchObject({ code: "SESSION_CLOSED" });
-      await expect(session.lease(input)).rejects.toMatchObject({ code: "SESSION_CLOSED" });
-      await expect(session.release({ lease_id: "lse_9f2c" })).rejects.toMatchObject({
-        code: "SESSION_CLOSED",
-      });
-      lateGrant.resolve(rawGrant);
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      expect(unhandled).toEqual([]);
-    } finally {
-      process.off("unhandledRejection", recordUnhandled);
-    }
-  });
-
-  it("closes a connection that finishes establishing after session shutdown", async () => {
-    const connection = new StubConnection();
-    const connectionDeferred = deferred<DaemonConnection>();
-    let connectCalls = 0;
-    const session = new McpSession({
-      connect: async () => {
-        connectCalls += 1;
-        return connectionDeferred.promise;
-      },
-      requesterId: "mcp-session-1",
-    });
-    const lease = session.lease(input);
-
-    await waitFor(() => connectCalls === 1);
-    await session.close();
-    connectionDeferred.resolve(connection);
-    await expect(lease).rejects.toMatchObject({ code: "SESSION_CLOSED" });
-    await waitFor(() => connection.closeCalls === 1);
-    expect(connection.requests).toEqual([]);
-  });
-
-  it("serializes lease and release mutations", async () => {
-    const connection = new StubConnection();
-    const grant = deferred<unknown>();
-    connection.responses.push(grant.promise, { leaseId: "lse_9f2c" });
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    const lease = session.lease(input);
-    const release = session.release({ lease_id: "lse_9f2c" });
-
-    await waitFor(() => connection.requests.length === 1);
-    expect(connection.requests).toHaveLength(1);
-    grant.resolve(rawGrant);
-    await lease;
-    await release;
-    expect(connection.requests.map((request) => request.type)).toEqual([
-      "lease.request",
-      "lease.release",
-    ]);
-  });
-
-  it("releases explicitly, clears expired ownership, and closes idempotently", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant, { leaseId: "lse_9f2c" });
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-    await expect(session.release({ lease_id: "lse_9f2c" })).resolves.toEqual({
-      lease_id: "lse_9f2c",
-      released: true,
-    });
-    await expect(session.release({ lease_id: "lse_9f2c" })).rejects.toMatchObject({
-      code: "LEASE_NOT_OWNED",
-    });
-    await Promise.all([session.close(), session.close(), session.close()]);
-    expect(connection.closeCalls).toBe(1);
-  });
-
-  it("forgets ownership when the daemon says a lease is unknown or expired", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant, new DaemonClientError("UNKNOWN_LEASE", "Lease expired"));
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-    await expect(session.release({ lease_id: "lse_9f2c" })).rejects.toMatchObject({
-      code: "UNKNOWN_LEASE",
-    });
-    await expect(session.release({ lease_id: "lse_9f2c" })).rejects.toMatchObject({
-      code: "LEASE_NOT_OWNED",
-    });
-  });
-
-  it("maps the daemon catalog to snake_case tool output", async () => {
-    const connection = new StubConnection();
-    connection.responses.push({
-      platforms: [
-        {
-          defaultRuntime: "26.5",
-          models: ["iPhone 16"],
-          platform: "ios",
-          runtimes: ["18.4", "26.5"],
-        },
-        { defaultRuntime: undefined, models: ["Pixel 8"], platform: "android", runtimes: [] },
-      ],
-    });
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-
-    await expect(session.listDevices({})).resolves.toEqual({
-      platforms: [
-        {
-          default_runtime: "26.5",
-          models: ["iPhone 16"],
-          platform: "ios",
-          runtimes: ["18.4", "26.5"],
-        },
-        { default_runtime: undefined, models: ["Pixel 8"], platform: "android", runtimes: [] },
-      ],
-    });
-    expect(connection.requests).toEqual([{ payload: {}, type: "catalog.get" }]);
-  });
-
-  it("forwards the platform filter without leasing or releasing anything", async () => {
-    const connection = new StubConnection();
-    connection.responses.push({ platforms: [] });
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-
-    await expect(session.listDevices({ platform: "android" })).resolves.toEqual({ platforms: [] });
-    expect(connection.requests).toEqual([
-      { payload: { platform: "android" }, type: "catalog.get" },
-    ]);
-  });
-
-  it("rejects listDevices after the session is closed without contacting the daemon", async () => {
-    const connection = new StubConnection();
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.close();
-
-    await expect(session.listDevices({})).rejects.toMatchObject({ code: "SESSION_CLOSED" });
-    expect(connection.requests).toEqual([]);
-  });
-
-  it("reports no lease held until a lease is granted, and the held lease's details after", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant, { leaseId: "lse_9f2c" });
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    expect(session.status()).toEqual({ held: false });
-
-    await session.lease(input);
-    expect(session.status()).toEqual({
-      device: "iPhone 17 Pro",
-      device_id: "ABCD",
-      expires_at_ms: 61_000,
-      held: true,
-      lease_id: "lse_9f2c",
-      os: "26.5",
-      platform: "ios",
-      state: "leased",
-    });
-
-    await session.release({ lease_id: "lse_9f2c" });
-    expect(session.status()).toEqual({ held: false });
-  });
-
-  it("reports the slid expiry after a heartbeat ack, with no daemon round-trip from status() itself", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-    expect(session.status()).toMatchObject({ expires_at_ms: 61_000, held: true });
-
-    const requestsBeforeStatus = connection.requests.length;
-    connection.pushHeartbeatAck({ leases: [{ leaseId: "lse_9f2c", ttlDeadline: 65_000 }] });
-
-    expect(session.status()).toMatchObject({ expires_at_ms: 65_000, held: true });
-    // status() is a synchronous local read; the ack refreshed the cache, not a round-trip.
-    expect(connection.requests).toHaveLength(requestsBeforeStatus);
-  });
-
-  it("ignores a heartbeat ack for a lease id this session does not currently own", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-
-    connection.pushHeartbeatAck({ leases: [{ leaseId: "some-other-lease", ttlDeadline: 99_999 }] });
-    expect(session.status()).toMatchObject({ expires_at_ms: 61_000, held: true });
-  });
-
-  it("tolerates a malformed heartbeat ack without throwing", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-
-    expect(() => connection.pushHeartbeatAck({ leases: "not-an-array" })).not.toThrow();
-    expect(() => connection.pushHeartbeatAck(null)).not.toThrow();
-    expect(session.status()).toMatchObject({ expires_at_ms: 61_000, held: true });
-  });
-
-  it("throws when status is queried on a closed session", async () => {
-    const connection = new StubConnection();
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.close();
-    expect(() => session.status()).toThrowError(
-      expect.objectContaining({ code: "SESSION_CLOSED" }),
-    );
-  });
-
-  it("clears ownership and notifies listeners when the daemon pushes a lease-lost fact", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-
-    const notices: unknown[] = [];
-    session.onLeaseLost((notice) => notices.push(notice));
-    connection.pushLeaseLost({ deviceId: "ABCD", leaseId: "lse_9f2c", reason: "expired" });
-
-    expect(session.status()).toEqual({ held: false });
-    expect(notices).toEqual([{ deviceId: "ABCD", leaseId: "lse_9f2c", reason: "expired" }]);
-    await expect(session.release({ lease_id: "lse_9f2c" })).rejects.toMatchObject({
-      code: "LEASE_NOT_OWNED",
-    });
-  });
-
-  it("ignores a lease-lost push for a lease id this session does not currently own", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-
-    const notices: unknown[] = [];
-    session.onLeaseLost((notice) => notices.push(notice));
-    connection.pushLeaseLost({ deviceId: "other", leaseId: "some-other-lease", reason: "killed" });
-
-    expect(notices).toEqual([]);
-    expect(session.status()).toMatchObject({ held: true, lease_id: "lse_9f2c" });
-  });
-
-  it("ignores malformed lease-lost pushes without throwing", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-
-    const notices: unknown[] = [];
-    session.onLeaseLost((notice) => notices.push(notice));
-    expect(() => connection.pushLeaseLost({} as never)).not.toThrow();
-
-    expect(notices).toEqual([]);
-    expect(session.status()).toMatchObject({ held: true, lease_id: "lse_9f2c" });
-  });
-
-  it("ignores a lease-lost push that arrives for a lease this session already released itself", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant, { leaseId: "lse_9f2c" });
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-    await session.release({ lease_id: "lse_9f2c" });
-
-    const notices: unknown[] = [];
-    session.onLeaseLost((notice) => notices.push(notice));
-    // The daemon suppresses this in practice (issue #15), but the client stays
-    // defensive: a stale push for an id this session no longer owns is a no-op.
-    connection.pushLeaseLost({ deviceId: "ABCD", leaseId: "lse_9f2c", reason: "expired" });
-    expect(notices).toEqual([]);
-  });
-
-  it("notifies onDeviceHealth without ending the lease when the daemon pushes device-unhealthy", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-
-    const notices: unknown[] = [];
-    session.onDeviceHealth((notice) => notices.push(notice));
-    connection.pushDeviceUnhealthy({ deviceId: "ABCD", leaseId: "lse_9f2c", reason: "crashed" });
-
-    expect(notices).toEqual([
-      { deviceId: "ABCD", kind: "unhealthy", leaseId: "lse_9f2c", reason: "crashed" },
-    ]);
-    // Still owned: unlike a lease-lost push, this does not end the lease.
-    expect(session.status()).toMatchObject({ held: true, lease_id: "lse_9f2c" });
-  });
-
-  it("notifies onDeviceHealth without ending the lease when the daemon pushes device-recovered", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-
-    const notices: unknown[] = [];
-    session.onDeviceHealth((notice) => notices.push(notice));
-    connection.pushDeviceRecovered({ attempts: 2, deviceId: "ABCD", leaseId: "lse_9f2c" });
-
-    expect(notices).toEqual([
-      { attempts: 2, deviceId: "ABCD", kind: "recovered", leaseId: "lse_9f2c" },
-    ]);
-    expect(session.status()).toMatchObject({ held: true, lease_id: "lse_9f2c" });
-  });
-
-  it("ignores device-unhealthy/device-recovered pushes for a lease id this session does not currently own", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-
-    const notices: unknown[] = [];
-    session.onDeviceHealth((notice) => notices.push(notice));
-    connection.pushDeviceUnhealthy({
-      deviceId: "other",
-      leaseId: "some-other-lease",
-      reason: "crashed",
-    });
-    connection.pushDeviceRecovered({ attempts: 1, deviceId: "other", leaseId: "some-other-lease" });
-
-    expect(notices).toEqual([]);
-  });
-
-  it("ignores malformed device-unhealthy/device-recovered pushes without throwing", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-
-    const notices: unknown[] = [];
-    session.onDeviceHealth((notice) => notices.push(notice));
-    expect(() => connection.pushDeviceUnhealthy({} as never)).not.toThrow();
-    expect(() => connection.pushDeviceRecovered(null)).not.toThrow();
-
-    expect(notices).toEqual([]);
-    expect(session.status()).toMatchObject({ held: true, lease_id: "lse_9f2c" });
-  });
-
-  it("stops delivering onDeviceHealth notices once the session is closed", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-
-    const notices: unknown[] = [];
-    session.onDeviceHealth((notice) => notices.push(notice));
-    await session.close();
-
-    // Closing unsubscribes the push listener, so a push arriving after close (a race
-    // between shutdown and an in-flight daemon message) is simply never delivered.
-    connection.pushDeviceUnhealthy({ deviceId: "ABCD", leaseId: "lse_9f2c", reason: "crashed" });
-    expect(notices).toEqual([]);
-  });
-
-  it("relays progress pushes to the in-flight lease request's onProgress callback", async () => {
-    const connection = new StubConnection();
-    const grant = deferred<unknown>();
-    connection.responses.push(grant.promise);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-
-    const progressEvents: unknown[] = [];
-    const lease = session.lease(input, undefined, (progress) => progressEvents.push(progress));
-    await waitFor(() => connection.requests.length === 1);
-
-    connection.pushProgress({ queuePosition: 2, stage: "queued" });
-    connection.pushProgress({ etaMs: 9_000, stage: "provisioning" });
-
-    expect(progressEvents).toEqual([
-      { queuePosition: 2, stage: "queued" },
-      { etaMs: 9_000, stage: "provisioning" },
-    ]);
-
-    grant.resolve(rawGrant);
-    await lease;
-  });
-
-  it("does nothing when a lease request has no onProgress callback", async () => {
-    const connection = new StubConnection();
-    const grant = deferred<unknown>();
-    connection.responses.push(grant.promise);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-
-    const lease = session.lease(input);
-    await waitFor(() => connection.requests.length === 1);
-    expect(() => connection.pushProgress({ queuePosition: 3, stage: "queued" })).not.toThrow();
-
-    grant.resolve(rawGrant);
-    await lease;
-  });
-
-  it("stops relaying progress once the lease request has settled", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-
-    const progressEvents: unknown[] = [];
-    await session.lease(input, undefined, (progress) => progressEvents.push(progress));
-    connection.pushProgress({ etaMs: 5_000, stage: "booting" });
-
-    expect(progressEvents).toEqual([]);
-  });
-
-  it("scopes the progress listener to one request: no leakage across sequential lease calls", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant, { leaseId: "lse_9f2c" });
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-
-    const firstProgress: unknown[] = [];
-    await session.lease(input, undefined, (progress) => firstProgress.push(progress));
-    await session.release({ lease_id: "lse_9f2c" });
-
-    const secondGrant = deferred<unknown>();
-    connection.responses.push(secondGrant.promise);
-    const secondProgress: unknown[] = [];
-    const secondLease = session.lease(input, undefined, (progress) =>
-      secondProgress.push(progress),
-    );
-    await waitFor(() => connection.requests.length === 3);
-
-    connection.pushProgress({ etaMs: 1_000, stage: "booting" });
-
-    expect(firstProgress).toEqual([]);
-    expect(secondProgress).toEqual([{ etaMs: 1_000, stage: "booting" }]);
-
-    secondGrant.resolve({ ...rawGrant, lease: { ...rawGrant.lease, id: "lse_second" } });
-    await secondLease;
-  });
-
-  it("stops relaying progress once a cancelled lease request tears down", async () => {
-    const connection = new StubConnection();
-    const grant = deferred<unknown>();
-    connection.responses.push(grant.promise);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    const controller = new AbortController();
-    const progressEvents: unknown[] = [];
-    const lease = session.lease(input, controller.signal, (progress) =>
-      progressEvents.push(progress),
-    );
-    await waitFor(() => connection.requests.length === 1);
-
-    controller.abort();
-    await expect(lease).rejects.toMatchObject({ code: "CANCELLED" });
-    connection.pushProgress({ etaMs: 1_000, stage: "booting" });
-
-    expect(progressEvents).toEqual([]);
-    grant.resolve(rawGrant);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  });
-
-  it("stops relaying progress once the session closes", async () => {
-    const connection = new StubConnection();
-    const grant = deferred<unknown>();
-    connection.responses.push(grant.promise);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-
-    const progressEvents: unknown[] = [];
-    const lease = session.lease(input, undefined, (progress) => progressEvents.push(progress));
-    await waitFor(() => connection.requests.length === 1);
-
-    await session.close();
-    connection.pushProgress({ queuePosition: 1, stage: "queued" });
-
-    expect(progressEvents).toEqual([]);
-    await expect(lease).rejects.toMatchObject({ code: "SESSION_CLOSED" });
-    grant.resolve(rawGrant);
-  });
-
-  it("ignores malformed progress pushes without throwing", async () => {
-    const connection = new StubConnection();
-    const grant = deferred<unknown>();
-    connection.responses.push(grant.promise);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-
-    const progressEvents: unknown[] = [];
-    const lease = session.lease(input, undefined, (progress) => progressEvents.push(progress));
-    await waitFor(() => connection.requests.length === 1);
-
-    expect(() => connection.pushProgress({ stage: "not-a-stage" })).not.toThrow();
-    expect(() => connection.pushProgress({ stage: "queued" })).not.toThrow();
-    expect(() => connection.pushProgress({ stage: "provisioning" })).not.toThrow();
-    expect(() => connection.pushProgress(null)).not.toThrow();
-
-    expect(progressEvents).toEqual([]);
-    grant.resolve(rawGrant);
-    await lease;
-  });
-
-  it("reconnects lazily after a daemon restart between two calls", async () => {
-    const connectionA = new StubConnection();
-    connectionA.responses.push({ platforms: [] });
-    const connectionB = new StubConnection();
-    connectionB.responses.push({ platforms: [] });
-    const connections = [connectionA, connectionB];
-    let connectCalls = 0;
-    const session = new McpSession({
-      connect: async () => {
-        connectCalls += 1;
-        return connections.shift()!;
-      },
-      requesterId: "mcp-session-1",
-    });
-
-    await expect(session.listDevices({})).resolves.toEqual({ platforms: [] });
-    expect(connectCalls).toBe(1);
-
-    // The daemon restarts: the socket underneath the cached connection dies.
-    connectionA.emitClose();
-
-    await expect(session.listDevices({})).resolves.toEqual({ platforms: [] });
-    expect(connectCalls).toBe(2);
-    expect(connectionA.requests).toEqual([{ payload: {}, type: "catalog.get" }]);
-    expect(connectionB.requests).toEqual([{ payload: {}, type: "catalog.get" }]);
-  });
-
-  it("surfaces DAEMON_CONNECTION_LOST, without retrying, when the connection dies mid lease request", async () => {
-    const connection = new StubConnection();
-    const grant = deferred<unknown>();
-    connection.responses.push(grant.promise);
-    let connectCalls = 0;
-    const session = new McpSession({
-      connect: async () => {
-        connectCalls += 1;
-        return connection;
-      },
-      requesterId: "mcp-session-1",
-    });
-
-    const lease = session.lease(input);
-    await waitFor(() => connection.requests.length === 1);
-
-    // The socket dies while the daemon is still deciding on the lease request.
-    connection.emitClose();
-    grant.reject(new DaemonClientError("DAEMON_CONNECTION_LOST", "Daemon connection closed"));
-
-    await expect(lease).rejects.toMatchObject({ code: "DAEMON_CONNECTION_LOST" });
-    // A retry here could provision and grant a second device -- must never happen.
-    expect(connectCalls).toBe(1);
-    expect(connection.requests).toHaveLength(1);
-    expect(session.status()).toEqual({ held: false });
-  });
-
-  it("retries a read-only catalog.get once after the connection dies mid-request", async () => {
-    const connection = new StubConnection();
-    const firstResponse = deferred<unknown>();
-    connection.responses.push(firstResponse.promise);
-    connection.responses.push({ platforms: [] });
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-
-    const listing = session.listDevices({});
-    await waitFor(() => connection.requests.length === 1);
-    connection.emitClose();
-    firstResponse.reject(
-      new DaemonClientError("DAEMON_CONNECTION_LOST", "Daemon connection closed"),
-    );
-
-    await expect(listing).resolves.toEqual({ platforms: [] });
-    expect(connection.requests).toEqual([
-      { payload: {}, type: "catalog.get" },
-      { payload: {}, type: "catalog.get" },
-    ]);
-  });
-
-  it("forces a fresh connection on retry when DAEMON_CONNECTION_LOST arrives without #connection having been cleared yet", async () => {
-    // This pins the ordering IpcDaemonConnection.request() also rejects synchronously once it
-    // observes the transport already closed, which can race ahead of the underlying `onClose`
-    // propagating back to `#handleConnectionClosed`. `connectionA` here rejects the same way but
-    // deliberately never calls `emitClose()`, so `#connection` is still set to it when the retry
-    // runs -- the retry must not just hand back the same dead connection.
-    const connectionA = new StubConnection();
-    connectionA.responses.push(
-      new DaemonClientError("DAEMON_CONNECTION_LOST", "Daemon connection is closed"),
-    );
-    const connectionB = new StubConnection();
-    connectionB.responses.push({ platforms: [] });
-    const connections = [connectionA, connectionB];
-    let connectCalls = 0;
-    const session = new McpSession({
-      connect: async () => {
-        connectCalls += 1;
-        return connections.shift()!;
-      },
-      requesterId: "mcp-session-1",
-    });
-
-    await expect(session.listDevices({})).resolves.toEqual({ platforms: [] });
-    expect(connectCalls).toBe(2);
-    expect(connectionA.requests).toEqual([{ payload: {}, type: "catalog.get" }]);
-    expect(connectionB.requests).toEqual([{ payload: {}, type: "catalog.get" }]);
-  });
-
-  it("clears an owned lease and notifies onLeaseLost when the connection dies across a restart", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-    expect(session.status()).toMatchObject({ held: true, lease_id: "lse_9f2c" });
-
-    const notices: unknown[] = [];
-    session.onLeaseLost((notice) => notices.push(notice));
-
-    // A graceful stop or an ungraceful crash both release the held lease daemon-side (see
-    // DaemonServer#stop / the startup path's orphan sweep) -- the reconnect never asks.
-    connection.emitClose();
-
-    expect(notices).toEqual([
-      { deviceId: "ABCD", leaseId: "lse_9f2c", reason: "daemon-connection-lost" },
-    ]);
-    expect(session.status()).toEqual({ held: false });
-  });
-
-  it("keeps an onDeviceHealth listener registered across a reconnect after the connection dies", async () => {
-    const connectionA = new StubConnection();
-    connectionA.responses.push(rawGrant);
-    const connectionB = new StubConnection();
-    const connections = [connectionA, connectionB];
-    const session = new McpSession({
-      connect: async () => connections.shift()!,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-
-    const notices: unknown[] = [];
-    session.onDeviceHealth((notice) => notices.push(notice));
-
-    // The connection dies (daemon restart); `#handleConnectionClosed` drops the push
-    // subscription along with the owned lease, so a stale push on the dead connection
-    // must not reach the listener.
-    connectionA.emitClose();
-    connectionA.pushDeviceUnhealthy({ deviceId: "ABCD", leaseId: "lse_9f2c", reason: "crashed" });
-    expect(notices).toEqual([]);
-
-    // A fresh lease through the lazily-reconnected session (connectionB) is owned
-    // again, and the *same* onDeviceHealth listener -- never re-registered by this
-    // test -- still fires for it: registration survives the reconnect without leaking.
-    connectionB.responses.push({
-      ...rawGrant,
-      lease: { ...rawGrant.lease, id: "lse_after_reconnect" },
-    });
-    await session.lease(input);
-    connectionB.pushDeviceUnhealthy({
-      deviceId: "ABCD",
-      leaseId: "lse_after_reconnect",
-      reason: "crashed",
-    });
-
-    expect(notices).toEqual([
-      { deviceId: "ABCD", kind: "unhealthy", leaseId: "lse_after_reconnect", reason: "crashed" },
-    ]);
-  });
-
-  it("surfaces DAEMON_UNAVAILABLE when reconnecting after a restart fails", async () => {
-    const connection = new StubConnection();
-    connection.responses.push({ platforms: [] });
-    let connectCalls = 0;
-    const session = new McpSession({
-      connect: async () => {
-        connectCalls += 1;
-        if (connectCalls === 1) return connection;
-        throw new Error("ECONNREFUSED");
-      },
-      requesterId: "mcp-session-1",
-    });
-
-    await expect(session.listDevices({})).resolves.toEqual({ platforms: [] });
-    connection.emitClose();
-
-    await expect(session.listDevices({})).rejects.toMatchObject({
-      code: "DAEMON_UNAVAILABLE",
-    });
-    expect(connectCalls).toBe(2);
-  });
 });
-
-class StubConnection implements DaemonConnection {
-  readonly requests: Array<{ readonly payload: unknown; readonly type: string }> = [];
-  readonly responses: unknown[] = [];
-  closeCalls = 0;
-  #closed = false;
-  readonly #listeners = new Set<(kind: string, payload: unknown) => void>();
-  readonly #closeListeners = new Set<() => void>();
-
-  async request(type: string, payload: unknown): Promise<unknown> {
-    this.requests.push({ payload, type });
-    const response = this.responses.shift();
-    if (response instanceof Error) throw response;
-    return response instanceof Promise ? response : response;
-  }
-
-  onPush(listener: (kind: string, payload: unknown) => void): () => void {
-    this.#listeners.add(listener);
-    return () => this.#listeners.delete(listener);
-  }
-
-  onClose(listener: () => void): () => void {
-    this.#closeListeners.add(listener);
-    return () => this.#closeListeners.delete(listener);
-  }
-
-  /** Simulates the socket dying under this connection (daemon restart/crash). */
-  emitClose(): void {
-    if (this.#closed) return;
-    this.#closed = true;
-    for (const listener of this.#closeListeners) listener();
-  }
-
-  pushLeaseLost(payload: {
-    readonly deviceId: string;
-    readonly leaseId: string;
-    readonly reason: string;
-  }): void {
-    for (const listener of this.#listeners) listener("lease-lost", payload);
-  }
-
-  pushDeviceUnhealthy(payload: unknown): void {
-    for (const listener of this.#listeners) listener("device-unhealthy", payload);
-  }
-
-  pushDeviceRecovered(payload: unknown): void {
-    for (const listener of this.#listeners) listener("device-recovered", payload);
-  }
-
-  /**
-   * Wraps the given stage payload under `{requestId, progress}` -- ADR 0003 §8's push
-   * correlation shape (see `DaemonServer#pushProgress`) -- so callers can keep passing the bare
-   * stage object `parseRawLeaseProgress` ultimately unwraps this back to.
-   */
-  pushProgress(payload: unknown): void {
-    for (const listener of this.#listeners)
-      listener("progress", { progress: payload, requestId: "test-request" });
-  }
-
-  /**
-   * Simulates the ack `IpcDaemonConnection` re-surfaces as a push after it auto-answers the
-   * server's `lease.heartbeat` push (see `src/daemon-client/connection.ts`).
-   */
-  pushHeartbeatAck(payload: unknown): void {
-    for (const listener of this.#listeners) listener("lease.heartbeat", payload);
-  }
-
-  async close(): Promise<void> {
-    this.closeCalls += 1;
-  }
-}
-
-function deferred<T>(): {
-  promise: Promise<T>;
-  reject: (error: unknown) => void;
-  resolve: (value: T) => void;
-} {
-  let resolve!: (value: T) => void;
-  let reject!: (error: unknown) => void;
-  const promise = new Promise<T>((nextResolve, nextReject) => {
-    resolve = nextResolve;
-    reject = nextReject;
-  });
-  promise.catch(() => undefined);
-  return { promise, reject, resolve };
-}
-
-async function waitFor(predicate: () => boolean): Promise<void> {
-  while (!predicate()) await new Promise((resolve) => setTimeout(resolve, 0));
-}

--- a/src/mcp/session.ts
+++ b/src/mcp/session.ts
@@ -1,35 +1,28 @@
 import {
-  parseRawCatalog,
-  parseRawDeviceRecovered,
-  parseRawDeviceUnhealthy,
-  parseRawLeaseGrant,
-  parseRawLeaseHeartbeatAck,
-  parseRawLeaseLost,
-  parseRawLeaseProgress,
-  type RawLeaseGrant,
-  type RawLeaseProgress,
-} from "../daemon-client/contracts.js";
-import { DaemonClientError, type DaemonConnection } from "../daemon-client/protocol.js";
+  isSimlockError,
+  SimlockError,
+  type LeaseProgress,
+  type LeaseRequestInput,
+  type SimlockClient,
+} from "../client/index.js";
 import type {
-  HeldLeaseStatus,
   LeaseSimulatorInput,
   LeaseSimulatorOutput,
   LeaseStatusOutput,
   ListDevicesInput,
   ListDevicesOutput,
-  NoLeaseStatus,
   ReleaseSimulatorInput,
   ReleaseSimulatorOutput,
 } from "./contracts.js";
-import {
-  leaseSimulatorOutputSchema,
-  listDevicesOutputSchema,
-  MAX_TIMEOUT_SECONDS,
-} from "./contracts.js";
 
 export interface McpSessionOptions {
-  readonly connect: () => Promise<DaemonConnection>;
-  readonly requesterId: string;
+  /**
+   * Opens one connection and completes the `hello` handshake, fixing this session's principal
+   * for the connection's lifetime (ADR §4). Called again -- building a brand new client, never
+   * reusing or repairing the dead one -- on lazy reconnect: the typed client "does not
+   * reconnect and does not retry" (ADR §10), so that policy has to live here.
+   */
+  readonly connect: () => Promise<SimlockClient>;
 }
 
 export interface McpErrorResult {
@@ -64,22 +57,7 @@ export type DeviceHealthNotice =
     };
 
 /** Delivered to a `lease()` call's own `onProgress` callback while that request is in flight. */
-export type LeaseProgressNotice = RawLeaseProgress;
-
-interface OwnedLease {
-  readonly device: string;
-  readonly deviceId: string;
-  readonly expiresAtMs: number;
-  readonly leaseId: string;
-  readonly os: string;
-  readonly platform: "android" | "ios";
-}
-
-interface LeaseAbortWatch {
-  readonly cancelled: Promise<never>;
-  cleanup(): Promise<void> | undefined;
-  dispose(): void;
-}
+export type LeaseProgressNotice = LeaseProgress;
 
 class McpSessionError extends Error {
   constructor(
@@ -92,100 +70,84 @@ class McpSessionError extends Error {
 }
 
 export function toMcpErrorResult(error: unknown): McpErrorResult {
-  if (error instanceof DaemonClientError || error instanceof McpSessionError) {
-    return { code: error.code, message: error.message };
-  }
+  if (isSimlockError(error)) return { code: error.code, message: error.message };
+  if (error instanceof McpSessionError) return { code: error.code, message: error.message };
   return { code: "INTERNAL", message: "Simlock could not complete the request" };
 }
 
+/**
+ * MCP's own connection lifecycle and tool surface (ADR §11: "MCP keeps only connection
+ * lifecycle (lazy reconnect, tool-call serialization) and its MCP-only relays"). Everything
+ * that used to be hand-built payload construction, response parsing, and a session-local
+ * owned-lease cache is gone -- `#client` (a `SimlockClient`, ADR §10) does all of that now.
+ * `lease_status` is one `lease.list` call, not a cache read (ADR §9); releasing a lease this
+ * session does not own surfaces the daemon's own `FORBIDDEN` rather than a client-side guard
+ * pre-empting it (ADR §11).
+ */
 export class McpSession {
-  readonly #connect: () => Promise<DaemonConnection>;
-  readonly #requesterId: string;
-  #connection: DaemonConnection | undefined;
-  #connecting: Promise<DaemonConnection> | undefined;
+  readonly #connect: () => Promise<SimlockClient>;
+  #client: SimlockClient | undefined;
+  #connecting: Promise<SimlockClient> | undefined;
   #closed = false;
-  #closedConnections = new Set<DaemonConnection>();
+  readonly #closedClients = new Set<SimlockClient>();
   #closePromise: Promise<void> | undefined;
-  #rejectClosed!: (reason: McpSessionError) => void;
-  #sessionClosed: Promise<never>;
-  #ownedLease: OwnedLease | undefined;
-  #pushUnsubscribe: (() => void) | undefined;
-  #closeUnsubscribe: (() => void) | undefined;
-  /** Scoped to the in-flight `lease()` call; cleared once that call settles or the session closes. */
-  #leaseProgressListener: ((progress: LeaseProgressNotice) => void) | undefined;
+  #clientUnsubscribers: Array<() => void> = [];
   readonly #leaseLostListeners = new Set<(notice: LeaseLostNotice) => void>();
   readonly #deviceHealthListeners = new Set<(notice: DeviceHealthNotice) => void>();
+  /** Serializes every mutating (and `listDevices`/`status`, for simplicity) tool call on this
+   * session so concurrent `lease_simulator`/`release_simulator` calls never interleave. */
   #mutations: Promise<void> = Promise.resolve();
 
   constructor(options: McpSessionOptions) {
     this.#connect = options.connect;
-    this.#requesterId = options.requesterId;
-    this.#sessionClosed = new Promise<never>((_resolve, reject) => {
-      this.#rejectClosed = reject;
-    });
-    void this.#sessionClosed.catch(() => undefined);
   }
 
-  /**
-   * `onProgress` is scoped to this call only: it receives queue/provisioning/boot updates for
-   * this request while it is in flight, and is torn down on completion, error, cancellation, or
-   * session close. It never leaks across sequential lease requests.
-   */
   lease(
     input: LeaseSimulatorInput,
     signal?: AbortSignal,
     onProgress?: (progress: LeaseProgressNotice) => void,
   ): Promise<LeaseSimulatorOutput> {
-    return this.#mutate(() => {
+    return this.#mutate(async () => {
       this.#throwIfClosed();
-      return this.#lease(input, signal, onProgress);
+      const client = await this.#clientForUse();
+      const request: LeaseRequestInput = { ...input, mode: "held" };
+      return client.requestLease(request, {
+        ...(onProgress === undefined ? {} : { onProgress }),
+        ...(signal === undefined ? {} : { signal }),
+      });
     });
   }
 
   release(input: ReleaseSimulatorInput): Promise<ReleaseSimulatorOutput> {
     return this.#mutate(async () => {
       this.#throwIfClosed();
-      if (this.#ownedLease?.leaseId !== input.lease_id) {
-        throw new McpSessionError("LEASE_NOT_OWNED", "This session does not own that lease");
-      }
-      const connection = await this.#connectionForUse();
-      try {
-        await Promise.race([
-          connection.request("lease.release", { leaseId: input.lease_id }),
-          this.#sessionClosed,
-        ]);
-      } catch (error: unknown) {
-        if (isNoLongerActiveLease(error)) this.#ownedLease = undefined;
-        throw error;
-      }
-      this.#ownedLease = undefined;
-      return { lease_id: input.lease_id, released: true };
+      const client = await this.#clientForUse();
+      const result = await client.releaseLease(input);
+      return { ...result, released: true };
     });
   }
 
   listDevices(input: ListDevicesInput): Promise<ListDevicesOutput> {
     return this.#mutate(async () => {
       this.#throwIfClosed();
-      const response = await this.#requestReadOnly(
-        "catalog.get",
-        input.platform === undefined ? {} : { platform: input.platform },
-      );
-      const catalog = parseRawCatalog(response);
-      return listDevicesOutputSchema.parse({
-        platforms: catalog.platforms.map((entry) => ({
-          default_runtime: entry.defaultRuntime,
-          models: entry.models,
-          platform: entry.platform,
-          runtimes: entry.runtimes,
-        })),
-      });
+      const client = await this.#clientForUse();
+      return client.getCatalog(input);
     });
   }
 
-  /** This session's current lease, or an explicit "no lease held" result. Cheap, local, and safe to poll. */
-  status(): LeaseStatusOutput {
-    this.#throwIfClosed();
-    return this.#ownedLease === undefined ? noLeaseStatus() : heldLeaseStatus(this.#ownedLease);
+  /**
+   * This session's current lease, or an explicit "no lease held" result -- one `lease.list`
+   * call (ADR §9), never a local cache. This session only ever requests `mode: "held"` leases
+   * under one requester id (its fixed principal), so `leases` holds at most one entry.
+   */
+  status(): Promise<LeaseStatusOutput> {
+    return this.#mutate(async () => {
+      this.#throwIfClosed();
+      const client = await this.#clientForUse();
+      const { leases } = await client.listLeases();
+      const lease = leases[0];
+      return lease === undefined ? { held: false } : { ...lease, held: true };
+    });
   }
 
   /** Notifies when this session's held lease ends elsewhere (expiry or a force-release). */
@@ -206,334 +168,103 @@ export class McpSession {
   close(): Promise<void> {
     if (this.#closePromise !== undefined) return this.#closePromise;
     this.#closed = true;
-    this.#ownedLease = undefined;
-    this.#leaseProgressListener = undefined;
-    this.#pushUnsubscribe?.();
-    this.#pushUnsubscribe = undefined;
-    this.#closeUnsubscribe?.();
-    this.#closeUnsubscribe = undefined;
-    this.#rejectClosed(new McpSessionError("SESSION_CLOSED", "MCP session is closed"));
-    const connection = this.#connection;
-    this.#connection = undefined;
+    this.#unwireClient();
+    const client = this.#client;
+    this.#client = undefined;
     if (this.#connecting !== undefined) {
-      void this.#connecting
-        .then((nextConnection) => this.#closeDaemonConnection(nextConnection))
-        .catch(noop);
+      void this.#connecting.then((next) => this.#closeClient(next)).catch(noop);
     }
-    this.#closePromise =
-      connection === undefined ? Promise.resolve() : this.#closeDaemonConnection(connection);
+    this.#closePromise = client === undefined ? Promise.resolve() : this.#closeClient(client);
     return this.#closePromise;
   }
 
-  async #lease(
-    input: LeaseSimulatorInput,
-    signal?: AbortSignal,
-    onProgress?: (progress: LeaseProgressNotice) => void,
-  ): Promise<LeaseSimulatorOutput> {
-    throwIfAborted(signal);
-
-    const abortWatch = this.#watchLeaseAbort(signal);
-    this.#leaseProgressListener = onProgress;
-    let responseReceived = false;
-    try {
-      const connection = await this.#connectionForUse();
-      await this.#throwIfCancelledBeforeRequest(signal);
-      const response = await this.#requestLease(connection, input, abortWatch.cancelled);
-      responseReceived = true;
-      return await this.#mapLeaseResponse(connection, response, signal, abortWatch);
-    } catch (error: unknown) {
-      await this.#cleanupFailedLease(responseReceived, abortWatch.cleanup());
-      throw error;
-    } finally {
-      this.#leaseProgressListener = undefined;
-      abortWatch.dispose();
-    }
-  }
-
-  #watchLeaseAbort(signal: AbortSignal | undefined): LeaseAbortWatch {
-    let cleanup: Promise<void> | undefined;
-    let reject: ((reason: McpSessionError) => void) | undefined;
-    const cancelled = new Promise<never>((_resolve, nextReject) => {
-      reject = nextReject;
-    });
-    void cancelled.catch(() => undefined);
-    const abort = () => {
-      cleanup ??= this.#closeConnection().catch(() => undefined);
-      reject?.(new McpSessionError("CANCELLED", "Lease request cancelled"));
-    };
-    signal?.addEventListener("abort", abort, { once: true });
-    return {
-      cancelled,
-      cleanup: () => cleanup,
-      dispose: () => signal?.removeEventListener("abort", abort),
-    };
-  }
-
-  async #throwIfCancelledBeforeRequest(signal: AbortSignal | undefined): Promise<void> {
-    if (!signal?.aborted) return;
-    await this.#closeConnection().catch(() => undefined);
-    throw new McpSessionError("CANCELLED", "Lease request cancelled");
-  }
-
-  #requestLease(
-    connection: DaemonConnection,
-    input: LeaseSimulatorInput,
-    cancelled: Promise<never>,
-  ): Promise<unknown> {
-    return Promise.race([
-      connection.request("lease.request", daemonLeaseRequest(input, this.#requesterId)),
-      cancelled,
-      this.#sessionClosed,
-    ]);
-  }
-
-  async #mapLeaseResponse(
-    connection: DaemonConnection,
-    response: unknown,
-    signal: AbortSignal | undefined,
-    abortWatch: LeaseAbortWatch,
-  ): Promise<LeaseSimulatorOutput> {
-    const grant = parseRawLeaseGrant(response);
-    this.#throwIfClosed();
-    if (signal?.aborted) {
-      await abortWatch.cleanup();
-      throw new McpSessionError("CANCELLED", "Lease request cancelled");
-    }
-    if (grant.lease.mode !== "held") {
-      await this.#releaseUnexpectedLease(connection, grant.lease.id);
-      throw new McpSessionError("INVALID_LEASE_GRANT", "Daemon returned a non-held lease grant");
-    }
-    const output = leaseSimulatorOutputSchema.parse(leaseSimulatorOutput(grant));
-    this.#ownedLease = {
-      device: output.device,
-      deviceId: output.device_id,
-      expiresAtMs: output.expires_at_ms,
-      leaseId: output.lease_id,
-      os: output.os,
-      platform: output.platform,
-    };
-    return output;
-  }
-
-  async #releaseUnexpectedLease(connection: DaemonConnection, leaseId: string): Promise<void> {
-    try {
-      await connection.request("lease.release", { leaseId });
-    } catch {
-      // The connection close below remains the daemon-side held-lease cleanup fallback.
-    } finally {
-      await this.#closeConnection().catch(() => undefined);
-    }
-  }
-
-  async #cleanupFailedLease(
-    responseReceived: boolean,
-    abortCleanup: Promise<void> | undefined,
-  ): Promise<void> {
-    if (abortCleanup !== undefined) await abortCleanup;
-    else if (responseReceived) await this.#closeConnection().catch(() => undefined);
-  }
-
   /**
-   * Reconnects lazily: a dead `#connection` (cleared by `#handleConnectionClosed`, below) makes
-   * the next call re-run `#connect()`, which auto-starts the daemon exactly as the CLI does and
-   * re-negotiates capabilities (e.g. the heartbeat) at `hello`, free of charge.
+   * Reconnects lazily: a dead `#client` (cleared by the client's own `onConnectionLost`, below)
+   * makes the next call re-run `#connect()`, building a brand new `SimlockClient` -- the typed
+   * client itself never reconnects (ADR §10), so constructing a fresh one here on every dead
+   * connection is what keeps MCP's process-outlives-a-connection lifecycle working.
    */
-  async #connectionForUse(): Promise<DaemonConnection> {
-    if (this.#connection !== undefined) return this.#connection;
+  async #clientForUse(): Promise<SimlockClient> {
+    if (this.#client !== undefined) return this.#client;
     this.#connecting ??= this.#connect();
     const connecting = this.#connecting;
     try {
-      const connection = await connecting;
+      const client = await connecting;
       if (this.#closed) {
-        await this.#closeDaemonConnection(connection);
+        await this.#closeClient(client);
         this.#throwIfClosed();
       }
-      this.#connection = connection;
-      this.#pushUnsubscribe = connection.onPush((kind, payload) => this.#handlePush(kind, payload));
-      this.#closeUnsubscribe = connection.onClose(() => this.#handleConnectionClosed(connection));
-      return connection;
+      this.#client = client;
+      this.#wireClient(client);
+      return client;
     } catch (error: unknown) {
       this.#throwIfClosed();
-      if (error instanceof DaemonClientError || error instanceof McpSessionError) throw error;
-      throw new DaemonClientError("DAEMON_UNAVAILABLE", errorMessage(error));
+      // `#connect` is expected to reject with a `SimlockError` (the real implementation always
+      // does -- see `main.ts`'s `connectWithAutoLaunch`), but this is a defensive fallback for
+      // any other injected `connect` so a caller never sees a bare, un-coded exception.
+      throw isSimlockError(error)
+        ? error
+        : new SimlockError(
+            "DAEMON_CONNECTION_LOST",
+            "transport",
+            error instanceof Error ? error.message : String(error),
+            {},
+          );
     } finally {
       if (this.#connecting === connecting) this.#connecting = undefined;
     }
   }
 
-  async #closeConnection(): Promise<void> {
-    const connection = this.#connection;
-    this.#connection = undefined;
-    this.#pushUnsubscribe?.();
-    this.#pushUnsubscribe = undefined;
-    this.#closeUnsubscribe?.();
-    this.#closeUnsubscribe = undefined;
-    if (connection !== undefined) await this.#closeDaemonConnection(connection);
-  }
-
   /**
-   * The invariant this relies on: a dead connection means the held lease is already gone
-   * daemon-side, by one of three paths — a graceful `daemon stop` releases held leases before
-   * exiting, an ordinary connection close releases that connection's held leases the same way,
-   * and an ungraceful death leaves the lease persisted for the startup path to release as
-   * `orphaned`. So this never asks the daemon; it just stops believing the lease is ours and
-   * tells the agent (#15's `onLeaseLost` channel) so it can decide whether to re-lease.
+   * Relays a freshly-connected client's pushes to this session's own listeners (which survive
+   * across a reconnect, unlike the client itself), and drops `#client` the moment this
+   * connection dies so the next call reconnects. The client already synthesizes `onLeaseLost`
+   * for every lease it held when its connection dies (ADR §10), so nothing extra is needed
+   * here for that case.
    */
-  #handleConnectionClosed(connection: DaemonConnection): void {
-    if (this.#connection !== connection) return;
-    this.#connection = undefined;
-    this.#pushUnsubscribe?.();
-    this.#pushUnsubscribe = undefined;
-    this.#closeUnsubscribe = undefined;
-    if (this.#ownedLease === undefined) return;
-    const lease = this.#ownedLease;
-    this.#ownedLease = undefined;
-    for (const listener of this.#leaseLostListeners) {
-      listener({
-        deviceId: lease.deviceId,
-        leaseId: lease.leaseId,
-        reason: "daemon-connection-lost",
-      });
-    }
+  #wireClient(client: SimlockClient): void {
+    this.#clientUnsubscribers = [
+      client.onLeaseLost((push) => {
+        for (const listener of this.#leaseLostListeners) listener(push);
+      }),
+      client.onDeviceUnhealthy((push) => {
+        for (const listener of this.#deviceHealthListeners) {
+          listener({
+            deviceId: push.deviceId,
+            kind: "unhealthy",
+            leaseId: push.leaseId,
+            reason: "crashed",
+          });
+        }
+      }),
+      client.onDeviceRecovered((push) => {
+        for (const listener of this.#deviceHealthListeners) {
+          listener({
+            attempts: push.attempts,
+            deviceId: push.deviceId,
+            kind: "recovered",
+            leaseId: push.leaseId,
+          });
+        }
+      }),
+      client.onConnectionLost(() => {
+        if (this.#client === client) {
+          this.#client = undefined;
+          this.#unwireClient();
+        }
+      }),
+    ];
   }
 
-  /**
-   * Retries at most once, and only for idempotent, read-only requests. A `lease.request` must
-   * never go through here: retrying it after a mid-request connection death could provision and
-   * grant a *second* device, which would violate "reconnecting never implicitly acquires one".
-   */
-  async #requestReadOnly(type: string, payload: unknown): Promise<unknown> {
-    const connection = await this.#connectionForUse();
-    try {
-      return await Promise.race([connection.request(type, payload), this.#sessionClosed]);
-    } catch (error: unknown) {
-      if (!(error instanceof DaemonClientError) || error.code !== "DAEMON_CONNECTION_LOST") {
-        throw error;
-      }
-      // The close listener may not have run yet -- `IpcDaemonConnection.request()` also
-      // rejects synchronously once it observes the transport already closed, ahead of the
-      // underlying `onClose` propagating back to `#handleConnectionClosed`. Don't trust that
-      // ordering: if this is still the connection that just failed, drop it explicitly so
-      // `#connectionForUse()` is forced to build a fresh one instead of handing back the same
-      // dead connection.
-      if (this.#connection === connection) await this.#closeConnection().catch(() => undefined);
-      const retryConnection = await this.#connectionForUse();
-      return await Promise.race([retryConnection.request(type, payload), this.#sessionClosed]);
-    }
+  #unwireClient(): void {
+    for (const unsubscribe of this.#clientUnsubscribers) unsubscribe();
+    this.#clientUnsubscribers = [];
   }
 
-  /**
-   * Relays a daemon push to this session's own listeners (lease-lost facts, in-flight lease
-   * progress, and the heartbeat ack that keeps `#ownedLease.expiresAtMs` truthful under the
-   * sliding TTL — see `IpcDaemonConnection`, which turns the server's `lease.heartbeat` push
-   * into an answered request and re-surfaces its ack here under the same push kind).
-   */
-  #handlePush(kind: string, payload: unknown): void {
-    switch (kind) {
-      case "progress":
-        this.#handleLeaseProgress(payload);
-        return;
-      case "lease.heartbeat":
-        this.#handleHeartbeatAck(payload);
-        return;
-      case "lease-lost":
-        this.#handleLeaseLost(payload);
-        return;
-      case "device-unhealthy":
-        this.#handleDeviceUnhealthy(payload);
-        return;
-      case "device-recovered":
-        this.#handleDeviceRecovered(payload);
-        return;
-    }
-  }
-
-  /** Relays a lease-lost push to `#leaseLostListeners`, if it names this session's own lease. */
-  #handleLeaseLost(payload: unknown): void {
-    let notice: LeaseLostNotice;
-    try {
-      notice = parseRawLeaseLost(payload);
-    } catch {
-      return;
-    }
-    if (this.#ownedLease === undefined || this.#ownedLease.leaseId !== notice.leaseId) return;
-    this.#ownedLease = undefined;
-    for (const listener of this.#leaseLostListeners) listener(notice);
-  }
-
-  /** Relays a device-unhealthy push to `#deviceHealthListeners`, if it names this session's lease. */
-  #handleDeviceUnhealthy(payload: unknown): void {
-    let raw: ReturnType<typeof parseRawDeviceUnhealthy>;
-    try {
-      raw = parseRawDeviceUnhealthy(payload);
-    } catch {
-      return;
-    }
-    if (this.#ownedLease === undefined || this.#ownedLease.leaseId !== raw.leaseId) return;
-    for (const listener of this.#deviceHealthListeners) {
-      listener({
-        deviceId: raw.deviceId,
-        kind: "unhealthy",
-        leaseId: raw.leaseId,
-        reason: "crashed",
-      });
-    }
-  }
-
-  /** Relays a device-recovered push to `#deviceHealthListeners`, if it names this session's lease. */
-  #handleDeviceRecovered(payload: unknown): void {
-    let raw: ReturnType<typeof parseRawDeviceRecovered>;
-    try {
-      raw = parseRawDeviceRecovered(payload);
-    } catch {
-      return;
-    }
-    if (this.#ownedLease === undefined || this.#ownedLease.leaseId !== raw.leaseId) return;
-    for (const listener of this.#deviceHealthListeners) {
-      listener({
-        attempts: raw.attempts,
-        deviceId: raw.deviceId,
-        kind: "recovered",
-        leaseId: raw.leaseId,
-      });
-    }
-  }
-
-  /**
-   * `lease_status` reads `#ownedLease.expiresAtMs` locally, with no daemon round-trip
-   * (deliberate — see PR #25). Under a sliding TTL that cache would otherwise go stale the
-   * moment a heartbeat renews the lease elsewhere; this keeps it truthful without adding a
-   * round-trip to `status()` itself.
-   */
-  #handleHeartbeatAck(payload: unknown): void {
-    if (this.#ownedLease === undefined) return;
-    let ack: ReturnType<typeof parseRawLeaseHeartbeatAck>;
-    try {
-      ack = parseRawLeaseHeartbeatAck(payload);
-    } catch {
-      return;
-    }
-    const slid = ack.leases.find((lease) => lease.leaseId === this.#ownedLease?.leaseId);
-    if (slid === undefined) return;
-    this.#ownedLease = { ...this.#ownedLease, expiresAtMs: slid.ttlDeadline };
-  }
-
-  /** Relays a daemon progress push to the in-flight `lease()` call's own `onProgress`, if any. */
-  #handleLeaseProgress(payload: unknown): void {
-    if (this.#leaseProgressListener === undefined) return;
-    let progress: LeaseProgressNotice;
-    try {
-      progress = parseRawLeaseProgress(payload);
-    } catch {
-      return;
-    }
-    this.#leaseProgressListener(progress);
-  }
-
-  async #closeDaemonConnection(connection: DaemonConnection): Promise<void> {
-    if (this.#closedConnections.has(connection)) return;
-    this.#closedConnections.add(connection);
-    await connection.close();
+  async #closeClient(client: SimlockClient): Promise<void> {
+    if (this.#closedClients.has(client)) return;
+    this.#closedClients.add(client);
+    await client.close();
   }
 
   #throwIfClosed(): void {
@@ -550,97 +281,4 @@ export class McpSession {
   }
 }
 
-function isNoLongerActiveLease(error: unknown): boolean {
-  return (
-    error instanceof DaemonClientError &&
-    (error.code === "UNKNOWN_LEASE" || error.code === "LEASE_EXPIRED")
-  );
-}
-
-function throwIfAborted(signal: AbortSignal | undefined): void {
-  if (signal?.aborted) throw new McpSessionError("CANCELLED", "Lease request cancelled");
-}
-
 function noop(): void {}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
-/**
- * Flat fields, not the legacy `device`/`os` aliases or a nested `request` wrapper -- the wire
- * moved to protocol 3 with no compatibility shim (ADR 0003 "Consequences"). Deriving this from
- * the contract's `lease.request` input schema (ADR 0003 §11: "MCP tool schemas are derived from
- * the contract schemas") is PR 4's job; this is only the minimal payload-shape fix needed to
- * keep MCP working against this PR's daemon.
- */
-function daemonLeaseRequest(
-  input: LeaseSimulatorInput,
-  requesterId: string,
-): Record<string, unknown> {
-  return {
-    allowDownload: input.allow_download,
-    mode: "held",
-    noWait: input.no_wait,
-    requesterId,
-    model: input.device,
-    ...(input.os === undefined ? {} : { osVersion: input.os }),
-    platform: input.platform,
-    ...(input.full ? { full: true } : {}),
-    ...(input.timeout_seconds === undefined
-      ? {}
-      : { timeoutMs: timeoutMilliseconds(input.timeout_seconds) }),
-  };
-}
-
-function timeoutMilliseconds(timeoutSeconds: number): number {
-  if (
-    !Number.isFinite(timeoutSeconds) ||
-    timeoutSeconds < 0 ||
-    timeoutSeconds > MAX_TIMEOUT_SECONDS
-  ) {
-    throw new McpSessionError(
-      "INVALID_TIMEOUT",
-      "timeout_seconds is too large to convert safely to milliseconds",
-    );
-  }
-  return timeoutSeconds * 1_000;
-}
-
-function noLeaseStatus(): NoLeaseStatus {
-  return { held: false };
-}
-
-function heldLeaseStatus(lease: OwnedLease): HeldLeaseStatus {
-  return {
-    device: lease.device,
-    device_id: lease.deviceId,
-    expires_at_ms: lease.expiresAtMs,
-    held: true,
-    lease_id: lease.leaseId,
-    os: lease.os,
-    platform: lease.platform,
-    state: "leased",
-  };
-}
-
-function leaseSimulatorOutput(grant: RawLeaseGrant): LeaseSimulatorOutput {
-  return {
-    address: grant.device.address,
-    device: grant.device.spec.model,
-    device_id: grant.device.driverDeviceId,
-    expires_at_ms: grant.lease.ttlDeadline,
-    lease_id: grant.lease.id,
-    mode: "held",
-    os: grant.device.spec.osVersion,
-    platform: grant.device.spec.platform,
-    slim: grant.slim,
-    state: "leased",
-    timing: {
-      estimated_boot_ms: grant.timing.estimatedBootMs,
-      estimated_provision_ms: grant.timing.estimatedProvisionMs,
-      estimated_reclaim_ms: grant.timing.estimatedReclaimMs,
-      estimated_ready_ms: grant.timing.estimatedReadyMs,
-    },
-  };
-}

--- a/src/mcp/test-support.ts
+++ b/src/mcp/test-support.ts
@@ -1,0 +1,207 @@
+/**
+ * A scripted `SimlockClient` double for MCP's own unit tests. MCP no longer talks to the
+ * daemon directly (PR 4 moved it onto `simlock/client`), so its tests script the typed
+ * client's surface instead of a raw `DaemonConnection`/`IpcConnection`.
+ */
+import {
+  SimlockError,
+  type AnySimlockError,
+  type CatalogGetInput,
+  type CatalogGetOutput,
+  type DeviceRecoveredPush,
+  type DeviceUnhealthyPush,
+  type DoctorReport,
+  type DoctorRunInput,
+  type LeaseCancelInput,
+  type LeaseCancelOutput,
+  type LeaseGrant,
+  type LeaseHeartbeatOutput,
+  type LeaseListOutput,
+  type LeaseLostPush,
+  type LeaseReleaseInput,
+  type LeaseReleaseOutput,
+  type LeaseRenewInput,
+  type LeaseRecord,
+  type LeaseRequestInput,
+  type RequestLeaseOptions,
+  type SimlockClient,
+  type StatusGetOutput,
+} from "../client/index.js";
+import type { Role } from "../contract/index.js";
+
+export interface FakeSimlockClientOptions {
+  readonly daemonVersion?: string;
+  readonly principal?: string;
+  readonly role?: Role;
+}
+
+function notStubbed(method: string): () => never {
+  return () => {
+    throw new Error(`FakeSimlockClient.${method} was not stubbed for this test`);
+  };
+}
+
+/** Records every call and lets a test script each method's response and fire pushes on demand. */
+export class FakeSimlockClient implements SimlockClient {
+  readonly principal: string;
+  readonly role: Role;
+  readonly daemonVersion: string;
+  closeCalls = 0;
+  readonly calls: Array<{ readonly method: string; readonly input: unknown }> = [];
+
+  getCatalogImpl: (input: CatalogGetInput) => Promise<CatalogGetOutput> = notStubbed("getCatalog");
+  getStatusImpl: () => Promise<StatusGetOutput> = notStubbed("getStatus");
+  requestLeaseImpl: (
+    input: LeaseRequestInput,
+    options: RequestLeaseOptions,
+  ) => Promise<LeaseGrant> = notStubbed("requestLease");
+  cancelLeaseImpl: (input: LeaseCancelInput) => Promise<LeaseCancelOutput> =
+    notStubbed("cancelLease");
+  renewLeaseImpl: (input: LeaseRenewInput) => Promise<LeaseRecord> = notStubbed("renewLease");
+  releaseLeaseImpl: (input: LeaseReleaseInput) => Promise<LeaseReleaseOutput> =
+    notStubbed("releaseLease");
+  listLeasesImpl: () => Promise<LeaseListOutput> = notStubbed("listLeases");
+  heartbeatImpl: () => Promise<LeaseHeartbeatOutput> = notStubbed("heartbeat");
+  runDoctorImpl: (input: DoctorRunInput) => Promise<DoctorReport> = notStubbed("runDoctor");
+
+  readonly #leaseLostListeners = new Set<(push: LeaseLostPush) => void>();
+  readonly #deviceUnhealthyListeners = new Set<(push: DeviceUnhealthyPush) => void>();
+  readonly #deviceRecoveredListeners = new Set<(push: DeviceRecoveredPush) => void>();
+  readonly #connectionLostListeners = new Set<(error: AnySimlockError) => void>();
+
+  constructor(options: FakeSimlockClientOptions = {}) {
+    this.principal = options.principal ?? "mcp-test";
+    this.role = options.role ?? "agent";
+    this.daemonVersion = options.daemonVersion ?? "test";
+  }
+
+  getCatalog(input: CatalogGetInput = {}): Promise<CatalogGetOutput> {
+    this.calls.push({ input, method: "getCatalog" });
+    return this.getCatalogImpl(input);
+  }
+
+  // fallow-ignore-next-line unused-class-member -- part of the SimlockClient interface this fake implements; MCP itself never calls status.get.
+  getStatus(): Promise<StatusGetOutput> {
+    this.calls.push({ input: undefined, method: "getStatus" });
+    return this.getStatusImpl();
+  }
+
+  requestLease(input: LeaseRequestInput, options: RequestLeaseOptions = {}): Promise<LeaseGrant> {
+    this.calls.push({ input, method: "requestLease" });
+    return this.requestLeaseImpl(input, options);
+  }
+
+  // fallow-ignore-next-line unused-class-member -- part of the SimlockClient interface this fake implements; MCP itself never calls lease.cancel.
+  cancelLease(input: LeaseCancelInput = {}): Promise<LeaseCancelOutput> {
+    this.calls.push({ input, method: "cancelLease" });
+    return this.cancelLeaseImpl(input);
+  }
+
+  // fallow-ignore-next-line unused-class-member -- part of the SimlockClient interface this fake implements; MCP itself never calls lease.renew.
+  renewLease(input: LeaseRenewInput): Promise<LeaseRecord> {
+    this.calls.push({ input, method: "renewLease" });
+    return this.renewLeaseImpl(input);
+  }
+
+  releaseLease(input: LeaseReleaseInput): Promise<LeaseReleaseOutput> {
+    this.calls.push({ input, method: "releaseLease" });
+    return this.releaseLeaseImpl(input);
+  }
+
+  listLeases(): Promise<LeaseListOutput> {
+    this.calls.push({ input: undefined, method: "listLeases" });
+    return this.listLeasesImpl();
+  }
+
+  // fallow-ignore-next-line unused-class-member -- part of the SimlockClient interface this fake implements; MCP itself never calls lease.heartbeat (the client handles it internally).
+  heartbeat(): Promise<LeaseHeartbeatOutput> {
+    this.calls.push({ input: undefined, method: "heartbeat" });
+    return this.heartbeatImpl();
+  }
+
+  // fallow-ignore-next-line unused-class-member -- part of the SimlockClient interface this fake implements; MCP itself never calls doctor.run.
+  runDoctor(input: DoctorRunInput = {}): Promise<DoctorReport> {
+    this.calls.push({ input, method: "runDoctor" });
+    return this.runDoctorImpl(input);
+  }
+
+  onLeaseLost(listener: (push: LeaseLostPush) => void): () => void {
+    this.#leaseLostListeners.add(listener);
+    return () => this.#leaseLostListeners.delete(listener);
+  }
+
+  onDeviceUnhealthy(listener: (push: DeviceUnhealthyPush) => void): () => void {
+    this.#deviceUnhealthyListeners.add(listener);
+    return () => this.#deviceUnhealthyListeners.delete(listener);
+  }
+
+  onDeviceRecovered(listener: (push: DeviceRecoveredPush) => void): () => void {
+    this.#deviceRecoveredListeners.add(listener);
+    return () => this.#deviceRecoveredListeners.delete(listener);
+  }
+
+  onConnectionLost(listener: (error: AnySimlockError) => void): () => void {
+    this.#connectionLostListeners.add(listener);
+    return () => this.#connectionLostListeners.delete(listener);
+  }
+
+  emitLeaseLost(push: LeaseLostPush): void {
+    for (const listener of this.#leaseLostListeners) listener(push);
+  }
+
+  emitDeviceUnhealthy(push: DeviceUnhealthyPush): void {
+    for (const listener of this.#deviceUnhealthyListeners) listener(push);
+  }
+
+  emitDeviceRecovered(push: DeviceRecoveredPush): void {
+    for (const listener of this.#deviceRecoveredListeners) listener(push);
+  }
+
+  /** Simulates the connection dying (a crash, not `close()`) without marking this fake closed. */
+  emitConnectionLost(
+    error: AnySimlockError = new SimlockError(
+      "DAEMON_CONNECTION_LOST",
+      "transport",
+      "Daemon connection lost",
+      {},
+    ),
+  ): void {
+    for (const listener of this.#connectionLostListeners) listener(error);
+  }
+
+  async close(): Promise<void> {
+    this.closeCalls += 1;
+    this.emitConnectionLost(
+      new SimlockError("DAEMON_CONNECTION_LOST", "transport", "Client closed the connection", {}),
+    );
+  }
+}
+
+export function sampleGrant(overrides: { readonly leaseId?: string } = {}): LeaseGrant {
+  const leaseId = overrides.leaseId ?? "lease-1";
+  return {
+    device: {
+      createdAt: 0,
+      driverData: null,
+      driverDeviceId: "SIM-1",
+      id: "device-1",
+      spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
+      state: "leased",
+    },
+    lease: {
+      deviceId: "device-1",
+      grantedAt: 0,
+      id: leaseId,
+      mode: "held",
+      ownerId: "mcp-test",
+      requesterId: "mcp-test",
+      ttlDeadline: 12_345,
+    },
+    timing: {
+      estimatedBootMs: 3,
+      estimatedProvisionMs: 2,
+      estimatedReadyMs: 6,
+      estimatedReclaimMs: 1,
+    },
+  };
+}


### PR DESCRIPTION
**Stacked on #96.** PR 4b of 5 implementing ADR 0003 (§11, with §9/§10).

Per §11: *"MCP tool schemas are derived from the contract schemas. Tool names stay. MCP keeps only connection lifecycle and its MCP-only relays. Its `LEASE_NOT_OWNED` guard is deleted; the daemon's owner rule answers `FORBIDDEN`."*

## What MCP stops doing

- **The cached owned-lease state is gone.** `lease_status` is now one `lease.list` call, which is what §9 says makes MCP a stateless view. A test asserts two independent calls hit the daemon, so the cache cannot quietly return.
- **The `LEASE_NOT_OWNED` guard is deleted.** A stale or foreign release now surfaces the daemon's `FORBIDDEN` unchanged.
- **The bespoke abort plumbing is gone**, replaced by the client's `AbortSignal` support — which sends a targeted `lease.cancel` instead of killing the connection to cancel, the behaviour §9 explicitly set out to fix.
- **The retry-once-for-reads path is gone.** The typed client never retries; lazy reconnect now means the next call builds a new client, never a silent retry of a call already sent.

## What MCP keeps

Connection lifecycle (lazy reconnect — legitimate, since the MCP process outlives a connection), tool-call serialization, and the three MCP-only relays: progress notifications, lease-lost, and device-health.

## Breaking changes for MCP callers — the highest-risk item in this release

Tool **names** are unchanged, but their schemas now derive from the contract:

- **`timeout_seconds` → `timeoutMs`.** This is a **unit change as well as a rename**: an un-updated caller passing seconds is silently wrong by 1000×. PR 5 documents this prominently.
- Top-level `slim: boolean` → `device.featureProfile: "full" | "reduced"`.
- Inputs and outputs move to the contract's camelCase vocabulary.

`lease_simulator` returns the grant's device projection — `{id, driverDeviceId, spec, address?, featureProfile?}` — not the full device record (see the projection fix stacked after this).

## Notes for reviewers

- Deriving tool I/O from the contract rather than hand-curating a projection is the reading of §11 taken here; a curated `.pick()` would be less noisy for an agent caller but re-creates exactly the translation code the ADR wants deleted.
- `lease_status` now goes through the same serialization queue as mutations, so it can no longer be answered while a lease or release is in flight. Chosen for read consistency; not required by the ADR.
- A defensive check that a grant came back `mode: "held"` was removed as redundant with dispatcher-level coverage — a real behaviour removed, not just a refactor.
- `connect.ts` re-implements the startup coordinator's launch-then-retry against the typed client, because that coordinator is typed against the legacy connection interface. Small, tested duplication.

Per ADR §12 the suite is trimmed to a smoke test plus MCP's own behaviour (lazy reconnect, serialization, the relays, and `lease_status` reflecting daemon state rather than a cache). Tests that only re-asserted contract behaviour are deleted.