### PR TITLE
fix(client): make abort actually cancel, and keep the mismatch escape hatch alive

### DIFF
--- a/src/contract/operations.ts
+++ b/src/contract/operations.ts
@@ -124,6 +124,20 @@ export const leaseRequest = defineOperation({
   role: "agent",
   input: leaseRequestInputSchema,
   output: leaseGrantSchema,
+  /**
+   * Deliberately no `authorize` hook, and not an oversight to pair with `lease.cancel`'s: ADR
+   * §4 is explicit that any agent session may request a lease under an arbitrary
+   * `requesterId` -- that is the whole mechanism behind "one connection (the host, acting as
+   * a proxy for many agents) holds many leases by passing one requester id per session". The
+   * lease's actual `ownerId` is never client-supplied (always `session.principal`, see the
+   * dispatcher's `#leaseRequest`), so this does not let one session take over another's
+   * lease -- only choose the attribution label on a lease it will itself own. `lease.cancel`
+   * used to look inconsistent next to this (forbidding a `requesterId` that did not equal the
+   * principal, on an operation that has none of `lease.request`'s ownership protection to
+   * begin with) -- fixed by gating `lease.cancel` on the pending request's recorded owner
+   * (`pendingRequestOwner`, see its own `authorize` hook below) instead, which is consistent
+   * with this operation's design rather than in tension with it.
+   */
 });
 
 // ---- lease.cancel (new, ADR §9) --------------------------------------------------------------
@@ -135,16 +149,25 @@ export const leaseCancel = defineOperation({
   input: z.object({ requesterId: z.string().optional() }),
   output: z.object({ result: z.enum(["cancelled", "not-found", "not-cancellable"]) }),
   /**
-   * ADR §9: "cancels this principal's pending request by requester id" -- not any pending
-   * request, keyed by a `requesterId` the caller can pass arbitrarily. Deliberately not
-   * `ownsLease` (that hook resolves a *lease's* recorded `ownerId` from the registry; a
-   * pending, not-yet-granted request has no lease yet to look up). `requesterId` defaults to
-   * the principal the same way the handler's own default does (see `dispatcher.ts`'s
-   * `#leaseCancel`), so an omitted `requesterId` always passes -- only an explicit, *different*
-   * `requesterId` is gated, and only admin may supply one.
+   * ADR §9: "cancels this principal's pending request by requester id". Gated on the pending
+   * request's *recorded owner* (`pendingRequestOwner`, ADR §4's `ownerId` -- always the
+   * creating session's principal, never the caller-suppliable `requesterId`), not on comparing
+   * `requesterId` to the principal directly -- that comparison would forbid exactly the case
+   * ADR §4 exists for: one connection (`principal: "host"`) proxying many agents, each under
+   * its own `requesterId` (`"agent-7"`). Deliberately not `ownsLease` (that hook resolves a
+   * *lease's* recorded `ownerId` from the registry; a pending, not-yet-granted request has no
+   * lease yet to look up -- `pendingRequestOwner` is the wait-queue equivalent). An omitted
+   * `requesterId` defaults to the principal the same way the handler's own default does (see
+   * `dispatcher.ts`'s `#leaseCancel`), so it always resolves to a request this principal owns.
+   * A `requesterId` with no pending request resolves `pendingRequestOwner` to `undefined`,
+   * which is treated as authorized (same convention as `ownsLease`) so the handler's own
+   * `not-found` surfaces instead of a misleading `FORBIDDEN`.
    */
-  authorize: (input, context) =>
-    context.role === "admin" || (input.requesterId ?? context.principal) === context.principal,
+  authorize: (input, context) => {
+    if (context.role === "admin") return true;
+    const owner = context.pendingRequestOwner(input.requesterId ?? context.principal);
+    return owner === undefined || owner === context.principal;
+  },
 });
 
 // ---- lease.renew ----------------------------------------------------------------------------

--- a/src/contract/protocol.ts
+++ b/src/contract/protocol.ts
@@ -86,10 +86,17 @@ export const helloRequestSchema = z
  * What the daemon replies with. `role` is declared now (every field a client will eventually
  * need to assert it got what it asked for, per ADR §5) but is a fixed value until PR 2 resolves
  * it from a real credential -- see `DaemonServer#handleHello`.
+ *
+ * `principal` is the connection's resolved, fixed-for-its-lifetime identity (ADR §4): what a
+ * `hello` request supplied, or the daemon's own default (today: `defaultRequesterId`) when it
+ * omitted one. Without this the client cannot learn its own principal in that fallback case, and
+ * would otherwise have to guess -- see the abort-authorization defect this closes in
+ * `simlock-client/client.ts`.
  */
 export const helloReplySchema = z.object({
   protocolVersion: z.number().int(),
   daemonProtocolRange: protocolRangeSchema,
   version: z.string(),
   role: z.enum(["agent", "admin"]),
+  principal: z.string(),
 });

--- a/src/contract/roles.ts
+++ b/src/contract/roles.ts
@@ -20,6 +20,16 @@ export interface AuthorizeContext {
   readonly principal: string;
   readonly role: Role;
   readonly ownerId: (id: string) => string | undefined;
+  /** ADR §4/§9: the session principal that created the pending request identified by
+   * `requesterId` -- looked up against the live wait queue, the same "lookup, not a value"
+   * shape as `ownerId` above and for the same reason (the only identifier available at
+   * `authorize` time is whatever the input schema already validated). Used by `lease.cancel`
+   * so a proxy connection (one principal, many `requesterId`s) can cancel what it created,
+   * rather than comparing the caller-suppliable `requesterId` to the principal directly.
+   * Returns `undefined` for a `requesterId` with no pending request, which `lease.cancel`'s
+   * `authorize` hook treats as authorized on purpose -- same convention as `ownsLease` -- so
+   * the handler's own `not-found` surfaces instead of a misleading `FORBIDDEN`. */
+  readonly pendingRequestOwner: (requesterId: string) => string | undefined;
 }
 
 /**

--- a/src/core/lease-acquisition-coordinator.ts
+++ b/src/core/lease-acquisition-coordinator.ts
@@ -124,6 +124,21 @@ export class LeaseAcquisitionCoordinator implements AcquisitionMaintenance {
     return this.options.queue.depth;
   }
 
+  /**
+   * The session principal a pending request was created under (ADR §4: `ownerId` on
+   * `LeaseRequestOptions`, always the session principal, never the caller-suppliable
+   * `requesterId`). `undefined` when no pending request exists for this requester id --
+   * `cancelPending`'s own `not-found` outcome is what surfaces that, not this lookup, so a
+   * caller cancelling a request that already settled (or never existed) is not authorized on
+   * a manufactured owner. A synchronous read like `queueDepth`, not routed through
+   * `decisions.run`: no state is asserted or mutated, and `#leaseCancel`'s contract-level
+   * `authorize` hook (ADR §2 step 3) runs before the handler, so it cannot go through the
+   * handler's own serialized decision anyway.
+   */
+  pendingRequestOwner(requesterId: string): string | undefined {
+    return this.options.queue.findPendingWaiter(requesterId)?.options.ownerId;
+  }
+
   get queueHeadSpec(): DeviceSpec | undefined {
     return (this.options.queue.head as AcquisitionWaiter | undefined)?.spec;
   }

--- a/src/core/lease-engine.ts
+++ b/src/core/lease-engine.ts
@@ -321,6 +321,13 @@ export class LeaseEngine {
     return this.#acquisition.cancelPending(requesterId);
   }
 
+  /** The session principal that owns a pending request, for `lease.cancel`'s owner-aware
+   * `authorize` hook (ADR §4). See the coordinator method's own comment. */
+  // fallow-ignore-next-line unused-class-member -- reached through the QueueControl port by the dispatcher's authorize context (same as the sibling cancelPending).
+  pendingRequestOwner(requesterId: string): string | undefined {
+    return this.#acquisition.pendingRequestOwner(requesterId);
+  }
+
   // fallow-ignore-next-line unused-class-member -- reached through the LeaseCommands port by DaemonServer (same as the sibling heartbeat).
   async renew(leaseId: string, ttlMs?: number): Promise<LeaseRecord> {
     return this.#releaseCoordinator.renew(leaseId, ttlMs);

--- a/src/core/lease-ports.ts
+++ b/src/core/lease-ports.ts
@@ -22,6 +22,12 @@ export interface QueueControl {
   readonly queueDepth: number;
   detachQueuedProgress(requesterId: string): Promise<void>;
   cancelPending(requesterId: string): Promise<"cancelled" | "not-found" | "not-cancellable">;
+  /** ADR §4: the session principal a pending request was created under -- always the creating
+   * session's principal (`LeaseRequestOptions.ownerId`), never the caller-suppliable
+   * `requesterId`. `undefined` when no pending request exists for this requester id. Used by
+   * `lease.cancel`'s `authorize` hook so a proxy connection (one principal, many
+   * `requesterId`s) can cancel what it created, per ADR §4/§9. */
+  pendingRequestOwner(requesterId: string): string | undefined;
 }
 
 /** Read-only capacity view used by daemon status. */

--- a/src/daemon/dispatcher.test.ts
+++ b/src/daemon/dispatcher.test.ts
@@ -282,16 +282,19 @@ describe("Dispatcher: ownership", () => {
     expect(admin.leases).toHaveLength(1);
   });
 
-  it("lease.cancel: rejects an agent naming a different requesterId with FORBIDDEN, admits an admin", async () => {
+  it("lease.cancel: naming a requesterId with no pending request always passes (not-found), admin bypasses too", async () => {
     const { dispatcher } = await buildDispatcher();
 
+    // A requesterId nobody has a pending request under: not gated, since there is no owner to
+    // compare against -- `pendingRequestOwner` resolves `undefined`, and `not-found` is what
+    // surfaces (the same convention `ownsLease` uses for an unknown lease id).
     await expect(
       dispatcher.dispatch(
         "lease.cancel",
         { requesterId: "tok_other" },
         session({ principal: "tok_agent", role: "agent" }),
       ),
-    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    ).resolves.toMatchObject({ result: "not-found" });
 
     // An omitted requesterId always passes (defaults to the principal) -- see the operation's
     // `authorize` hook doc in `operations.ts`.
@@ -306,6 +309,74 @@ describe("Dispatcher: ownership", () => {
         session({ principal: "tok_admin", role: "admin" }),
       ),
     ).resolves.toMatchObject({ result: "not-found" });
+  });
+
+  it("lease.cancel: gated on the pending request's recorded owner (ADR §4), not the requesterId -- so a proxy connection can cancel what it created", async () => {
+    const { dispatcher, engine } = await buildDispatcher();
+
+    // Fill iOS capacity (maxRunning: 2, see testConfig) so a third request queues instead of
+    // granting immediately -- cancellability requires a still-`queued` waiter.
+    await dispatcher.dispatch(
+      "lease.request",
+      {
+        model: "iPhone 17 Pro",
+        mode: "detached",
+        requesterId: "tok_owner1",
+        osVersion: "26.5",
+        platform: "ios",
+      },
+      session({ principal: "tok_owner1" }),
+    );
+    await dispatcher.dispatch(
+      "lease.request",
+      {
+        model: "iPhone 17 Pro",
+        mode: "detached",
+        requesterId: "tok_owner2",
+        osVersion: "26.5",
+        platform: "ios",
+      },
+      session({ principal: "tok_owner2" }),
+    );
+
+    // ADR §4's proxy case: one connection, principal "host", requesting under a different
+    // requesterId ("agent-7") than its own principal.
+    const queuedRequest = dispatcher.dispatch(
+      "lease.request",
+      {
+        model: "iPhone 17 Pro",
+        mode: "held",
+        requesterId: "agent-7",
+        osVersion: "26.5",
+        platform: "ios",
+      },
+      session({ principal: "host" }),
+    );
+    await expect.poll(() => engine.queueDepth).toBe(1);
+
+    // Naming "agent-7" from a session that is neither "host" (the recorded owner) nor admin is
+    // FORBIDDEN, even though "agent-7" is the pending request's own requesterId -- the ADR
+    // incoherence this fixes: `lease.cancel` is no longer gated on `requesterId === principal`.
+    await expect(
+      dispatcher.dispatch(
+        "lease.cancel",
+        { requesterId: "agent-7" },
+        session({ principal: "tok_other", role: "agent" }),
+      ),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+    // The owning principal ("host") cancels what it created, under the requesterId it created
+    // it with -- this is the case the old `requesterId === principal` comparison forbade
+    // outright.
+    await expect(
+      dispatcher.dispatch(
+        "lease.cancel",
+        { requesterId: "agent-7" },
+        session({ principal: "host", role: "agent" }),
+      ),
+    ).resolves.toMatchObject({ result: "cancelled" });
+
+    await expect(queuedRequest).rejects.toThrow();
   });
 });
 

--- a/src/daemon/dispatcher.ts
+++ b/src/daemon/dispatcher.ts
@@ -221,6 +221,7 @@ export class Dispatcher {
       const context: AuthorizeContext = {
         ownerId: (leaseId) =>
           this.options.registry.snapshot.leases.find((lease) => lease.id === leaseId)?.ownerId,
+        pendingRequestOwner: (requesterId) => this.options.queue.pendingRequestOwner(requesterId),
         principal: session.principal,
         role: session.role,
       };

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -1431,6 +1431,27 @@ describe("DaemonServer roles and ownership (ADR 0003 §2-4)", () => {
     await client.close();
   });
 
+  it("hello reports the resolved principal: the client-supplied one verbatim, or the daemon's default when omitted (ADR §4)", async () => {
+    const harness = await createHarness();
+
+    const explicit = await createClient(harness.socketPath);
+    const explicitReply = await explicit.request("hello", {
+      clientVersion: "test",
+      protocolVersion: DAEMON_PROTOCOL_VERSION,
+      principal: "host",
+    });
+    expect(explicitReply.payload).toMatchObject({ principal: "host" });
+    await explicit.close();
+
+    const omitted = await createClient(harness.socketPath);
+    const omittedReply = await omitted.request("hello", {
+      clientVersion: "test",
+      protocolVersion: DAEMON_PROTOCOL_VERSION,
+    });
+    expect(omittedReply.payload).toMatchObject({ principal: "test-process" });
+    await omitted.close();
+  });
+
   it("allows an admin session to call the same admin-only operation", async () => {
     const harness = await createHarness({ resolveRole: { resolve: () => "admin" } });
     const client = await createClient(harness.socketPath);

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -696,6 +696,11 @@ export class DaemonServer {
         daemonProtocolRange: this.#protocolRange,
         version: this.options.version,
         role: connection.role,
+        // ADR §4: report the resolved principal back -- see `helloReplySchema`'s comment. Read
+        // from `connection.principal`, set a few lines above from `payload.principal` or the
+        // daemon's own default, so this is always the same value every subsequent dispatched
+        // request is authorized against.
+        principal: connection.principal,
       },
       "hello",
     );

--- a/src/simlock-client/client.test.ts
+++ b/src/simlock-client/client.test.ts
@@ -43,9 +43,9 @@ function sampleGrant(
 }
 
 describe("connectSimlock: handshake", () => {
-  it("rejects a version mismatch before any other request is sent", async () => {
+  it("a version mismatch leaves the connection open and usable for stopDaemon() only (ADR §6)", async () => {
     const connection = new ScriptedConnection();
-    const connectPromise = connectSimlock({ connection });
+    const connectPromise = connectSimlockAdmin({ connection, credential: "operator-secret" });
     await flushMicrotasks();
     const hello = connection.lastSentOf("hello");
     expect(hello).toBeDefined();
@@ -55,28 +55,56 @@ describe("connectSimlock: handshake", () => {
       daemonVersion: "9.9.9",
     });
 
-    await expect(connectPromise).rejects.toMatchObject({
+    // The daemon deliberately keeps this connection open after a failed range negotiation
+    // (ADR §6, see the comments in `daemon/server.ts#handleHello`) so an admin client can
+    // still send `daemon.stop` on it instead of restarting the daemon -- closing here, what
+    // this client used to do unconditionally, made that escape hatch dead on arrival.
+    const client = await connectPromise;
+    expect(connection.closed).toBe(false);
+
+    // Every other operation rejects with the captured mismatch error, never reaching the wire.
+    const before = connection.sent.length;
+    await expect(client.getStatus()).rejects.toMatchObject({
       code: "PROTOCOL_VERSION_UNSUPPORTED",
-      details: { daemon: { max: 5, min: 5 }, daemonVersion: "9.9.9" },
     });
-    expect(connection.sent).toHaveLength(1);
+    await expect(client.runCleanup()).rejects.toMatchObject({
+      code: "PROTOCOL_VERSION_UNSUPPORTED",
+    });
+    expect(connection.sent).toHaveLength(before);
+
+    const stopPromise = client.stopDaemon();
+    await flushMicrotasks();
+    const stopCall = connection.lastSentOf("daemon.stop")!;
+    expect(stopCall).toBeDefined();
+    connection.reply(stopCall.id, { stopping: true });
+    await expect(stopPromise).resolves.toEqual({ stopping: true });
+
+    await client.close();
+    expect(connection.closed).toBe(true);
   });
 
-  it("maps a legacy protocol-2 daemon's mismatch code onto the contract's shape", async () => {
+  it("maps a legacy protocol-2 daemon's mismatch code onto the contract's shape, and still leaves the connection open (ADR §6)", async () => {
     const connection = new ScriptedConnection();
     const connectPromise = connectSimlock({ connection });
     await flushMicrotasks();
     const hello = connection.lastSentOf("hello")!;
     connection.fail(hello.id, "PROTOCOL_VERSION_MISMATCH", "old daemon says no");
 
-    await expect(connectPromise).rejects.toMatchObject({
+    // Resolves rather than rejects: this maps onto the same `PROTOCOL_VERSION_UNSUPPORTED`
+    // code as a modern range mismatch, so it gets the same ADR §6 treatment -- the connection
+    // stays open, and the returned client's every operation rejects with the mapped error.
+    const client = await connectPromise;
+    expect(connection.closed).toBe(false);
+    expect(connection.sent).toHaveLength(1);
+
+    await expect(client.getStatus()).rejects.toMatchObject({
       code: "PROTOCOL_VERSION_UNSUPPORTED",
       details: { daemon: { max: 2, min: 2 }, daemonVersion: "unknown" },
     });
     expect(connection.sent).toHaveLength(1);
   });
 
-  it("a bad admin credential causes zero requests after hello", async () => {
+  it("a bad admin credential causes zero requests after hello, and closes the connection", async () => {
     const connection = new ScriptedConnection();
     const connectPromise = connectSimlockAdmin({ connection, credential: "wrong" });
     await flushMicrotasks();
@@ -86,6 +114,9 @@ describe("connectSimlock: handshake", () => {
 
     await expect(connectPromise).rejects.toMatchObject({ code: "ADMIN_AUTHENTICATION_FAILED" });
     expect(connection.sent).toHaveLength(1);
+    // Unlike a protocol-version mismatch (ADR §6's frozen exception), a bad credential is not
+    // the escape hatch -- the connection closes and serves nothing.
+    expect(connection.closed).toBe(true);
   });
 
   it("agent role: a FORBIDDEN reply from the daemon surfaces as a typed error", async () => {
@@ -379,6 +410,146 @@ describe("requestLease abort (ADR §10)", () => {
 
     // No lease.cancel was ever sent for an already-resolved request.
     expect(connection.sent).toHaveLength(before);
+  });
+});
+
+describe("principal resolution (ADR §4, B3)", () => {
+  it('adopts the daemon-resolved principal from hello\'s reply, never defaulting to ""', async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    const hello = connection.lastSentOf("hello")!;
+    // No principal was supplied -- the daemon resolves its own default (a pid, in practice).
+    expect((hello.payload as { principal?: string }).principal).toBeUndefined();
+    connection.reply(hello.id, {
+      daemonProtocolRange: { max: 3, min: 3 },
+      principal: "48213",
+      protocolVersion: 3,
+      role: "agent",
+      version: "0.3.0",
+    });
+    const client = await connectPromise;
+
+    expect(client.principal).toBe("48213");
+  });
+});
+
+describe("requestLease abort: ADR §4 identity cases (B3)", () => {
+  it("no principal supplied: abort while queued cancels with the daemon-resolved principal, and leaves no lease held", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    const hello = connection.lastSentOf("hello")!;
+    connection.reply(hello.id, {
+      daemonProtocolRange: { max: 3, min: 3 },
+      principal: "48213",
+      protocolVersion: 3,
+      role: "agent",
+      version: "0.3.0",
+    });
+    const client = await connectPromise;
+
+    const controller = new AbortController();
+    const leasePromise = client.requestLease(
+      { model: "iPhone 17", platform: "ios" },
+      { signal: controller.signal },
+    );
+    await flushMicrotasks();
+    const requestCall = connection.lastSentOf("lease.request")!;
+
+    controller.abort();
+    await flushMicrotasks();
+    const cancelCall = connection.lastSentOf("lease.cancel")!;
+    // Before this fix, this was always "" -- the daemon fixes the connection's principal to
+    // its own default, and the client had no way to learn it. Sent as the resolved principal
+    // now, never "".
+    expect((cancelCall.payload as { requesterId?: string }).requesterId).toBe("48213");
+
+    connection.reply(cancelCall.id, { result: "cancelled" });
+    await flushMicrotasks();
+    connection.fail(requestCall.id, "QUEUE_TIMEOUT", "cancelled by request");
+
+    await expect(leasePromise).rejects.toMatchObject({ code: "CANCELLED" });
+
+    // No lease is held: connection death fires no onLeaseLost for anything.
+    const leaseLost = vi.fn();
+    client.onLeaseLost(leaseLost);
+    connection.simulateDeath();
+    await flushMicrotasks();
+    expect(leaseLost).not.toHaveBeenCalled();
+  });
+
+  it('ADR §4 proxy case (principal "host", requesterId "agent-7"): abort in flight releases the grant and leaves no lease held', async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection, principal: "host" });
+    await flushMicrotasks();
+    completeHello(connection, { principal: "host" });
+    const client = await connectPromise;
+    expect(client.principal).toBe("host");
+
+    const controller = new AbortController();
+    const leasePromise = client.requestLease(
+      { model: "iPhone 17", platform: "ios", requesterId: "agent-7" },
+      { signal: controller.signal },
+    );
+    await flushMicrotasks();
+    const requestCall = connection.lastSentOf("lease.request")!;
+
+    controller.abort();
+    await flushMicrotasks();
+    const cancelCall = connection.lastSentOf("lease.cancel")!;
+    // Before this fix, the daemon's `authorize` hook compared this `requesterId` straight to
+    // the principal and rejected FORBIDDEN outright -- exactly ADR §4's proxy case. The
+    // request is still sent with the proxied requesterId (attribution); the daemon now
+    // authorizes the cancel against the pending request's recorded *owner* instead.
+    expect((cancelCall.payload as { requesterId?: string }).requesterId).toBe("agent-7");
+    connection.reply(cancelCall.id, { result: "not-cancellable" });
+    await flushMicrotasks();
+
+    connection.reply(requestCall.id, sampleGrant({ leaseId: "lease_proxy_abandoned" }));
+    await flushMicrotasks();
+    const releaseCall = connection.lastSentOf("lease.release")!;
+    expect((releaseCall.payload as { leaseId: string }).leaseId).toBe("lease_proxy_abandoned");
+    connection.reply(releaseCall.id, { leaseId: "lease_proxy_abandoned" });
+
+    await expect(leasePromise).rejects.toMatchObject({ code: "CANCELLED" });
+
+    // Already released via the abandoned-grant path -- not tracked as held any more.
+    const leaseLost = vi.fn();
+    client.onLeaseLost(leaseLost);
+    connection.simulateDeath();
+    await flushMicrotasks();
+    expect(leaseLost).not.toHaveBeenCalled();
+  });
+
+  it("a FORBIDDEN from the abort's lease.cancel surfaces instead of being read as a dead connection", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const controller = new AbortController();
+    const leasePromise = client.requestLease(
+      { model: "iPhone 17", platform: "ios" },
+      { signal: controller.signal },
+    );
+    await flushMicrotasks();
+
+    controller.abort();
+    await flushMicrotasks();
+    const cancelCall = connection.lastSentOf("lease.cancel")!;
+    connection.fail(cancelCall.id, "FORBIDDEN", "not authorized");
+
+    await expect(leasePromise).rejects.toMatchObject({ code: "FORBIDDEN" });
+    // Not misread as the connection dying -- it's still alive and usable for another call.
+    expect(connection.closed).toBe(false);
+    const anotherCall = client.cancelLease();
+    await flushMicrotasks();
+    const anotherCancelCall = connection.lastSentOf("lease.cancel")!;
+    expect(anotherCancelCall.id).not.toBe(cancelCall.id);
+    connection.reply(anotherCancelCall.id, { result: "not-found" });
+    await expect(anotherCall).resolves.toMatchObject({ result: "not-found" });
   });
 });
 

--- a/src/simlock-client/client.ts
+++ b/src/simlock-client/client.ts
@@ -207,16 +207,102 @@ export async function connectSimlockClient(
       capabilities: { heartbeat: options.heartbeat ?? true },
     });
   } catch (error: unknown) {
+    // ADR §6: a `PROTOCOL_VERSION_UNSUPPORTED` `hello` rejection is the one handshake failure
+    // the daemon deliberately keeps the connection open for -- an admin client whose range
+    // does not overlap the daemon's must still be able to send `daemon.stop` on *this*
+    // connection instead of restarting it (see the comments around the mismatch reply in
+    // `daemon/server.ts#handleHello`, and `#dispatchLine`'s `daemon.stop`-ahead-of-the-mismatch-
+    // gate check). Closing here -- every other handshake failure, a bad credential
+    // (`ADMIN_AUTHENTICATION_FAILED`) included -- still closes and serves nothing.
+    if (isSimlockError(error) && error.code === "PROTOCOL_VERSION_UNSUPPORTED") {
+      return buildDegradedClient(wire, error, options.principal ?? "", admin);
+    }
     await connection.close();
     throw error;
   }
-  const impl = new SimlockClientImpl(
-    wire,
-    hello.role,
-    options.principal ?? "",
-    hello.daemonVersion,
-  );
+  const impl = new SimlockClientImpl(wire, hello.role, hello.principal, hello.daemonVersion);
   return admin ? impl.asAdmin() : impl;
+}
+
+/**
+ * ADR §6's escape hatch, on the client side: everything but `stopDaemon()` and `close()`
+ * rejects with the captured `PROTOCOL_VERSION_UNSUPPORTED` error (never sent to the daemon --
+ * every other operation requires a completed handshake this connection never got); `close()`
+ * still works so a caller that decides not to stop the daemon can tidy up. `stopDaemon()` calls
+ * straight through the wire: the daemon accepts `daemon.stop` "at any protocol version it has
+ * ever spoken" (ADR §6), ahead of its own mismatch gate, specifically so this is reachable.
+ *
+ * `role`/`principal` cannot be the connection's real resolved values -- the daemon resolves
+ * them before the mismatch check but the failed `hello` never reports them back (see the PR
+ * report's weak-spots list) -- so `role` reflects which entry point the caller used
+ * (`connectSimlock` vs. `connectSimlockAdmin`) rather than a verified fact, and `principal` is
+ * whatever the caller supplied (or `""` when it supplied none). Neither is load-bearing here:
+ * the only operation this client permits (`daemon.stop`) is gated by the daemon's own role
+ * check on the credential it already verified, not by anything this object reports about
+ * itself.
+ */
+function buildDegradedClient(
+  wire: SimlockWire,
+  error: SimlockError<"PROTOCOL_VERSION_UNSUPPORTED">,
+  principal: string,
+  admin: boolean,
+): SimlockClient | SimlockAdminClient {
+  const rejected = <T>(): Promise<T> => Promise.reject(error);
+  const client: SimlockAdminClient = {
+    principal,
+    role: admin ? "admin" : "agent",
+    daemonVersion: error.details.daemonVersion,
+
+    getCatalog: () => rejected(),
+    getStatus: () => rejected(),
+    requestLease: () => rejected(),
+    cancelLease: () => rejected(),
+    renewLease: () => rejected(),
+    releaseLease: () => rejected(),
+    listLeases: () => rejected(),
+    heartbeat: () => rejected(),
+    runDoctor: () => rejected(),
+
+    onLeaseLost: () => () => {},
+    onDeviceUnhealthy: () => () => {},
+    onDeviceRecovered: () => () => {},
+    // The one live fact this connection can still report: it can still die later even though
+    // `hello` never fully succeeded (e.g. the daemon exits while this degraded client sits
+    // idle).
+    onConnectionLost: (listener) => wire.onDeath(listener),
+
+    close: () => wire.close(),
+
+    releaseAllLeases: () => rejected(),
+    list: () => rejected(),
+    runCleanup: () => rejected(),
+    runNuke: () => rejected(),
+    getConfig: () => rejected(),
+    stopDaemon: () =>
+      wire.call("daemon.stop", {}).then(
+        (payload) => {
+          const result = OPERATIONS["daemon.stop"].output.safeParse(payload);
+          if (!result.success) {
+            throw new SimlockError(
+              "BAD_FRAME",
+              "protocol",
+              "Daemon's daemon.stop response did not match the contract output schema",
+              {},
+            );
+          }
+          return result.data;
+        },
+        (callError: unknown) => {
+          throw toSimlockError(callError);
+        },
+      ),
+    replayEvents: () => rejected(),
+    subscribeEvents: () => rejected(),
+    createToken: () => rejected(),
+    listTokens: () => rejected(),
+    revokeToken: () => rejected(),
+  };
+  return client;
 }
 
 async function resolveConnection(options: ConnectOptions): Promise<IpcConnection> {
@@ -451,12 +537,18 @@ class SimlockClientImpl {
     let outcome: LeaseCancelOutput["result"];
     try {
       outcome = (await this.#call("lease.cancel", { requesterId })).result;
-    } catch {
-      // The connection itself may have died mid-cancel; fall through and let awaiting
+    } catch (error: unknown) {
+      // Only a connection that actually died mid-cancel falls through to let awaiting
       // `requestPromise` below surface whatever that produces (most likely
-      // `DAEMON_CONNECTION_LOST`, which is a more accurate rejection than a manufactured
-      // `CANCELLED` would be here).
-      return requestPromise;
+      // `DAEMON_CONNECTION_LOST`, a more accurate rejection than a manufactured `CANCELLED`
+      // would be here). Every other rejection -- `FORBIDDEN`, `BAD_REQUEST` -- is a real
+      // answer from the daemon and must surface as-is: this `catch` used to swallow those
+      // unconditionally, which is what let an aborted `requestLease` silently resolve with a
+      // real grant instead of `CANCELLED` (see the PR report's B3).
+      if (isSimlockError(error) && error.kind === "transport") {
+        return requestPromise;
+      }
+      throw error;
     }
 
     if (outcome === "not-found") {

--- a/src/simlock-client/test-support.ts
+++ b/src/simlock-client/test-support.ts
@@ -93,15 +93,24 @@ export class ScriptedConnection implements IpcConnection {
 }
 
 /** Replies to the connection's `hello` frame with a normal, matching-protocol, given-role
- * response -- the common setup step for every test that needs a connected client. */
+ * response -- the common setup step for every test that needs a connected client.
+ * `principal` defaults to whatever the client itself sent (ADR §4: the daemon's default when
+ * `hello` omits one is out of this test double's scope, so a test exercising that specific
+ * fallback -- see `server.test.ts` -- passes an explicit `principal` here instead). */
 export function completeHello(
   connection: ScriptedConnection,
-  options: { readonly role?: "agent" | "admin"; readonly version?: string } = {},
+  options: {
+    readonly role?: "agent" | "admin";
+    readonly version?: string;
+    readonly principal?: string;
+  } = {},
 ): void {
   const hello = connection.lastSentOf("hello");
   if (hello === undefined) throw new Error("Expected the client to have sent hello already");
+  const sentPrincipal = (hello.payload as { principal?: string }).principal;
   connection.reply(hello.id, {
     daemonProtocolRange: { max: 3, min: 3 },
+    principal: options.principal ?? sentPrincipal ?? "default-principal",
     protocolVersion: 3,
     role: options.role ?? "agent",
     version: options.version ?? "0.3.0",

--- a/src/simlock-client/wire.ts
+++ b/src/simlock-client/wire.ts
@@ -37,6 +37,9 @@ export interface HelloResult {
   readonly daemonProtocolRange: ProtocolRange;
   readonly daemonVersion: string;
   readonly role: Role;
+  /** ADR §4: the connection's resolved, fixed-for-its-lifetime principal -- see
+   * `helloReplySchema`'s comment. */
+  readonly principal: string;
 }
 
 interface PendingCall {
@@ -128,6 +131,7 @@ export class SimlockWire {
     return {
       daemonProtocolRange: parsed.data.daemonProtocolRange,
       daemonVersion: parsed.data.version,
+      principal: parsed.data.principal,
       protocolVersion: parsed.data.protocolVersion,
       role: parsed.data.role,
     };


### PR DESCRIPTION
**Stacked on #99.** Two blocking defects from the adversarial review of this stack.

## The abort signal was a silent no-op that handed the caller the lease it abandoned

The client always sent an **explicit** `requesterId` on the abort's `lease.cancel`, and `lease.cancel`'s `authorize` required `requesterId === principal` for a non-admin session. Two independent triggers:

1. With no caller-supplied principal, the client stored `""` while the daemon fixed the connection principal to its own `defaultRequesterId` — and `hello`'s reply did not return it, so the client could not know it. The cancel was `FORBIDDEN`.
2. **ADR §4's central proxy case** — one connection with `principal: "host"` leasing under `requesterId: "agent-7"` — was forbidden outright. That is the scenario the whole ADR exists for.

In both cases the bare `catch` (commented as handling only a dead connection) swallowed the rejection and returned the original request promise, so the caller's `await` **resolved with a real grant** and the client tracked it as held. ADR §10 requires the opposite: *"the caller never holds a lease it abandoned."*

Fixed properly rather than papered over:

- `hello`'s reply now carries the **resolved principal**, and the client adopts it instead of `""`.
- **`lease.cancel` is now owner-aware.** A new `QueueControl.pendingRequestOwner(requesterId)` reads the pending request's recorded `ownerId` (already stored on the waiter), threaded through `LeaseEngine` into the dispatcher's `AuthorizeContext`. `authorize` compares *the pending request's owner* to the session principal, so the §4 proxy can cancel what it created. No core schema change was needed.
- The `catch` is narrowed to transport-kind errors, so a `FORBIDDEN`/`BAD_REQUEST` from the cancel surfaces instead of being misread as "the connection died".

`lease.request` is now explicitly documented as deliberately authorize-free, resolving the incoherence the review noted (it accepted any `requesterId` while `lease.cancel` refused one).

## The client closed the socket on a protocol mismatch, killing §6's escape hatch

The daemon goes out of its way to keep the socket open after a failed range negotiation, and checks `daemon.stop` *ahead* of the mismatch gate, precisely so a mismatched admin client can stop it rather than restarting the daemon and dropping every held lease on the machine. The client closed the connection on **any** `hello` failure, so `simlock daemon stop` — the exact command the error message tells the user to run — could not work.

Not reachable at `{3,3}` today, but it would ship broken into every 0.3.0 client and bite at the first version bump. Now a `PROTOCOL_VERSION_UNSUPPORTED` rejection returns a degraded client permitting only `stopDaemon()`; every other handshake failure, including `ADMIN_AUTHENTICATION_FAILED`, still closes and serves nothing.

## Residual limitation

If a caller supplies a `requesterId` it genuinely does not own, the `FORBIDDEN` now surfaces correctly, but a grant that still arrives afterwards is tracked with nothing releasing it. Pre-existing best-effort gap; the owner-aware check should make it unreachable in normal operation.

The degraded client's own `principal`/`role` fields are best-effort, since a failed `hello` never reports the daemon's resolved values — not load-bearing, because `stopDaemon()` is gated by the daemon's credential check, not by anything the client claims about itself.