### PR TITLE
docs: document the contract, the client, the security model, and 0.3.0's breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,108 @@
+# Changelog
+
+## [0.3.0](https://github.com/callstackincubator/simlock/compare/v0.2.0...v0.3.0) (2026-09-03)
+
+ADR 0003 (`docs/adr/0003-one-typed-daemon-contract-behind-every-frontend.md`):
+every daemon operation is now declared once, as a typed contract
+(`src/contract/`), served by one shared dispatcher to all four frontends —
+the CLI, the stdio MCP server, the HTTP gateway, and a new programmatic
+client (`simlock/client`, `simlock/admin`, see `docs/CLIENT.md`). This is a
+breaking release for every frontend's wire vocabulary; see below.
+
+### ⚠ BREAKING CHANGES
+
+- **CLI:** `--json` output and stderr event lines (`lease`, `daemon`, and
+  progress/push lines) are now the contract's own values, serialized as-is.
+  The old snake_case renderings (`expires_at_ms`, `estimated_boot_ms`,
+  `eta_seconds`, …) are gone. Exit codes are unchanged; human-readable
+  `status`/`catalog` formatting is unchanged.
+- **MCP:** tool names are unchanged, but every tool's input/output schema is
+  now derived from the contract instead of hand-declared. Two field changes
+  need every caller updated:
+  - `lease_simulator`'s `timeout_seconds` is now `timeoutMs` — **a unit
+    change, not just a rename.** A caller that keeps the old field name
+    under the new key silently waits 1000× too long before timing out; this
+    is the single highest-risk change in this release.
+  - The top-level `slim: boolean` on a grant is gone; it is now
+    `device.featureProfile` (`"full" | "reduced" | undefined`). A caller
+    still checking `result.slim === true` silently never sees a
+    feature-loss signal again.
+
+  See `docs/CLI.md#simlock-mcp` for the full callout.
+
+- **Socket protocol:** moves to protocol 3 with no compatibility shim. A
+  version-mismatched client fails `hello` with
+  `PROTOCOL_VERSION_UNSUPPORTED` and never restarts the daemon — run
+  `simlock daemon stop` once it's idle. `daemon.stop` is a frozen exception,
+  accepted at any protocol version the daemon has ever spoken (still
+  admin-role gated).
+- **`lease.request`'s wire shape** drops the legacy `device`/`os` field
+  aliases and the nested `request` wrapper the pre-0.3.0 daemon accepted;
+  an old client sending them now gets `BAD_REQUEST` instead of those keys
+  silently vanishing.
+- **HTTP:** `GET /v1/leases/:id` (and `renew`/`events`/`DELETE` on the same
+  resource) now returns `404 UNKNOWN_LEASE` instead of `403 FORBIDDEN` for
+  another requester's lease — see `docs/HTTP-API.md#get-v1leasesid`.
+- **`token create|list|revoke`** are now daemon operations (admin role) —
+  the daemon is the sole owner of `tokens.json`. `config set` and
+  `daemon logs` remain file operations.
+
+### Bug Fixes
+
+- **http:** `allowDownload` is now clamped through `config.downloads.policy`
+  the same way the socket protocol always was — HTTP previously passed a
+  client-supplied `allowDownload` through unclamped, so a `"never"` policy
+  could be bypassed over HTTP even though the socket already blocked it.
+- **http:** a request arriving before the daemon's startup convergence
+  finishes now waits on the shared dispatcher's readiness gate instead of
+  being refused — the HTTP gateway's listener starts at socket-claim time
+  rather than only after convergence completes.
+- **cli:** filter lease-lost pushes by this connection's own lease id, so a
+  second CLI invocation sharing a principal (e.g. a detached lease from an
+  earlier `--detach`) doesn't misreport a push for a lease this process
+  never held.
+- **contract:** restrict `lease.cancel` to the calling principal (only
+  admin may cancel on another principal's behalf).
+- **daemon:** require the admin role for `daemon.stop`.
+
+### Features
+
+- **contract:** declare every daemon operation once — name, role, input/
+  output zod schema, optional `authorize` hook — with public TypeScript
+  types inferred from the schemas (`src/contract/`).
+- **daemon:** move request handling into one transport-independent
+  dispatcher (`src/daemon/dispatcher.ts`) serving both the unix socket and,
+  in-process, the HTTP gateway.
+- **daemon:** negotiate protocol versions as `{min, max}` ranges instead of
+  an exact match.
+- **daemon:** resolve `hello`'s admin credential — an operator token or the
+  daemon's per-start `admin.token` secret — before any other request on the
+  connection runs; wire the admin handshake and route lease-scoped pushes to
+  every live connection sharing a lease's owner, not just the holder.
+- **core:** persist a lease's `ownerId`, distinct from `requesterId` (ADR
+  0003 §4) — the session principal a lease was granted to, vs. the
+  per-request attribution a connection may vary. `lease.released`/
+  `lease.expired` now carry `ownerId` in their event payloads.
+- **client:** add the typed daemon client core (`simlock-client`) and
+  publish it as the `simlock/client` and `simlock/admin` package entry
+  points — one connection, no reconnect, no retry, with `AbortSignal`-driven
+  cancellation on `requestLease` (see `docs/CLIENT.md`).
+- **cli, mcp:** move onto the typed client, deleting the hand-built request
+  payloads and raw response parsers both frontends carried before.
+- **http:** move HTTP onto the shared dispatcher, deleting its own copies
+  of status assembly, decoration, error mapping, and ownership checks.
+
+### Documentation
+
+- record ADR 0003 (`docs/adr/0003-one-typed-daemon-contract-behind-every-frontend.md`).
+- add `docs/CLIENT.md` for the new programmatic client; document the
+  contract/dispatcher architecture and the cooperative-identity security
+  model in `docs/ARCHITECTURE.md`; document the breaking changes above in
+  `docs/CLI.md` and `docs/HTTP-API.md`; record true-cancellation-during-
+  provisioning and the HTTP tracker/notice-buffer stateful leftovers in
+  `docs/known-pitfalls.md`.
+
+## [0.2.0] and earlier
+
+Not tracked in this file — see `git log` for history before this changelog
+was introduced.

--- a/README.md
+++ b/README.md
@@ -49,19 +49,14 @@ simlock lease --platform ios --device "iPhone 16" --detach
 ```
 
 ```json
-{
-  "lease": "lse_9f2c",
-  "platform": "ios",
-  "device": "iPhone 16",
-  "os": "18.4",
-  "udid": "ABCD-...",
-  "state": "leased"
-}
+{"device":{"id":"dev_1a2b","driverDeviceId":"ABCD-...","spec":{"platform":"ios","model":"iPhone 16","osVersion":"18.4"},"address":"ABCD-..."},"lease":{"id":"lse_9f2c","deviceId":"dev_1a2b","requesterId":"agent-1","ownerId":"agent-1","mode":"detached","grantedAt":1735689600000,"ttlDeadline":1735690500000},"timing":{"estimatedProvisionMs":0,"estimatedBootMs":0,"estimatedReclaimMs":0,"estimatedReadyMs":0},"role":"admin"}
 ```
 
 That's the whole interaction: ask for a platform and a device model, get
 back an identified, ready-to-use device. Release it explicitly, or let its
-TTL expire.
+TTL expire. This is the contract's own `LeaseGrant` shape, serialized
+as-is — the CLI's `--json` output is a contract value, not a bespoke
+rendering (see [docs/CLI.md](docs/CLI.md)).
 
 Now say a second agent asks for the same `iPhone 16` a moment later. It's
 already leased to the first agent — no problem, Simlock just provisions
@@ -69,19 +64,12 @@ another one. Progress streams as JSON lines on stderr while it happens, and
 the lease result lands on stdout the moment the new device is ready:
 
 ```json
-{"event":"provisioning","eta_seconds":5}
-{"event":"booting","eta_seconds":30}
+{"push":"progress","requestId":"2","progress":{"stage":"provisioning","etaMs":5000}}
+{"push":"progress","requestId":"2","progress":{"stage":"booting","etaMs":30000}}
 ```
 
 ```json
-{
-  "lease": "lse_a731",
-  "platform": "ios",
-  "device": "iPhone 16",
-  "os": "18.4",
-  "udid": "EFGH-...",
-  "state": "leased"
-}
+{"device":{"id":"dev_3c4d","driverDeviceId":"EFGH-...","spec":{"platform":"ios","model":"iPhone 16","osVersion":"18.4"},"address":"EFGH-..."},"lease":{"id":"lse_a731","deviceId":"dev_3c4d","requesterId":"agent-2","ownerId":"agent-2","mode":"detached","grantedAt":1735689630000,"ttlDeadline":1735690530000},"timing":{"estimatedProvisionMs":5000,"estimatedBootMs":30000,"estimatedReclaimMs":0,"estimatedReadyMs":35000},"role":"admin"}
 ```
 
 No manual bookkeeping, no "device busy" error to handle — just a second

--- a/README.md
+++ b/README.md
@@ -49,7 +49,30 @@ simlock lease --platform ios --device "iPhone 16" --detach
 ```
 
 ```json
-{"device":{"id":"dev_1a2b","driverDeviceId":"ABCD-...","spec":{"platform":"ios","model":"iPhone 16","osVersion":"18.4"},"address":"ABCD-..."},"lease":{"id":"lse_9f2c","deviceId":"dev_1a2b","requesterId":"agent-1","ownerId":"agent-1","mode":"detached","grantedAt":1735689600000,"ttlDeadline":1735690500000},"timing":{"estimatedProvisionMs":0,"estimatedBootMs":0,"estimatedReclaimMs":0,"estimatedReadyMs":0},"role":"admin"}
+{
+  "device": {
+    "id": "dev_1a2b",
+    "driverDeviceId": "ABCD-...",
+    "spec": { "platform": "ios", "model": "iPhone 16", "osVersion": "18.4" },
+    "address": "ABCD-..."
+  },
+  "lease": {
+    "id": "lse_9f2c",
+    "deviceId": "dev_1a2b",
+    "requesterId": "agent-1",
+    "ownerId": "agent-1",
+    "mode": "detached",
+    "grantedAt": 1735689600000,
+    "ttlDeadline": 1735690500000
+  },
+  "timing": {
+    "estimatedProvisionMs": 0,
+    "estimatedBootMs": 0,
+    "estimatedReclaimMs": 0,
+    "estimatedReadyMs": 0
+  },
+  "role": "admin"
+}
 ```
 
 That's the whole interaction: ask for a platform and a device model, get
@@ -69,7 +92,30 @@ the lease result lands on stdout the moment the new device is ready:
 ```
 
 ```json
-{"device":{"id":"dev_3c4d","driverDeviceId":"EFGH-...","spec":{"platform":"ios","model":"iPhone 16","osVersion":"18.4"},"address":"EFGH-..."},"lease":{"id":"lse_a731","deviceId":"dev_3c4d","requesterId":"agent-2","ownerId":"agent-2","mode":"detached","grantedAt":1735689630000,"ttlDeadline":1735690530000},"timing":{"estimatedProvisionMs":5000,"estimatedBootMs":30000,"estimatedReclaimMs":0,"estimatedReadyMs":35000},"role":"admin"}
+{
+  "device": {
+    "id": "dev_3c4d",
+    "driverDeviceId": "EFGH-...",
+    "spec": { "platform": "ios", "model": "iPhone 16", "osVersion": "18.4" },
+    "address": "EFGH-..."
+  },
+  "lease": {
+    "id": "lse_a731",
+    "deviceId": "dev_3c4d",
+    "requesterId": "agent-2",
+    "ownerId": "agent-2",
+    "mode": "detached",
+    "grantedAt": 1735689630000,
+    "ttlDeadline": 1735690530000
+  },
+  "timing": {
+    "estimatedProvisionMs": 5000,
+    "estimatedBootMs": 30000,
+    "estimatedReclaimMs": 0,
+    "estimatedReadyMs": 35000
+  },
+  "role": "admin"
+}
 ```
 
 No manual bookkeeping, no "device busy" error to handle — just a second

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -17,7 +17,11 @@ An optional local stdio MCP integration exposes the focused lease/release
 workflow to compatible agent clients; the CLI remains the full operator
 interface. An optional, token-authenticated HTTP API lets remote agents lease
 devices from a self-hosted simlock host over the network (see
-[HTTP-API.md](HTTP-API.md)).
+[HTTP-API.md](HTTP-API.md)). A host process that wants to allocate devices
+without spawning a `simlock` command at all — agent-device, for
+example — can instead depend on `simlock/client`/`simlock/admin`, the typed
+programmatic client the CLI and MCP frontends are themselves built on (see
+[CLIENT.md](CLIENT.md)).
 
 - `simlock lease` returns a *ready* device — booted and health-checked — that
   no other agent will touch for the duration of the lease.
@@ -45,5 +49,5 @@ devices from a self-hosted simlock host over the network (see
   optional MCP server reserves stdout for MCP JSON-RPC.
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for how it's built, [CLI.md](CLI.md)
-for the command surface, and [known-pitfalls.md](known-pitfalls.md) for
-accepted gaps.
+for the command surface, [CLIENT.md](CLIENT.md) for the programmatic client,
+and [known-pitfalls.md](known-pitfalls.md) for accepted gaps.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,49 +28,179 @@ remote agent ──token auth──> HTTP gateway ──same role interfaces─�
                                                                                 emulator/adb)
 ```
 
-- **CLI, stdio MCP server, and HTTP gateway**: sibling thin frontends. The
+- **CLI, stdio MCP server, and HTTP gateway**: sibling thin frontends over one
+  typed contract (ADR 0003; see "Contract, dispatcher, and roles" below). The
   core never knows which frontend made a request. The CLI and MCP server sit
-  over the shared daemon client and unix socket; the CLI is the full operator
+  over `simlock/client`/`simlock/admin` (the typed daemon client, see
+  [CLIENT.md](CLIENT.md)) and the unix socket; the CLI is the full operator
   interface, and the MCP server intentionally limits its tool surface to
   leasing and releasing for an agent session. The HTTP gateway is different in
   kind, not just transport: it is the one frontend meant to be reached over a
-  real network, so it calls the same role interfaces (`LeaseCommands`,
-  `QueueControl`, `CapacityReader`, `CatalogReader`) in-process rather than
-  going through the unix socket, requires a bearer token on every route but
-  `GET /v1/healthz`, and only ever grants detached-style, TTL-renewed leases —
-  "held lease = live connection" does not survive a real network the way it
-  does a local process. It starts only after the daemon's own startup
-  convergence completes (see "Startup: claim first, converge after" below),
-  so unlike the socket protocol's parked-request behavior during that window,
-  a request arriving before then is simply refused. See
-  [HTTP-API.md](HTTP-API.md) for the full route reference.
+  real network, so it calls the daemon's dispatcher **in-process** — the exact
+  same one the socket path calls — rather than going through the unix socket
+  at all, requires a bearer token on every route but `GET /v1/healthz`, and
+  only ever grants detached-style, TTL-renewed leases — "held lease = live
+  connection" does not survive a real network the way it does a local
+  process. Its listener now starts right after the socket claim, the same
+  moment the unix socket itself starts accepting connections and before
+  startup convergence runs (`DaemonServer`'s `onSocketClaimed` hook, see
+  "Startup: claim first, converge after" below) — a bug fix from the pre-ADR
+  gateway, which started only once convergence had already finished and so
+  never needed to park anything. A request that arrives before convergence
+  completes now waits on the shared dispatcher's readiness gate exactly like
+  a socket request, instead of being refused. See [HTTP-API.md](HTTP-API.md)
+  for the full route reference.
 - **CLI**: in the default *held* mode it acquires a lease, prints one JSON
   result line on stdout, then stays alive holding the daemon connection; the
   connection is the lease heartbeat. Progress streams as JSON lines on stderr.
 - **stdio MCP server**: its process owns one agent session and exposes MCP over
-  stdin/stdout. A lease is held by that process's daemon connection until the
-  session explicitly releases it or the MCP transport disconnects, at which
-  point the connection closes and releases the lease. Like the CLI, it relays
-  the daemon's progress pushes for the in-flight `lease_simulator` request —
-  as MCP `notifications/progress` instead of stderr JSON lines, and only when
-  the client supplied a progress token. Unlike the CLI, this process outlives
-  any single daemon connection: `McpSession` does not cache a dead connection.
-  `DaemonConnection#onClose` (`src/daemon-client/protocol.ts`) tells the
-  session the moment its connection dies — from a graceful `daemon stop`, a
-  crash, or `kill -9` — and the next tool call reconnects lazily, auto-starting
-  the daemon exactly as the CLI does. A held lease never survives its
-  connection dying (the daemon releases it on graceful close, and
-  `StartupConverger` sweeps any orphaned lease from an ungraceful death at its
-  own startup — see "Lease subsystem boundaries and wiring" above), so the
-  session never asks the daemon whether its old lease survived; it clears
-  `#ownedLease` and fires `onLeaseLost` (reason
-  `daemon-connection-lost`) so the agent hears the fact instead of silently
-  reacquiring a device. A dead connection surfaces as typed
-  `DAEMON_CONNECTION_LOST` (mid-request) or `DAEMON_UNAVAILABLE` (a failed
-  reconnect), not the opaque `INTERNAL`; only idempotent, read-only requests
-  (`catalog.get`) retry once, never `lease.request`.
+  stdin/stdout. `McpSession` (`src/mcp/session.ts`) holds one `simlock/client`
+  connection at a time and does nothing today's typed client does not already
+  do (ADR §11: MCP keeps only "connection lifecycle ... and its MCP-only
+  relays"): tool calls are serialized onto it, `lease_status` is one
+  `lease.list` call rather than a session-local cache, and a release the
+  session does not own surfaces the daemon's own `FORBIDDEN` rather than a
+  client-side guard pre-empting it. A lease is held by that connection until
+  the session explicitly releases it or the connection dies. Like the CLI, it
+  relays the daemon's progress pushes for the in-flight `lease_simulator`
+  request — as MCP `notifications/progress` instead of stderr JSON lines, and
+  only when the client supplied a progress token. Unlike the CLI, this
+  process outlives any single daemon connection: the typed client itself
+  never reconnects (ADR §10), so `McpSession` builds a brand new one lazily,
+  on the next tool call, once its current client's `onConnectionLost` fires
+  — auto-starting the daemon exactly as the CLI does
+  (`connectWithAutoLaunch`, `src/mcp/connect.ts`), and never on a version
+  mismatch or a refused handshake, only on "nothing is listening". A held
+  lease never survives its connection dying (the daemon releases it on
+  graceful close, and `StartupConverger` sweeps any orphaned lease from an
+  ungraceful death at its own startup — see "Lease subsystem boundaries and
+  wiring" above): the client already synthesizes `onLeaseLost` (reason
+  `daemon-connection-lost`) for every lease it held the moment its connection
+  dies, so the session relays that straight through rather than asking the
+  daemon whether its old lease survived.
 - **Daemon**: owns all state, serializes all decisions. Started on demand,
   reachable over a unix socket.
+
+## Contract, dispatcher, and roles (ADR 0003)
+
+Every daemon operation is declared exactly once, in `src/contract/`: a name
+(`lease.request`, `daemon.stop`, ...), a role, a zod input schema, a zod
+output schema, and an optional `authorize` hook. Public TypeScript types are
+inferred from those schemas, never hand-written a second time. The contract
+module imports nothing from `core`, `daemon`, or `drivers` (enforced by
+`src/contract/boundary.test.ts`) — core's own domain records
+(`DeviceRecord`, `LeaseRecord`, `LeaseGrant`) stay private, and the daemon
+maps them onto the contract's shapes in exactly one place
+(`src/daemon/dispatcher.ts`'s handlers). If a core type's shape changes
+without a matching edit in `src/contract/schemas.ts`, that surfaces as a
+compile error or, for a structurally-compatible-but-different shape, a
+runtime output-validation failure at the dispatcher boundary — never silent
+drift onto the wire.
+
+**One dispatcher (`src/daemon/dispatcher.ts`) serves every transport.**
+`Dispatcher#dispatch(operation, input, session)` runs, in order: parse the
+input against the operation's schema, reject a session whose role is below
+the operation's with `FORBIDDEN`, run the `authorize` hook if the operation
+declares one, park on startup readiness (every operation but `status.get`),
+call the handler, parse the output. Handlers never see a raw payload or run
+a role check themselves. The unix socket server (`DaemonServer`) is framing
+plus connection/session lifecycle around this one dispatcher instance; the
+HTTP gateway (`src/http/app.ts`) calls the **exact same dispatcher
+in-process** — `DaemonServer` exposes it as the one privileged seam an
+auxiliary frontend gets — via a bearer-token-to-`DispatchSession` adapter
+(`src/http/dispatcher-session.ts`). **HTTP never routes through the unix
+socket, or through a second `Dispatcher` instance built with
+equivalent-looking options; it is the same object, called directly.** Parity
+between the socket and HTTP frontends is a consequence of that sharing, not
+of a shared wire format — and every socket-side fix (the download policy in
+`config.downloads.policy`, startup-readiness parking, error mapping)
+applies to HTTP automatically because there is only one code path to fix.
+
+**Two roles**, `agent` and `admin`, declared in `src/contract/roles.ts`.
+Read-only and lease-lifecycle operations are `agent`; anything that reads or
+mutates state outside the caller's own leases (`list.get`, `cleanup.run`,
+`nuke.run`, `config.get`, `daemon.stop`, `events.*`, `token.*`) is `admin`.
+`doctor.run` is the one operation whose role is a function of its input
+rather than a fixed value: `fix: false` is agent-visible (read-only, but it
+shells out per device); `fix: true` is admin-only.
+
+**Principal, requester, and owner are three different things** (ADR §4):
+
+- The **principal** is the session identity declared once at `hello` and
+  fixed for the connection's lifetime — for HTTP, the bearer token's
+  requester id.
+- The **requester id** is per-request attribution. `lease.request` accepts
+  an optional `requesterId`, defaulting to the principal; core's
+  one-lease-per-requester rule stays keyed on it. This is what lets one
+  connection (a host process proxying several agents) hold many leases, one
+  per requester id, without the socket needing per-agent identity.
+- The **owner id** is a field persisted on the lease record, set from the
+  session principal at grant time. `lease.renew`/`lease.release`/`lease.list`
+  compare `ownerId` to the calling principal (`ownsLease` in
+  `src/contract/roles.ts`); `admin` bypasses. A record written before this
+  field existed loads with `ownerId` defaulted to `requesterId`.
+
+### Security model: cooperative identity, not a hostile-process boundary
+
+**Socket identity is cooperative, and the docs say so plainly because the
+code doesn't hide it either.** Every peer connecting to the unix socket is
+the same OS user — file permissions on the socket and on `~/.simlock/*`
+already establish that as the real trust boundary. Ownership checks
+(`ownsLease`, the principal/requester/owner split above) protect against
+*accidents* — releasing a guessed lease id, one agent's request colliding
+with another's — not against a hostile local process, which could always
+just open the socket itself and claim to be anyone. Real per-connection
+identity (a token on every socket connection, not just HTTP's) was
+considered and rejected for exactly this reason: it would kill the
+zero-setup local experience for the one trust boundary that already exists,
+without adding real protection against the thing socket identity cannot
+stop anyway (see the ADR's "Alternatives considered").
+
+**Admin authority comes only from a credential presented at `hello`, never
+from the socket itself.** Two credentials are accepted, checked in this
+order:
+
+1. **An operator token**, minted with `simlock token create --role
+   operator` and stored (hashed) in `tokens.json`. Long-lived, revocable —
+   what a supervisor process uses.
+2. **The daemon's per-start admin secret.** Generated fresh on every daemon
+   start; only its hash is kept in memory. The plaintext is written to
+   `admin.token` under the data directory *after* the socket claim succeeds
+   (temp file, then atomic rename — a daemon that loses the start race never
+   touches the real file), with owner-only permissions (`0o600`) set at
+   creation, and removed on graceful stop. `hello` verifies against the
+   in-memory hash, so a credential can be checked before the file has even
+   landed on disk.
+
+A missing or wrong credential fails the handshake with
+`ADMIN_AUTHENTICATION_FAILED` before any other request on that connection
+runs. The credential is never logged, never returned by any operation,
+never read from a config file, and never inferred from the socket path or a
+client-declared role. How a caller supplies it, in resolution order: the
+`credential` connect option (`simlock/admin`'s `connectSimlockAdmin`),
+`--token` (CLI flag), `SIMLOCK_ADMIN_TOKEN` (CLI env var), the local
+`admin.token` file (CLI, briefly retried to ride out a daemon still writing
+it). **The CLI connects as admin whenever the local `admin.token` file is
+readable** — that's what keeps `simlock lease --detach` followed later by
+`simlock release <id>` working across two separate CLI invocations with
+different pid-derived identities, since both connect as admin and admin
+bypasses the per-connection ownership check that would otherwise apply.
+When none of the four sources resolves (a different OS user, or the file
+genuinely missing), the CLI falls back to an agent-role session with a
+one-line stderr notice, and `simlock lease`'s output JSON includes the
+connection's resolved `role` so a caller can tell which one it got.
+
+**`doctor.run` without `fix` is agent-visible and read-only, but it still
+shells out per device** (`simctl`/`adb`) to compare registry state against
+driver reality — worth knowing before calling it from a tight loop or a
+context where that per-device process-spawn cost is unwelcome. `fix: true`
+requires the admin role because it can quarantine or destroy devices.
+
+See [CLIENT.md](CLIENT.md) for how `simlock/client`/`simlock/admin` expose
+`credential` and role at connect time, [CLI.md](CLI.md#admin-credential-resolution)
+for the CLI's own walkthrough of the same resolution order, and
+[HTTP-API.md](HTTP-API.md#authentication) for how HTTP's bearer-token roles
+map onto `agent`/`admin`.
 
 ## Core vs. drivers
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -120,8 +120,9 @@ simlock lease --platform <ios|android> --device <model> [--os <version>]
   force a re-provision of one already running, even while slim devices sit
   idle in the warm pool.
 - `--detach` — detached mode: print the lease result (the same JSON shape as
-  held mode's grant line, below, including `slim`) and exit; the lease is
-  TTL-bound and must be renewed with `simlock lease renew`.
+  held mode's grant line, below, including `device.featureProfile`) and
+  exit; the lease is TTL-bound and must be renewed with `simlock lease
+  renew`.
 - `--bind-pid <pid>` — held mode only: watch this pid for death instead of
   the CLI's actual parent. For a holder spawned from a short-lived subshell,
   the immediate parent can die (and get reaped) while the owning agent is
@@ -138,11 +139,17 @@ serialized as-is, plus the one field the CLI adds on top, the connection's
 resolved `role` (ADR 0003 §5):
 
 ```json
-{"device":{"id":"dev_1a2b","driverDeviceId":"ABCD-...","spec":{"platform":"ios","model":"iPhone 17 Pro","osVersion":"26.5"},"state":"leased","address":"...","featureProfile":"reduced", "...":"..."},"lease":{"id":"lse_9f2c","deviceId":"dev_1a2b","requesterId":"agent-1","ownerId":"agent-1","mode":"held","grantedAt":1735689600000,"ttlDeadline":1735689660000},"timing":{"estimatedProvisionMs":0,"estimatedBootMs":0,"estimatedReclaimMs":0,"estimatedReadyMs":0},"role":"agent"}
+{"device":{"id":"dev_1a2b","driverDeviceId":"ABCD-...","spec":{"platform":"ios","model":"iPhone 17 Pro","osVersion":"26.5"},"address":"...","featureProfile":"reduced"},"lease":{"id":"lse_9f2c","deviceId":"dev_1a2b","requesterId":"agent-1","ownerId":"agent-1","mode":"held","grantedAt":1735689600000,"ttlDeadline":1735689660000},"timing":{"estimatedProvisionMs":0,"estimatedBootMs":0,"estimatedReclaimMs":0,"estimatedReadyMs":0},"role":"agent"}
 ```
 
-`device.featureProfile` is `"reduced"` when the granted device had its
-feature set reduced (iOS slim mode applied and this request did not pass
+`device` is a **projection** of the registry's device record — `id`,
+`driverDeviceId`, `spec`, `address?`, `featureProfile?` — not the full
+record `status.get`/`list.get` return to an admin caller. Internal
+bookkeeping fields (`driverData`, `quarantine*`, `foreign*`, `recovering*`,
+the derived `transitionAgeMs`) never appear on a grant; a caller that wants
+those needs the admin-role `list.get`/`status.get`, not `lease.request`'s
+output. `device.featureProfile` is `"reduced"` when the granted device had
+its feature set reduced (iOS slim mode applied and this request did not pass
 `--full`), and `"full"` or absent otherwise — always absent for Android. It
 lets an agent explain a feature-loss failure (missing push notification,
 Spotlight result, StoreKit sheet, universal link, or system picker) instead
@@ -268,6 +275,35 @@ The requester identity for leases made through this server is
 [Agent identity](#agent-identity). Set a distinct `SIMLOCK_AGENT_ID` per MCP
 server process (one per agent session) so the one-lease-per-agent rule is
 meaningful.
+
+### Breaking in 0.3.0: tool schemas are now the contract's own field names
+
+Tool names are unchanged. Every tool's input/output schema is now derived
+directly from `src/contract`'s zod schemas (`src/mcp/contracts.ts`) instead
+of a hand-maintained snake_case shape — one vocabulary across CLI, MCP,
+HTTP, and `simlock/client`, not a fourth one. Two changes in here are easy
+to miss and will silently produce wrong behavior if you don't update a
+caller:
+
+- **`lease_simulator`'s `timeout_seconds` is now `timeoutMs` — a unit
+  change, not just a rename.** A caller that keeps sending the old field
+  name under the new one (`{"timeoutMs": 30}` meaning "30 seconds", the old
+  convention) waits 1000× longer than intended before timing out. This is
+  the single highest-risk change in this release — it does not fail loudly,
+  it just waits far too long. Update every caller's timeout field name *and*
+  multiply its value by 1000.
+- **The top-level `slim: boolean` on a grant is gone; it's now
+  `device.featureProfile`** (`"full" | "reduced" | undefined`, undefined
+  meaning "not applicable" — always undefined for Android). A caller
+  checking `result.slim === true` now silently never sees a feature-loss
+  signal at all — `result.slim` is simply `undefined` on every response,
+  which is falsy, not an error. Check `result.device.featureProfile ===
+  "reduced"` instead.
+
+Every other field keeps the contract's own camelCase names it already had
+under the pre-0.3.0 hand-written schemas (`leaseId`, `deviceId`,
+`allowDownload`, `requesterId`, ...); those did not change shape, only their
+schema's source of truth.
 
 ## `simlock status`
 

--- a/docs/CLIENT.md
+++ b/docs/CLIENT.md
@@ -1,0 +1,166 @@
+# Programmatic client (`simlock/client`, `simlock/admin`)
+
+Part of the user manual: the typed daemon client a host process (for
+example, agent-device) uses to lease devices over the daemon's unix socket
+without spawning a `simlock` command. It is the same client the CLI and MCP
+frontends are built on (`src/cli`, `src/mcp/session.ts`) — nothing about it
+is second-class relative to the CLI.
+
+Two entry points, split by import path rather than by a runtime flag:
+
+```ts
+import { connectSimlock } from "simlock/client"; // agent role
+import { connectSimlockAdmin } from "simlock/admin"; // agent + admin role
+```
+
+`connectSimlockAdmin` returns a superset of `connectSimlock`'s client — every
+agent-role method plus the admin-role ones (`list`, `runCleanup`, `runNuke`,
+`getConfig`, `stopDaemon`, `replayEvents`/`subscribeEvents`,
+`createToken`/`listTokens`/`revokeToken`). The split exists so
+`simlock/client` doesn't even show admin methods in a caller's editor; the
+daemon's own role check is what actually stops an agent-role session from
+calling one (ADR 0003 §3) — this is a discoverability choice, not the
+enforcement mechanism.
+
+Both are async factories that open one connection and complete the `hello`
+handshake:
+
+```ts
+const client = await connectSimlock({
+  endpoint: "/path/to/daemon.sock", // or omit + pass `connection` in tests
+  principal: "agent-1",
+});
+
+const grant = await client.requestLease({ platform: "ios", model: "iPhone 17 Pro" });
+// grant: { device, lease, timing } — the contract's LeaseGrant, verbatim
+
+await client.releaseLease({ leaseId: grant.lease.id });
+await client.close();
+```
+
+`connectSimlockAdmin` additionally accepts `credential` — an operator token
+or the daemon's per-start `admin.token` secret (see
+[ARCHITECTURE.md](ARCHITECTURE.md#security-model-cooperative-identity-not-a-hostile-process-boundary)
+for what those are and how the CLI resolves one). A missing or wrong
+credential fails the handshake with `ADMIN_AUTHENTICATION_FAILED` before any
+other request is sent on that connection:
+
+```ts
+import { connectSimlockAdmin, isSimlockError } from "simlock/admin";
+
+try {
+  const admin = await connectSimlockAdmin({ endpoint: sockPath, credential: token });
+} catch (error) {
+  if (isSimlockError(error) && error.code === "ADMIN_AUTHENTICATION_FAILED") {
+    // bad or missing credential
+  }
+}
+```
+
+Every exported type — `LeaseRequestInput`, `LeaseGrant`, `LeaseRecord`,
+`DoctorReport`, `SimlockConfig`, error codes, and so on — is derived from
+`src/contract`'s zod schemas, the same vocabulary the CLI's `--json` output
+and MCP's tool schemas now share. Nothing core-private
+(`DeviceRecord`/`LeaseRecord`-the-core-type) ever appears on this surface;
+see `src/simlock-client/no-core-leak.test.ts`.
+
+## One connection, no reconnect, no retry
+
+This is the one thing to internalize before building anything on top of this
+client: **it owns exactly one connection and never reconnects or retries,
+not even for reads.** When the connection dies — the daemon stops, crashes,
+or the socket is killed out from under it — every in-flight call rejects
+with `DAEMON_CONNECTION_LOST`, `onLeaseLost` fires for each lease this
+client held (reason `daemon-connection-lost`), and the client is done. There
+is no automatic retry loop hiding behind any method, including `getStatus`
+or `getCatalog` — a shared retry policy is a trap the moment it touches a
+mutation, so this module simply does not have one at all, for anything.
+
+Reconnect policy is deliberately a frontend's own concern, not something
+this client can make a universal decision about:
+
+- **MCP** keeps a lazy reconnect, because its process outlives any single
+  connection — the next tool call after a dead connection builds a brand new
+  client (see `src/mcp/session.ts`, `src/mcp/connect.ts`).
+- **The CLI** needs none — a CLI invocation's whole purpose ends with its
+  connection.
+- **A host process** (agent-device) has its own supervisor and its own
+  opinion about what "still needed" means across a daemon restart; this
+  client does not guess on its behalf.
+
+The payoff of never reconnecting automatically: "reconnecting never
+implicitly acquires a device" is trivially true for a client that cannot
+reconnect at all. If you need resilience across a dropped connection, build
+it explicitly — call `connectSimlock`/`connectSimlockAdmin` again and decide
+for yourself whether the lease you held is worth re-requesting.
+
+```ts
+client.onConnectionLost((error) => {
+  // Fires exactly once. Every in-flight call has already rejected
+  // DAEMON_CONNECTION_LOST and every onLeaseLost for a held lease has
+  // already fired by the time this runs.
+});
+```
+
+## Abort semantics
+
+`requestLease` takes an `AbortSignal` as part of its options. Aborting does
+not simply drop the caller's interest client-side — it drives the daemon's
+own `lease.cancel` operation (ADR 0003 §9) and waits for a real outcome, so
+the caller is never left guessing whether a device is or isn't leased to it:
+
+```ts
+const controller = new AbortController();
+const promise = client.requestLease(
+  { platform: "ios", model: "iPhone 17 Pro" },
+  { signal: controller.signal, onProgress: (p) => console.log(p) },
+);
+controller.abort();
+await promise; // rejects with a CANCELLED SimlockError, in every case below
+```
+
+Four cases, by when the signal fires:
+
+- **Before the request is even sent** — rejects `CANCELLED` immediately;
+  nothing is sent to the daemon at all.
+- **While the request is still queued** — sends `lease.cancel`, waits for
+  the original request to actually reject, then surfaces `CANCELLED`
+  regardless of what that rejection's own code/message was.
+- **While device work is already in flight** (provisioning, booting,
+  reclaiming) — `lease.cancel` answers `not-cancellable` at this stage; the
+  client waits for the request's real outcome. If a grant still lands, it is
+  released immediately (`releaseLease`, best-effort) so the caller never
+  ends up holding a device it already told the client it didn't want, and
+  `CANCELLED` is surfaced either way.
+- **After the grant already resolved** — the abort is ignored; you have a
+  device, and aborting an already-finished request is a no-op by design, not
+  an implicit release.
+
+**True cancellation during provisioning is out of scope for this release.**
+The "device work already in flight" case above releases the grant
+immediately once it lands rather than actually interrupting the in-flight
+provision/boot/reclaim — the daemon keeps doing the work, the caller just
+doesn't end up holding the result. This is recorded as a known gap in
+[known-pitfalls.md](known-pitfalls.md).
+
+## What this client does not do
+
+- It does not start or stop the daemon. `connectSimlock`/`connectSimlockAdmin`
+  only ever connect to an already-listening socket; auto-launch (what the
+  CLI and MCP do on a missing daemon) is a frontend concern layered on top,
+  not something this module provides. Build your own launch-then-retry
+  policy around it if you need one — `src/mcp/connect.ts`'s
+  `connectWithAutoLaunch` is a worked example, deliberately never launching
+  on anything but "nothing is listening" (a version mismatch or a refused
+  handshake means something answered, and launching there risks a second
+  daemon instance or masking a real incompatibility).
+- It does not restart the daemon on a protocol version mismatch. See
+  [ARCHITECTURE.md](ARCHITECTURE.md) and the ADR §6 for why: that would
+  release every held lease on the machine. `PROTOCOL_VERSION_UNSUPPORTED`
+  names the running daemon's version; the fix is `simlock daemon stop` when
+  it's idle, run by an operator or supervisor, not this client.
+- It does not expose a role the daemon itself would reject — `simlock/admin`
+  showing you `stopDaemon`/`runNuke`/etc. is a TypeScript-editor
+  convenience, not the actual gate. The daemon's own role check is what
+  actually stops an agent-credentialed connection from calling one; do not
+  treat "the method exists on the type" as proof of authorization.

--- a/docs/HTTP-API.md
+++ b/docs/HTTP-API.md
@@ -8,10 +8,16 @@ another machine is the operator's own tunnel (Tailscale, cloudflared, a
 reverse proxy) — Simlock does no TLS termination in v1, and `Authorization`
 is required on every route regardless of how it's reached, loopback included.
 
-The gateway calls the same role interfaces the CLI and MCP server call
-(`LeaseCommands`, `QueueControl`, `CapacityReader`, `CatalogReader`); the core
-never knows HTTP exists. See [ARCHITECTURE.md](ARCHITECTURE.md) for how it
-fits alongside the other frontends.
+The gateway calls the exact same in-process `Dispatcher` the unix socket
+calls (ADR 0003 §2) — not a second copy of role/ownership logic, and not a
+loopback hop through the socket either. Every route that maps onto a daemon
+operation gets the same input parsing, role check, `authorize`/ownership
+hook, and startup-readiness parking a socket request gets, from that one
+shared instance. This is also why a fix on the socket side (the download
+policy, startup-readiness parking, error mapping) lands on HTTP for free —
+see [ARCHITECTURE.md](ARCHITECTURE.md#contract-dispatcher-and-roles-adr-0003)
+for how it fits together, and the two bug fixes called out below for what
+this actually changed.
 
 ## Leases are detached-only over HTTP
 
@@ -100,6 +106,14 @@ shares a pool key with, a slim device, so it can wait for a fresh device to
 provision or force a re-provision of one already running, even while slim
 devices sit idle in the warm pool. See [CONFIGURATION.md](CONFIGURATION.md)
 for what slim mode disables.
+
+`allowDownload` is now clamped through `config.downloads.policy` the same
+way the socket protocol always was (**bug fix, 0.3.0**): before this
+release, HTTP passed a client-supplied `allowDownload` straight through
+unclamped, so a `"never"` policy could still be bypassed over HTTP even
+though it already blocked the same thing on the socket. Both frontends now
+go through the one shared dispatcher, so there is only one place left to get
+this wrong.
 An `Idempotency-Key` header (at most 200 characters) makes a replay of the
 same key, from the same requester, return the original request resource
 instead of double-queueing — held in memory with a TTL, so a replay after a
@@ -184,7 +198,19 @@ as a bug.
 
 Role: `agent` (own lease; `operator` any). Re-fetches the lease — a client
 that restarts mid-lease recovers its state instead of leaking the lease.
-`404 UNKNOWN_LEASE` once it has expired or been released.
+`404 UNKNOWN_LEASE` once it has expired or been released, **and now also for
+another requester's own, still-live lease** (bug fix, 0.3.0: this used to be
+`403 FORBIDDEN`, which told an unauthorized caller a lease id was valid).
+Every route under `/v1/leases/{id}` (this one, `renew`, `events`, `DELETE`)
+resolves the lease the same way `lease.list`'s dispatcher handler already
+filters leases — to the session's own set, admin sees all — so an id outside
+that set simply isn't in the list; `404` covers "doesn't exist" and "not
+yours" identically, the same way `lease.list` itself does not distinguish
+them. This is different from the lease-*request* routes below
+(`/v1/lease-requests/{id}` and friends), which are still HTTP's own resource
+and still answer `403 FORBIDDEN` for another requester's request — that
+envelope stays HTTP-specific until
+[#72](https://github.com/callstackincubator/simlock/issues/72).
 
 `expiresAt` is always the authoritative deadline. After a **daemon** restart
 the gateway no longer remembers a per-request `ttlMs`, so the payload reports
@@ -244,8 +270,8 @@ Every failure is the same shape the daemon protocol uses:
 |---|---|
 | 400 | `BAD_REQUEST` (malformed body, bad query param, validation) |
 | 401 | `UNAUTHENTICATED` (missing or unrecognized token) |
-| 403 | `FORBIDDEN` (role doesn't permit the route; or the lease/request belongs to another requester) |
-| 404 | `UNKNOWN_REQUEST`, `UNKNOWN_LEASE` |
+| 403 | `FORBIDDEN` (role doesn't permit the route; or a `/v1/lease-requests/*` route whose request belongs to another requester) |
+| 404 | `UNKNOWN_REQUEST` (unknown request id), `UNKNOWN_LEASE` (unknown lease id, expired/released, **or a `/v1/leases/*` route naming another requester's lease** — see [`GET /v1/leases/{id}`](#get-v1leasesid)) |
 | 409 | `REQUESTER_ALREADY_LEASED` (body names the existing lease id), `REQUEST_NOT_CANCELLABLE` (body names the lease id if the request had already been granted) |
 | 422 | `UNKNOWN_MODEL`, `RUNTIME_MISSING`, `NO_DRIVER` |
 | 503 | `NO_CAPACITY` (only with `noWait: true`; response carries `Retry-After`) |
@@ -263,12 +289,15 @@ Every failure is the same shape the daemon protocol uses:
   (including across a restart) creates a fresh request rather than erroring
   — the `409` above is the real backstop against a double grant, not the
   idempotency cache.
-- **Startup.** The gateway starts only after the daemon's own startup
-  convergence finishes (unlike the unix socket, which accepts connections
-  immediately and parks non-`hello`/`status.get` requests until convergence
-  completes). A connection refused while the daemon is still starting up is
-  accepted v1 behavior — there is no HTTP-level "starting" response to
-  mirror the socket protocol's parked dispatch.
+- **Startup.** The gateway's listener now starts the moment the daemon
+  claims its socket — the same instant the unix socket itself starts
+  accepting connections, before startup convergence (`doctor.reconcile()`,
+  running-capacity convergence) has run (**bug fix, 0.3.0**: the gateway
+  used to start only once convergence had already finished, so it could not
+  observe or need this). A request that arrives before convergence completes
+  now waits on the shared dispatcher's readiness gate exactly like a socket
+  request, instead of being refused — every route but the routes that don't
+  dispatch at all (`GET /v1/healthz`) can block briefly on a cold start.
 - **Shutdown.** `simlock daemon stop` closes the HTTP listener (and any open
   connection, in-flight SSE streams included) before releasing held leases
   or tearing down the lease engine, so no HTTP request can run against a

--- a/docs/adr/0003-one-typed-daemon-contract-behind-every-frontend.md
+++ b/docs/adr/0003-one-typed-daemon-contract-behind-every-frontend.md
@@ -1,6 +1,6 @@
 # 0003. One typed daemon contract behind every frontend
 
-- **Status:** Accepted — implemented (0.3.0)
+- **Status:** Accepted
 - **Date:** 2026-09-03
 - **Issue:** [#71](https://github.com/callstackincubator/simlock/issues/71)
   (part of [#70](https://github.com/callstackincubator/simlock/issues/70))

--- a/docs/adr/0003-one-typed-daemon-contract-behind-every-frontend.md
+++ b/docs/adr/0003-one-typed-daemon-contract-behind-every-frontend.md
@@ -1,6 +1,6 @@
 # 0003. One typed daemon contract behind every frontend
 
-- **Status:** Accepted — not yet implemented
+- **Status:** Accepted — implemented (0.3.0)
 - **Date:** 2026-09-03
 - **Issue:** [#71](https://github.com/callstackincubator/simlock/issues/71)
   (part of [#70](https://github.com/callstackincubator/simlock/issues/70))

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,4 +22,4 @@ Status values:
 |---|---|---|
 | [0001](0001-simlock-owned-device-roots.md) | Simlock-owned device roots | Accepted — not yet implemented |
 | [0002](0002-opt-in-slim-ios-simulators.md) | Opt-in slim iOS simulators | Accepted |
-| [0003](0003-one-typed-daemon-contract-behind-every-frontend.md) | One typed daemon contract behind every frontend | Accepted — not yet implemented |
+| [0003](0003-one-typed-daemon-contract-behind-every-frontend.md) | One typed daemon contract behind every frontend | Accepted |

--- a/docs/known-pitfalls.md
+++ b/docs/known-pitfalls.md
@@ -147,6 +147,77 @@ built in stage 4. `component.install-started`'s payload already carries
 enough (`platform`, `componentId`) that a future pass wiring this through
 would mostly be plumbing, not new information to invent.
 
+## True cancellation during provisioning is not implemented (ADR 0003 §10)
+
+`simlock/client`'s `requestLease` takes an `AbortSignal`. When device work is
+already in flight (provisioning, booting, reclaiming) and the caller aborts,
+the client sends `lease.cancel`, which answers `not-cancellable` at that
+stage — the daemon keeps doing the work. What the client does instead:
+it waits for the request's real outcome, and if a grant still lands, releases
+it immediately so the caller never ends up holding a device it already
+walked away from, then surfaces `CANCELLED` either way.
+
+**The pitfall:** this is release-on-arrival, not interruption. The
+provisioning/boot/reclaim work the abort was meant to stop keeps running to
+completion (or failure) on its own, consuming the time and driver resources
+it would have anyway, and the released device pays a purge (see "Release
+hands the purge off" in [ARCHITECTURE.md](ARCHITECTURE.md)) before it's
+usable by anyone else. A caller that aborts expecting the operation to
+actually stop gets a device that is unavailable for roughly as long as an
+uncancelled request would have taken, just without ending up holding it.
+
+**Status:** known and accepted for this release, deliberately out of scope
+per the ADR ("True cancellation during provisioning is deliberately out of
+scope here"). Actually interrupting driver work mid-flight would mean
+threading cancellation through `Driver.provision`/`makeReady`/`reclaim`
+themselves — real protocol and driver-interface machinery across both
+platforms, not a client-side change.
+
+**Possible future fix:** none planned yet. A caller that needs to bound the
+cost of an abandoned request should set `timeoutMs`/`--timeout` tightly
+rather than relying on abort to cut a request short once device work has
+started.
+
+## The HTTP tracker and notice buffer are the last frontend-held state (#72)
+
+ADR 0003 moved request handling into one shared, transport-independent
+dispatcher (`src/daemon/dispatcher.ts`) that both the unix socket and HTTP
+call — but two pieces of state still live in the HTTP frontend rather than
+the daemon's core:
+
+- **`LeaseRequestTracker`** (`src/http/tracker.ts`) — the in-memory registry
+  behind `POST /v1/lease-requests` and the resource it returns
+  (`GET`/`DELETE /v1/lease-requests/{id}`, its SSE stream, `Idempotency-Key`
+  replay). This is what lets HTTP offer an async-resource-shaped API
+  (`202`-then-poll) on top of the core's request/grant flow, which itself
+  has no notion of a durable, independently-addressable "request resource."
+- **`LeaseNoticeBuffer`** (`src/http/notices.ts`) — buffers owner-routed
+  device-health facts (`device_unhealthy`, `device_recovered`) per lease so
+  a polling-only HTTP client (no open connection to push to) can drain them
+  on its next `renew` or SSE reconnect instead of missing them entirely.
+
+**The pitfall:** both reset on a daemon restart (in-memory, no persistence),
+and both are HTTP-specific reimplementations of "track something about a
+request/lease across calls" that the socket frontends don't need because
+they hold a live connection instead. A daemon restart loses in-flight
+lease-request tracking state and buffered notices the same way it always
+did pre-ADR 0003 — see [Lifecycle semantics](HTTP-API.md#lifecycle-semantics)
+for the documented recovery loop (`404` → re-request → maybe `409` → `GET`),
+which exists specifically because the tracker does not survive a restart.
+
+**Status:** known, and explicitly called out as the ADR's own unfinished
+seam, not an oversight: "the HTTP tracker and notice buffer remain the known
+stateful leftovers in a frontend." The ADR's dispatcher work "prepares the
+seam... but does not do that work" of removing them.
+
+**Planned fix:** [#72](https://github.com/callstackincubator/simlock/issues/72),
+re-scoped by this ADR to core durability and idempotency — moving durable,
+idempotent lease requests into the core registry itself, so a lease request
+becomes a first-class, restart-surviving core concept instead of a resource
+HTTP alone tracks. Once that lands, `LeaseRequestTracker` and
+`LeaseNoticeBuffer` should be able to shrink to thin views over core state
+rather than independent bookkeeping.
+
 ## iOS slim mode: accepted costs and feature loss (#87)
 
 `ios.slim` (opt-in, default off) has the iOS driver disable ~170 launchd
@@ -183,8 +254,12 @@ universal links, Siri/Apple Intelligence, iCloud sync, and some system
 pickers to not work on a slim device — the categories that back them are
 exactly the ones slimming disables. Mitigations: `simlock lease --full` (MCP
 `full: true`, HTTP `full: true`) opts a single lease out of slimming, and
-every lease response carries a `slim` flag so a caller can tell a
-feature-loss failure apart from an actual bug instead of guessing.
+every lease response carries a feature-profile signal so a caller can tell a
+feature-loss failure apart from an actual bug instead of guessing —
+`device.featureProfile === "reduced"` on the CLI/MCP/client contract shape
+(`slim` as a top-level boolean grant field is gone as of 0.3.0, ADR 0003
+§11), or HTTP's own `lease.slim` boolean, which is still derived from the
+same underlying signal.
 
 **Mixing slim and full devices under one spec can make `--full` wait or
 re-provision.** `full` is part of spec identity (`DeviceSpec.full`, compared by `sameSpec`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simlock",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Control plane for iOS simulators and Android emulators.",
   "keywords": [
     "agents",


### PR DESCRIPTION
**Stacked on #98.** PR 5 of 5 implementing ADR 0003 (§11, §12, Consequences).

## New and rewritten documentation

- **`docs/CLIENT.md`** (new) — the programmatic client: connecting, the four abort behaviours, and the contract that it never reconnects and never retries, so reconnect policy is the caller's. Linked from `README.md` and `docs/ABOUT.md`.
- **`docs/ARCHITECTURE.md`** — a new section on the contract module, the single dispatcher serving every transport, roles, and the principal/requester/owner distinction. Makes explicit that HTTP calls the dispatcher **in-process** rather than routing through the loopback socket.
- **The security model, stated plainly**, as §4 and §5 require: socket identity is **cooperative** — every socket peer is the same OS user, which is the real trust boundary, and ownership checks protect against accidents, not a hostile local process. Documents both admin credentials and the CLI's resolution order, and that `doctor.run` without `fix` is agent-visible and read-only but shells out per device.

## Breaking changes documented for 0.3.0

- **MCP: `timeout_seconds` → `timeoutMs`.** A unit change as well as a rename — an un-updated caller is silently wrong by 1000×. Documented prominently; it is the highest-risk item in this release. Also `slim` → `device.featureProfile`.
- **CLI:** `--json` and stderr lines are contract values; the snake_case keys are gone. Exit codes unchanged.
- **HTTP:** bodies are contract types; `GET /v1/leases/:id` returns 404 rather than 403 for another requester's lease.
- **Wire:** protocol 3, no compatibility shim. `PROTOCOL_VERSION_UNSUPPORTED` on mismatch, the client never restarts the daemon, and `daemon.stop` is accepted at any protocol version the daemon has spoken — while still requiring the admin role.

## Bug fixes documented as such

The `allowDownload` clamp now applying to HTTP, and an HTTP request during startup parking rather than being refused. Both were divergences the ADR set out to close.

## Docs that disagreed with the code

Found and fixed, rather than papered over: HTTP's "same role interfaces" description and its startup-refuse behaviour; the 403/404 change; undocumented `allowDownload` clamping; MCP's breaking changes documented nowhere; `README.md`'s pre-ADR snake_case example; stale `slim` references in `known-pitfalls.md`; and `ARCHITECTURE.md` bullets describing code paths this stack deleted.

## Follow-ups recorded in `known-pitfalls.md`

True cancellation during provisioning is not implemented — aborting mid-provision releases the grant rather than stopping the work, exactly as §10 requires be recorded. The HTTP tracker and notice buffer are named as the last frontend-held state, which #72 removes.

`docs/EVENTS.md` was already in sync — PR 2 documented `ownerId` on `lease.released`/`lease.expired` in the same change, per events rule 8.

## Smoke tests (§12)

All four exist. Client, CLI and MCP are explicitly labelled as the §12 smoke test. HTTP's round-trip lifecycle test covers it in substance but is not labelled and runs against a fake dispatcher — noted rather than reworked.

## Notes for reviewers

- `CHANGELOG.md` is new and hand-written. The repo generates it via release-it/conventional-changelog, but this stack's commits carry no `!` or `BREAKING CHANGE:` footers, so automatic detection would not have surfaced any of the breaks above. Worth deciding whether future commits adopt that convention.
- `src/contract/*.ts` still carry stale in-code comments from earlier PRs ("PR 2 adds…", "no handler exists yet" for token operations) that no longer match reality. Not documentation, so untouched here; flagged for a cleanup pass.
- ADR 0003's status is now `Accepted`, with the index synced.