### PR TITLE
fix(contract): a lease grant returns a device projection, not the whole record

### DIFF
--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -844,9 +844,6 @@ function fakeClient(overrides: Partial<SimlockAdminClient> = {}): SimlockAdminCl
       id: "dev_1",
       driverDeviceId: "dev_1",
       spec: { platform: "ios", model: "iPhone 17 Pro", osVersion: "26.5" },
-      state: "leased",
-      driverData: undefined,
-      createdAt: 0,
     },
     lease: {
       id: "lse_1",

--- a/src/contract/schemas.test.ts
+++ b/src/contract/schemas.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import { grantedDeviceSchema, leaseGrantSchema } from "./schemas.js";
+
+/**
+ * Regression coverage for the defect fixed alongside ADR 0003 §1: a lease grant's device must
+ * never carry core-private, driver-internal, or quarantine/recovery bookkeeping fields --
+ * `driverData`, `state`, `createdAt`, any `quarantine*` field, any `foreign*` field, or
+ * `recovering*`/`recoveryAttempts`. Those stay exclusive to `deviceRecordSchema`, used only by
+ * the admin-only `list.get`/`status.get` operations.
+ *
+ * This asserts the behavior a caller of `simlock/client`/`simlock/admin` actually sees, not an
+ * implementation detail: `leaseGrantSchema.parse` is exactly what `DaemonDispatcher#dispatch`'s
+ * `#parseOutput` runs a grant through before it reaches any transport, and zod's default
+ * "strip unknown keys" object mode is what performs the core-record -> contract-type mapping
+ * for the device on a grant.
+ */
+describe("leaseGrantSchema's device projection", () => {
+  const internalDeviceFields = [
+    "driverData",
+    "state",
+    "createdAt",
+    "lastLeaseEndedAt",
+    "foreignStateDetectedAt",
+    "foreignProvenanceDetectedAt",
+    "recoveringSince",
+    "recoveryAttempts",
+    "quarantinedAt",
+    "quarantineAttempts",
+    "quarantineNextRetryAt",
+    "transitionAgeMs",
+  ] as const;
+
+  /** A device shaped like a full core `DeviceRecord` mid-quarantine, exactly the kind of
+   * payload a real `LeaseGrant` from `core`'s lease engine would carry into `#parseOutput`. */
+  function fullCoreShapedDevice(): Record<string, unknown> {
+    return {
+      id: "device-1",
+      driverDeviceId: "SIM-1",
+      spec: { platform: "ios", model: "iPhone 17 Pro", osVersion: "26.5" },
+      state: "quarantined",
+      driverData: { udid: "SIM-1", secretDriverInternals: true },
+      createdAt: 0,
+      lastLeaseEndedAt: 10,
+      foreignStateDetectedAt: 20,
+      foreignProvenanceDetectedAt: 30,
+      recoveringSince: 40,
+      recoveryAttempts: 2,
+      quarantinedAt: 50,
+      quarantineAttempts: 3,
+      quarantineNextRetryAt: 60,
+      address: "127.0.0.1:1234",
+      featureProfile: "reduced",
+      transitionAgeMs: 70,
+    };
+  }
+
+  it("strips every internal DeviceRecord field off a grant's device", () => {
+    const grant = leaseGrantSchema.parse({
+      device: fullCoreShapedDevice(),
+      lease: {
+        id: "lease-1",
+        deviceId: "device-1",
+        requesterId: "req",
+        ownerId: "req",
+        mode: "held",
+        grantedAt: 0,
+        ttlDeadline: 1000,
+      },
+      timing: {
+        estimatedProvisionMs: 0,
+        estimatedBootMs: 0,
+        estimatedReclaimMs: 0,
+        estimatedReadyMs: 0,
+      },
+    });
+
+    for (const field of internalDeviceFields) {
+      expect(grant.device).not.toHaveProperty(field);
+    }
+    expect(grant.device).toEqual({
+      id: "device-1",
+      driverDeviceId: "SIM-1",
+      spec: { platform: "ios", model: "iPhone 17 Pro", osVersion: "26.5" },
+      address: "127.0.0.1:1234",
+      featureProfile: "reduced",
+    });
+  });
+
+  it("rejects a device object that is missing the fields a grant must keep", () => {
+    expect(() => grantedDeviceSchema.parse({ id: "device-1" })).toThrow();
+  });
+
+  it("keeps id, driverDeviceId, spec, and the optional address/featureProfile", () => {
+    const parsed = grantedDeviceSchema.parse({
+      id: "device-1",
+      driverDeviceId: "SIM-1",
+      spec: { platform: "android", model: "Pixel 8", osVersion: "34" },
+    });
+    expect(parsed).toEqual({
+      id: "device-1",
+      driverDeviceId: "SIM-1",
+      spec: { platform: "android", model: "Pixel 8", osVersion: "34" },
+    });
+  });
+});

--- a/src/contract/schemas.ts
+++ b/src/contract/schemas.ts
@@ -5,7 +5,11 @@
  * `DeviceRecord`, `LeaseRecord`, `Config`, `DoctorFinding`, `Proposal`, `EventEnvelope`, and so
  * on are core-private types. Re-declaring their fields here, by hand, is exactly what keeps
  * private domain records off the public package surface (the daemon maps its own records onto
- * these shapes in exactly one place -- `src/daemon/server.ts`). If a core type's shape changes
+ * these shapes in exactly one place -- `DaemonDispatcher#dispatch`'s `#parseOutput` call in
+ * `src/daemon/dispatcher.ts`, which parses every handler's result through the operation's
+ * output schema before it reaches a transport, stripping any field (such as `DeviceRecord`'s
+ * quarantine/foreign/recovery bookkeeping) that a narrower output schema like
+ * `grantedDeviceSchema` does not declare). If a core type's shape changes
  * without a matching edit here, that is a compile-time or (for shapes structurally compatible
  * but semantically different) a runtime output-validation failure at the daemon boundary --
  * see `DaemonServer`'s output parsing -- not a silent drift.
@@ -60,6 +64,45 @@ export const deviceRecordSchema = z.object({
   transitionAgeMs: z.number().optional(),
 });
 
+/**
+ * The device a `lease.request`/`lease.renew` grant carries -- deliberately narrower than
+ * `deviceRecordSchema` (ADR 0003 §1: "the daemon maps [core records] onto contract types in
+ * exactly one place"). A grant is agent-facing, not an admin inspection of the registry, so it
+ * carries only what a caller needs to drive the device it was just handed:
+ *
+ * - `id`: the lease-facing device identity (what `lease.list`/`lease.renew` correlate against).
+ * - `driverDeviceId`: the driver address a caller actually drives (simctl UDID / adb serial).
+ * - `spec`, `address`, `featureProfile`: same meanings as on `DeviceRecord` (src/core/domain.ts).
+ *
+ * Everything else on `DeviceRecord` -- `driverData` (opaque driver-private blob), `state`,
+ * `createdAt`, every `quarantine*`/`foreign*`/`recovering*` field, and the `status`/`list`
+ * decoration's `transitionAgeMs` -- is internal reclamation/health bookkeeping a grant recipient
+ * has no business seeing, and stays off this shape. `list.get`/`status.get` (admin-only) still
+ * return the full `deviceRecordSchema` -- an operator inspecting the registry legitimately wants
+ * the whole record.
+ */
+export const grantedDeviceSchema = z.object({
+  id: z.string(),
+  driverDeviceId: z.string(),
+  spec: deviceSpecSchema,
+  /**
+   * The driver-reported address (see `DriverDevice.address`), current as of this device's
+   * last `ready` transition. Undefined for a device still `provisioning` (never made ready
+   * yet) and, as an upgrade path, for a record written by a pre-address daemon -- `state.json`
+   * from before this field existed loads without one rather than failing to start. It becomes
+   * defined the next time the device is made ready (`boot`/`readyProvisioned`); nothing here
+   * ever guesses at a value it wasn't told.
+   */
+  address: z.string().optional(),
+  /**
+   * Mirrors `DriverDevice.featureProfile` (see `driver.ts`), current as of this device's last
+   * `ready` transition. Undefined for a device still `provisioning` (never made ready yet)
+   * and for any driver that does not reduce anything -- today's behaviour, and every non-iOS
+   * driver.
+   */
+  featureProfile: featureProfileSchema.optional(),
+});
+
 export const leaseModeSchema = z.enum(["held", "detached"]);
 
 /**
@@ -87,7 +130,7 @@ const leaseTimingSchema = z.object({
 });
 
 export const leaseGrantSchema = z.object({
-  device: deviceRecordSchema,
+  device: grantedDeviceSchema,
   lease: leaseRecordSchema,
   timing: leaseTimingSchema,
 });

--- a/src/mcp/test-support.ts
+++ b/src/mcp/test-support.ts
@@ -181,12 +181,9 @@ export function sampleGrant(overrides: { readonly leaseId?: string } = {}): Leas
   const leaseId = overrides.leaseId ?? "lease-1";
   return {
     device: {
-      createdAt: 0,
-      driverData: null,
       driverDeviceId: "SIM-1",
       id: "device-1",
       spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
-      state: "leased",
     },
     lease: {
       deviceId: "device-1",

--- a/src/simlock-client/client.test.ts
+++ b/src/simlock-client/client.test.ts
@@ -20,12 +20,9 @@ function sampleGrant(
   const deviceId = overrides.deviceId ?? "device_1";
   return {
     device: {
-      createdAt: 0,
-      driverData: null,
       driverDeviceId: "sim-1",
       id: deviceId,
       spec: { model: "iPhone 17", osVersion: "18.0", platform: "ios" },
-      state: "leased",
     },
     lease: {
       deviceId,


### PR DESCRIPTION
**Stacked on #97.** A defect found while reviewing PR 4b, fixed against ADR 0003 §1.

## The defect

§1 says core domain records stay private and the daemon maps them onto contract types in exactly one place, *"This is what keeps private types out of the public package surface."*

`leaseGrantSchema.device` pointed at `deviceRecordSchema`, a field-for-field re-declaration of the core `DeviceRecord`. Not importing the core type satisfies the letter of §1 but defeats its purpose: `driverData` (an opaque driver-private blob — simctl/AVD internals), `quarantinedAt`, `quarantineAttempts`, `quarantineNextRetryAt`, `foreignStateDetectedAt`, `foreignProvenanceDetectedAt`, `recoveringSince`, `recoveryAttempts` and `transitionAgeMs` were all on the public `simlock/client` surface and in every MCP `lease_simulator` result. Before this stack, a grant's device was only `{address, driverDeviceId, spec}`.

## The fix

A deliberate projection:

```ts
device: { id, driverDeviceId, spec, address?, featureProfile? }
```

`id` is the lease-facing device identity; `driverDeviceId` is the address a caller actually drives. The full `deviceRecordSchema` is untouched on `list.get` and `status.get`, which are **admin**-role operations where an operator legitimately wants the whole record.

No new mapping code was needed: the single core→contract mapping point already exists at the dispatcher's output parse, and zod strips unknown keys by default, so narrowing the schema *is* the projection. A regression test parses a full device record through `leaseGrantSchema` and asserts every internal field is stripped — the leak cannot reopen silently.

The three places that hand-built a grant device with full-record fields were type errors, not silent passes, and are fixed.

## Note for reviewers

The projection relies on zod's default strip behaviour; adding `.passthrough()` to these schemas later would reopen the leak with no compile-time signal. The regression test is what guards it. Nothing programmatically ties `grantedDeviceSchema`'s keys to `deviceRecordSchema`'s, so a new `DeviceRecord` field is correctly absent from grants by default, but no test forces a human to make that call explicitly.