### PR TITLE
fix(cli): stop a stale admin.token bricking the CLI; be admin on the first run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,108 @@
+# Changelog
+
+## [0.3.0](https://github.com/callstackincubator/simlock/compare/v0.2.0...v0.3.0) (2026-09-03)
+
+ADR 0003 (`docs/adr/0003-one-typed-daemon-contract-behind-every-frontend.md`):
+every daemon operation is now declared once, as a typed contract
+(`src/contract/`), served by one shared dispatcher to all four frontends —
+the CLI, the stdio MCP server, the HTTP gateway, and a new programmatic
+client (`simlock/client`, `simlock/admin`, see `docs/CLIENT.md`). This is a
+breaking release for every frontend's wire vocabulary; see below.
+
+### ⚠ BREAKING CHANGES
+
+- **CLI:** `--json` output and stderr event lines (`lease`, `daemon`, and
+  progress/push lines) are now the contract's own values, serialized as-is.
+  The old snake_case renderings (`expires_at_ms`, `estimated_boot_ms`,
+  `eta_seconds`, …) are gone. Exit codes are unchanged; human-readable
+  `status`/`catalog` formatting is unchanged.
+- **MCP:** tool names are unchanged, but every tool's input/output schema is
+  now derived from the contract instead of hand-declared. Two field changes
+  need every caller updated:
+  - `lease_simulator`'s `timeout_seconds` is now `timeoutMs` — **a unit
+    change, not just a rename.** A caller that keeps the old field name
+    under the new key silently waits 1000× too long before timing out; this
+    is the single highest-risk change in this release.
+  - The top-level `slim: boolean` on a grant is gone; it is now
+    `device.featureProfile` (`"full" | "reduced" | undefined`). A caller
+    still checking `result.slim === true` silently never sees a
+    feature-loss signal again.
+
+  See `docs/CLI.md#simlock-mcp` for the full callout.
+
+- **Socket protocol:** moves to protocol 3 with no compatibility shim. A
+  version-mismatched client fails `hello` with
+  `PROTOCOL_VERSION_UNSUPPORTED` and never restarts the daemon — run
+  `simlock daemon stop` once it's idle. `daemon.stop` is a frozen exception,
+  accepted at any protocol version the daemon has ever spoken (still
+  admin-role gated).
+- **`lease.request`'s wire shape** drops the legacy `device`/`os` field
+  aliases and the nested `request` wrapper the pre-0.3.0 daemon accepted;
+  an old client sending them now gets `BAD_REQUEST` instead of those keys
+  silently vanishing.
+- **HTTP:** `GET /v1/leases/:id` (and `renew`/`events`/`DELETE` on the same
+  resource) now returns `404 UNKNOWN_LEASE` instead of `403 FORBIDDEN` for
+  another requester's lease — see `docs/HTTP-API.md#get-v1leasesid`.
+- **`token create|list|revoke`** are now daemon operations (admin role) —
+  the daemon is the sole owner of `tokens.json`. `config set` and
+  `daemon logs` remain file operations.
+
+### Bug Fixes
+
+- **http:** `allowDownload` is now clamped through `config.downloads.policy`
+  the same way the socket protocol always was — HTTP previously passed a
+  client-supplied `allowDownload` through unclamped, so a `"never"` policy
+  could be bypassed over HTTP even though the socket already blocked it.
+- **http:** a request arriving before the daemon's startup convergence
+  finishes now waits on the shared dispatcher's readiness gate instead of
+  being refused — the HTTP gateway's listener starts at socket-claim time
+  rather than only after convergence completes.
+- **cli:** filter lease-lost pushes by this connection's own lease id, so a
+  second CLI invocation sharing a principal (e.g. a detached lease from an
+  earlier `--detach`) doesn't misreport a push for a lease this process
+  never held.
+- **contract:** restrict `lease.cancel` to the calling principal (only
+  admin may cancel on another principal's behalf).
+- **daemon:** require the admin role for `daemon.stop`.
+
+### Features
+
+- **contract:** declare every daemon operation once — name, role, input/
+  output zod schema, optional `authorize` hook — with public TypeScript
+  types inferred from the schemas (`src/contract/`).
+- **daemon:** move request handling into one transport-independent
+  dispatcher (`src/daemon/dispatcher.ts`) serving both the unix socket and,
+  in-process, the HTTP gateway.
+- **daemon:** negotiate protocol versions as `{min, max}` ranges instead of
+  an exact match.
+- **daemon:** resolve `hello`'s admin credential — an operator token or the
+  daemon's per-start `admin.token` secret — before any other request on the
+  connection runs; wire the admin handshake and route lease-scoped pushes to
+  every live connection sharing a lease's owner, not just the holder.
+- **core:** persist a lease's `ownerId`, distinct from `requesterId` (ADR
+  0003 §4) — the session principal a lease was granted to, vs. the
+  per-request attribution a connection may vary. `lease.released`/
+  `lease.expired` now carry `ownerId` in their event payloads.
+- **client:** add the typed daemon client core (`simlock-client`) and
+  publish it as the `simlock/client` and `simlock/admin` package entry
+  points — one connection, no reconnect, no retry, with `AbortSignal`-driven
+  cancellation on `requestLease` (see `docs/CLIENT.md`).
+- **cli, mcp:** move onto the typed client, deleting the hand-built request
+  payloads and raw response parsers both frontends carried before.
+- **http:** move HTTP onto the shared dispatcher, deleting its own copies
+  of status assembly, decoration, error mapping, and ownership checks.
+
+### Documentation
+
+- record ADR 0003 (`docs/adr/0003-one-typed-daemon-contract-behind-every-frontend.md`).
+- add `docs/CLIENT.md` for the new programmatic client; document the
+  contract/dispatcher architecture and the cooperative-identity security
+  model in `docs/ARCHITECTURE.md`; document the breaking changes above in
+  `docs/CLI.md` and `docs/HTTP-API.md`; record true-cancellation-during-
+  provisioning and the HTTP tracker/notice-buffer stateful leftovers in
+  `docs/known-pitfalls.md`.
+
+## [0.2.0] and earlier
+
+Not tracked in this file — see `git log` for history before this changelog
+was introduced.

--- a/README.md
+++ b/README.md
@@ -49,19 +49,14 @@ simlock lease --platform ios --device "iPhone 16" --detach
 ```
 
 ```json
-{
-  "lease": "lse_9f2c",
-  "platform": "ios",
-  "device": "iPhone 16",
-  "os": "18.4",
-  "udid": "ABCD-...",
-  "state": "leased"
-}
+{"device":{"id":"dev_1a2b","driverDeviceId":"ABCD-...","spec":{"platform":"ios","model":"iPhone 16","osVersion":"18.4"},"address":"ABCD-..."},"lease":{"id":"lse_9f2c","deviceId":"dev_1a2b","requesterId":"agent-1","ownerId":"agent-1","mode":"detached","grantedAt":1735689600000,"ttlDeadline":1735690500000},"timing":{"estimatedProvisionMs":0,"estimatedBootMs":0,"estimatedReclaimMs":0,"estimatedReadyMs":0},"role":"admin"}
 ```
 
 That's the whole interaction: ask for a platform and a device model, get
 back an identified, ready-to-use device. Release it explicitly, or let its
-TTL expire.
+TTL expire. This is the contract's own `LeaseGrant` shape, serialized
+as-is — the CLI's `--json` output is a contract value, not a bespoke
+rendering (see [docs/CLI.md](docs/CLI.md)).
 
 Now say a second agent asks for the same `iPhone 16` a moment later. It's
 already leased to the first agent — no problem, Simlock just provisions
@@ -69,19 +64,12 @@ another one. Progress streams as JSON lines on stderr while it happens, and
 the lease result lands on stdout the moment the new device is ready:
 
 ```json
-{"event":"provisioning","eta_seconds":5}
-{"event":"booting","eta_seconds":30}
+{"push":"progress","requestId":"2","progress":{"stage":"provisioning","etaMs":5000}}
+{"push":"progress","requestId":"2","progress":{"stage":"booting","etaMs":30000}}
 ```
 
 ```json
-{
-  "lease": "lse_a731",
-  "platform": "ios",
-  "device": "iPhone 16",
-  "os": "18.4",
-  "udid": "EFGH-...",
-  "state": "leased"
-}
+{"device":{"id":"dev_3c4d","driverDeviceId":"EFGH-...","spec":{"platform":"ios","model":"iPhone 16","osVersion":"18.4"},"address":"EFGH-..."},"lease":{"id":"lse_a731","deviceId":"dev_3c4d","requesterId":"agent-2","ownerId":"agent-2","mode":"detached","grantedAt":1735689630000,"ttlDeadline":1735690530000},"timing":{"estimatedProvisionMs":5000,"estimatedBootMs":30000,"estimatedReclaimMs":0,"estimatedReadyMs":35000},"role":"admin"}
 ```
 
 No manual bookkeeping, no "device busy" error to handle — just a second

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -17,7 +17,11 @@ An optional local stdio MCP integration exposes the focused lease/release
 workflow to compatible agent clients; the CLI remains the full operator
 interface. An optional, token-authenticated HTTP API lets remote agents lease
 devices from a self-hosted simlock host over the network (see
-[HTTP-API.md](HTTP-API.md)).
+[HTTP-API.md](HTTP-API.md)). A host process that wants to allocate devices
+without spawning a `simlock` command at all — agent-device, for
+example — can instead depend on `simlock/client`/`simlock/admin`, the typed
+programmatic client the CLI and MCP frontends are themselves built on (see
+[CLIENT.md](CLIENT.md)).
 
 - `simlock lease` returns a *ready* device — booted and health-checked — that
   no other agent will touch for the duration of the lease.
@@ -45,5 +49,5 @@ devices from a self-hosted simlock host over the network (see
   optional MCP server reserves stdout for MCP JSON-RPC.
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for how it's built, [CLI.md](CLI.md)
-for the command surface, and [known-pitfalls.md](known-pitfalls.md) for
-accepted gaps.
+for the command surface, [CLIENT.md](CLIENT.md) for the programmatic client,
+and [known-pitfalls.md](known-pitfalls.md) for accepted gaps.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,49 +28,179 @@ remote agent ──token auth──> HTTP gateway ──same role interfaces─�
                                                                                 emulator/adb)
 ```
 
-- **CLI, stdio MCP server, and HTTP gateway**: sibling thin frontends. The
+- **CLI, stdio MCP server, and HTTP gateway**: sibling thin frontends over one
+  typed contract (ADR 0003; see "Contract, dispatcher, and roles" below). The
   core never knows which frontend made a request. The CLI and MCP server sit
-  over the shared daemon client and unix socket; the CLI is the full operator
+  over `simlock/client`/`simlock/admin` (the typed daemon client, see
+  [CLIENT.md](CLIENT.md)) and the unix socket; the CLI is the full operator
   interface, and the MCP server intentionally limits its tool surface to
   leasing and releasing for an agent session. The HTTP gateway is different in
   kind, not just transport: it is the one frontend meant to be reached over a
-  real network, so it calls the same role interfaces (`LeaseCommands`,
-  `QueueControl`, `CapacityReader`, `CatalogReader`) in-process rather than
-  going through the unix socket, requires a bearer token on every route but
-  `GET /v1/healthz`, and only ever grants detached-style, TTL-renewed leases —
-  "held lease = live connection" does not survive a real network the way it
-  does a local process. It starts only after the daemon's own startup
-  convergence completes (see "Startup: claim first, converge after" below),
-  so unlike the socket protocol's parked-request behavior during that window,
-  a request arriving before then is simply refused. See
-  [HTTP-API.md](HTTP-API.md) for the full route reference.
+  real network, so it calls the daemon's dispatcher **in-process** — the exact
+  same one the socket path calls — rather than going through the unix socket
+  at all, requires a bearer token on every route but `GET /v1/healthz`, and
+  only ever grants detached-style, TTL-renewed leases — "held lease = live
+  connection" does not survive a real network the way it does a local
+  process. Its listener now starts right after the socket claim, the same
+  moment the unix socket itself starts accepting connections and before
+  startup convergence runs (`DaemonServer`'s `onSocketClaimed` hook, see
+  "Startup: claim first, converge after" below) — a bug fix from the pre-ADR
+  gateway, which started only once convergence had already finished and so
+  never needed to park anything. A request that arrives before convergence
+  completes now waits on the shared dispatcher's readiness gate exactly like
+  a socket request, instead of being refused. See [HTTP-API.md](HTTP-API.md)
+  for the full route reference.
 - **CLI**: in the default *held* mode it acquires a lease, prints one JSON
   result line on stdout, then stays alive holding the daemon connection; the
   connection is the lease heartbeat. Progress streams as JSON lines on stderr.
 - **stdio MCP server**: its process owns one agent session and exposes MCP over
-  stdin/stdout. A lease is held by that process's daemon connection until the
-  session explicitly releases it or the MCP transport disconnects, at which
-  point the connection closes and releases the lease. Like the CLI, it relays
-  the daemon's progress pushes for the in-flight `lease_simulator` request —
-  as MCP `notifications/progress` instead of stderr JSON lines, and only when
-  the client supplied a progress token. Unlike the CLI, this process outlives
-  any single daemon connection: `McpSession` does not cache a dead connection.
-  `DaemonConnection#onClose` (`src/daemon-client/protocol.ts`) tells the
-  session the moment its connection dies — from a graceful `daemon stop`, a
-  crash, or `kill -9` — and the next tool call reconnects lazily, auto-starting
-  the daemon exactly as the CLI does. A held lease never survives its
-  connection dying (the daemon releases it on graceful close, and
-  `StartupConverger` sweeps any orphaned lease from an ungraceful death at its
-  own startup — see "Lease subsystem boundaries and wiring" above), so the
-  session never asks the daemon whether its old lease survived; it clears
-  `#ownedLease` and fires `onLeaseLost` (reason
-  `daemon-connection-lost`) so the agent hears the fact instead of silently
-  reacquiring a device. A dead connection surfaces as typed
-  `DAEMON_CONNECTION_LOST` (mid-request) or `DAEMON_UNAVAILABLE` (a failed
-  reconnect), not the opaque `INTERNAL`; only idempotent, read-only requests
-  (`catalog.get`) retry once, never `lease.request`.
+  stdin/stdout. `McpSession` (`src/mcp/session.ts`) holds one `simlock/client`
+  connection at a time and does nothing today's typed client does not already
+  do (ADR §11: MCP keeps only "connection lifecycle ... and its MCP-only
+  relays"): tool calls are serialized onto it, `lease_status` is one
+  `lease.list` call rather than a session-local cache, and a release the
+  session does not own surfaces the daemon's own `FORBIDDEN` rather than a
+  client-side guard pre-empting it. A lease is held by that connection until
+  the session explicitly releases it or the connection dies. Like the CLI, it
+  relays the daemon's progress pushes for the in-flight `lease_simulator`
+  request — as MCP `notifications/progress` instead of stderr JSON lines, and
+  only when the client supplied a progress token. Unlike the CLI, this
+  process outlives any single daemon connection: the typed client itself
+  never reconnects (ADR §10), so `McpSession` builds a brand new one lazily,
+  on the next tool call, once its current client's `onConnectionLost` fires
+  — auto-starting the daemon exactly as the CLI does
+  (`connectWithAutoLaunch`, `src/mcp/connect.ts`), and never on a version
+  mismatch or a refused handshake, only on "nothing is listening". A held
+  lease never survives its connection dying (the daemon releases it on
+  graceful close, and `StartupConverger` sweeps any orphaned lease from an
+  ungraceful death at its own startup — see "Lease subsystem boundaries and
+  wiring" above): the client already synthesizes `onLeaseLost` (reason
+  `daemon-connection-lost`) for every lease it held the moment its connection
+  dies, so the session relays that straight through rather than asking the
+  daemon whether its old lease survived.
 - **Daemon**: owns all state, serializes all decisions. Started on demand,
   reachable over a unix socket.
+
+## Contract, dispatcher, and roles (ADR 0003)
+
+Every daemon operation is declared exactly once, in `src/contract/`: a name
+(`lease.request`, `daemon.stop`, ...), a role, a zod input schema, a zod
+output schema, and an optional `authorize` hook. Public TypeScript types are
+inferred from those schemas, never hand-written a second time. The contract
+module imports nothing from `core`, `daemon`, or `drivers` (enforced by
+`src/contract/boundary.test.ts`) — core's own domain records
+(`DeviceRecord`, `LeaseRecord`, `LeaseGrant`) stay private, and the daemon
+maps them onto the contract's shapes in exactly one place
+(`src/daemon/dispatcher.ts`'s handlers). If a core type's shape changes
+without a matching edit in `src/contract/schemas.ts`, that surfaces as a
+compile error or, for a structurally-compatible-but-different shape, a
+runtime output-validation failure at the dispatcher boundary — never silent
+drift onto the wire.
+
+**One dispatcher (`src/daemon/dispatcher.ts`) serves every transport.**
+`Dispatcher#dispatch(operation, input, session)` runs, in order: parse the
+input against the operation's schema, reject a session whose role is below
+the operation's with `FORBIDDEN`, run the `authorize` hook if the operation
+declares one, park on startup readiness (every operation but `status.get`),
+call the handler, parse the output. Handlers never see a raw payload or run
+a role check themselves. The unix socket server (`DaemonServer`) is framing
+plus connection/session lifecycle around this one dispatcher instance; the
+HTTP gateway (`src/http/app.ts`) calls the **exact same dispatcher
+in-process** — `DaemonServer` exposes it as the one privileged seam an
+auxiliary frontend gets — via a bearer-token-to-`DispatchSession` adapter
+(`src/http/dispatcher-session.ts`). **HTTP never routes through the unix
+socket, or through a second `Dispatcher` instance built with
+equivalent-looking options; it is the same object, called directly.** Parity
+between the socket and HTTP frontends is a consequence of that sharing, not
+of a shared wire format — and every socket-side fix (the download policy in
+`config.downloads.policy`, startup-readiness parking, error mapping)
+applies to HTTP automatically because there is only one code path to fix.
+
+**Two roles**, `agent` and `admin`, declared in `src/contract/roles.ts`.
+Read-only and lease-lifecycle operations are `agent`; anything that reads or
+mutates state outside the caller's own leases (`list.get`, `cleanup.run`,
+`nuke.run`, `config.get`, `daemon.stop`, `events.*`, `token.*`) is `admin`.
+`doctor.run` is the one operation whose role is a function of its input
+rather than a fixed value: `fix: false` is agent-visible (read-only, but it
+shells out per device); `fix: true` is admin-only.
+
+**Principal, requester, and owner are three different things** (ADR §4):
+
+- The **principal** is the session identity declared once at `hello` and
+  fixed for the connection's lifetime — for HTTP, the bearer token's
+  requester id.
+- The **requester id** is per-request attribution. `lease.request` accepts
+  an optional `requesterId`, defaulting to the principal; core's
+  one-lease-per-requester rule stays keyed on it. This is what lets one
+  connection (a host process proxying several agents) hold many leases, one
+  per requester id, without the socket needing per-agent identity.
+- The **owner id** is a field persisted on the lease record, set from the
+  session principal at grant time. `lease.renew`/`lease.release`/`lease.list`
+  compare `ownerId` to the calling principal (`ownsLease` in
+  `src/contract/roles.ts`); `admin` bypasses. A record written before this
+  field existed loads with `ownerId` defaulted to `requesterId`.
+
+### Security model: cooperative identity, not a hostile-process boundary
+
+**Socket identity is cooperative, and the docs say so plainly because the
+code doesn't hide it either.** Every peer connecting to the unix socket is
+the same OS user — file permissions on the socket and on `~/.simlock/*`
+already establish that as the real trust boundary. Ownership checks
+(`ownsLease`, the principal/requester/owner split above) protect against
+*accidents* — releasing a guessed lease id, one agent's request colliding
+with another's — not against a hostile local process, which could always
+just open the socket itself and claim to be anyone. Real per-connection
+identity (a token on every socket connection, not just HTTP's) was
+considered and rejected for exactly this reason: it would kill the
+zero-setup local experience for the one trust boundary that already exists,
+without adding real protection against the thing socket identity cannot
+stop anyway (see the ADR's "Alternatives considered").
+
+**Admin authority comes only from a credential presented at `hello`, never
+from the socket itself.** Two credentials are accepted, checked in this
+order:
+
+1. **An operator token**, minted with `simlock token create --role
+   operator` and stored (hashed) in `tokens.json`. Long-lived, revocable —
+   what a supervisor process uses.
+2. **The daemon's per-start admin secret.** Generated fresh on every daemon
+   start; only its hash is kept in memory. The plaintext is written to
+   `admin.token` under the data directory *after* the socket claim succeeds
+   (temp file, then atomic rename — a daemon that loses the start race never
+   touches the real file), with owner-only permissions (`0o600`) set at
+   creation, and removed on graceful stop. `hello` verifies against the
+   in-memory hash, so a credential can be checked before the file has even
+   landed on disk.
+
+A missing or wrong credential fails the handshake with
+`ADMIN_AUTHENTICATION_FAILED` before any other request on that connection
+runs. The credential is never logged, never returned by any operation,
+never read from a config file, and never inferred from the socket path or a
+client-declared role. How a caller supplies it, in resolution order: the
+`credential` connect option (`simlock/admin`'s `connectSimlockAdmin`),
+`--token` (CLI flag), `SIMLOCK_ADMIN_TOKEN` (CLI env var), the local
+`admin.token` file (CLI, briefly retried to ride out a daemon still writing
+it). **The CLI connects as admin whenever the local `admin.token` file is
+readable** — that's what keeps `simlock lease --detach` followed later by
+`simlock release <id>` working across two separate CLI invocations with
+different pid-derived identities, since both connect as admin and admin
+bypasses the per-connection ownership check that would otherwise apply.
+When none of the four sources resolves (a different OS user, or the file
+genuinely missing), the CLI falls back to an agent-role session with a
+one-line stderr notice, and `simlock lease`'s output JSON includes the
+connection's resolved `role` so a caller can tell which one it got.
+
+**`doctor.run` without `fix` is agent-visible and read-only, but it still
+shells out per device** (`simctl`/`adb`) to compare registry state against
+driver reality — worth knowing before calling it from a tight loop or a
+context where that per-device process-spawn cost is unwelcome. `fix: true`
+requires the admin role because it can quarantine or destroy devices.
+
+See [CLIENT.md](CLIENT.md) for how `simlock/client`/`simlock/admin` expose
+`credential` and role at connect time, [CLI.md](CLI.md#admin-credential-resolution)
+for the CLI's own walkthrough of the same resolution order, and
+[HTTP-API.md](HTTP-API.md#authentication) for how HTTP's bearer-token roles
+map onto `agent`/`admin`.
 
 ## Core vs. drivers
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -120,8 +120,9 @@ simlock lease --platform <ios|android> --device <model> [--os <version>]
   force a re-provision of one already running, even while slim devices sit
   idle in the warm pool.
 - `--detach` — detached mode: print the lease result (the same JSON shape as
-  held mode's grant line, below, including `slim`) and exit; the lease is
-  TTL-bound and must be renewed with `simlock lease renew`.
+  held mode's grant line, below, including `device.featureProfile`) and
+  exit; the lease is TTL-bound and must be renewed with `simlock lease
+  renew`.
 - `--bind-pid <pid>` — held mode only: watch this pid for death instead of
   the CLI's actual parent. For a holder spawned from a short-lived subshell,
   the immediate parent can die (and get reaped) while the owning agent is
@@ -138,11 +139,17 @@ serialized as-is, plus the one field the CLI adds on top, the connection's
 resolved `role` (ADR 0003 §5):
 
 ```json
-{"device":{"id":"dev_1a2b","driverDeviceId":"ABCD-...","spec":{"platform":"ios","model":"iPhone 17 Pro","osVersion":"26.5"},"state":"leased","address":"...","featureProfile":"reduced", "...":"..."},"lease":{"id":"lse_9f2c","deviceId":"dev_1a2b","requesterId":"agent-1","ownerId":"agent-1","mode":"held","grantedAt":1735689600000,"ttlDeadline":1735689660000},"timing":{"estimatedProvisionMs":0,"estimatedBootMs":0,"estimatedReclaimMs":0,"estimatedReadyMs":0},"role":"agent"}
+{"device":{"id":"dev_1a2b","driverDeviceId":"ABCD-...","spec":{"platform":"ios","model":"iPhone 17 Pro","osVersion":"26.5"},"address":"...","featureProfile":"reduced"},"lease":{"id":"lse_9f2c","deviceId":"dev_1a2b","requesterId":"agent-1","ownerId":"agent-1","mode":"held","grantedAt":1735689600000,"ttlDeadline":1735689660000},"timing":{"estimatedProvisionMs":0,"estimatedBootMs":0,"estimatedReclaimMs":0,"estimatedReadyMs":0},"role":"agent"}
 ```
 
-`device.featureProfile` is `"reduced"` when the granted device had its
-feature set reduced (iOS slim mode applied and this request did not pass
+`device` is a **projection** of the registry's device record — `id`,
+`driverDeviceId`, `spec`, `address?`, `featureProfile?` — not the full
+record `status.get`/`list.get` return to an admin caller. Internal
+bookkeeping fields (`driverData`, `quarantine*`, `foreign*`, `recovering*`,
+the derived `transitionAgeMs`) never appear on a grant; a caller that wants
+those needs the admin-role `list.get`/`status.get`, not `lease.request`'s
+output. `device.featureProfile` is `"reduced"` when the granted device had
+its feature set reduced (iOS slim mode applied and this request did not pass
 `--full`), and `"full"` or absent otherwise — always absent for Android. It
 lets an agent explain a feature-loss failure (missing push notification,
 Spotlight result, StoreKit sheet, universal link, or system picker) instead
@@ -268,6 +275,35 @@ The requester identity for leases made through this server is
 [Agent identity](#agent-identity). Set a distinct `SIMLOCK_AGENT_ID` per MCP
 server process (one per agent session) so the one-lease-per-agent rule is
 meaningful.
+
+### Breaking in 0.3.0: tool schemas are now the contract's own field names
+
+Tool names are unchanged. Every tool's input/output schema is now derived
+directly from `src/contract`'s zod schemas (`src/mcp/contracts.ts`) instead
+of a hand-maintained snake_case shape — one vocabulary across CLI, MCP,
+HTTP, and `simlock/client`, not a fourth one. Two changes in here are easy
+to miss and will silently produce wrong behavior if you don't update a
+caller:
+
+- **`lease_simulator`'s `timeout_seconds` is now `timeoutMs` — a unit
+  change, not just a rename.** A caller that keeps sending the old field
+  name under the new one (`{"timeoutMs": 30}` meaning "30 seconds", the old
+  convention) waits 1000× longer than intended before timing out. This is
+  the single highest-risk change in this release — it does not fail loudly,
+  it just waits far too long. Update every caller's timeout field name *and*
+  multiply its value by 1000.
+- **The top-level `slim: boolean` on a grant is gone; it's now
+  `device.featureProfile`** (`"full" | "reduced" | undefined`, undefined
+  meaning "not applicable" — always undefined for Android). A caller
+  checking `result.slim === true` now silently never sees a feature-loss
+  signal at all — `result.slim` is simply `undefined` on every response,
+  which is falsy, not an error. Check `result.device.featureProfile ===
+  "reduced"` instead.
+
+Every other field keeps the contract's own camelCase names it already had
+under the pre-0.3.0 hand-written schemas (`leaseId`, `deviceId`,
+`allowDownload`, `requesterId`, ...); those did not change shape, only their
+schema's source of truth.
 
 ## `simlock status`
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -44,7 +44,10 @@ longer dumped to stderr on every failure, only on request via `--help`.
 | 13 | `REQUESTER_ALREADY_LEASED` | requester already holds a lease or has a pending request — one lease per agent in v1; release the named lease first |
 | 14 | — | `lease` held mode only: the daemon ended the lease without the holder asking (TTL backstop, operator `release`, or an unrecoverable device) |
 
-Every row but 14 matches `DAEMON_ERROR_EXIT_CODES` in `src/cli/index.ts` exactly; 14 is not a daemon error code but an outcome of held mode, so it lives beside the table's other `lease` outcome, 0.
+Every row but 14 matches the `cliExitCode` column of the contract's error
+table (`src/contract/errors.ts`'s `ERROR_TABLE`) exactly — the CLI does not
+maintain a second mapping; 14 is not a daemon error code but an outcome of
+held mode, so it lives beside the table's other `lease` outcome, 0.
 A daemon error code with no entry here (for example `UNKNOWN_LEASE`,
 surfaced by `lease renew`) falls back to exit 1; the structured stderr line
 still reports the specific code.
@@ -129,17 +132,24 @@ have a request queued fails with `REQUESTER_ALREADY_LEASED` (exit 13); the
 error message names the existing lease id to release first.
 
 **Held mode (default):** intended to be run in the background by the agent.
-As soon as the device is ready, one JSON line is printed on stdout:
+As soon as the device is ready, one JSON line is printed on stdout — the
+contract's `lease.request` output (`LeaseGrant`: `device`, `lease`, `timing`)
+serialized as-is, plus the one field the CLI adds on top, the connection's
+resolved `role` (ADR 0003 §5):
 
 ```json
-{"lease":"lse_9f2c","platform":"ios","device":"iPhone 17 Pro","os":"26.5","udid":"ABCD-...","state":"leased","slim":true}
+{"device":{"id":"dev_1a2b","driverDeviceId":"ABCD-...","spec":{"platform":"ios","model":"iPhone 17 Pro","osVersion":"26.5"},"state":"leased","address":"...","featureProfile":"reduced", "...":"..."},"lease":{"id":"lse_9f2c","deviceId":"dev_1a2b","requesterId":"agent-1","ownerId":"agent-1","mode":"held","grantedAt":1735689600000,"ttlDeadline":1735689660000},"timing":{"estimatedProvisionMs":0,"estimatedBootMs":0,"estimatedReclaimMs":0,"estimatedReadyMs":0},"role":"agent"}
 ```
 
-`slim` is `true` when the granted device had its feature set reduced (iOS
-slim mode applied and this request did not pass `--full`) and `false`
-otherwise — always `false` for Android. It lets an agent explain a
-feature-loss failure (missing push notification, Spotlight result, StoreKit
-sheet, universal link, or system picker) instead of misreading it as a bug.
+`device.featureProfile` is `"reduced"` when the granted device had its
+feature set reduced (iOS slim mode applied and this request did not pass
+`--full`), and `"full"` or absent otherwise — always absent for Android. It
+lets an agent explain a feature-loss failure (missing push notification,
+Spotlight result, StoreKit sheet, universal link, or system picker) instead
+of misreading it as a bug. See `src/contract/schemas.ts`
+(`deviceRecordSchema`, `leaseRecordSchema`, `leaseGrantSchema`) for the full
+field list — this is the one vocabulary every frontend (CLI, MCP, HTTP, the
+`simlock/client` package) now shares.
 
 then the process stays alive holding the lease. **Kill the process to
 release** — or let it die on its own: held mode watches its parent (the pid
@@ -150,11 +160,14 @@ action selected for that request. A queued request reports its position
 without speculative work stages; reclaiming work is reported separately:
 
 ```json
-{"event":"queued","queue_position":1}
-{"event":"provisioning","eta_seconds":90}
-{"event":"booting","eta_seconds":60}
-{"event":"reclaiming","eta_seconds":34}
+{"push":"progress","stage":"queued","queuePosition":1}
+{"push":"progress","stage":"provisioning","etaMs":90000}
+{"push":"progress","stage":"booting","etaMs":60000}
+{"push":"progress","stage":"reclaiming","etaMs":34000}
 ```
+
+`push` is the one field the CLI adds to identify the line's kind; everything
+else is the contract's `LeaseProgress` push, serialized as-is (ADR 0003 §11).
 
 `reclaiming` follows `queued` when the device the request is waiting on is
 being purged for its previous holder: the position alone would not say that
@@ -168,12 +181,12 @@ leased device for as long as the connection holds it, on the same stderr
 stream:
 
 ```json
-{"event":"device_unhealthy","lease":"lse_9f2c","device_id":"dev_1a2b"}
-{"event":"device_recovered","lease":"lse_9f2c","device_id":"dev_1a2b","attempts":1}
+{"push":"device-unhealthy","leaseId":"lse_9f2c","deviceId":"dev_1a2b"}
+{"push":"device-recovered","leaseId":"lse_9f2c","deviceId":"dev_1a2b","attempts":1}
 ```
 
-`device_unhealthy` means the device stopped running outside simlock and a
-reboot is in progress under the same lease; `device_recovered` means that
+`device-unhealthy` means the device stopped running outside simlock and a
+reboot is in progress under the same lease; `device-recovered` means that
 reboot passed readiness. The lease itself is untouched by either — it is
 still held and must still be released the normal way. Recovery can instead
 give up (the device vanished, its provenance no longer checks out, or reboot
@@ -181,12 +194,12 @@ attempts ran out); giving up is not itself one of these lines — it ends the
 lease, which surfaces as the same line any other lease loss does:
 
 ```json
-{"event":"lease_lost","lease":"lse_9f2c","device_id":"dev_1a2b","reason":"device-lost"}
+{"push":"lease-lost","leaseId":"lse_9f2c","deviceId":"dev_1a2b","reason":"device-lost"}
 ```
 
-In all three lines `device_id` is the registry device id — the `id` column of
+In all three lines `deviceId` is the registry device id — the `id` column of
 `simlock list --devices`, and the same identifier the event bus uses — not the
-driver-level `udid` the grant returns on stdout. A `lease_lost` line is
+driver-level `udid` the grant returns on stdout. A `lease-lost` line is
 terminal for held mode: there is no longer a lease to
 hold, so the process writes that line and exits `14` rather than waiting for a
 signal, and it does not try to release a lease the daemon has already taken
@@ -355,7 +368,14 @@ lines. `--follow` keeps streaming; `--since 1h` replays recent history.
 ## `simlock daemon <start|stop|status|logs>`
 
 Manage the daemon explicitly. Other commands auto-start it on demand;
-`daemon` exists for operators and debugging. `logs` tails daemon logs.
+`daemon` exists for operators and debugging. `logs` tails daemon logs and
+works even when the daemon is dead — it reads the log file directly, no
+connection attempted. `status` never auto-starts the daemon and distinguishes
+two failure shapes: `{"status":"stopped"}` when nothing is listening on the
+socket at all, versus `{"status":"handshake-refused","error":{"code":...}}`
+(exit 1) when a daemon answered but refused the connection (a bad admin
+credential, or a protocol version mismatch) — the two used to be reported
+identically as "stopped".
 
 The daemon writes one structured JSON line per record to `~/.simlock/daemon.log`
 (timestamp, level, module, message, and any fields) covering startup (version,
@@ -377,11 +397,37 @@ under `capacity.config` — see
 is running, both a global and a per-platform running limit must have room
 before Simlock provisions or boots a shutdown device.
 
+## Admin credential resolution
+
+Several commands (`list`, `cleanup`, `nuke`, `events`, `config get`,
+`daemon stop`, `token create|list|revoke`, and cross-process `release`) need
+the daemon's `admin` role. The CLI resolves a credential to send at
+handshake, in order:
+
+1. `--token <secret>` — accepted anywhere on the command line.
+2. `SIMLOCK_ADMIN_TOKEN` — the environment variable.
+3. the local `admin.token` file the daemon writes under `SIMLOCK_HOME` at
+   startup (read is retried briefly, to ride out the daemon still writing it
+   after a fresh `daemon start`).
+
+When none of the three resolves (a different OS user, or the file genuinely
+missing), the CLI connects as `agent` instead and writes a one-line stderr
+notice; admin-only operations then fail with `FORBIDDEN` from the daemon,
+same as any other role violation. `simlock lease`'s output JSON includes the
+connection's resolved `role` so a caller can tell which one it got.
+
+This is also why `simlock lease --detach` followed later by
+`simlock release <lease-id>` from a different invocation works even though
+each CLI process has a different pid-derived identity: both commands connect
+as admin (when the local file is readable), and admin bypasses the
+per-connection ownership check that would otherwise apply.
+
 ## `simlock token create --role <agent|operator> [--label <text>]` / `list` / `revoke <token-id>`
 
-Mint and manage bearer tokens for the HTTP API. Operates on
-`~/.simlock/tokens.json` directly (under `SIMLOCK_HOME`) — no daemon
-round-trip, like `config` reading its file.
+Mint and manage bearer tokens for the HTTP API. `token.create|list|revoke`
+are daemon operations (admin role) — the daemon is the only process that
+ever reads or writes `tokens.json`; the CLI is a thin client over the same
+`simlock/admin` connection every other admin command uses.
 
 `create` prints the minted secret **once**, alongside the token record:
 
@@ -395,8 +441,9 @@ id doubles as the requester identity over HTTP — one token is one requester,
 same as the CLI's `--agent-id`.
 
 `list` prints `{"tokens":[...]}` — the same record shape as `create`, minus
-the secret and its hash. `revoke <token-id>` prints `{"revoked":true}`, or a
-structured `UNKNOWN_TOKEN` error (exit 1) for an id that does not exist.
+the secret and its hash. `revoke <token-id>` prints `{"revoked":true}` or
+`{"revoked":false}` for an id that does not exist — the daemon's
+`token.revoke` operation does not treat an unknown id as an error.
 
 ## Environment variables
 
@@ -410,6 +457,13 @@ agent's environment repoints every command at an isolated data directory —
 useful for running multiple independent simlock instances on one machine, or
 for tests. When the CLI or MCP server auto-starts the daemon, the daemon
 process inherits the variable like the rest of the environment.
+
+### `SIMLOCK_ADMIN_TOKEN`
+
+The second source in [admin credential resolution](#admin-credential-resolution)
+— an operator token (`simlock token create --role operator`) or the daemon's
+per-start `admin.token` secret, either works. Set it once in a supervisor's
+environment to avoid every admin command reading `admin.token` off disk.
 
 ### `SIMLOCK_DRIVERS_MODULE` (advanced / testing hook)
 

--- a/docs/CLIENT.md
+++ b/docs/CLIENT.md
@@ -1,0 +1,166 @@
+# Programmatic client (`simlock/client`, `simlock/admin`)
+
+Part of the user manual: the typed daemon client a host process (for
+example, agent-device) uses to lease devices over the daemon's unix socket
+without spawning a `simlock` command. It is the same client the CLI and MCP
+frontends are built on (`src/cli`, `src/mcp/session.ts`) — nothing about it
+is second-class relative to the CLI.
+
+Two entry points, split by import path rather than by a runtime flag:
+
+```ts
+import { connectSimlock } from "simlock/client"; // agent role
+import { connectSimlockAdmin } from "simlock/admin"; // agent + admin role
+```
+
+`connectSimlockAdmin` returns a superset of `connectSimlock`'s client — every
+agent-role method plus the admin-role ones (`list`, `runCleanup`, `runNuke`,
+`getConfig`, `stopDaemon`, `replayEvents`/`subscribeEvents`,
+`createToken`/`listTokens`/`revokeToken`). The split exists so
+`simlock/client` doesn't even show admin methods in a caller's editor; the
+daemon's own role check is what actually stops an agent-role session from
+calling one (ADR 0003 §3) — this is a discoverability choice, not the
+enforcement mechanism.
+
+Both are async factories that open one connection and complete the `hello`
+handshake:
+
+```ts
+const client = await connectSimlock({
+  endpoint: "/path/to/daemon.sock", // or omit + pass `connection` in tests
+  principal: "agent-1",
+});
+
+const grant = await client.requestLease({ platform: "ios", model: "iPhone 17 Pro" });
+// grant: { device, lease, timing } — the contract's LeaseGrant, verbatim
+
+await client.releaseLease({ leaseId: grant.lease.id });
+await client.close();
+```
+
+`connectSimlockAdmin` additionally accepts `credential` — an operator token
+or the daemon's per-start `admin.token` secret (see
+[ARCHITECTURE.md](ARCHITECTURE.md#security-model-cooperative-identity-not-a-hostile-process-boundary)
+for what those are and how the CLI resolves one). A missing or wrong
+credential fails the handshake with `ADMIN_AUTHENTICATION_FAILED` before any
+other request is sent on that connection:
+
+```ts
+import { connectSimlockAdmin, isSimlockError } from "simlock/admin";
+
+try {
+  const admin = await connectSimlockAdmin({ endpoint: sockPath, credential: token });
+} catch (error) {
+  if (isSimlockError(error) && error.code === "ADMIN_AUTHENTICATION_FAILED") {
+    // bad or missing credential
+  }
+}
+```
+
+Every exported type — `LeaseRequestInput`, `LeaseGrant`, `LeaseRecord`,
+`DoctorReport`, `SimlockConfig`, error codes, and so on — is derived from
+`src/contract`'s zod schemas, the same vocabulary the CLI's `--json` output
+and MCP's tool schemas now share. Nothing core-private
+(`DeviceRecord`/`LeaseRecord`-the-core-type) ever appears on this surface;
+see `src/simlock-client/no-core-leak.test.ts`.
+
+## One connection, no reconnect, no retry
+
+This is the one thing to internalize before building anything on top of this
+client: **it owns exactly one connection and never reconnects or retries,
+not even for reads.** When the connection dies — the daemon stops, crashes,
+or the socket is killed out from under it — every in-flight call rejects
+with `DAEMON_CONNECTION_LOST`, `onLeaseLost` fires for each lease this
+client held (reason `daemon-connection-lost`), and the client is done. There
+is no automatic retry loop hiding behind any method, including `getStatus`
+or `getCatalog` — a shared retry policy is a trap the moment it touches a
+mutation, so this module simply does not have one at all, for anything.
+
+Reconnect policy is deliberately a frontend's own concern, not something
+this client can make a universal decision about:
+
+- **MCP** keeps a lazy reconnect, because its process outlives any single
+  connection — the next tool call after a dead connection builds a brand new
+  client (see `src/mcp/session.ts`, `src/mcp/connect.ts`).
+- **The CLI** needs none — a CLI invocation's whole purpose ends with its
+  connection.
+- **A host process** (agent-device) has its own supervisor and its own
+  opinion about what "still needed" means across a daemon restart; this
+  client does not guess on its behalf.
+
+The payoff of never reconnecting automatically: "reconnecting never
+implicitly acquires a device" is trivially true for a client that cannot
+reconnect at all. If you need resilience across a dropped connection, build
+it explicitly — call `connectSimlock`/`connectSimlockAdmin` again and decide
+for yourself whether the lease you held is worth re-requesting.
+
+```ts
+client.onConnectionLost((error) => {
+  // Fires exactly once. Every in-flight call has already rejected
+  // DAEMON_CONNECTION_LOST and every onLeaseLost for a held lease has
+  // already fired by the time this runs.
+});
+```
+
+## Abort semantics
+
+`requestLease` takes an `AbortSignal` as part of its options. Aborting does
+not simply drop the caller's interest client-side — it drives the daemon's
+own `lease.cancel` operation (ADR 0003 §9) and waits for a real outcome, so
+the caller is never left guessing whether a device is or isn't leased to it:
+
+```ts
+const controller = new AbortController();
+const promise = client.requestLease(
+  { platform: "ios", model: "iPhone 17 Pro" },
+  { signal: controller.signal, onProgress: (p) => console.log(p) },
+);
+controller.abort();
+await promise; // rejects with a CANCELLED SimlockError, in every case below
+```
+
+Four cases, by when the signal fires:
+
+- **Before the request is even sent** — rejects `CANCELLED` immediately;
+  nothing is sent to the daemon at all.
+- **While the request is still queued** — sends `lease.cancel`, waits for
+  the original request to actually reject, then surfaces `CANCELLED`
+  regardless of what that rejection's own code/message was.
+- **While device work is already in flight** (provisioning, booting,
+  reclaiming) — `lease.cancel` answers `not-cancellable` at this stage; the
+  client waits for the request's real outcome. If a grant still lands, it is
+  released immediately (`releaseLease`, best-effort) so the caller never
+  ends up holding a device it already told the client it didn't want, and
+  `CANCELLED` is surfaced either way.
+- **After the grant already resolved** — the abort is ignored; you have a
+  device, and aborting an already-finished request is a no-op by design, not
+  an implicit release.
+
+**True cancellation during provisioning is out of scope for this release.**
+The "device work already in flight" case above releases the grant
+immediately once it lands rather than actually interrupting the in-flight
+provision/boot/reclaim — the daemon keeps doing the work, the caller just
+doesn't end up holding the result. This is recorded as a known gap in
+[known-pitfalls.md](known-pitfalls.md).
+
+## What this client does not do
+
+- It does not start or stop the daemon. `connectSimlock`/`connectSimlockAdmin`
+  only ever connect to an already-listening socket; auto-launch (what the
+  CLI and MCP do on a missing daemon) is a frontend concern layered on top,
+  not something this module provides. Build your own launch-then-retry
+  policy around it if you need one — `src/mcp/connect.ts`'s
+  `connectWithAutoLaunch` is a worked example, deliberately never launching
+  on anything but "nothing is listening" (a version mismatch or a refused
+  handshake means something answered, and launching there risks a second
+  daemon instance or masking a real incompatibility).
+- It does not restart the daemon on a protocol version mismatch. See
+  [ARCHITECTURE.md](ARCHITECTURE.md) and the ADR §6 for why: that would
+  release every held lease on the machine. `PROTOCOL_VERSION_UNSUPPORTED`
+  names the running daemon's version; the fix is `simlock daemon stop` when
+  it's idle, run by an operator or supervisor, not this client.
+- It does not expose a role the daemon itself would reject — `simlock/admin`
+  showing you `stopDaemon`/`runNuke`/etc. is a TypeScript-editor
+  convenience, not the actual gate. The daemon's own role check is what
+  actually stops an agent-credentialed connection from calling one; do not
+  treat "the method exists on the type" as proof of authorization.

--- a/docs/HTTP-API.md
+++ b/docs/HTTP-API.md
@@ -8,10 +8,16 @@ another machine is the operator's own tunnel (Tailscale, cloudflared, a
 reverse proxy) — Simlock does no TLS termination in v1, and `Authorization`
 is required on every route regardless of how it's reached, loopback included.
 
-The gateway calls the same role interfaces the CLI and MCP server call
-(`LeaseCommands`, `QueueControl`, `CapacityReader`, `CatalogReader`); the core
-never knows HTTP exists. See [ARCHITECTURE.md](ARCHITECTURE.md) for how it
-fits alongside the other frontends.
+The gateway calls the exact same in-process `Dispatcher` the unix socket
+calls (ADR 0003 §2) — not a second copy of role/ownership logic, and not a
+loopback hop through the socket either. Every route that maps onto a daemon
+operation gets the same input parsing, role check, `authorize`/ownership
+hook, and startup-readiness parking a socket request gets, from that one
+shared instance. This is also why a fix on the socket side (the download
+policy, startup-readiness parking, error mapping) lands on HTTP for free —
+see [ARCHITECTURE.md](ARCHITECTURE.md#contract-dispatcher-and-roles-adr-0003)
+for how it fits together, and the two bug fixes called out below for what
+this actually changed.
 
 ## Leases are detached-only over HTTP
 
@@ -100,6 +106,14 @@ shares a pool key with, a slim device, so it can wait for a fresh device to
 provision or force a re-provision of one already running, even while slim
 devices sit idle in the warm pool. See [CONFIGURATION.md](CONFIGURATION.md)
 for what slim mode disables.
+
+`allowDownload` is now clamped through `config.downloads.policy` the same
+way the socket protocol always was (**bug fix, 0.3.0**): before this
+release, HTTP passed a client-supplied `allowDownload` straight through
+unclamped, so a `"never"` policy could still be bypassed over HTTP even
+though it already blocked the same thing on the socket. Both frontends now
+go through the one shared dispatcher, so there is only one place left to get
+this wrong.
 An `Idempotency-Key` header (at most 200 characters) makes a replay of the
 same key, from the same requester, return the original request resource
 instead of double-queueing — held in memory with a TTL, so a replay after a
@@ -184,7 +198,19 @@ as a bug.
 
 Role: `agent` (own lease; `operator` any). Re-fetches the lease — a client
 that restarts mid-lease recovers its state instead of leaking the lease.
-`404 UNKNOWN_LEASE` once it has expired or been released.
+`404 UNKNOWN_LEASE` once it has expired or been released, **and now also for
+another requester's own, still-live lease** (bug fix, 0.3.0: this used to be
+`403 FORBIDDEN`, which told an unauthorized caller a lease id was valid).
+Every route under `/v1/leases/{id}` (this one, `renew`, `events`, `DELETE`)
+resolves the lease the same way `lease.list`'s dispatcher handler already
+filters leases — to the session's own set, admin sees all — so an id outside
+that set simply isn't in the list; `404` covers "doesn't exist" and "not
+yours" identically, the same way `lease.list` itself does not distinguish
+them. This is different from the lease-*request* routes below
+(`/v1/lease-requests/{id}` and friends), which are still HTTP's own resource
+and still answer `403 FORBIDDEN` for another requester's request — that
+envelope stays HTTP-specific until
+[#72](https://github.com/callstackincubator/simlock/issues/72).
 
 `expiresAt` is always the authoritative deadline. After a **daemon** restart
 the gateway no longer remembers a per-request `ttlMs`, so the payload reports
@@ -244,8 +270,8 @@ Every failure is the same shape the daemon protocol uses:
 |---|---|
 | 400 | `BAD_REQUEST` (malformed body, bad query param, validation) |
 | 401 | `UNAUTHENTICATED` (missing or unrecognized token) |
-| 403 | `FORBIDDEN` (role doesn't permit the route; or the lease/request belongs to another requester) |
-| 404 | `UNKNOWN_REQUEST`, `UNKNOWN_LEASE` |
+| 403 | `FORBIDDEN` (role doesn't permit the route; or a `/v1/lease-requests/*` route whose request belongs to another requester) |
+| 404 | `UNKNOWN_REQUEST` (unknown request id), `UNKNOWN_LEASE` (unknown lease id, expired/released, **or a `/v1/leases/*` route naming another requester's lease** — see [`GET /v1/leases/{id}`](#get-v1leasesid)) |
 | 409 | `REQUESTER_ALREADY_LEASED` (body names the existing lease id), `REQUEST_NOT_CANCELLABLE` (body names the lease id if the request had already been granted) |
 | 422 | `UNKNOWN_MODEL`, `RUNTIME_MISSING`, `NO_DRIVER` |
 | 503 | `NO_CAPACITY` (only with `noWait: true`; response carries `Retry-After`) |
@@ -263,12 +289,15 @@ Every failure is the same shape the daemon protocol uses:
   (including across a restart) creates a fresh request rather than erroring
   — the `409` above is the real backstop against a double grant, not the
   idempotency cache.
-- **Startup.** The gateway starts only after the daemon's own startup
-  convergence finishes (unlike the unix socket, which accepts connections
-  immediately and parks non-`hello`/`status.get` requests until convergence
-  completes). A connection refused while the daemon is still starting up is
-  accepted v1 behavior — there is no HTTP-level "starting" response to
-  mirror the socket protocol's parked dispatch.
+- **Startup.** The gateway's listener now starts the moment the daemon
+  claims its socket — the same instant the unix socket itself starts
+  accepting connections, before startup convergence (`doctor.reconcile()`,
+  running-capacity convergence) has run (**bug fix, 0.3.0**: the gateway
+  used to start only once convergence had already finished, so it could not
+  observe or need this). A request that arrives before convergence completes
+  now waits on the shared dispatcher's readiness gate exactly like a socket
+  request, instead of being refused — every route but the routes that don't
+  dispatch at all (`GET /v1/healthz`) can block briefly on a cold start.
 - **Shutdown.** `simlock daemon stop` closes the HTTP listener (and any open
   connection, in-flight SSE streams included) before releasing held leases
   or tearing down the lease engine, so no HTTP request can run against a

--- a/docs/adr/0003-one-typed-daemon-contract-behind-every-frontend.md
+++ b/docs/adr/0003-one-typed-daemon-contract-behind-every-frontend.md
@@ -1,6 +1,6 @@
 # 0003. One typed daemon contract behind every frontend
 
-- **Status:** Accepted — implemented (0.3.0)
+- **Status:** Accepted
 - **Date:** 2026-09-03
 - **Issue:** [#71](https://github.com/callstackincubator/simlock/issues/71)
   (part of [#70](https://github.com/callstackincubator/simlock/issues/70))

--- a/docs/adr/0003-one-typed-daemon-contract-behind-every-frontend.md
+++ b/docs/adr/0003-one-typed-daemon-contract-behind-every-frontend.md
@@ -1,6 +1,6 @@
 # 0003. One typed daemon contract behind every frontend
 
-- **Status:** Accepted — not yet implemented
+- **Status:** Accepted — implemented (0.3.0)
 - **Date:** 2026-09-03
 - **Issue:** [#71](https://github.com/callstackincubator/simlock/issues/71)
   (part of [#70](https://github.com/callstackincubator/simlock/issues/70))

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,4 +22,4 @@ Status values:
 |---|---|---|
 | [0001](0001-simlock-owned-device-roots.md) | Simlock-owned device roots | Accepted — not yet implemented |
 | [0002](0002-opt-in-slim-ios-simulators.md) | Opt-in slim iOS simulators | Accepted |
-| [0003](0003-one-typed-daemon-contract-behind-every-frontend.md) | One typed daemon contract behind every frontend | Accepted — not yet implemented |
+| [0003](0003-one-typed-daemon-contract-behind-every-frontend.md) | One typed daemon contract behind every frontend | Accepted |

--- a/docs/known-pitfalls.md
+++ b/docs/known-pitfalls.md
@@ -147,6 +147,77 @@ built in stage 4. `component.install-started`'s payload already carries
 enough (`platform`, `componentId`) that a future pass wiring this through
 would mostly be plumbing, not new information to invent.
 
+## True cancellation during provisioning is not implemented (ADR 0003 §10)
+
+`simlock/client`'s `requestLease` takes an `AbortSignal`. When device work is
+already in flight (provisioning, booting, reclaiming) and the caller aborts,
+the client sends `lease.cancel`, which answers `not-cancellable` at that
+stage — the daemon keeps doing the work. What the client does instead:
+it waits for the request's real outcome, and if a grant still lands, releases
+it immediately so the caller never ends up holding a device it already
+walked away from, then surfaces `CANCELLED` either way.
+
+**The pitfall:** this is release-on-arrival, not interruption. The
+provisioning/boot/reclaim work the abort was meant to stop keeps running to
+completion (or failure) on its own, consuming the time and driver resources
+it would have anyway, and the released device pays a purge (see "Release
+hands the purge off" in [ARCHITECTURE.md](ARCHITECTURE.md)) before it's
+usable by anyone else. A caller that aborts expecting the operation to
+actually stop gets a device that is unavailable for roughly as long as an
+uncancelled request would have taken, just without ending up holding it.
+
+**Status:** known and accepted for this release, deliberately out of scope
+per the ADR ("True cancellation during provisioning is deliberately out of
+scope here"). Actually interrupting driver work mid-flight would mean
+threading cancellation through `Driver.provision`/`makeReady`/`reclaim`
+themselves — real protocol and driver-interface machinery across both
+platforms, not a client-side change.
+
+**Possible future fix:** none planned yet. A caller that needs to bound the
+cost of an abandoned request should set `timeoutMs`/`--timeout` tightly
+rather than relying on abort to cut a request short once device work has
+started.
+
+## The HTTP tracker and notice buffer are the last frontend-held state (#72)
+
+ADR 0003 moved request handling into one shared, transport-independent
+dispatcher (`src/daemon/dispatcher.ts`) that both the unix socket and HTTP
+call — but two pieces of state still live in the HTTP frontend rather than
+the daemon's core:
+
+- **`LeaseRequestTracker`** (`src/http/tracker.ts`) — the in-memory registry
+  behind `POST /v1/lease-requests` and the resource it returns
+  (`GET`/`DELETE /v1/lease-requests/{id}`, its SSE stream, `Idempotency-Key`
+  replay). This is what lets HTTP offer an async-resource-shaped API
+  (`202`-then-poll) on top of the core's request/grant flow, which itself
+  has no notion of a durable, independently-addressable "request resource."
+- **`LeaseNoticeBuffer`** (`src/http/notices.ts`) — buffers owner-routed
+  device-health facts (`device_unhealthy`, `device_recovered`) per lease so
+  a polling-only HTTP client (no open connection to push to) can drain them
+  on its next `renew` or SSE reconnect instead of missing them entirely.
+
+**The pitfall:** both reset on a daemon restart (in-memory, no persistence),
+and both are HTTP-specific reimplementations of "track something about a
+request/lease across calls" that the socket frontends don't need because
+they hold a live connection instead. A daemon restart loses in-flight
+lease-request tracking state and buffered notices the same way it always
+did pre-ADR 0003 — see [Lifecycle semantics](HTTP-API.md#lifecycle-semantics)
+for the documented recovery loop (`404` → re-request → maybe `409` → `GET`),
+which exists specifically because the tracker does not survive a restart.
+
+**Status:** known, and explicitly called out as the ADR's own unfinished
+seam, not an oversight: "the HTTP tracker and notice buffer remain the known
+stateful leftovers in a frontend." The ADR's dispatcher work "prepares the
+seam... but does not do that work" of removing them.
+
+**Planned fix:** [#72](https://github.com/callstackincubator/simlock/issues/72),
+re-scoped by this ADR to core durability and idempotency — moving durable,
+idempotent lease requests into the core registry itself, so a lease request
+becomes a first-class, restart-surviving core concept instead of a resource
+HTTP alone tracks. Once that lands, `LeaseRequestTracker` and
+`LeaseNoticeBuffer` should be able to shrink to thin views over core state
+rather than independent bookkeeping.
+
 ## iOS slim mode: accepted costs and feature loss (#87)
 
 `ios.slim` (opt-in, default off) has the iOS driver disable ~170 launchd
@@ -183,8 +254,12 @@ universal links, Siri/Apple Intelligence, iCloud sync, and some system
 pickers to not work on a slim device — the categories that back them are
 exactly the ones slimming disables. Mitigations: `simlock lease --full` (MCP
 `full: true`, HTTP `full: true`) opts a single lease out of slimming, and
-every lease response carries a `slim` flag so a caller can tell a
-feature-loss failure apart from an actual bug instead of guessing.
+every lease response carries a feature-profile signal so a caller can tell a
+feature-loss failure apart from an actual bug instead of guessing —
+`device.featureProfile === "reduced"` on the CLI/MCP/client contract shape
+(`slim` as a top-level boolean grant field is gone as of 0.3.0, ADR 0003
+§11), or HTTP's own `lease.slim` boolean, which is still derived from the
+same underlying signal.
 
 **Mixing slim and full devices under one spec can make `--full` wait or
 re-provision.** `full` is part of spec identity (`DeviceSpec.full`, compared by `sameSpec`,

--- a/e2e/heartbeat-ttl.test.ts
+++ b/e2e/heartbeat-ttl.test.ts
@@ -74,9 +74,11 @@ describe("sliding TTL and heartbeat", () => {
     try {
       const leaseResult = await mcp.client.callTool({
         name: "lease_simulator",
-        arguments: { platform: "ios", device: "iPhone 16", os: "18.4" },
+        arguments: { model: "iPhone 16", osVersion: "18.4", platform: "ios" },
       });
-      const mcpLease = leaseResult.structuredContent as { lease_id: string; expires_at_ms: number };
+      const mcpLease = leaseResult.structuredContent as {
+        lease: { id: string; ttlDeadline: number };
+      };
 
       const cliGrant = JSON.parse(await cliHeld.firstStdoutLine()) as {
         lease: string;
@@ -110,7 +112,7 @@ describe("sliding TTL and heartbeat", () => {
       );
 
       const rowsAfterExpiry = await leaseRows(env);
-      const mcpRow = rowsAfterExpiry.find((row) => row.id === mcpLease.lease_id);
+      const mcpRow = rowsAfterExpiry.find((row) => row.id === mcpLease.lease.id);
       const cliRow = rowsAfterExpiry.find((row) => row.id === cliGrant.lease);
       expect(
         mcpRow,
@@ -120,22 +122,21 @@ describe("sliding TTL and heartbeat", () => {
         cliRow,
         "CLI held lease should have survived past the detached lease's expiry",
       ).toBeDefined();
-      expect(mcpRow?.ttlDeadline).toBeGreaterThan(mcpLease.expires_at_ms);
+      expect(mcpRow?.ttlDeadline).toBeGreaterThan(mcpLease.lease.ttlDeadline);
       expect(mcpRow?.lastHeartbeatAt).toBeGreaterThan(0);
       expect(cliRow?.ttlDeadline).toBeGreaterThan(cliGrant.expires_at_ms);
       expect(cliRow?.lastHeartbeatAt).toBeGreaterThan(0);
 
       const statusResult = await mcp.client.callTool({ name: "lease_status", arguments: {} });
-      const statusExpiry = (statusResult.structuredContent as { expires_at_ms: number })
-        .expires_at_ms;
-      expect(statusExpiry).toBeGreaterThan(mcpLease.expires_at_ms);
+      const statusExpiry = (statusResult.structuredContent as { ttlDeadline: number }).ttlDeadline;
+      expect(statusExpiry).toBeGreaterThan(mcpLease.lease.ttlDeadline);
 
       const recorded = await env.events();
       expect(
         recorded.filter(
           (entry) =>
             entry.event === "lease.renewed" &&
-            (entry.payload as { leaseId?: string }).leaseId === mcpLease.lease_id,
+            (entry.payload as { leaseId?: string }).leaseId === mcpLease.lease.id,
         ).length,
         "expected repeated lease.renewed events for the heartbeating MCP lease",
       ).toBeGreaterThan(1);
@@ -156,7 +157,7 @@ describe("sliding TTL and heartbeat", () => {
 
       await mcp.client.callTool({
         name: "release_simulator",
-        arguments: { lease_id: mcpLease.lease_id },
+        arguments: { leaseId: mcpLease.lease.id },
       });
     } finally {
       cliHeld.kill("SIGKILL");

--- a/e2e/lease-lifecycle.test.ts
+++ b/e2e/lease-lifecycle.test.ts
@@ -73,21 +73,18 @@ describe("lease lifecycle across both frontends", () => {
     try {
       const leaseResult = await mcp.client.callTool({
         name: "lease_simulator",
-        arguments: { platform: "ios", device: "iPhone 16", os: "18.4" },
+        arguments: { model: "iPhone 16", osVersion: "18.4", platform: "ios" },
       });
       const leased = leaseResult.structuredContent as {
-        lease_id: string;
-        device_id: string;
-        device: string;
-        platform: string;
+        device: { driverDeviceId: string; spec: { model: string } };
+        lease: { id: string };
       };
-      expect(leased.device).toBe("iPhone 16");
+      expect(leased.device.spec.model).toBe("iPhone 16");
 
       const statusResult = await mcp.client.callTool({ name: "lease_status", arguments: {} });
       expect(statusResult.structuredContent).toMatchObject({
         held: true,
-        lease_id: leased.lease_id,
-        device_id: leased.device_id,
+        id: leased.lease.id,
       });
 
       // The CLI frontend must see the exact same lease, keyed by the same requester id.
@@ -95,7 +92,7 @@ describe("lease lifecycle across both frontends", () => {
       expect(cliLeases.code).toBe(0);
       expect(cliLeases.json).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ id: leased.lease_id, requesterId: agentId }),
+          expect.objectContaining({ id: leased.lease.id, requesterId: agentId }),
         ]),
       );
 
@@ -106,10 +103,10 @@ describe("lease lifecycle across both frontends", () => {
 
       const releaseResult = await mcp.client.callTool({
         name: "release_simulator",
-        arguments: { lease_id: leased.lease_id },
+        arguments: { leaseId: leased.lease.id },
       });
       expect(releaseResult.structuredContent).toMatchObject({
-        lease_id: leased.lease_id,
+        leaseId: leased.lease.id,
         released: true,
       });
 
@@ -119,10 +116,13 @@ describe("lease lifecycle across both frontends", () => {
       expect(cliLeasesAfter.json).toEqual([]);
       const midPurge = await env.cli(["list", "--devices"]);
       expect(midPurge.json).toEqual([
-        expect.objectContaining({ driverDeviceId: leased.device_id, state: "reclaiming" }),
+        expect.objectContaining({
+          driverDeviceId: leased.device.driverDeviceId,
+          state: "reclaiming",
+        }),
       ]);
 
-      await waitForDeviceState(env, leased.device_id, "ready");
+      await waitForDeviceState(env, leased.device.driverDeviceId, "ready");
     } finally {
       await mcp.close();
     }

--- a/e2e/mcp-session.test.ts
+++ b/e2e/mcp-session.test.ts
@@ -29,10 +29,10 @@ describe("MCP session semantics", () => {
 
       const leaseResult = await mcp.client.callTool({
         name: "lease_simulator",
-        arguments: { platform: "ios", device: "iPhone 16", os: "18.4" },
+        arguments: { model: "iPhone 16", osVersion: "18.4", platform: "ios" },
         _meta: { progressToken: "flow7-token" },
       });
-      const leased = leaseResult.structuredContent as { lease_id: string; device_id: string };
+      const leased = leaseResult.structuredContent as { lease: { id: string } };
 
       const progress = mcp.progressNotifications();
       expect(progress.length, "expected at least one notifications/progress frame").toBeGreaterThan(
@@ -50,20 +50,23 @@ describe("MCP session semantics", () => {
       const statusAfter = await mcp.client.callTool({ name: "lease_status", arguments: {} });
       expect(statusAfter.structuredContent).toMatchObject({
         held: true,
-        lease_id: leased.lease_id,
+        id: leased.lease.id,
       });
 
       const released = await mcp.client.callTool({
         name: "release_simulator",
-        arguments: { lease_id: leased.lease_id },
+        arguments: { leaseId: leased.lease.id },
       });
-      expect(released.structuredContent).toEqual({ lease_id: leased.lease_id, released: true });
+      expect(released.structuredContent).toEqual({
+        leaseId: leased.lease.id,
+        released: true,
+      });
     } finally {
       await mcp.close();
     }
   });
 
-  it("relays a force-release from the CLI as a logging warning, then LEASE_NOT_OWNED is a clean tool error, and the server stays usable", async () => {
+  it("relays a force-release from the CLI as a logging warning, then FORBIDDEN is a clean tool error, and the server stays usable", async () => {
     const env = await withDaemon();
     await env.driverScript.set({
       ios: { knownModels: ["iPhone 16"], availableOsVersions: ["18.4"] },
@@ -73,9 +76,9 @@ describe("MCP session semantics", () => {
     try {
       const leaseResult = await mcp.client.callTool({
         name: "lease_simulator",
-        arguments: { platform: "ios", device: "iPhone 16", os: "18.4" },
+        arguments: { model: "iPhone 16", osVersion: "18.4", platform: "ios" },
       });
-      const leased = leaseResult.structuredContent as { lease_id: string; device_id: string };
+      const leased = leaseResult.structuredContent as { lease: { id: string } };
 
       const forceRelease = await env.cli(["release", "--all", "--yes"]);
       expect(forceRelease.code).toBe(0);
@@ -83,33 +86,33 @@ describe("MCP session semantics", () => {
       const warning = await mcp.waitForNotification((notification) => {
         if (notification.kind !== "logging") return undefined;
         const data = notification.params.data as
-          | { lease_id?: string; device_id?: string; reason?: string }
+          | { deviceId?: string; leaseId?: string; reason?: string }
           | undefined;
-        return data?.lease_id === leased.lease_id ? notification.params : undefined;
+        return data?.leaseId === leased.lease.id ? notification.params : undefined;
       });
       expect(warning.logger).toBe("simlock");
       expect(warning.level).toBe("warning");
-      // The daemon push carries its own internal registry device id, not the
-      // driver-opaque `device_id` (udid) the MCP lease result reports -- only assert
-      // it names *a* device, plus the lease id and reason, which do match exactly.
       expect(warning.data).toMatchObject({
-        lease_id: leased.lease_id,
-        device_id: expect.any(String),
+        deviceId: expect.any(String),
+        leaseId: leased.lease.id,
         reason: "explicit",
       });
 
       const statusAfter = await mcp.client.callTool({ name: "lease_status", arguments: {} });
       expect(statusAfter.structuredContent).toEqual({ held: false });
 
+      // The daemon's own ownership rule now answers, not a client-side pre-check (ADR
+      // 0003 §11): a stale release for a lease this session no longer owns/holds is
+      // FORBIDDEN, exactly the same as it would be for a lease this session never held.
       const staleRelease = await mcp.client.callTool({
         name: "release_simulator",
-        arguments: { lease_id: leased.lease_id },
+        arguments: { leaseId: leased.lease.id },
       });
       expect(staleRelease.isError).toBe(true);
       const errorPayload = JSON.parse(
         (staleRelease.content as { text: string }[])[0]?.text ?? "{}",
       ) as McpErrorPayload;
-      expect(errorPayload.code).toBe("LEASE_NOT_OWNED");
+      expect(errorPayload.code).toBe("FORBIDDEN");
 
       // Still usable: a clean tool error must not have wedged the session/transport.
       const devices = await mcp.client.callTool({ name: "list_devices", arguments: {} });
@@ -133,14 +136,14 @@ describe("MCP session semantics", () => {
     try {
       const leaseResult = await mcp.client.callTool({
         name: "lease_simulator",
-        arguments: { platform: "ios", device: "iPhone 16", os: "18.4" },
+        arguments: { model: "iPhone 16", osVersion: "18.4", platform: "ios" },
       });
-      const leased = leaseResult.structuredContent as { lease_id: string };
+      const leased = leaseResult.structuredContent as { lease: { id: string } };
 
       const lostNotice = mcp.waitForNotification((notification) => {
         if (notification.kind !== "logging") return undefined;
-        const data = notification.params.data as { lease_id?: string; reason?: string } | undefined;
-        return data?.lease_id === leased.lease_id ? data.reason : undefined;
+        const data = notification.params.data as { leaseId?: string; reason?: string } | undefined;
+        return data?.leaseId === leased.lease.id ? data.reason : undefined;
       });
 
       await env.restartDaemon();

--- a/e2e/slow-ios-slim.test.ts
+++ b/e2e/slow-ios-slim.test.ts
@@ -452,42 +452,45 @@ describe.skipIf(process.platform !== "darwin")(
           const fullResult = await mcp.client.callTool(
             {
               name: "lease_simulator",
-              arguments: { platform: "ios", device: model, os, full: true },
+              arguments: { full: true, model, osVersion: os, platform: "ios" },
             },
             undefined,
             leaseCallOptions,
           );
           const fullLeased = fullResult.structuredContent as {
-            lease_id: string;
-            slim: boolean;
+            device: { featureProfile?: "full" | "reduced" };
+            lease: { id: string };
           };
-          expect(fullLeased.slim, "MCP full:true lease must report slim:false").toBe(false);
+          expect(
+            fullLeased.device.featureProfile,
+            "MCP full:true lease must report a full feature profile",
+          ).toBe("full");
 
           await mcp.client.callTool({
             name: "release_simulator",
-            arguments: { lease_id: fullLeased.lease_id },
+            arguments: { leaseId: fullLeased.lease.id },
           });
 
           const slimResult = await mcp.client.callTool(
             {
               name: "lease_simulator",
-              arguments: { platform: "ios", device: model, os },
+              arguments: { model, osVersion: os, platform: "ios" },
             },
             undefined,
             leaseCallOptions,
           );
           const slimLeased = slimResult.structuredContent as {
-            lease_id: string;
-            slim: boolean;
+            device: { featureProfile?: "full" | "reduced" };
+            lease: { id: string };
           };
           expect(
-            slimLeased.slim,
-            "MCP plain lease under ios.slim.enabled must report slim:true",
-          ).toBe(true);
+            slimLeased.device.featureProfile,
+            "MCP plain lease under ios.slim.enabled must report a reduced feature profile",
+          ).toBe("reduced");
 
           await mcp.client.callTool({
             name: "release_simulator",
-            arguments: { lease_id: slimLeased.lease_id },
+            arguments: { leaseId: slimLeased.lease.id },
           });
         } finally {
           await mcp.close();

--- a/package.json
+++ b/package.json
@@ -27,6 +27,16 @@
     "!dist/**/*.test.d.ts"
   ],
   "type": "module",
+  "exports": {
+    "./client": {
+      "types": "./dist/client/index.d.ts",
+      "default": "./dist/client/index.js"
+    },
+    "./admin": {
+      "types": "./dist/admin/index.d.ts",
+      "default": "./dist/admin/index.js"
+    }
+  },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "build:e2e": "tsc -p e2e/fake-driver/tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simlock",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Control plane for iOS simulators and Android emulators.",
   "keywords": [
     "agents",

--- a/src/admin/index.ts
+++ b/src/admin/index.ts
@@ -1,0 +1,89 @@
+/**
+ * `simlock/admin` (ADR 0003 §10). Extends `simlock/client`'s agent surface with the `admin`
+ * rows of ADR §3's operation matrix. The split from `simlock/client` is by import path only --
+ * the daemon's own role check is what actually stops an agent-role session from calling one of
+ * these; nothing here enforces roles client-side beyond simply not exposing the methods.
+ */
+import { NodeIpcTransport, type IpcConnection, type IpcConnector } from "../ports/index.js";
+import {
+  connectSimlockClient,
+  type ConnectOptions,
+  type SimlockAdminClient,
+} from "../simlock-client/client.js";
+
+export type {
+  AnySimlockError,
+  CatalogGetInput,
+  CatalogGetOutput,
+  CleanupRunInput,
+  CleanupRunOutput,
+  DaemonStopOutput,
+  DeviceRecoveredPush,
+  DeviceUnhealthyPush,
+  DoctorReport,
+  DoctorRunInput,
+  EventPush,
+  EventsReplayInput,
+  EventsReplayOutput,
+  EventsSubscribeOutput,
+  EventsUnsubscribeOutput,
+  LeaseCancelInput,
+  LeaseCancelOutput,
+  LeaseGrant,
+  LeaseHeartbeatOutput,
+  LeaseListOutput,
+  LeaseLostPush,
+  LeaseProgress,
+  LeaseReleaseAllOutput,
+  LeaseReleaseInput,
+  LeaseReleaseOutput,
+  LeaseRenewInput,
+  LeaseRecord,
+  LeaseRequestInput,
+  ListGetInput,
+  ListGetOutput,
+  NukeReport,
+  NukeRunInput,
+  RequestLeaseOptions,
+  SimlockAdminClient,
+  SimlockConfig,
+  SimlockErrorCode,
+  StatusGetOutput,
+  TokenCreateInput,
+  TokenCreateOutput,
+  TokenListOutput,
+  TokenRevokeInput,
+  TokenRevokeOutput,
+} from "../simlock-client/client.js";
+export { isSimlockError, SimlockError } from "../simlock-client/client.js";
+
+/** Same as `simlock/client`'s `ConnectSimlockOptions`, plus `credential` -- ADR §5's first
+ * resolution source ("the `credential` connect option (programmatic client)"). A missing or
+ * wrong credential fails the handshake with `ADMIN_AUTHENTICATION_FAILED` before any other
+ * request is ever sent on this connection. */
+export interface ConnectSimlockAdminOptions {
+  readonly connection?: IpcConnection;
+  readonly endpoint?: string;
+  readonly ipc?: IpcConnector;
+  readonly principal?: string;
+  readonly credential?: string;
+  readonly heartbeat?: boolean;
+}
+
+/** Opens one connection to the daemon and completes the `hello` handshake, requesting the
+ * admin role via `credential`. */
+export async function connectSimlockAdmin(
+  options: ConnectSimlockAdminOptions,
+): Promise<SimlockAdminClient> {
+  const resolved: ConnectOptions = {
+    ...(options.connection === undefined ? {} : { connection: options.connection }),
+    ...(options.connection === undefined
+      ? { connector: options.ipc ?? new NodeIpcTransport() }
+      : {}),
+    ...(options.endpoint === undefined ? {} : { endpoint: options.endpoint }),
+    ...(options.principal === undefined ? {} : { principal: options.principal }),
+    ...(options.credential === undefined ? {} : { credential: options.credential }),
+    ...(options.heartbeat === undefined ? {} : { heartbeat: options.heartbeat }),
+  };
+  return connectSimlockClient(resolved, true);
+}

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -10,16 +10,21 @@ import { type Config, CleanupReaper, FakeDriver, LeaseEngine, Registry } from ".
 import {
   CryptoTokenSecrets,
   FakeClock,
+  FakeDaemonLauncher,
   FakeParentWatch,
   MemoryFilesystem,
+  MemoryIpcTransport,
   NodeFilesystem,
   NodeIpcTransport,
+  type Filesystem,
   type IdGenerator,
 } from "../ports/index.js";
 import { FakeSystemStats } from "../ports/index.js";
 import { TokenStore } from "../http/token-store.js";
 import { DaemonEndpointHost } from "../daemon/connection-host.js";
 import { DaemonServer } from "../daemon/server.js";
+import { AdminSecretManager } from "../daemon/admin-secret.js";
+import { createCredentialRoleResolver } from "../daemon/session.js";
 import { SimlockError, type AnySimlockError } from "../contract/index.js";
 import type {
   CatalogGetOutput,
@@ -35,12 +40,14 @@ import type {
 } from "../simlock-client/client.js";
 import { connectSimlockAdmin } from "../admin/index.js";
 import {
+  buildCliEnvironment,
   errorExitCode,
   fallbackRequesterId,
   parseDuration,
   readLogFile,
   runCli,
   type CliEnvironment,
+  type CliEnvironmentPorts,
 } from "./index.js";
 
 const gibibyte = 1024 ** 3;
@@ -129,8 +136,10 @@ describe("CLI: exit codes", () => {
         ["status"],
         output.environmentWith({
           readAdminTokenFile: async () => "a-token",
-          connectAdmin: async () =>
-            fakeClient({ getStatus: () => Promise.reject(simlockError("NO_CAPACITY")) }),
+          connectAdmin: async (resolveCredential) => {
+            await resolveCredential();
+            return fakeClient({ getStatus: () => Promise.reject(simlockError("NO_CAPACITY")) });
+          },
         }),
       ),
     ).resolves.toBe(11);
@@ -157,8 +166,8 @@ describe("CLI: admin credential resolution (ADR 0003 §5)", () => {
       output.environmentWith({
         adminTokenFromEnv: "from-env",
         readAdminTokenFile: async () => "from-file",
-        connectAdmin: async (credential) => {
-          seen = credential;
+        connectAdmin: async (resolveCredential) => {
+          seen = await resolveCredential();
           return fakeClient();
         },
       }),
@@ -175,8 +184,8 @@ describe("CLI: admin credential resolution (ADR 0003 §5)", () => {
       output.environmentWith({
         adminTokenFromEnv: "from-env",
         readAdminTokenFile: async () => "from-file",
-        connectAdmin: async (credential) => {
-          seen = credential;
+        connectAdmin: async (resolveCredential) => {
+          seen = await resolveCredential();
           return fakeClient();
         },
       }),
@@ -191,8 +200,8 @@ describe("CLI: admin credential resolution (ADR 0003 §5)", () => {
       ["status"],
       output.environmentWith({
         readAdminTokenFile: async () => "from-file",
-        connectAdmin: async (credential) => {
-          seen = credential;
+        connectAdmin: async (resolveCredential) => {
+          seen = await resolveCredential();
           return fakeClient();
         },
       }),
@@ -212,8 +221,8 @@ describe("CLI: admin credential resolution (ADR 0003 §5)", () => {
           reads += 1;
           return reads < 3 ? undefined : "from-file-after-retry";
         },
-        connectAdmin: async (credential) => {
-          seen = credential;
+        connectAdmin: async (resolveCredential) => {
+          seen = await resolveCredential();
           return fakeClient();
         },
       }),
@@ -230,8 +239,8 @@ describe("CLI: admin credential resolution (ADR 0003 §5)", () => {
       ["status"],
       output.environmentWith({
         readAdminTokenFile: async () => undefined,
-        connectAdmin: async (credential) => {
-          seen = credential;
+        connectAdmin: async (resolveCredential) => {
+          seen = await resolveCredential();
           return fakeClient();
         },
       }),
@@ -240,6 +249,168 @@ describe("CLI: admin credential resolution (ADR 0003 §5)", () => {
     expect(output.stderr.trim().split("\n")).toHaveLength(1);
     const notice: unknown = JSON.parse(output.stderr);
     expect((notice as { notice: string }).notice).toMatch(/agent/i);
+  });
+
+  it("does not read the admin.token file at all when --token is given (B2 ordering)", async () => {
+    // The file source must never be consulted -- let alone before the connection exists -- when
+    // a higher-priority source already answered. Also guards against a regression back to
+    // resolving credentials before `connectAdmin` is even called.
+    const output = outputCapture();
+    let fileReads = 0;
+    await runCli(
+      ["--token", "from-flag", "status"],
+      output.environmentWith({
+        readAdminTokenFile: async () => {
+          fileReads += 1;
+          return "from-file";
+        },
+        connectAdmin: async (resolveCredential) => {
+          await resolveCredential();
+          return fakeClient();
+        },
+      }),
+    );
+    expect(fileReads).toBe(0);
+  });
+
+  it("B1: degrades to an agent session with a stderr notice when the daemon rejects the credential", async () => {
+    const output = outputCapture();
+    let attempt = 0;
+    let seenOnRetry: string | undefined | "unset" = "unset";
+    await runCli(
+      ["status"],
+      output.environmentWith({
+        readAdminTokenFile: async () => "stale-secret",
+        connectAdmin: async (resolveCredential) => {
+          attempt += 1;
+          if (attempt === 1) {
+            const credential = await resolveCredential();
+            expect(credential).toBe("stale-secret");
+            throw simlockError("ADMIN_AUTHENTICATION_FAILED");
+          }
+          seenOnRetry = await resolveCredential();
+          return fakeClient();
+        },
+      }),
+    );
+    expect(attempt).toBe(2);
+    expect(seenOnRetry).toBeUndefined();
+    expect(output.stderr.trim().split("\n")).toHaveLength(1);
+    const notice = JSON.parse(output.stderr) as { notice: string };
+    expect(notice.notice).toMatch(/admin\.token/i);
+    expect(notice.notice).toMatch(/agent/i);
+  });
+
+  it("B1: does not retry, and propagates the error, when the connection already had no credential", async () => {
+    const output = outputCapture();
+    let attempts = 0;
+    const exitCode = await runCli(
+      ["status"],
+      output.environmentWith({
+        readAdminTokenFile: async () => undefined,
+        connectAdmin: async (resolveCredential) => {
+          attempts += 1;
+          await resolveCredential();
+          throw simlockError("ADMIN_AUTHENTICATION_FAILED");
+        },
+      }),
+    );
+    expect(attempts).toBe(1);
+    expect(exitCode).not.toBe(0);
+    expect(JSON.parse(output.stderr).error.code).toBe("ADMIN_AUTHENTICATION_FAILED");
+  });
+
+  it("B1: an explicit but wrong --token also degrades to agent, with a generic (not file-specific) notice", async () => {
+    const output = outputCapture();
+    let attempt = 0;
+    await runCli(
+      ["--token", "wrong", "status"],
+      output.environmentWith({
+        connectAdmin: async (resolveCredential) => {
+          attempt += 1;
+          const credential = await resolveCredential();
+          if (attempt === 1) {
+            expect(credential).toBe("wrong");
+            throw simlockError("ADMIN_AUTHENTICATION_FAILED");
+          }
+          expect(credential).toBeUndefined();
+          return fakeClient();
+        },
+      }),
+    );
+    expect(attempt).toBe(2);
+    const notice = JSON.parse(output.stderr) as { notice: string };
+    expect(notice.notice).not.toMatch(/admin\.token/i);
+    expect(notice.notice).toMatch(/agent/i);
+  });
+
+  it("B2: reaches admin on a cold start, on the very first invocation, no daemon running yet", async () => {
+    const filesystem = new MemoryFilesystem();
+    const ipcTransport = new MemoryIpcTransport();
+    const socketPath = "/simlock/daemon.sock";
+    const adminTokenPath = "/simlock/admin.token";
+    const launcher = new FakeDaemonLauncher(async () => {
+      await startInMemoryDaemon({ adminTokenPath, filesystem, ipcTransport, socketPath });
+    });
+    const output = outputCapture({
+      filesystem,
+      clock: new FakeClock(0),
+      systemStats: new FakeSystemStats({
+        cpuCount: 8,
+        freeRamBytes: 32 * gibibyte,
+        totalRamBytes: 32 * gibibyte,
+      }),
+      ipc: ipcTransport,
+      launcher,
+      dataDirectory: "/simlock",
+    });
+    const exitCode = await runCli(
+      ["lease", "--platform", "ios", "--device", "iPhone 17 Pro", "--detach"],
+      output.environmentWith(),
+    );
+    expect(exitCode).toBe(0);
+    expect(launcher.launches).toBe(1);
+    const grant = JSON.parse(output.stdout) as LeaseGrant & { role: string };
+    expect(grant.role).toBe("admin");
+    // Provisioning progress pushes are expected noise on stderr; the agent-fallback notice is
+    // the thing that must be absent.
+    expect(output.stderr).not.toContain("notice");
+  });
+
+  it("B1: a stale admin.token degrades to an agent session instead of bricking the invocation", async () => {
+    const filesystem = new MemoryFilesystem();
+    const ipcTransport = new MemoryIpcTransport();
+    const socketPath = "/simlock/daemon.sock";
+    const adminTokenPath = "/simlock/admin.token";
+    // A daemon actually runs and persists its own secret first, then the file is overwritten
+    // with a value that hashes to nothing the running daemon recognizes -- exactly what a
+    // `kill -9`'d daemon's leftover `admin.token` looks like to the *next* daemon incarnation,
+    // which never touches a file it did not itself just persist.
+    await startInMemoryDaemon({ adminTokenPath, filesystem, ipcTransport, socketPath });
+    await filesystem.writeFileAtomic(adminTokenPath, "stale-secret-from-a-killed-daemon\n");
+    const launcher = new FakeDaemonLauncher();
+    const output = outputCapture({
+      filesystem,
+      clock: new FakeClock(0),
+      systemStats: new FakeSystemStats({
+        cpuCount: 8,
+        freeRamBytes: 32 * gibibyte,
+        totalRamBytes: 32 * gibibyte,
+      }),
+      ipc: ipcTransport,
+      launcher,
+      dataDirectory: "/simlock",
+    });
+    const exitCode = await runCli(
+      ["lease", "--platform", "ios", "--device", "iPhone 17 Pro", "--detach"],
+      output.environmentWith(),
+    );
+    expect(exitCode).toBe(0);
+    // The daemon was already running -- a bad credential must never trigger an auto-launch.
+    expect(launcher.launches).toBe(0);
+    const grant = JSON.parse(output.stdout) as LeaseGrant & { role: string };
+    expect(grant.role).toBe("agent");
+    expect(output.stderr).toContain("admin.token");
   });
 });
 
@@ -346,6 +517,83 @@ describe("CLI: config set validates before writing (ADR 0003 §11)", () => {
       ),
     ).resolves.toBe(0);
     expect(written).toEqual({ downloads: { policy: "never" } });
+  });
+});
+
+describe("CLI: config set validates with the real config loader (ADR 0003 §11, B9)", () => {
+  it("rejects an unknown config key instead of silently dropping it", async () => {
+    const output = outputCapture(realCliEnvironmentPorts());
+    let wrote = false;
+    const exitCode = await runCli(
+      ["config", "set", "capacty.limits.ios.maxDevices", "2"],
+      output.environmentWith({
+        readConfigFile: async () => ({}),
+        writeConfigFile: async () => {
+          wrote = true;
+        },
+      }),
+    );
+    expect(exitCode).toBe(2);
+    expect(wrote).toBe(false);
+    expect(JSON.parse(output.stderr).error.code).toBe("USAGE");
+  });
+
+  it("rejects a mistyped key (missing the Ms suffix) instead of validating clean", async () => {
+    const output = outputCapture(realCliEnvironmentPorts());
+    let wrote = false;
+    const exitCode = await runCli(
+      ["config", "set", "lease.heldTtlBackstop", "60000"],
+      output.environmentWith({
+        readConfigFile: async () => ({}),
+        writeConfigFile: async () => {
+          wrote = true;
+        },
+      }),
+    );
+    expect(exitCode).toBe(2);
+    expect(wrote).toBe(false);
+  });
+
+  it("still writes a genuinely valid key", async () => {
+    const output = outputCapture(realCliEnvironmentPorts());
+    let written: Record<string, unknown> | undefined;
+    const exitCode = await runCli(
+      // Well above the default heartbeat interval (5 min) * 4, so this doesn't also trip
+      // `validateHeartbeatInterval` -- this test is only about the key itself validating clean.
+      ["config", "set", "lease.heldTtlBackstopMs", "2400000"],
+      output.environmentWith({
+        readConfigFile: async () => ({}),
+        writeConfigFile: async (contents) => {
+          written = contents;
+        },
+      }),
+    );
+    expect(exitCode).toBe(0);
+    expect(written).toEqual({ lease: { heldTtlBackstopMs: 2400000 } });
+  });
+
+  it("does not let a stray file at the scratch validation path change the outcome", async () => {
+    // Guards against B9's second bug: the validation scratch path must never be able to read a
+    // real file, whether one happens to already exist there or not.
+    const filesystem = new MemoryFilesystem();
+    await filesystem.mkdirp("/");
+    await filesystem.writeFileAtomic(
+      "/config-set-validation.json",
+      `${JSON.stringify({ totally: { bogus: true } })}\n`,
+    );
+    const output = outputCapture(realCliEnvironmentPorts(filesystem));
+    let wrote = false;
+    const exitCode = await runCli(
+      ["config", "set", "downloads.policy", "never"],
+      output.environmentWith({
+        readConfigFile: async () => ({}),
+        writeConfigFile: async () => {
+          wrote = true;
+        },
+      }),
+    );
+    expect(exitCode).toBe(0);
+    expect(wrote).toBe(true);
   });
 });
 
@@ -470,13 +718,15 @@ describe("CLI smoke test (ADR 0003 §12: one per frontend)", () => {
     const { socketPath } = await startTestDaemon();
     const ipc = new NodeIpcTransport();
     const environment = outputCapture().environmentWith({
-      connectAdmin: (credential) =>
-        connectSimlockAdmin({
+      connectAdmin: async (resolveCredential) => {
+        const credential = await resolveCredential();
+        return connectSimlockAdmin({
           ipc,
           endpoint: socketPath,
           principal: "smoke-test",
           ...(credential === undefined ? {} : { credential }),
-        }),
+        });
+      },
     });
 
     const leaseOut = outputCapture();
@@ -655,30 +905,56 @@ interface OutputCapture {
   environmentWith(overrides?: Partial<CliEnvironment>): CliEnvironment;
 }
 
-function outputCapture(): OutputCapture {
+/**
+ * `ports` is `undefined` for the fully-mocked default every other suite uses (a bare object
+ * literal, `connectAdmin` etc. never call their argument unless a test's override does).
+ * Passing `ports` (built with `realCliEnvironmentPorts`, or by hand for the cold-start/B1
+ * suites) routes `environmentWith` through the real `buildCliEnvironment` instead -- the only
+ * way to exercise the production credential-resolution ordering (B2) and the real config
+ * validator (B9) rather than re-testing a test double.
+ */
+function outputCapture(ports?: CliEnvironmentPorts): OutputCapture {
   const capture: OutputCapture = {
     stdout: "",
     stderr: "",
     environmentWith(overrides = {}) {
-      return {
-        configPath: "/simlock/config.json",
-        requesterId: "test-requester",
-        now: () => 0,
-        connectAdmin: async () => fakeClient(),
-        connectExistingAdmin: async () => fakeClient(),
-        readAdminTokenFile: async () => undefined,
-        sleep: async () => {},
-        readConfigFile: async () => ({}),
-        writeConfigFile: async () => {},
-        validateConfig: async () => {},
-        readLogFile: async () => "",
-        signals: new EventEmitter() as unknown as CliEnvironment["signals"],
-        parentWatch: new FakeParentWatch(),
-        stderr: { write: (value: string) => (capture.stderr += value) },
-        stdout: { write: (value: string) => (capture.stdout += value) },
-        confirm: async () => true,
-        ...overrides,
-      };
+      const stderrOut = { write: (value: string) => (capture.stderr += value) };
+      const stdoutOut = { write: (value: string) => (capture.stdout += value) };
+      if (ports === undefined) {
+        return {
+          configPath: "/simlock/config.json",
+          requesterId: "test-requester",
+          now: () => 0,
+          connectAdmin: async () => fakeClient(),
+          connectExistingAdmin: async () => fakeClient(),
+          readAdminTokenFile: async () => undefined,
+          sleep: async () => {},
+          readConfigFile: async () => ({}),
+          writeConfigFile: async () => {},
+          validateConfig: async () => {},
+          readLogFile: async () => "",
+          signals: new EventEmitter() as unknown as CliEnvironment["signals"],
+          parentWatch: new FakeParentWatch(),
+          stderr: stderrOut,
+          stdout: stdoutOut,
+          confirm: async () => true,
+          ...overrides,
+        };
+      }
+      const base = buildCliEnvironment(
+        {
+          ...ports,
+          signals:
+            ports.signals ??
+            (new EventEmitter() as unknown as NonNullable<CliEnvironmentPorts["signals"]>),
+          parentWatch: ports.parentWatch ?? new FakeParentWatch(),
+          confirm: ports.confirm ?? (async () => true),
+          stderr: stderrOut,
+          stdout: stdoutOut,
+        },
+        {},
+      );
+      return { ...base, ...overrides };
     },
   };
   return capture;
@@ -759,6 +1035,115 @@ async function startTestDaemon(): Promise<{ socketPath: string; daemon: DaemonSe
   runningDaemons.push(daemon);
   await daemon.start();
   return { socketPath, daemon };
+}
+
+/** Bare-minimum ports for exercising `buildCliEnvironment`'s real `validateConfig` (B9) without
+ * a daemon connection -- `config set` never calls `connectAdmin`, so `ipc`/`launcher` are inert
+ * placeholders. */
+function realCliEnvironmentPorts(
+  filesystem: Filesystem = new MemoryFilesystem(),
+): CliEnvironmentPorts {
+  return {
+    filesystem,
+    clock: new FakeClock(0),
+    systemStats: new FakeSystemStats({
+      cpuCount: 8,
+      freeRamBytes: 32 * gibibyte,
+      totalRamBytes: 32 * gibibyte,
+    }),
+    ipc: new MemoryIpcTransport(),
+    launcher: new FakeDaemonLauncher(),
+    dataDirectory: "/simlock",
+  };
+}
+
+/**
+ * A real `DaemonServer` wired against in-memory ports (`MemoryFilesystem` + `MemoryIpcTransport`
+ * shared with the CLI environment under test), with the genuine credential handshake
+ * (`AdminSecretManager` + `createCredentialRoleResolver`) instead of `startTestDaemon`'s
+ * `resolveRole: { resolve: () => "admin" }` shortcut -- B1 and B2 both hinge on that handshake
+ * actually running.
+ */
+async function startInMemoryDaemon(options: {
+  readonly filesystem: MemoryFilesystem;
+  readonly ipcTransport: MemoryIpcTransport;
+  readonly socketPath: string;
+  readonly adminTokenPath: string;
+}): Promise<{ daemon: DaemonServer; adminSecret: AdminSecretManager }> {
+  const { adminTokenPath, filesystem, ipcTransport, socketPath } = options;
+  const clock = new FakeClock(1_000);
+  const eventBus = new EventBus(clock);
+  const registry = await Registry.load({
+    clock,
+    eventBus,
+    filesystem,
+    idGenerator: sequence(),
+    statePath: "/state.json",
+  });
+  const driver = new FakeDriver({ availableOsVersions: ["26.5"], clock, platform: "ios" });
+  const config = testConfig();
+  const engine = new LeaseEngine({
+    clock,
+    config,
+    drivers: [driver],
+    eventBus,
+    idGenerator: sequence(),
+    registry,
+    systemStats: new FakeSystemStats({
+      cpuCount: 8,
+      freeRamBytes: 32 * gibibyte,
+      totalRamBytes: 32 * gibibyte,
+    }),
+  });
+  const reaper = new CleanupReaper({
+    clock,
+    config,
+    eventBus,
+    executor: engine.cleanup,
+    filesystem,
+    registry,
+  });
+  const tokens = new TokenStore({
+    clock,
+    filesystem,
+    idGenerator: sequence(),
+    path: "/tokens.json",
+    secrets: new CryptoTokenSecrets(),
+  });
+  const adminSecret = new AdminSecretManager({
+    filesystem,
+    secrets: new CryptoTokenSecrets(),
+    path: adminTokenPath,
+  });
+  const resolveRole = createCredentialRoleResolver({
+    verifyOperatorToken: async (secret) => (await tokens.verify(secret))?.role === "operator",
+    verifyAdminSecret: (secret) => adminSecret.verify(secret),
+  });
+  const daemon = new DaemonServer({
+    adminSecret,
+    capacity: engine,
+    catalog: engine,
+    clock,
+    config,
+    defaultRequesterId: "test-process",
+    eventBus,
+    host: new DaemonEndpointHost({
+      connector: ipcTransport,
+      endpoint: socketPath,
+      filesystem,
+      listenerFactory: ipcTransport,
+    }),
+    leases: engine,
+    queue: engine,
+    reaper,
+    registry,
+    resolveRole,
+    tokens,
+    version: "test",
+  });
+  runningDaemons.push(daemon);
+  await daemon.start();
+  return { daemon, adminSecret };
 }
 
 function testConfig(): Config {

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { EventBus } from "../bus/index.js";
 import { type Config, CleanupReaper, FakeDriver, LeaseEngine, Registry } from "../core/index.js";
@@ -11,24 +11,36 @@ import {
   CryptoTokenSecrets,
   FakeClock,
   FakeParentWatch,
-  FakeSystemStats,
   MemoryFilesystem,
   NodeFilesystem,
   NodeIpcTransport,
+  type IdGenerator,
 } from "../ports/index.js";
+import { FakeSystemStats } from "../ports/index.js";
 import { TokenStore } from "../http/token-store.js";
 import { DaemonEndpointHost } from "../daemon/connection-host.js";
 import { DaemonServer } from "../daemon/server.js";
-import { connectExistingDaemon } from "../daemon-client/client.js";
+import { SimlockError, type AnySimlockError } from "../contract/index.js";
+import type {
+  CatalogGetOutput,
+  DoctorReport,
+  LeaseGrant,
+  LeaseListOutput,
+  LeaseRecord,
+  ListGetOutput,
+  SimlockAdminClient,
+  SimlockConfig,
+  StatusGetOutput,
+  TokenListOutput,
+} from "../simlock-client/client.js";
+import { connectSimlockAdmin } from "../admin/index.js";
 import {
-  DaemonClientError,
   errorExitCode,
   fallbackRequesterId,
   parseDuration,
   readLogFile,
   runCli,
   type CliEnvironment,
-  type DaemonConnection,
 } from "./index.js";
 
 const gibibyte = 1024 ** 3;
@@ -69,7 +81,22 @@ describe("readLogFile", () => {
   });
 });
 
-describe("CLI boundary", () => {
+/**
+ * ADR 0003 §12: "one smoke test per frontend ... frontends are now serialization". This suite
+ * -- the CLI's own -- keeps: exit-code mapping off `ERROR_TABLE` (not a second map), the
+ * admin-credential resolution order and its agent-fallback notice (ADR §5), `daemon status`'s
+ * absent-vs-refused distinction (ADR §11), `config set`'s validate-before-write, `--json` shape
+ * (no snake_case renderings), and the `--yes`/confirm guards on destructive commands (safety
+ * rule 5). Deleted from the pre-ADR suite: every test that only re-walked a daemon operation's
+ * request/response shape through the CLI (lease grant field-by-field, doctor findings,
+ * cleanup/nuke proposals, catalog/list passthrough, events replay/follow wire format, renew,
+ * lease-lost/device-health push parsing, `--bind-pid`/parent-watch termination races) -- that
+ * behaviour is the daemon's contract now, covered once at `daemon/dispatcher.test.ts`, and
+ * `SimlockClientImpl`'s own suite in `simlock-client/client.test.ts`; re-asserting it a third
+ * time through the CLI tested only that this module still calls `client.foo()`, which the
+ * TypeScript compiler already guarantees against `SimlockAdminClient`'s interface.
+ */
+describe("CLI: exit codes", () => {
   it.each([
     ["QUEUE_TIMEOUT", 10],
     ["NO_CAPACITY", 11],
@@ -79,1157 +106,605 @@ describe("CLI boundary", () => {
     ["LICENSE_NOT_ACCEPTED", 12],
     ["BAD_REQUEST", 2],
     ["REQUESTER_ALREADY_LEASED", 13],
-  ] as const)("maps %s daemon errors to exit %d", async (code, expected) => {
-    const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response("status.get", new DaemonClientError(code, "failed"));
+    ["UNKNOWN_LEASE", 1],
+  ] as const)("maps %s to exit %d, from ERROR_TABLE not a second map", async (code, expected) => {
+    const error = simlockError(code);
+    expect(errorExitCode(error)).toBe(expected);
 
+    const output = outputCapture();
     await expect(
-      runCli(["status"], output.environmentWith({ connect: async () => connection })),
+      runCli(
+        ["status"],
+        output.environmentWith({
+          connectAdmin: async () => fakeClient({ getStatus: () => Promise.reject(error) }),
+        }),
+      ),
     ).resolves.toBe(expected);
-    expect(errorExitCode(new DaemonClientError(code, "failed"))).toBe(expected);
   });
 
   it("writes a single structured JSON error line to stderr for a daemon error", async () => {
     const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response("status.get", new DaemonClientError("NO_CAPACITY", "No capacity"));
-
-    await expect(
-      runCli(["status"], output.environmentWith({ connect: async () => connection })),
-    ).resolves.toBe(11);
-    expect(output.stdout).toBe("");
-    expect(output.stderr.trim().split("\n")).toHaveLength(1);
-    expect(JSON.parse(output.stderr)).toEqual({
-      error: { code: "NO_CAPACITY", message: "No capacity" },
-    });
-  });
-
-  it("gives REQUESTER_ALREADY_LEASED its own exit code and an actionable message", async () => {
-    const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response(
-      "lease.request",
-      new DaemonClientError(
-        "REQUESTER_ALREADY_LEASED",
-        "Requester test-requester already holds lease lse_1; release it (`simlock release lse_1`) before requesting another device",
-      ),
-    );
-
     await expect(
       runCli(
-        ["lease", "--platform", "ios", "--device", "iPhone 16", "--detach"],
-        output.environmentWith({ connect: async () => connection }),
-      ),
-    ).resolves.toBe(13);
-    expect(output.stdout).toBe("");
-    const parsed = JSON.parse(output.stderr) as { error: { code: string; message: string } };
-    expect(parsed.error.code).toBe("REQUESTER_ALREADY_LEASED");
-    expect(parsed.error.message).toContain("lse_1");
-    expect(parsed.error.message).toContain("simlock release lse_1");
-  });
-
-  it("parses human durations and bare milliseconds", () => {
-    expect(parseDuration("90s")).toBe(90_000);
-    expect(parseDuration("10m")).toBe(600_000);
-    expect(parseDuration("250")).toBe(250);
-  });
-
-  it("resolves the fallback requester id from SIMLOCK_AGENT_ID, else the process pid", () => {
-    expect(fallbackRequesterId({ SIMLOCK_AGENT_ID: "agent-from-env" })).toBe("agent-from-env");
-    expect(fallbackRequesterId({})).toBe(String(process.pid));
-  });
-
-  it("reports missing lease arguments as a structured USAGE error", async () => {
-    const output = outputCapture();
-
-    await expect(runCli(["lease"], output.environment)).resolves.toBe(2);
-    expect(output.stdout).toBe("");
-    expect(output.stderr.trim().split("\n")).toHaveLength(1);
-    expect(JSON.parse(output.stderr)).toEqual({
-      error: { code: "USAGE", message: expect.stringContaining("--platform") },
-    });
-  });
-
-  it("rejects --json on a command whose output is already unconditionally JSON", async () => {
-    const output = outputCapture();
-
-    await expect(runCli(["list", "--json"], output.environment)).resolves.toBe(2);
-    expect(output.stdout).toBe("");
-    expect(JSON.parse(output.stderr)).toMatchObject({ error: { code: "USAGE" } });
-  });
-
-  it("lists the MCP server in root help", async () => {
-    const output = outputCapture();
-
-    await expect(runCli([], output.environment)).resolves.toBe(0);
-    expect(output.stdout).toContain("mcp");
-    expect(output.stdout).toContain("Start the stdio MCP server");
-  });
-
-  it("does not load the MCP runner for non-MCP commands", async () => {
-    const output = outputCapture();
-    const loadMcpStdio = vi.fn(async () => vi.fn(async () => undefined));
-    const connection = new StubConnection();
-    connection.response("status.get", {});
-
-    await expect(
-      runCli(
-        ["status", "--json"],
-        output.environmentWith({ connect: async () => connection, loadMcpStdio }),
-      ),
-    ).resolves.toBe(0);
-    expect(loadMcpStdio).not.toHaveBeenCalled();
-  });
-
-  it.each([["--help"], ["-h"]])("prints MCP help without starting it: %s", async (help) => {
-    const output = outputCapture();
-    const runner = vi.fn(async () => undefined);
-
-    await expect(
-      runCli(["mcp", help], output.environmentWith({ runMcpStdio: runner })),
-    ).resolves.toBe(0);
-    expect(output.stdout).toBe("Usage: simlock mcp\n");
-    expect(output.stderr).toBe("");
-    expect(runner).not.toHaveBeenCalled();
-  });
-
-  it("waits for the MCP runner without writing before it completes", async () => {
-    const output = outputCapture();
-    let complete!: () => void;
-    const runner = vi.fn(
-      () =>
-        new Promise<void>((resolve) => {
-          complete = resolve;
-        }),
-    );
-    const run = runCli(["mcp"], output.environmentWith({ runMcpStdio: runner }));
-
-    await vi.waitFor(() => expect(runner).toHaveBeenCalledTimes(1));
-    expect(output.stdout).toBe("");
-    expect(output.stderr).toBe("");
-    complete();
-    await expect(run).resolves.toBe(0);
-    expect(output.stdout).toBe("");
-    expect(output.stderr).toBe("");
-  });
-
-  it.each([["--json"], ["unexpected"], ["--help=true"]])(
-    "rejects unexpected MCP input: %s",
-    async (argument) => {
-      const output = outputCapture();
-      const runner = vi.fn(async () => undefined);
-
-      await expect(
-        runCli(["mcp", argument], output.environmentWith({ runMcpStdio: runner })),
-      ).resolves.toBe(2);
-      expect(output.stdout).toBe("");
-      expect(JSON.parse(output.stderr)).toMatchObject({ error: { code: "USAGE" } });
-      expect(runner).not.toHaveBeenCalled();
-    },
-  );
-
-  it("reports MCP startup failures as a structured INTERNAL error on stderr", async () => {
-    const output = outputCapture();
-    const runner = vi.fn(async () => {
-      throw new Error("MCP startup failed");
-    });
-
-    await expect(runCli(["mcp"], output.environmentWith({ runMcpStdio: runner }))).resolves.toBe(1);
-    expect(output.stdout).toBe("");
-    expect(JSON.parse(output.stderr)).toEqual({
-      error: { code: "INTERNAL", message: "MCP startup failed" },
-    });
-    expect(runner).toHaveBeenCalledTimes(1);
-  });
-
-  it("keeps held lease stdout pure, renders progress to stderr, and releases on SIGTERM", async () => {
-    const harness = await createHarness();
-    const output = outputCapture();
-    const signals = new EventEmitter();
-    const run = runCli(
-      ["lease", "--platform", "ios", "--device", "iPhone 16"],
-      output.environmentWith({
-        connect: () => connectExistingDaemon(harness.socketPath, new NodeIpcTransport()),
-        signals,
-      }),
-    );
-
-    await vi.waitFor(() => expect(output.stdout).not.toBe(""));
-    signals.emit("SIGTERM");
-
-    await expect(run).resolves.toBe(0);
-    expect(output.stdout.trim().split("\n")).toHaveLength(1);
-    expect(JSON.parse(output.stdout)).toMatchObject({
-      device: "iPhone 16",
-      os: "26.5",
-      platform: "ios",
-      state: "leased",
-    });
-    expect(
-      output.stderr
-        .trim()
-        .split("\n")
-        .map((line) => JSON.parse(line)),
-    ).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ event: "provisioning" }),
-        expect.objectContaining({ event: "booting" }),
-      ]),
-    );
-    await expect.poll(() => harness.registry.snapshot.leases).toHaveLength(0);
-  });
-
-  it("sends full: true in the lease.request payload for --full and reports slim in the result", async () => {
-    const output = outputCapture();
-    const signals = new EventEmitter();
-    const connection = new StubConnection();
-    connection.response("lease.request", {
-      device: {
-        driverDeviceId: "ABCD",
-        featureProfile: "full",
-        spec: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
-        state: "leased",
-      },
-      lease: { id: "lse_full", mode: "held", ttlDeadline: 61_000 },
-      timing: {
-        estimatedBootMs: 0,
-        estimatedProvisionMs: 0,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 0,
-      },
-    });
-    const run = runCli(
-      ["lease", "--platform", "ios", "--device", "iPhone 16", "--full"],
-      output.environmentWith({ connect: async () => connection, signals }),
-    );
-
-    await vi.waitFor(() => expect(output.stdout).not.toBe(""));
-    signals.emit("SIGTERM");
-    await expect(run).resolves.toBe(0);
-
-    const leaseCall = connection.calls.find((call) => call.type === "lease.request");
-    expect(leaseCall?.payload).toMatchObject({ full: true });
-    expect(JSON.parse(output.stdout)).toMatchObject({ slim: false });
-  });
-
-  it("omits full from the lease.request payload without --full", async () => {
-    const output = outputCapture();
-    const signals = new EventEmitter();
-    const connection = new StubConnection();
-    connection.response("lease.request", {
-      device: {
-        driverDeviceId: "ABCD",
-        spec: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
-        state: "leased",
-      },
-      lease: { id: "lse_default", mode: "held", ttlDeadline: 61_000 },
-      timing: {
-        estimatedBootMs: 0,
-        estimatedProvisionMs: 0,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 0,
-      },
-    });
-    const run = runCli(
-      ["lease", "--platform", "ios", "--device", "iPhone 16"],
-      output.environmentWith({ connect: async () => connection, signals }),
-    );
-
-    await vi.waitFor(() => expect(output.stdout).not.toBe(""));
-    signals.emit("SIGTERM");
-    await expect(run).resolves.toBe(0);
-
-    const leaseCall = connection.calls.find((call) => call.type === "lease.request");
-    expect(leaseCall?.payload).not.toHaveProperty("full");
-    expect(JSON.parse(output.stdout)).toMatchObject({ slim: false });
-  });
-
-  it("reports a post-signal release failure as a structured stderr line, not prose", async () => {
-    const output = outputCapture();
-    const signals = new EventEmitter();
-    const connection = new StubConnection();
-    connection.response("lease.request", {
-      device: {
-        driverDeviceId: "ABCD",
-        spec: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
-        state: "leased",
-      },
-      lease: { id: "lse_release_fail", mode: "held", ttlDeadline: 61_000 },
-      timing: {
-        estimatedBootMs: 0,
-        estimatedProvisionMs: 0,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 0,
-      },
-    });
-    connection.response("lease.release", new Error("release failed"));
-    const run = runCli(
-      ["lease", "--platform", "ios", "--device", "iPhone 16"],
-      output.environmentWith({ connect: async () => connection, signals }),
-    );
-
-    await vi.waitFor(() => expect(output.stdout).not.toBe(""));
-    signals.emit("SIGTERM");
-
-    await expect(run).resolves.toBe(0);
-    expect(output.stderr.trim().split("\n")).toHaveLength(1);
-    expect(JSON.parse(output.stderr)).toEqual({
-      error: { code: "INTERNAL", message: "release failed" },
-    });
-  });
-
-  it("writes structured stderr lines for device-unhealthy/device-recovered pushes, ignoring malformed ones", async () => {
-    const output = outputCapture();
-    const signals = new EventEmitter();
-    const connection = new StubConnection();
-    connection.response("lease.request", {
-      device: {
-        driverDeviceId: "ABCD",
-        spec: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
-        state: "leased",
-      },
-      lease: { id: "lse_health", mode: "held", ttlDeadline: 61_000 },
-      timing: {
-        estimatedBootMs: 0,
-        estimatedProvisionMs: 0,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 0,
-      },
-    });
-    connection.response("lease.release", { leaseId: "lse_health" });
-    const run = runCli(
-      ["lease", "--platform", "ios", "--device", "iPhone 16"],
-      output.environmentWith({ connect: async () => connection, signals }),
-    );
-
-    await vi.waitFor(() => expect(output.stdout).not.toBe(""));
-    connection.push("device-unhealthy", {
-      deviceId: "ABCD",
-      leaseId: "lse_health",
-      reason: "crashed",
-    });
-    connection.push("device-recovered", { attempts: 2, deviceId: "ABCD", leaseId: "lse_health" });
-    // Malformed pushes must not crash the CLI or emit a diagnostic line.
-    connection.push("device-unhealthy", { deviceId: 42 });
-    connection.push("device-recovered", null);
-
-    signals.emit("SIGTERM");
-    await expect(run).resolves.toBe(0);
-
-    expect(output.stdout.trim().split("\n")).toHaveLength(1);
-    expect(
-      output.stderr
-        .trim()
-        .split("\n")
-        .map((line) => JSON.parse(line)),
-    ).toEqual([
-      { device_id: "ABCD", event: "device_unhealthy", lease: "lse_health" },
-      { attempts: 2, device_id: "ABCD", event: "device_recovered", lease: "lse_health" },
-    ]);
-  });
-
-  it("reports a lost lease, exits 14, and does not re-release it", async () => {
-    const output = outputCapture();
-    const signals = new EventEmitter();
-    const connection = new StubConnection();
-    connection.response("lease.request", {
-      device: {
-        driverDeviceId: "ABCD",
-        spec: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
-        state: "leased",
-      },
-      lease: { id: "lse_lost", mode: "held", ttlDeadline: 61_000 },
-      timing: {
-        estimatedBootMs: 0,
-        estimatedProvisionMs: 0,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 0,
-      },
-    });
-    connection.response("lease.release", new Error("lease.release must not be called"));
-    const run = runCli(
-      ["lease", "--platform", "ios", "--device", "iPhone 16"],
-      output.environmentWith({ connect: async () => connection, signals }),
-    );
-
-    await vi.waitFor(() => expect(output.stdout).not.toBe(""));
-    // A malformed push must not end the holder's lease: it is ignored outright,
-    // and the process keeps waiting exactly as it did before.
-    connection.push("lease-lost", { deviceId: 42 });
-    // No signal: the daemon ending the lease is what must stop the holder.
-    connection.push("lease-lost", {
-      deviceId: "ABCD",
-      leaseId: "lse_lost",
-      reason: "device-lost",
-    });
-
-    await expect(run).resolves.toBe(14);
-    expect(output.stdout.trim().split("\n")).toHaveLength(1);
-    expect(
-      output.stderr
-        .trim()
-        .split("\n")
-        .map((line) => JSON.parse(line)),
-    ).toEqual([
-      { device_id: "ABCD", event: "lease_lost", lease: "lse_lost", reason: "device-lost" },
-    ]);
-  });
-
-  it("flagship e2e: queues a second CLI holder until the first connection drops", async () => {
-    const harness = await createHarness();
-    const first = outputCapture();
-    const second = outputCapture();
-    const firstSignals = new EventEmitter();
-    const secondSignals = new EventEmitter();
-    const firstRun = runCli(
-      ["lease", "--platform", "ios", "--device", "iPhone 16"],
-      first.environmentWith({
-        connect: () => connectExistingDaemon(harness.socketPath, new NodeIpcTransport()),
-        requesterId: "agent-a",
-        signals: firstSignals,
-      }),
-    );
-    await vi.waitFor(() => expect(first.stdout).not.toBe(""));
-    const secondRun = runCli(
-      ["lease", "--platform", "ios", "--device", "iPhone 16"],
-      second.environmentWith({
-        connect: () => connectExistingDaemon(harness.socketPath, new NodeIpcTransport()),
-        requesterId: "agent-b",
-        signals: secondSignals,
-      }),
-    );
-    await vi.waitFor(() =>
-      expect(harness.eventBus.replay().some((event) => event.event === "lease.queued")).toBe(true),
-    );
-    expect(second.stdout).toBe("");
-    expect(
-      second.stderr
-        .trim()
-        .split("\n")
-        .map((line) => JSON.parse(line)),
-    ).toEqual([{ event: "queued", queue_position: 1 }]);
-
-    firstSignals.emit("SIGTERM");
-    await expect(firstRun).resolves.toBe(0);
-    await vi.waitFor(() => expect(second.stdout).not.toBe(""));
-    secondSignals.emit("SIGTERM");
-    await expect(secondRun).resolves.toBe(0);
-    expect(
-      second.stderr
-        .trim()
-        .split("\n")
-        .map((line) => JSON.parse(line)),
-    ).toEqual([{ event: "queued", queue_position: 1 }]);
-  });
-
-  it("--agent-id overrides the environment's fallback requester id", async () => {
-    const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response("lease.request", {
-      device: {
-        driverDeviceId: "ABCD",
-        spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
-        state: "leased",
-      },
-      lease: { id: "lse_1", mode: "detached", ttlDeadline: 1_000 },
-      timing: {
-        estimatedBootMs: 1,
-        estimatedProvisionMs: 1,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 2,
-      },
-    });
-
-    await expect(
-      runCli(
-        [
-          "lease",
-          "--platform",
-          "ios",
-          "--device",
-          "iPhone 17 Pro",
-          "--detach",
-          "--agent-id",
-          "agent-x",
-        ],
-        output.environmentWith({ connect: async () => connection, requesterId: "fallback-id" }),
-      ),
-    ).resolves.toBe(0);
-
-    expect(connection.calls).toEqual([
-      expect.objectContaining({
-        payload: expect.objectContaining({ requesterId: "agent-x" }),
-        type: "lease.request",
-      }),
-    ]);
-  });
-
-  it("falls back to the environment's requester id when --agent-id is omitted", async () => {
-    const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response("lease.request", {
-      device: {
-        driverDeviceId: "ABCD",
-        spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
-        state: "leased",
-      },
-      lease: { id: "lse_1", mode: "detached", ttlDeadline: 1_000 },
-      timing: {
-        estimatedBootMs: 1,
-        estimatedProvisionMs: 1,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 2,
-      },
-    });
-
-    await expect(
-      runCli(
-        ["lease", "--platform", "ios", "--device", "iPhone 17 Pro", "--detach"],
-        output.environmentWith({ connect: async () => connection, requesterId: "fallback-id" }),
-      ),
-    ).resolves.toBe(0);
-
-    expect(connection.calls).toEqual([
-      expect.objectContaining({
-        payload: expect.objectContaining({ requesterId: "fallback-id" }),
-        type: "lease.request",
-      }),
-    ]);
-  });
-
-  it("rejects an empty --agent-id as a usage error", async () => {
-    const output = outputCapture();
-
-    await expect(
-      runCli(
-        ["lease", "--platform", "ios", "--device", "iPhone 17 Pro", "--agent-id", ""],
-        output.environment,
-      ),
-    ).resolves.toBe(2);
-    expect(output.stderr).toContain("--agent-id");
-  });
-
-  it("enforces one lease per --agent-id: same id collides, distinct ids do not", async () => {
-    const harness = await createHarness();
-    const first = outputCapture();
-
-    await expect(
-      runCli(
-        [
-          "lease",
-          "--platform",
-          "ios",
-          "--device",
-          "iPhone 16",
-          "--detach",
-          "--agent-id",
-          "dup-agent",
-        ],
-        first.environmentWith({
-          connect: () => connectExistingDaemon(harness.socketPath, new NodeIpcTransport()),
-        }),
-      ),
-    ).resolves.toBe(0);
-
-    const second = outputCapture();
-    await expect(
-      runCli(
-        [
-          "lease",
-          "--platform",
-          "ios",
-          "--device",
-          "iPhone 16",
-          "--detach",
-          "--agent-id",
-          "dup-agent",
-        ],
-        second.environmentWith({
-          connect: () => connectExistingDaemon(harness.socketPath, new NodeIpcTransport()),
-        }),
-      ),
-    ).resolves.toBe(13);
-    expect(second.stderr).toContain("dup-agent");
-    expect(second.stderr).toContain("already");
-    expect(JSON.parse(second.stderr)).toMatchObject({
-      error: { code: "REQUESTER_ALREADY_LEASED" },
-    });
-
-    const third = outputCapture();
-    await expect(
-      runCli(
-        [
-          "lease",
-          "--platform",
-          "ios",
-          "--device",
-          "iPhone 16",
-          "--detach",
-          "--agent-id",
-          "other-agent",
-          "--no-wait",
-        ],
-        third.environmentWith({
-          connect: () => connectExistingDaemon(harness.socketPath, new NodeIpcTransport()),
+        ["status"],
+        output.environmentWith({
+          readAdminTokenFile: async () => "a-token",
+          connectAdmin: async () =>
+            fakeClient({ getStatus: () => Promise.reject(simlockError("NO_CAPACITY")) }),
         }),
       ),
     ).resolves.toBe(11);
-    expect(third.stderr).not.toContain("already");
+    expect(output.stdout).toBe("");
+    expect(output.stderr.trim().split("\n")).toHaveLength(1);
+    expect(JSON.parse(output.stderr)).toEqual({
+      error: { code: "NO_CAPACITY", message: "No capacity available" },
+    });
   });
 
-  it("prints a detached token, exits, and renews it", async () => {
-    const detached = outputCapture();
-    const connection = new StubConnection();
-    connection.response("lease.request", {
-      device: {
-        driverDeviceId: "ABCD",
-        spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
-        state: "leased",
-      },
-      lease: { id: "lse_9f2c", mode: "detached", ttlDeadline: 61_000 },
-      timing: {
-        estimatedBootMs: 20,
-        estimatedProvisionMs: 10,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 30,
-      },
-    });
+  it("maps a usage error to exit 2 with code USAGE", async () => {
+    const output = outputCapture();
+    await expect(runCli(["nope"], output.environmentWith())).resolves.toBe(2);
+    expect(JSON.parse(output.stderr).error.code).toBe("USAGE");
+  });
+});
 
-    await expect(
-      runCli(
-        ["lease", "--platform", "ios", "--device", "iPhone 17 Pro", "--detach"],
-        detached.environmentWith({ connect: async () => connection }),
-      ),
-    ).resolves.toBe(0);
-    expect(detached.stdout).toBe(
-      '{"device":"iPhone 17 Pro","expires_at_ms":61000,"lease":"lse_9f2c","os":"26.5","platform":"ios","slim":false,"state":"leased","timing":{"estimated_boot_ms":20,"estimated_provision_ms":10,"estimated_reclaim_ms":0,"estimated_ready_ms":30},"udid":"ABCD"}\n',
+describe("CLI: admin credential resolution (ADR 0003 §5)", () => {
+  it("prefers --token over SIMLOCK_ADMIN_TOKEN and the admin.token file", async () => {
+    const output = outputCapture();
+    let seen: string | undefined;
+    await runCli(
+      ["--token", "from-flag", "status"],
+      output.environmentWith({
+        adminTokenFromEnv: "from-env",
+        readAdminTokenFile: async () => "from-file",
+        connectAdmin: async (credential) => {
+          seen = credential;
+          return fakeClient();
+        },
+      }),
     );
-    expect(connection.closed).toBe(true);
-
-    const renew = outputCapture();
-    const renewConnection = new StubConnection();
-    renewConnection.response("lease.renew", { id: "lse_9f2c", ttlDeadline: 61_000 });
-    await expect(
-      runCli(
-        ["lease", "renew", "lse_9f2c", "--ttl", "1m"],
-        renew.environmentWith({ connect: async () => renewConnection }),
-      ),
-    ).resolves.toBe(0);
-    expect(renewConnection.calls).toContainEqual({
-      payload: { leaseId: "lse_9f2c", ttlMs: 60_000 },
-      type: "lease.renew",
-    });
-  });
-
-  it("keeps status JSON stable", async () => {
-    const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response("status.get", { devices: [], leases: [], revision: 3 });
-
-    await expect(
-      runCli(["status", "--json"], output.environmentWith({ connect: async () => connection })),
-    ).resolves.toBe(0);
-    expect(JSON.parse(output.stdout)).toMatchInlineSnapshot(`
-      {
-        "devices": [],
-        "leases": [],
-        "revision": 3,
-      }
-    `);
-  });
-
-  it("renders managed and running capacity separately", async () => {
-    const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response("status.get", {
-      capacity: {
-        global: { maxRunning: 3, overLimit: false, reserved: 1, running: 1, warm: 1 },
-        ios: {
-          limit: 4,
-          maxRunning: 2,
-          overLimit: false,
-          reserved: 1,
-          running: 1,
-          used: 3,
-          warm: 1,
-        },
-        android: {
-          limit: 2,
-          maxRunning: 2,
-          overLimit: false,
-          reserved: 0,
-          running: 0,
-          used: 1,
-          warm: 0,
-        },
-      },
-      devices: [],
-      leases: [],
-    });
-
-    await expect(
-      runCli(["status"], output.environmentWith({ connect: async () => connection })),
-    ).resolves.toBe(0);
-    expect(output.stdout).toContain("Running global: 1 + 1 reserved/3, warm 1");
-    expect(output.stdout).toContain("Capacity ios: managed 3/4, running 1 + 1 reserved/2, warm 1");
-  });
-
-  it("requests the full device catalog and prints it as JSON", async () => {
-    const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response("catalog.get", {
-      platforms: [
-        { defaultRuntime: "26.5", models: ["iPhone 16"], platform: "ios", runtimes: ["26.5"] },
-      ],
-    });
-
-    await expect(
-      runCli(["catalog", "--json"], output.environmentWith({ connect: async () => connection })),
-    ).resolves.toBe(0);
-    expect(connection.calls).toContainEqual({ payload: {}, type: "catalog.get" });
-    expect(JSON.parse(output.stdout)).toEqual({
-      platforms: [
-        { defaultRuntime: "26.5", models: ["iPhone 16"], platform: "ios", runtimes: ["26.5"] },
-      ],
-    });
-  });
-
-  it("narrows the catalog request to the requested platform", async () => {
-    const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response("catalog.get", { platforms: [] });
-
-    await expect(
-      runCli(
-        ["catalog", "--platform", "android", "--json"],
-        output.environmentWith({ connect: async () => connection }),
-      ),
-    ).resolves.toBe(0);
-    expect(connection.calls).toContainEqual({
-      payload: { platform: "android" },
-      type: "catalog.get",
-    });
-  });
-
-  it("renders the catalog as human-readable text, marking the default runtime", async () => {
-    const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response("catalog.get", {
-      platforms: [
-        {
-          defaultRuntime: "26.5",
-          models: ["iPhone 16", "iPhone 17 Pro"],
-          platform: "ios",
-          runtimes: ["18.4", "26.5"],
-        },
-      ],
-    });
-
-    await expect(
-      runCli(["catalog"], output.environmentWith({ connect: async () => connection })),
-    ).resolves.toBe(0);
-    expect(output.stdout).toBe(
-      "Platform: ios\n" +
-        "  Models: iPhone 16, iPhone 17 Pro\n" +
-        "  Runtimes: 18.4, 26.5 (default: 26.5)\n",
-    );
-  });
-
-  it("passes every doctor finding through to stdout as JSON, driver-advisory included", async () => {
-    const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response("doctor.run", {
-      findings: [
-        { deviceId: "dev_1", kind: "registry-device-missing", platform: "ios" },
-        {
-          code: "slim-runtime-unsupported",
-          kind: "driver-advisory",
-          message: "iOS 18.4 is below the 18.5 persistent-override floor",
-          platform: "ios",
-        },
-      ],
-    });
-
-    await expect(
-      runCli(["doctor"], output.environmentWith({ connect: async () => connection })),
-    ).resolves.toBe(0);
-    expect(connection.calls).toContainEqual({ payload: { fix: false }, type: "doctor.run" });
-    expect(JSON.parse(output.stdout)).toEqual({
-      findings: [
-        { deviceId: "dev_1", kind: "registry-device-missing", platform: "ios" },
-        {
-          code: "slim-runtime-unsupported",
-          kind: "driver-advisory",
-          message: "iOS 18.4 is below the 18.5 persistent-override floor",
-          platform: "ios",
-        },
-      ],
-    });
-  });
-
-  it("surfaces a driver-advisory finding as a plain warning line on stderr, distinct from drift", async () => {
-    const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response("doctor.run", {
-      findings: [
-        { deviceId: "dev_1", kind: "registry-device-missing", platform: "ios" },
-        {
-          code: "slim-runtime-unsupported",
-          kind: "driver-advisory",
-          message: "iOS 18.4 is below the 18.5 persistent-override floor",
-          platform: "ios",
-        },
-      ],
-    });
-
-    await expect(
-      runCli(["doctor", "--fix"], output.environmentWith({ connect: async () => connection })),
-    ).resolves.toBe(0);
-    expect(connection.calls).toContainEqual({ payload: { fix: true }, type: "doctor.run" });
-    expect(output.stderr).toBe(
-      "Warning [ios] slim-runtime-unsupported: iOS 18.4 is below the 18.5 persistent-override floor\n",
-    );
-    // Only the advisory gets a warning line -- the drift finding is not echoed to stderr.
-    expect(output.stderr).not.toContain("registry-device-missing");
-  });
-
-  it("writes nothing to stderr when doctor reports no driver-advisory findings", async () => {
-    const output = outputCapture();
-    const connection = new StubConnection();
-    connection.response("doctor.run", {
-      findings: [{ deviceId: "dev_1", kind: "registry-device-missing", platform: "ios" }],
-    });
-
-    await expect(
-      runCli(["doctor"], output.environmentWith({ connect: async () => connection })),
-    ).resolves.toBe(0);
+    expect(seen).toBe("from-flag");
     expect(output.stderr).toBe("");
   });
 
-  it("releases and exits when the watched parent process dies, via the same path as a signal", async () => {
+  it("prefers SIMLOCK_ADMIN_TOKEN over the admin.token file when --token is absent", async () => {
     const output = outputCapture();
-    const signals = new EventEmitter();
-    const parentWatch = new FakeParentWatch();
-    const connection = new StubConnection();
-    connection.response("lease.request", {
-      device: {
-        driverDeviceId: "ABCD",
-        spec: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
-        state: "leased",
-      },
-      lease: { id: "lse_parent_death", mode: "held", ttlDeadline: 61_000 },
-      timing: {
-        estimatedBootMs: 0,
-        estimatedProvisionMs: 0,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 0,
-      },
-    });
-    const run = runCli(
-      ["lease", "--platform", "ios", "--device", "iPhone 16"],
+    let seen: string | undefined;
+    await runCli(
+      ["status"],
       output.environmentWith({
-        connect: async () => connection,
-        parentPid: 4321,
-        parentWatch,
-        signals,
-      }),
-    );
-
-    await vi.waitFor(() => expect(output.stdout).not.toBe(""));
-    parentWatch.exit(4321);
-
-    await expect(run).resolves.toBe(0);
-    expect(connection.calls.map((call) => call.type)).toEqual(["lease.request", "lease.release"]);
-    expect(connection.closed).toBe(true);
-  });
-
-  it("--bind-pid overrides which pid the CLI watches for parent death", async () => {
-    const output = outputCapture();
-    const signals = new EventEmitter();
-    const parentWatch = new FakeParentWatch();
-    const connection = new StubConnection();
-    connection.response("lease.request", {
-      device: {
-        driverDeviceId: "ABCD",
-        spec: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
-        state: "leased",
-      },
-      lease: { id: "lse_bind_pid", mode: "held", ttlDeadline: 61_000 },
-      timing: {
-        estimatedBootMs: 0,
-        estimatedProvisionMs: 0,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 0,
-      },
-    });
-    let finished = false;
-    const run = runCli(
-      ["lease", "--platform", "ios", "--device", "iPhone 16", "--bind-pid", "9999"],
-      output.environmentWith({
-        connect: async () => connection,
-        parentPid: 4321,
-        parentWatch,
-        signals,
-      }),
-    );
-    void run.then(() => (finished = true));
-
-    await vi.waitFor(() => expect(output.stdout).not.toBe(""));
-    // The default parent pid is not the one bound for this invocation -- must not terminate it.
-    parentWatch.exit(4321);
-    await new Promise((resolve) => setTimeout(resolve, 10));
-    expect(finished).toBe(false);
-
-    parentWatch.exit(9999);
-    await expect(run).resolves.toBe(0);
-  });
-
-  it("rejects a non-numeric --bind-pid as a structured USAGE error", async () => {
-    const output = outputCapture();
-
-    await expect(
-      runCli(
-        ["lease", "--platform", "ios", "--device", "iPhone 16", "--bind-pid", "not-a-pid"],
-        output.environment,
-      ),
-    ).resolves.toBe(2);
-    expect(JSON.parse(output.stderr)).toEqual({
-      error: { code: "USAGE", message: "lease --bind-pid must be a positive integer" },
-    });
-  });
-
-  it("declares the heartbeat capability for held-mode leases, not for detached ones", async () => {
-    const capabilitiesSeen: unknown[] = [];
-    const heldConnection = new StubConnection();
-    heldConnection.response("lease.request", {
-      device: {
-        driverDeviceId: "ABCD",
-        spec: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
-        state: "leased",
-      },
-      lease: { id: "lse_held_cap", mode: "held", ttlDeadline: 61_000 },
-      timing: {
-        estimatedBootMs: 0,
-        estimatedProvisionMs: 0,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 0,
-      },
-    });
-    const heldOutput = outputCapture();
-    const heldSignals = new EventEmitter();
-    const heldRun = runCli(
-      ["lease", "--platform", "ios", "--device", "iPhone 16"],
-      heldOutput.environmentWith({
-        connect: async (capabilities) => {
-          capabilitiesSeen.push(capabilities);
-          return heldConnection;
+        adminTokenFromEnv: "from-env",
+        readAdminTokenFile: async () => "from-file",
+        connectAdmin: async (credential) => {
+          seen = credential;
+          return fakeClient();
         },
-        signals: heldSignals,
       }),
     );
-    await vi.waitFor(() => expect(heldOutput.stdout).not.toBe(""));
-    heldSignals.emit("SIGTERM");
-    await expect(heldRun).resolves.toBe(0);
+    expect(seen).toBe("from-env");
+  });
 
-    const detachedConnection = new StubConnection();
-    detachedConnection.response("lease.request", {
-      device: {
-        driverDeviceId: "ABCD",
-        spec: { model: "iPhone 16", osVersion: "26.5", platform: "ios" },
-        state: "leased",
-      },
-      lease: { id: "lse_detached_cap", mode: "detached", ttlDeadline: 61_000 },
-      timing: {
-        estimatedBootMs: 0,
-        estimatedProvisionMs: 0,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 0,
-      },
-    });
+  it("falls back to the admin.token file when neither --token nor the env var is set", async () => {
+    const output = outputCapture();
+    let seen: string | undefined;
+    await runCli(
+      ["status"],
+      output.environmentWith({
+        readAdminTokenFile: async () => "from-file",
+        connectAdmin: async (credential) => {
+          seen = credential;
+          return fakeClient();
+        },
+      }),
+    );
+    expect(seen).toBe("from-file");
+    expect(output.stderr).toBe("");
+  });
+
+  it("retries a briefly-missing admin.token file before giving up", async () => {
+    const output = outputCapture();
+    let reads = 0;
+    let seen: string | undefined;
+    await runCli(
+      ["status"],
+      output.environmentWith({
+        readAdminTokenFile: async () => {
+          reads += 1;
+          return reads < 3 ? undefined : "from-file-after-retry";
+        },
+        connectAdmin: async (credential) => {
+          seen = credential;
+          return fakeClient();
+        },
+      }),
+    );
+    expect(reads).toBe(3);
+    expect(seen).toBe("from-file-after-retry");
+    expect(output.stderr).toBe("");
+  });
+
+  it("connects with no credential and writes a stderr notice when every source is empty", async () => {
+    const output = outputCapture();
+    let seen: string | undefined | "unset" = "unset";
+    await runCli(
+      ["status"],
+      output.environmentWith({
+        readAdminTokenFile: async () => undefined,
+        connectAdmin: async (credential) => {
+          seen = credential;
+          return fakeClient();
+        },
+      }),
+    );
+    expect(seen).toBeUndefined();
+    expect(output.stderr.trim().split("\n")).toHaveLength(1);
+    const notice: unknown = JSON.parse(output.stderr);
+    expect((notice as { notice: string }).notice).toMatch(/agent/i);
+  });
+});
+
+describe("CLI: daemon status (ADR 0003 §11)", () => {
+  it("reports stopped when the socket cannot be reached at all", async () => {
+    const output = outputCapture();
     await expect(
       runCli(
-        ["lease", "--platform", "ios", "--device", "iPhone 16", "--detach"],
-        outputCapture().environmentWith({
-          connect: async (capabilities) => {
-            capabilitiesSeen.push(capabilities);
-            return detachedConnection;
+        ["daemon", "status", "--json"],
+        output.environmentWith({
+          connectExistingAdmin: async () => {
+            throw new Error("connect ECONNREFUSED");
           },
         }),
       ),
     ).resolves.toBe(0);
-
-    expect(capabilitiesSeen).toEqual([{ heartbeat: true }, undefined]);
+    expect(JSON.parse(output.stdout)).toEqual({ status: "stopped" });
   });
 
-  it("rejects an invalid --platform without contacting the daemon", async () => {
+  it("reports stopped for a transport-kind SimlockError (connection lost)", async () => {
     const output = outputCapture();
-
-    await expect(runCli(["catalog", "--platform", "windows"], output.environment)).resolves.toBe(2);
-    expect(output.stderr).toContain("--platform must be ios or android");
-  });
-});
-
-describe("simlock token", () => {
-  it("creates an agent token, printing the record and secret on one JSON line", async () => {
-    const { environment, output } = tokenHarness();
-
     await expect(
-      runCli(["token", "create", "--role", "agent", "--label", "ci-runner"], environment),
+      runCli(
+        ["daemon", "status", "--json"],
+        output.environmentWith({
+          connectExistingAdmin: async () => {
+            throw simlockError("DAEMON_CONNECTION_LOST");
+          },
+        }),
+      ),
     ).resolves.toBe(0);
-    expect(output.stderr).toBe("");
-    const parsed = JSON.parse(output.stdout) as {
-      secret: string;
-      token: { id: string; role: string; label: string; createdAt: number };
-    };
-    expect(parsed.token).toEqual({
-      createdAt: 1_000,
-      id: "tok_1",
-      label: "ci-runner",
-      role: "agent",
-    });
-    expect(parsed.secret).toMatch(/^slk_/);
-    expect(JSON.stringify(parsed.token)).not.toContain("hash");
+    expect(JSON.parse(output.stdout)).toEqual({ status: "stopped" });
   });
 
-  it("creates an operator token without a label, omitting the field entirely", async () => {
-    const { environment, output } = tokenHarness();
-
-    await expect(runCli(["token", "create", "--role", "operator"], environment)).resolves.toBe(0);
-    const parsed = JSON.parse(output.stdout) as { token: Record<string, unknown> };
-    expect(parsed.token.role).toBe("operator");
-    expect("label" in parsed.token).toBe(false);
+  it("distinguishes a refused handshake (socket reachable) from an absent socket", async () => {
+    const output = outputCapture();
+    await expect(
+      runCli(
+        ["daemon", "status", "--json"],
+        output.environmentWith({
+          connectExistingAdmin: async () => {
+            throw simlockError("ADMIN_AUTHENTICATION_FAILED");
+          },
+        }),
+      ),
+    ).resolves.toBe(1);
+    const parsed = JSON.parse(output.stdout) as { status: string; error: { code: string } };
+    expect(parsed.status).toBe("handshake-refused");
+    expect(parsed.error.code).toBe("ADMIN_AUTHENTICATION_FAILED");
   });
 
-  it("rejects a missing --role as a structured usage error", async () => {
-    const { environment, output } = tokenHarness();
-
-    await expect(runCli(["token", "create"], environment)).resolves.toBe(2);
-    expect(output.stdout).toBe("");
-    expect(JSON.parse(output.stderr)).toEqual({
-      error: { code: "USAGE", message: expect.stringContaining("--role") },
-    });
-  });
-
-  it("rejects an invalid --role as a structured usage error", async () => {
-    const { environment, output } = tokenHarness();
-
-    await expect(runCli(["token", "create", "--role", "superuser"], environment)).resolves.toBe(2);
-    expect(JSON.parse(output.stderr)).toMatchObject({ error: { code: "USAGE" } });
-  });
-
-  it("lists created tokens without exposing their hash", async () => {
-    const { environment, output, store } = tokenHarness();
-    await store.create("agent", "one");
-    await store.create("operator", "two");
-
-    await expect(runCli(["token", "list"], environment)).resolves.toBe(0);
-    const parsed = JSON.parse(output.stdout) as { tokens: Array<Record<string, unknown>> };
-    expect(parsed.tokens.map((token) => token.label)).toEqual(["one", "two"]);
-    expect(JSON.stringify(parsed.tokens)).not.toContain("hash");
-  });
-
-  it("revokes an existing token", async () => {
-    const { environment, output, store } = tokenHarness();
-    const { record } = await store.create("agent");
-
-    await expect(runCli(["token", "revoke", record.id], environment)).resolves.toBe(0);
-    expect(JSON.parse(output.stdout)).toEqual({ revoked: true });
-    await expect(store.list()).resolves.toEqual([]);
-  });
-
-  it("reports UNKNOWN_TOKEN revoking a token id that does not exist", async () => {
-    const { environment, output } = tokenHarness();
-
-    await expect(runCli(["token", "revoke", "tok_missing"], environment)).resolves.toBe(1);
-    expect(output.stdout).toBe("");
-    expect(JSON.parse(output.stderr)).toEqual({
-      error: { code: "UNKNOWN_TOKEN", message: expect.stringContaining("tok_missing") },
-    });
-  });
-
-  it("prints usage for the bare command and --help without touching the store", async () => {
-    const { environment, output } = tokenHarness();
-
-    await expect(runCli(["token"], environment)).resolves.toBe(0);
-    expect(output.stdout).toContain("simlock token create");
-    expect(output.stdout).toContain("simlock token list");
-    expect(output.stdout).toContain("simlock token revoke");
-  });
-
-  it("rejects an unknown token subcommand", async () => {
-    const { environment, output } = tokenHarness();
-
-    await expect(runCli(["token", "bogus"], environment)).resolves.toBe(2);
-    expect(JSON.parse(output.stderr)).toMatchObject({ error: { code: "USAGE" } });
+  it("never auto-launches the daemon for daemon status/stop", async () => {
+    const output = outputCapture();
+    let launched = false;
+    await runCli(
+      ["daemon", "status"],
+      output.environmentWith({
+        connectAdmin: async () => {
+          launched = true;
+          return fakeClient();
+        },
+        connectExistingAdmin: async () => fakeClient(),
+      }),
+    );
+    expect(launched).toBe(false);
   });
 });
 
-function tokenHarness(): {
-  environment: CliEnvironment;
-  output: ReturnType<typeof outputCapture>;
-  store: TokenStore;
-} {
-  const output = outputCapture();
-  const store = new TokenStore({
-    clock: new FakeClock(1_000),
-    filesystem: new MemoryFilesystem(),
-    idGenerator: sequence(),
-    path: "/tokens.json",
-    secrets: new CryptoTokenSecrets(),
+describe("CLI: config set validates before writing (ADR 0003 §11)", () => {
+  it("rejects an invalid merged config without writing the file", async () => {
+    const output = outputCapture();
+    let wrote = false;
+    await expect(
+      runCli(
+        ["config", "set", "lease.heldTtlBackstopMs", "not-a-number"],
+        output.environmentWith({
+          readConfigFile: async () => ({}),
+          writeConfigFile: async () => {
+            wrote = true;
+          },
+          validateConfig: async () => {
+            throw new Error("lease.heldTtlBackstopMs must be a number");
+          },
+        }),
+      ),
+    ).resolves.toBe(2);
+    expect(wrote).toBe(false);
+    expect(JSON.parse(output.stderr).error.code).toBe("USAGE");
   });
-  return { environment: output.environmentWith({ tokenStore: store }), output, store };
+
+  it("writes the file once validation passes", async () => {
+    const output = outputCapture();
+    let written: Record<string, unknown> | undefined;
+    await expect(
+      runCli(
+        ["config", "set", "downloads.policy", "never"],
+        output.environmentWith({
+          readConfigFile: async () => ({}),
+          writeConfigFile: async (contents) => {
+            written = contents;
+          },
+          validateConfig: async () => {},
+        }),
+      ),
+    ).resolves.toBe(0);
+    expect(written).toEqual({ downloads: { policy: "never" } });
+  });
+});
+
+describe("CLI: --json shape is the contract, as-is (ADR 0003 §11)", () => {
+  it("status --json has no snake_case renderings", async () => {
+    const output = outputCapture();
+    await runCli(
+      ["status", "--json"],
+      output.environmentWith({ connectAdmin: async () => fakeClient() }),
+    );
+    const text = output.stdout;
+    expect(text).not.toMatch(/expires_at_ms|estimated_boot_ms|queue_position|device_unhealthy/);
+    const parsed = JSON.parse(text) as StatusGetOutput;
+    expect(parsed.queueDepth).toBe(0);
+  });
+
+  it("lease output is the contract's LeaseGrant plus the resolved role", async () => {
+    const output = outputCapture();
+    await runCli(
+      ["lease", "--platform", "ios", "--device", "iPhone 17 Pro", "--detach"],
+      output.environmentWith({ connectAdmin: async () => fakeClient({ role: "admin" }) }),
+    );
+    const parsed = JSON.parse(output.stdout) as LeaseGrant & { role: string };
+    expect(parsed.lease.id).toBe("lse_1");
+    expect(parsed.role).toBe("admin");
+    expect(output.stdout).not.toMatch(/expires_at_ms|estimated_boot_ms/);
+  });
+});
+
+describe("CLI: --yes / confirm guards (safety rule 5)", () => {
+  it("release --all without --yes and a non-interactive confirm refuses", async () => {
+    const output = outputCapture();
+    let released = false;
+    await expect(
+      runCli(
+        ["release", "--all"],
+        output.environmentWith({
+          confirm: async () => false,
+          connectAdmin: async () =>
+            fakeClient({
+              releaseAllLeases: () => {
+                released = true;
+                return Promise.resolve({ leaseIds: [] });
+              },
+            }),
+        }),
+      ),
+    ).resolves.toBe(2);
+    expect(released).toBe(false);
+  });
+
+  it("release --all --yes bypasses the interactive confirm", async () => {
+    const output = outputCapture();
+    let released = false;
+    await expect(
+      runCli(
+        ["release", "--all", "--yes"],
+        output.environmentWith({
+          confirm: async () => false,
+          connectAdmin: async () =>
+            fakeClient({
+              releaseAllLeases: () => {
+                released = true;
+                return Promise.resolve({ leaseIds: ["lse_1"] });
+              },
+            }),
+        }),
+      ),
+    ).resolves.toBe(0);
+    expect(released).toBe(true);
+  });
+
+  it("nuke without confirmation or --yes refuses before connecting", async () => {
+    const output = outputCapture();
+    let connected = false;
+    await expect(
+      runCli(
+        ["nuke"],
+        output.environmentWith({
+          confirm: async () => false,
+          connectAdmin: async () => {
+            connected = true;
+            return fakeClient();
+          },
+        }),
+      ),
+    ).resolves.toBe(2);
+    expect(connected).toBe(false);
+  });
+});
+
+describe("CLI: token operations never write tokens.json directly", () => {
+  it("token create/list/revoke all go through the client, not a local TokenStore", async () => {
+    const calls: string[] = [];
+    const client = fakeClient({
+      createToken: (input) => {
+        calls.push("create");
+        return Promise.resolve({
+          secret: "sec_1",
+          token: { id: "tok_1", role: input.role, createdAt: 0 },
+        });
+      },
+      listTokens: () => {
+        calls.push("list");
+        return Promise.resolve({ tokens: [{ id: "tok_1", role: "operator", createdAt: 0 }] });
+      },
+      revokeToken: () => {
+        calls.push("revoke");
+        return Promise.resolve({ revoked: true });
+      },
+    });
+    const environment = outputCapture().environmentWith({ connectAdmin: async () => client });
+    await runCli(["token", "create", "--role", "operator"], environment);
+    await runCli(["token", "list"], environment);
+    await runCli(["token", "revoke", "tok_1"], environment);
+    expect(calls).toEqual(["create", "list", "revoke"]);
+  });
+});
+
+describe("CLI smoke test (ADR 0003 §12: one per frontend)", () => {
+  it("lease --detach, status, release, and token create round-trip through a real daemon", async () => {
+    const { socketPath } = await startTestDaemon();
+    const ipc = new NodeIpcTransport();
+    const environment = outputCapture().environmentWith({
+      connectAdmin: (credential) =>
+        connectSimlockAdmin({
+          ipc,
+          endpoint: socketPath,
+          principal: "smoke-test",
+          ...(credential === undefined ? {} : { credential }),
+        }),
+    });
+
+    const leaseOut = outputCapture();
+    const leaseExit = await runCli(
+      ["lease", "--platform", "ios", "--device", "iPhone 17 Pro", "--detach"],
+      leaseOut.environmentWith({ connectAdmin: environment.connectAdmin }),
+    );
+    expect(leaseExit).toBe(0);
+    const grant = JSON.parse(leaseOut.stdout) as LeaseGrant;
+    expect(grant.lease.mode).toBe("detached");
+
+    const statusOut = outputCapture();
+    await runCli(
+      ["status", "--json"],
+      statusOut.environmentWith({ connectAdmin: environment.connectAdmin }),
+    );
+    const status = JSON.parse(statusOut.stdout) as StatusGetOutput;
+    expect(status.leases.map((lease) => lease.id)).toContain(grant.lease.id);
+
+    const releaseOut = outputCapture();
+    const releaseExit = await runCli(
+      ["release", grant.lease.id],
+      releaseOut.environmentWith({ connectAdmin: environment.connectAdmin }),
+    );
+    expect(releaseExit).toBe(0);
+
+    const tokenOut = outputCapture();
+    const tokenExit = await runCli(
+      ["token", "create", "--role", "operator", "--label", "ci"],
+      tokenOut.environmentWith({ connectAdmin: environment.connectAdmin }),
+    );
+    expect(tokenExit).toBe(0);
+    const created = JSON.parse(tokenOut.stdout) as { secret: string; token: { id: string } };
+    expect(typeof created.secret).toBe("string");
+    expect((created as unknown as Record<string, unknown>).token).not.toHaveProperty("hash");
+  });
+});
+
+describe("CLI: pure helpers", () => {
+  it("fallbackRequesterId prefers SIMLOCK_AGENT_ID over a pid-derived default", () => {
+    expect(fallbackRequesterId({ SIMLOCK_AGENT_ID: "agent-7" })).toBe("agent-7");
+    expect(fallbackRequesterId({})).toBe(String(process.pid));
+  });
+
+  it("parseDuration parses units and rejects garbage", () => {
+    expect(parseDuration("500")).toBe(500);
+    expect(parseDuration("500ms")).toBe(500);
+    expect(parseDuration("2s")).toBe(2_000);
+    expect(parseDuration("3m")).toBe(180_000);
+    expect(parseDuration("1h")).toBe(3_600_000);
+    expect(() => parseDuration("banana")).toThrow();
+  });
+});
+
+// ---- test doubles -----------------------------------------------------------------------------
+
+function simlockError(code: AnySimlockError["code"]): AnySimlockError {
+  const messages: Partial<Record<string, string>> = {
+    NO_CAPACITY: "No capacity available",
+  };
+  const kind =
+    code === "DAEMON_CONNECTION_LOST" ||
+    code === "DAEMON_STOPPING" ||
+    code === "DAEMON_STARTUP_FAILED"
+      ? "transport"
+      : (
+            [
+              "BAD_FRAME",
+              "HANDSHAKE_REQUIRED",
+              "BAD_REQUEST",
+              "UNKNOWN_REQUEST",
+              "PROTOCOL_VERSION_UNSUPPORTED",
+              "ADMIN_AUTHENTICATION_FAILED",
+              "FORBIDDEN",
+              "UNKNOWN_DAEMON_ERROR",
+            ] as const
+          ).includes(code as never)
+        ? "protocol"
+        : "domain";
+  return new SimlockError(
+    code,
+    kind,
+    messages[code] ?? `${code} failed`,
+    {} as never,
+  ) as unknown as AnySimlockError;
 }
 
-class StubConnection implements DaemonConnection {
-  readonly calls: Array<{ readonly payload: unknown; readonly type: string }> = [];
-  closed = false;
-  readonly #listeners = new Set<(kind: string, payload: unknown) => void>();
-  readonly #responses = new Map<string, unknown>();
-
-  response(type: string, value: unknown): void {
-    this.#responses.set(type, value);
-  }
-
-  async request(type: string, payload: unknown): Promise<unknown> {
-    this.calls.push({ payload, type });
-    const value = this.#responses.get(type);
-    if (value instanceof Error) {
-      throw value;
-    }
-    return value;
-  }
-
-  onPush(listener: (kind: string, payload: unknown) => void): () => void {
-    this.#listeners.add(listener);
-    return () => this.#listeners.delete(listener);
-  }
-
-  onClose(): () => void {
-    return () => undefined;
-  }
-
-  push(kind: string, payload: unknown): void {
-    for (const listener of this.#listeners) {
-      listener(kind, payload);
-    }
-  }
-
-  async close(): Promise<void> {
-    this.closed = true;
-  }
+function fakeClient(overrides: Partial<SimlockAdminClient> = {}): SimlockAdminClient {
+  const emptyStatus: StatusGetOutput = {
+    devices: [],
+    leases: [],
+    capacity: {
+      ios: { limit: 1, running: 0, maxRunning: 1, reserved: 0, overLimit: false, warm: 0, used: 0 },
+      android: {
+        limit: 1,
+        running: 0,
+        maxRunning: 1,
+        reserved: 0,
+        overLimit: false,
+        warm: 0,
+        used: 0,
+      },
+      global: { running: 0, maxRunning: 2, reserved: 0, overLimit: false, warm: 0 },
+    },
+    health: "running",
+    queueDepth: 0,
+  };
+  const emptyCatalog: CatalogGetOutput = { platforms: [] };
+  const emptyDoctor: DoctorReport = { findings: [] };
+  const emptyLeaseList: LeaseListOutput = { leases: [] };
+  const emptyListGet: ListGetOutput = [];
+  const emptyTokenList: TokenListOutput = { tokens: [] };
+  const grant: LeaseGrant = {
+    device: {
+      id: "dev_1",
+      driverDeviceId: "dev_1",
+      spec: { platform: "ios", model: "iPhone 17 Pro", osVersion: "26.5" },
+      state: "leased",
+      driverData: undefined,
+      createdAt: 0,
+    },
+    lease: {
+      id: "lse_1",
+      deviceId: "dev_1",
+      requesterId: "test-requester",
+      ownerId: "test-requester",
+      mode: "held",
+      grantedAt: 0,
+      ttlDeadline: 60_000,
+    },
+    timing: {
+      estimatedProvisionMs: 0,
+      estimatedBootMs: 0,
+      estimatedReclaimMs: 0,
+      estimatedReadyMs: 0,
+    },
+  };
+  const base: SimlockAdminClient = {
+    principal: "test-requester",
+    role: "admin",
+    daemonVersion: "test",
+    getCatalog: () => Promise.resolve(emptyCatalog),
+    getStatus: () => Promise.resolve(emptyStatus),
+    requestLease: () => Promise.resolve(grant),
+    cancelLease: () => Promise.resolve({ result: "not-found" }),
+    renewLease: () => Promise.resolve(grant.lease as LeaseRecord),
+    releaseLease: (input) => Promise.resolve({ leaseId: input.leaseId }),
+    listLeases: () => Promise.resolve(emptyLeaseList),
+    heartbeat: () => Promise.resolve({ leases: [] }),
+    runDoctor: () => Promise.resolve(emptyDoctor),
+    onLeaseLost: () => () => {},
+    onDeviceUnhealthy: () => () => {},
+    onDeviceRecovered: () => () => {},
+    onConnectionLost: () => () => {},
+    close: () => Promise.resolve(),
+    releaseAllLeases: () => Promise.resolve({ leaseIds: [] }),
+    list: () => Promise.resolve(emptyListGet),
+    runCleanup: () => Promise.resolve([]),
+    runNuke: () => Promise.resolve({ deletedDevices: [], releasedLeaseIds: [] }),
+    getConfig: () => Promise.resolve({} as SimlockConfig),
+    stopDaemon: () => Promise.resolve({ stopping: true }),
+    replayEvents: () => Promise.resolve([]),
+    subscribeEvents: () => Promise.resolve(() => Promise.resolve()),
+    createToken: (input) =>
+      Promise.resolve({
+        secret: "sec_1",
+        token: { id: "tok_1", role: input.role, createdAt: 0 },
+      }),
+    listTokens: () => Promise.resolve(emptyTokenList),
+    revokeToken: () => Promise.resolve({ revoked: true }),
+    ...overrides,
+  };
+  return base;
 }
 
-async function createHarness() {
-  const directory = await mkdtemp(join(tmpdir(), "simlock-cli-"));
+interface OutputCapture {
+  stdout: string;
+  stderr: string;
+  environmentWith(overrides?: Partial<CliEnvironment>): CliEnvironment;
+}
+
+function outputCapture(): OutputCapture {
+  const capture: OutputCapture = {
+    stdout: "",
+    stderr: "",
+    environmentWith(overrides = {}) {
+      return {
+        configPath: "/simlock/config.json",
+        requesterId: "test-requester",
+        now: () => 0,
+        connectAdmin: async () => fakeClient(),
+        connectExistingAdmin: async () => fakeClient(),
+        readAdminTokenFile: async () => undefined,
+        sleep: async () => {},
+        readConfigFile: async () => ({}),
+        writeConfigFile: async () => {},
+        validateConfig: async () => {},
+        readLogFile: async () => "",
+        signals: new EventEmitter() as unknown as CliEnvironment["signals"],
+        parentWatch: new FakeParentWatch(),
+        stderr: { write: (value: string) => (capture.stderr += value) },
+        stdout: { write: (value: string) => (capture.stdout += value) },
+        confirm: async () => true,
+        ...overrides,
+      };
+    },
+  };
+  return capture;
+}
+
+// ---- real-daemon harness for the smoke test ----------------------------------------------------
+
+function sequence(): IdGenerator {
+  let next = 0;
+  return { generate: () => `id${next++}` };
+}
+
+async function startTestDaemon(): Promise<{ socketPath: string; daemon: DaemonServer }> {
+  const directory = await mkdtemp(join(tmpdir(), "simlock-cli-smoke-"));
   temporaryDirectories.push(directory);
   const socketPath = join(directory, "daemon.sock");
   const clock = new FakeClock(1_000);
   const eventBus = new EventBus(clock);
+  const filesystem = new MemoryFilesystem();
   const registry = await Registry.load({
     clock,
     eventBus,
-    filesystem: new MemoryFilesystem(),
+    filesystem,
     idGenerator: sequence(),
     statePath: "/state.json",
   });
@@ -1248,6 +723,21 @@ async function createHarness() {
       totalRamBytes: 32 * gibibyte,
     }),
   });
+  const reaper = new CleanupReaper({
+    clock,
+    config,
+    eventBus,
+    executor: engine.cleanup,
+    filesystem,
+    registry,
+  });
+  const tokens = new TokenStore({
+    clock,
+    filesystem,
+    idGenerator: sequence(),
+    path: "/tokens.json",
+    secrets: new CryptoTokenSecrets(),
+  });
   const daemon = new DaemonServer({
     capacity: engine,
     catalog: engine,
@@ -1263,25 +753,15 @@ async function createHarness() {
     }),
     leases: engine,
     queue: engine,
-    reaper: new CleanupReaper({
-      clock,
-      config,
-      eventBus,
-      executor: engine.cleanup,
-      filesystem: new MemoryFilesystem(),
-      registry,
-    }),
+    reaper,
     registry,
+    resolveRole: { resolve: () => "admin" },
+    tokens,
     version: "test",
   });
   runningDaemons.push(daemon);
   await daemon.start();
-  return { eventBus, registry, socketPath };
-}
-
-function sequence() {
-  let next = 1;
-  return { generate: () => `${next++}` };
+  return { socketPath, daemon };
 }
 
 function testConfig(): Config {
@@ -1289,7 +769,7 @@ function testConfig(): Config {
     diskPressure: { freeBytesThreshold: 10 * gibibyte },
     eventBuffer: { capacity: 100 },
     health: {
-      enabled: true,
+      enabled: false,
       maxConcurrentRecoveries: 1,
       maxRecoveryAttempts: 3,
       probeIntervalMs: 30_000,
@@ -1301,14 +781,14 @@ function testConfig(): Config {
     http: { enabled: false, host: "127.0.0.1", port: 4700 },
     ios: { slim: { enabled: false, bootTimeoutMs: 600_000 } },
     idle: { deleteAfterMs: 60_000, shutdownAfterMs: 10_000 },
-    lease: { detachedTtlMs: 60_000, heldTtlBackstopMs: 60_000, heartbeatIntervalMs: 15_000 },
+    lease: { detachedTtlMs: 60_000, heldTtlBackstopMs: 60_000, heartbeatIntervalMs: 5_000 },
     capacity: {
       strategy: "resource",
       config: {
         limits: {
           android: { maxDevices: 1, maxRunning: 1 },
           ios: { maxDevices: 1, maxRunning: 1 },
-          maxRunning: 1 + 1,
+          maxRunning: 2,
         },
         ramBudget: { androidBytesPerDevice: 4 * gibibyte, iosBytesPerDevice: gibibyte },
       },
@@ -1321,35 +801,6 @@ function testConfig(): Config {
         retryBackoffMs: 30_000,
         retryBackoffMultiplier: 2,
       },
-    },
-  };
-}
-
-function outputCapture() {
-  let stderr = "";
-  let stdout = "";
-  const environment: CliEnvironment = {
-    connect: async () => {
-      throw new Error("Unexpected daemon connection");
-    },
-    configPath: "/config.json",
-    readConfigFile: async () => ({}),
-    requesterId: "test-requester",
-    signals: new EventEmitter(),
-    stderr: { write: (value: string) => (stderr += value) },
-    stdout: { write: (value: string) => (stdout += value) },
-    writeConfigFile: async () => undefined,
-  };
-  return {
-    environment,
-    environmentWith(overrides: Partial<CliEnvironment>): CliEnvironment {
-      return { ...environment, ...overrides };
-    },
-    get stderr() {
-      return stderr;
-    },
-    get stdout() {
-      return stdout;
     },
   };
 }

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -594,9 +594,6 @@ function fakeClient(overrides: Partial<SimlockAdminClient> = {}): SimlockAdminCl
       id: "dev_1",
       driverDeviceId: "dev_1",
       spec: { platform: "ios", model: "iPhone 17 Pro", osVersion: "26.5" },
-      state: "leased",
-      driverData: undefined,
-      createdAt: 0,
     },
     lease: {
       id: "lse_1",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,6 +5,7 @@ import { parseArgs } from "node:util";
 import { loadConfig, type ConfigOverrides } from "../core/index.js";
 import {
   IpcError,
+  MemoryFilesystem,
   NodeDaemonLauncher,
   NodeFilesystem,
   NodeIpcTransport,
@@ -19,6 +20,7 @@ import {
   type IpcConnector,
   type ParentWatch,
   type ParentWatchHandle,
+  type SystemStats,
 } from "../ports/index.js";
 import { connectSimlockAdmin } from "../admin/index.js";
 import {
@@ -96,16 +98,24 @@ export interface CliEnvironment {
    * principal": `--agent-id` overrides `lease.request`'s `requesterId` field, never this. */
   readonly requesterId: string;
   readonly now?: () => number;
-  /** Connects (auto-launching the daemon if it is not already running) with the given
-   * credential, or none (ADR §5's agent fallback). */
+  /**
+   * Connects (auto-launching the daemon if it is not already running) and completes `hello`
+   * with whatever `resolveCredential` resolves to.
+   *
+   * `resolveCredential` is called only *after* the raw connection is established -- which is
+   * also where auto-launch happens (ADR §5: "written atomically after the socket claim
+   * succeeds"). A caller resolving the local `admin.token` file before the connection exists
+   * (the pre-fix bug: B2) races the whole daemon spawn instead of just the narrow
+   * claim-to-persist window the file-retry loop is meant for. See `readAdminTokenFileWithRetry`.
+   */
   readonly connectAdmin: (
-    credential: string | undefined,
+    resolveCredential: () => Promise<string | undefined>,
     options?: { readonly heartbeat?: boolean },
   ) => Promise<SimlockAdminClient>;
   /** Same as `connectAdmin` but never auto-launches -- `daemon stop`/`daemon status` must not
    * start a daemon just to ask whether one is running. */
   readonly connectExistingAdmin: (
-    credential: string | undefined,
+    resolveCredential: () => Promise<string | undefined>,
     options?: { readonly heartbeat?: boolean },
   ) => Promise<SimlockAdminClient>;
   /** `SIMLOCK_ADMIN_TOKEN`, ADR §5's second resolution source. */
@@ -147,22 +157,16 @@ export function fallbackRequesterId(env: NodeJS.ProcessEnv): string {
  * socket (reachable) and `admin.token` landing on disk (`DaemonServer#start` awaits the socket
  * claim, *then* `adminSecret.persist()`). A CLI invocation that races a fresh `daemon start`
  * retries a few times, briefly, rather than either blocking indefinitely or giving up on the
- * first empty read.
+ * first empty read. This only ever runs *after* the connection is already established (see
+ * `connectAdmin`'s doc) -- so the race it covers is the narrow claim-to-persist window, not the
+ * whole daemon spawn.
  */
 const ADMIN_TOKEN_FILE_READ_ATTEMPTS = 3;
 const ADMIN_TOKEN_FILE_RETRY_DELAY_MS = 50;
 
-/** ADR §5's resolution order: `--token`, then `SIMLOCK_ADMIN_TOKEN`, then the local
- * `admin.token` file (briefly retried). `undefined` means every source came up empty --
- * callers fall back to an agent-role connection with a stderr notice. */
-async function resolveAdminCredential(
+async function readAdminTokenFileWithRetry(
   environment: CliEnvironment,
-  tokenFlag: string | undefined,
 ): Promise<string | undefined> {
-  if (tokenFlag !== undefined && tokenFlag !== "") return tokenFlag;
-  if (environment.adminTokenFromEnv !== undefined && environment.adminTokenFromEnv !== "") {
-    return environment.adminTokenFromEnv;
-  }
   for (let attempt = 0; attempt < ADMIN_TOKEN_FILE_READ_ATTEMPTS; attempt++) {
     const token = await environment.readAdminTokenFile();
     if (token !== undefined) return token;
@@ -173,31 +177,79 @@ async function resolveAdminCredential(
   return undefined;
 }
 
+/** Where a resolved admin credential came from -- distinguishes an explicit-but-wrong
+ * credential (flag/env) from a stale local file (B1) for the fallback notice, and "none" for
+ * "every source came up empty" (unchanged from before). */
+type CredentialSource = "flag" | "env" | "file" | "none";
+
+function isAdminAuthFailure(error: unknown): boolean {
+  return isSimlockError(error) && error.code === "ADMIN_AUTHENTICATION_FAILED";
+}
+
+/** ADR §5's fallback: "an agent session with a stderr notice." B1 extends this to a credential
+ * the daemon actively rejected (not just one that was never found), and calls out a stale
+ * `admin.token` by name -- the actionable case a generic notice would otherwise bury. */
+function writeAgentFallbackNotice(environment: CliEnvironment, source: CredentialSource): void {
+  const notice =
+    source === "file"
+      ? "local admin.token credential was rejected by the daemon (stale after an unclean " +
+        "shutdown or restart?); connecting as agent (admin-only commands will fail with FORBIDDEN)"
+      : source === "none"
+        ? "admin credential unavailable; connecting as agent (admin-only commands will fail with FORBIDDEN)"
+        : "admin credential was rejected by the daemon; connecting as agent (admin-only " +
+          "commands will fail with FORBIDDEN)";
+  environment.stderr.write(`${JSON.stringify({ notice })}\n`);
+}
+
 /**
  * The one connection helper every daemon-touching command uses (ADR §5's "the CLI is the
- * operator interface"). Resolves the admin credential, writes a stderr notice when none was
- * found (ADR §5's fallback), then connects -- auto-launching the daemon unless `launch: false`.
+ * operator interface").
+ *
+ * ADR §5's resolution order -- `--token`, then `SIMLOCK_ADMIN_TOKEN`, then the local
+ * `admin.token` file (briefly retried, see `readAdminTokenFileWithRetry`) -- is implemented as
+ * a resolver passed to `connectAdmin`/`connectExistingAdmin`, not resolved up front: the file
+ * source must not be read until the connection (and any auto-launch it triggers) has already
+ * settled (B2), since the daemon only writes it after claiming its socket.
+ *
+ * B1: a credential the daemon actively rejects (`ADMIN_AUTHENTICATION_FAILED` -- most commonly
+ * a stale `admin.token` left behind by an unclean shutdown) degrades to a fresh agent-role
+ * connection with a stderr notice, exactly like "no credential found" does, instead of failing
+ * the whole invocation. Retried at most once, and only when a credential was actually offered --
+ * an agent connection legitimately failing `hello` for an unrelated reason still propagates.
  */
 async function connectDaemonClient(
   environment: CliEnvironment,
   tokenFlag: string | undefined,
   options: { readonly launch?: boolean; readonly heartbeat?: boolean } = {},
 ): Promise<SimlockAdminClient> {
-  const credential = await resolveAdminCredential(environment, tokenFlag);
-  if (credential === undefined) {
-    environment.stderr.write(
-      `${JSON.stringify({
-        notice:
-          "admin credential unavailable; connecting as agent (admin-only commands will fail with FORBIDDEN)",
-      })}\n`,
-    );
-  }
   const connect =
     options.launch === false ? environment.connectExistingAdmin : environment.connectAdmin;
-  return connect(
-    credential,
-    options.heartbeat === undefined ? {} : { heartbeat: options.heartbeat },
-  );
+  const connectOptions = options.heartbeat === undefined ? {} : { heartbeat: options.heartbeat };
+
+  let source: CredentialSource = "none";
+  const resolveCredential = async (): Promise<string | undefined> => {
+    if (tokenFlag !== undefined && tokenFlag !== "") {
+      source = "flag";
+      return tokenFlag;
+    }
+    if (environment.adminTokenFromEnv !== undefined && environment.adminTokenFromEnv !== "") {
+      source = "env";
+      return environment.adminTokenFromEnv;
+    }
+    const fileToken = await readAdminTokenFileWithRetry(environment);
+    source = fileToken === undefined ? "none" : "file";
+    return fileToken;
+  };
+
+  try {
+    const client = await connect(resolveCredential, connectOptions);
+    if (source === "none") writeAgentFallbackNotice(environment, "none");
+    return client;
+  } catch (error: unknown) {
+    if (!isAdminAuthFailure(error) || source === "none") throw error;
+    writeAgentFallbackNotice(environment, source);
+    return connect(async () => undefined, connectOptions);
+  }
 }
 
 /** Auto-launches the daemon on a refused/missing socket, mirroring
@@ -243,43 +295,69 @@ function isUnavailable(error: unknown): boolean {
   );
 }
 
-function defaultCliEnvironment(env: NodeJS.ProcessEnv = process.env): CliEnvironment {
-  const dataDirectory = resolveSimlockHome(env);
-  const filesystem = new NodeFilesystem();
-  const clock = new SystemClock();
-  const systemStats = new NodeSystemStats();
-  const ipc = new NodeIpcTransport();
+/** The infrastructure `defaultCliEnvironment` wires up. Factored out so tests can build the
+ * exact same environment logic (credential-resolution ordering, `config set` validation)
+ * against in-memory ports instead of the real filesystem/socket/subprocess -- see
+ * `src/cli/index.test.ts`'s cold-start and stale-token suites. */
+export interface CliEnvironmentPorts {
+  readonly filesystem: Filesystem;
+  readonly clock: Clock;
+  readonly systemStats: SystemStats;
+  readonly ipc: IpcConnector;
+  readonly launcher: DaemonLauncher;
+  readonly dataDirectory: string;
+  readonly parentWatch?: ParentWatch;
+  readonly signals?: Signals;
+  readonly stderr?: Output;
+  readonly stdout?: Output;
+  readonly confirm?: (question: string) => Promise<boolean>;
+  readonly parentPid?: number;
+}
+
+/**
+ * Builds a `CliEnvironment` from an explicit set of ports (see `CliEnvironmentPorts`) plus the
+ * bits still read straight from `env`/`process` (the requester id default, `SIMLOCK_ADMIN_TOKEN`,
+ * `process.ppid`). `defaultCliEnvironment` is this with real Node ports; tests call it directly
+ * with in-memory ones.
+ */
+export function buildCliEnvironment(
+  ports: CliEnvironmentPorts,
+  env: NodeJS.ProcessEnv = process.env,
+): CliEnvironment {
+  const { clock, dataDirectory, filesystem, ipc, launcher, systemStats } = ports;
   const socketPath = join(dataDirectory, "daemon.sock");
   const configPath = join(dataDirectory, "config.json");
   const logPath = join(dataDirectory, "daemon.log");
   const adminTokenPath = join(dataDirectory, "admin.token");
   const requesterId = fallbackRequesterId(env);
-  const launcher = new NodeDaemonLauncher({
-    args: [join(dirname(fileURLToPath(import.meta.url)), "../daemon/main.js")],
-    command: process.execPath,
-    logPath,
-  });
   const autoLaunchIpc = new AutoLaunchIpcConnector(ipc, clock, launcher);
 
-  const connect = (
+  // ADR §5 / B2: the raw connection (and, for `connectAdmin`, any auto-launch it triggers) is
+  // established *before* `resolveCredential` is ever called -- `admin.token` is written only
+  // after the daemon claims its socket, so reading it any earlier races the whole daemon spawn
+  // instead of the narrow claim-to-persist window `readAdminTokenFileWithRetry` covers.
+  const connect = async (
     connector: IpcConnector,
-    credential: string | undefined,
+    resolveCredential: () => Promise<string | undefined>,
     options?: { readonly heartbeat?: boolean },
-  ): Promise<SimlockAdminClient> =>
-    connectSimlockAdmin({
-      ipc: connector,
-      endpoint: socketPath,
+  ): Promise<SimlockAdminClient> => {
+    const connection = await connector.connect(socketPath);
+    const credential = await resolveCredential();
+    return connectSimlockAdmin({
+      connection,
       principal: requesterId,
       ...(credential === undefined ? {} : { credential }),
       ...(options?.heartbeat === undefined ? {} : { heartbeat: options.heartbeat }),
     });
+  };
 
   return {
     configPath,
     requesterId,
     now: () => clock.now(),
-    connectAdmin: (credential, options) => connect(autoLaunchIpc, credential, options),
-    connectExistingAdmin: (credential, options) => connect(ipc, credential, options),
+    connectAdmin: (resolveCredential, options) =>
+      connect(autoLaunchIpc, resolveCredential, options),
+    connectExistingAdmin: (resolveCredential, options) => connect(ipc, resolveCredential, options),
     ...(env.SIMLOCK_ADMIN_TOKEN === undefined
       ? {}
       : { adminTokenFromEnv: env.SIMLOCK_ADMIN_TOKEN }),
@@ -287,8 +365,8 @@ function defaultCliEnvironment(env: NodeJS.ProcessEnv = process.env): CliEnviron
     sleep: (milliseconds) => new Promise<void>((resolve) => clock.setTimer(milliseconds, resolve)),
     // Captured once at process startup, before anything can reparent this
     // process -- `--bind-pid` overrides it per invocation.
-    parentPid: process.ppid,
-    parentWatch: new NodeParentWatch(),
+    parentPid: ports.parentPid ?? process.ppid,
+    parentWatch: ports.parentWatch ?? new NodeParentWatch(),
     readConfigFile: async () => {
       if (!(await filesystem.exists(configPath))) return {};
       return requireObject(JSON.parse(await filesystem.readFile(configPath)) as unknown);
@@ -297,22 +375,56 @@ function defaultCliEnvironment(env: NodeJS.ProcessEnv = process.env): CliEnviron
       await filesystem.mkdirp(dataDirectory);
       await filesystem.writeFileAtomic(configPath, `${JSON.stringify(contents, null, 2)}\n`);
     },
+    // ADR §11 part D: "validates the merged file through the config loader before writing."
+    // B9: two things the pre-fix version got wrong --
+    //  - `warn` was never passed, so `validateConfigLayer`'s default no-op silently dropped
+    //    unknown/mistyped keys instead of rejecting them. Collected here and thrown when any
+    //    "Unknown config key" warning fires -- but not for a legacy-spelling warning (still
+    //    valid config, just deprecated), so a legitimate legacy `config set` keeps working.
+    //  - `configPath` pointed at a sentinel file inside the *real* data directory, which a
+    //    stray file there could turn into a false pass or fail, despite the comment's claim
+    //    that the path was "never read" -- `loadConfig`'s `readConfigFile` does read it when it
+    //    exists. A fresh `MemoryFilesystem` makes that literally true: nothing can ever exist
+    //    at this path.
     validateConfig: async (merged) => {
+      const unknownKeyWarnings: string[] = [];
       await loadConfig({
-        // Never read: the point is to validate `merged` (the full post-edit file content) as
-        // its own layer, not to re-merge it over whatever is still on disk at `configPath`.
-        configPath: join(dataDirectory, ".config-set-validation-scratch.json"),
-        filesystem,
+        configPath: "/config-set-validation.json",
+        filesystem: new MemoryFilesystem(),
         overrides: merged as ConfigOverrides,
         systemStats,
+        warn: (message) => {
+          if (message.startsWith("Unknown config key:")) unknownKeyWarnings.push(message);
+        },
       });
+      if (unknownKeyWarnings.length > 0) throw new Error(unknownKeyWarnings.join("; "));
     },
     readLogFile: async () => readLogFile(filesystem, logPath),
-    signals: process,
-    stderr: process.stderr,
-    stdout: process.stdout,
-    confirm: confirmTerminal,
+    signals: ports.signals ?? process,
+    stderr: ports.stderr ?? process.stderr,
+    stdout: ports.stdout ?? process.stdout,
+    confirm: ports.confirm ?? confirmTerminal,
   };
+}
+
+function defaultCliEnvironment(env: NodeJS.ProcessEnv = process.env): CliEnvironment {
+  const dataDirectory = resolveSimlockHome(env);
+  const logPath = join(dataDirectory, "daemon.log");
+  return buildCliEnvironment(
+    {
+      filesystem: new NodeFilesystem(),
+      clock: new SystemClock(),
+      systemStats: new NodeSystemStats(),
+      ipc: new NodeIpcTransport(),
+      launcher: new NodeDaemonLauncher({
+        args: [join(dirname(fileURLToPath(import.meta.url)), "../daemon/main.js")],
+        command: process.execPath,
+        logPath,
+      }),
+      dataDirectory,
+    },
+    env,
+  );
 }
 
 async function readAdminTokenFile(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,34 +2,33 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 
+import { loadConfig, type ConfigOverrides } from "../core/index.js";
 import {
-  CryptoIdGenerator,
-  CryptoTokenSecrets,
+  IpcError,
   NodeDaemonLauncher,
   NodeFilesystem,
   NodeIpcTransport,
   NodeParentWatch,
+  NodeSystemStats,
   resolveSimlockHome,
   SystemClock,
+  type Clock,
+  type DaemonLauncher,
   type Filesystem,
+  type IpcConnection,
+  type IpcConnector,
   type ParentWatch,
   type ParentWatchHandle,
 } from "../ports/index.js";
-import { TokenStore, type TokenRecord, type TokenRole } from "../http/token-store.js";
+import { connectSimlockAdmin } from "../admin/index.js";
 import {
-  connectDaemon,
-  connectExistingDaemon,
-  type DaemonClientCapabilities,
-} from "../daemon-client/client.js";
-import {
-  parseRawDeviceRecovered,
-  parseRawDeviceUnhealthy,
-  parseRawLeaseGrant,
-  parseRawLeaseLost,
-} from "../daemon-client/contracts.js";
-import { DaemonClientError, type DaemonConnection } from "../daemon-client/protocol.js";
-
-export { DaemonClientError, type DaemonConnection } from "../daemon-client/protocol.js";
+  isSimlockError,
+  type CatalogGetOutput,
+  type DoctorReport,
+  type SimlockAdminClient,
+  type StatusGetOutput,
+} from "../admin/index.js";
+import { ERROR_TABLE } from "../contract/index.js";
 
 const USAGE = `Usage: simlock <command> [options]
 
@@ -37,7 +36,11 @@ Commands:
   lease, release, status, list, catalog, cleanup, doctor, nuke, events,
   daemon, config, token
   mcp                         Start the stdio MCP server
-Run 'simlock <command> --help' for command usage.`;
+Run 'simlock <command> --help' for command usage.
+
+Pass --token <secret> anywhere on the command line to connect as admin
+explicitly; see docs/CLI.md#admin-credential-resolution for the default
+resolution order.`;
 
 /**
  * Held mode ends with the lease already gone: the daemon released it without
@@ -47,40 +50,10 @@ Run 'simlock <command> --help' for command usage.`;
  */
 const LEASE_LOST_EXIT_CODE = 14;
 
-const DAEMON_ERROR_EXIT_CODES: Readonly<Record<string, number>> = {
-  BAD_FRAME: 2,
-  BAD_REQUEST: 2,
-  INSUFFICIENT_DISK_SPACE: 12,
-  LICENSE_NOT_ACCEPTED: 12,
-  NO_CAPACITY: 11,
-  NO_DRIVER: 12,
-  QUEUE_TIMEOUT: 10,
-  REQUESTER_ALREADY_LEASED: 13,
-  RUNTIME_MISSING: 12,
-  UNKNOWN_MODEL: 12,
-};
-
 class UsageError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "UsageError";
-  }
-}
-
-/**
- * `token` operates on the filesystem directly (no daemon round-trip), so its
- * failures need their own structured error code -- not a `DaemonClientError`
- * (nothing was sent to the daemon) and not `UsageError` (exit 2 is reserved
- * for bad flags/arguments). Defaults to exit 1 like any other non-usage,
- * non-daemon failure.
- */
-class TokenCliError extends Error {
-  constructor(
-    readonly code: string,
-    message: string,
-  ) {
-    super(message);
-    this.name = "TokenCliError";
   }
 }
 
@@ -105,13 +78,47 @@ interface Signals {
 
 type McpStdioRunner = () => Promise<void>;
 
+/**
+ * ADR 0003 §11: the CLI renders the contract, and nothing else. Every daemon-touching command
+ * goes through `connectAdmin`/`connectExistingAdmin` -- both always hand back a
+ * `SimlockAdminClient` (ADR §5: "the CLI connects as admin whenever the local file is
+ * readable, falling back to an agent session ... when it is not"). Whether the connection
+ * actually *is* admin is entirely the daemon's call (`client.role`); an unauthenticated
+ * connection still gets an admin-shaped client back, and simply gets `FORBIDDEN` from the
+ * daemon on any operation that requires more than agent. This is what lets `lease`/`release`
+ * (agent-role operations) and `list`/`cleanup`/`nuke`/`token`/... (admin-role operations) share
+ * one connection helper instead of two.
+ */
 export interface CliEnvironment {
   readonly configPath: string;
-  readonly connect: (capabilities?: DaemonClientCapabilities) => Promise<DaemonConnection>;
-  readonly connectExisting?: () => Promise<DaemonConnection>;
-  readonly now?: () => number;
+  /** ADR §4's requester default and this connection's fixed principal -- see §9's
+   * "SIMLOCK_AGENT_ID and --agent-id still set the requester id ... they are not the
+   * principal": `--agent-id` overrides `lease.request`'s `requesterId` field, never this. */
   readonly requesterId: string;
+  readonly now?: () => number;
+  /** Connects (auto-launching the daemon if it is not already running) with the given
+   * credential, or none (ADR §5's agent fallback). */
+  readonly connectAdmin: (
+    credential: string | undefined,
+    options?: { readonly heartbeat?: boolean },
+  ) => Promise<SimlockAdminClient>;
+  /** Same as `connectAdmin` but never auto-launches -- `daemon stop`/`daemon status` must not
+   * start a daemon just to ask whether one is running. */
+  readonly connectExistingAdmin: (
+    credential: string | undefined,
+    options?: { readonly heartbeat?: boolean },
+  ) => Promise<SimlockAdminClient>;
+  /** `SIMLOCK_ADMIN_TOKEN`, ADR §5's second resolution source. */
+  readonly adminTokenFromEnv?: string;
+  /** One read attempt at the local `admin.token` file, ADR §5's third resolution source.
+   * `undefined` for "missing, unreadable, or empty" -- callers retry, not this. */
+  readonly readAdminTokenFile: () => Promise<string | undefined>;
+  readonly sleep: (milliseconds: number) => Promise<void>;
   readonly readConfigFile: () => Promise<Record<string, unknown>>;
+  readonly writeConfigFile: (contents: Record<string, unknown>) => Promise<void>;
+  /** `config set` (ADR §11 part D): validates the merged file through the config loader before
+   * `writeConfigFile` is ever called. Throws (any error) for an invalid merged config. */
+  readonly validateConfig: (merged: Record<string, unknown>) => Promise<void>;
   readonly readLogFile?: () => Promise<string>;
   /** Loads the MCP frontend only when the `mcp` command is dispatched. */
   readonly loadMcpStdio?: () => Promise<McpStdioRunner>;
@@ -123,14 +130,6 @@ export interface CliEnvironment {
   readonly stderr: Output;
   readonly stdout: Output;
   readonly confirm?: (question: string) => Promise<boolean>;
-  readonly writeConfigFile: (contents: Record<string, unknown>) => Promise<void>;
-  /**
-   * `token` reads/writes tokens.json directly, like `config` does with
-   * config.json -- no daemon round-trip. Optional so most tests (which never
-   * touch `token`) don't need to fabricate one; `runToken` fails clearly if
-   * it is missing.
-   */
-  readonly tokenStore?: TokenStore;
 }
 
 /**
@@ -143,61 +142,221 @@ export function fallbackRequesterId(env: NodeJS.ProcessEnv): string {
   return env.SIMLOCK_AGENT_ID ?? String(process.pid);
 }
 
+/**
+ * ADR §5: "a daemon still writing the file" is a real race between the daemon claiming its
+ * socket (reachable) and `admin.token` landing on disk (`DaemonServer#start` awaits the socket
+ * claim, *then* `adminSecret.persist()`). A CLI invocation that races a fresh `daemon start`
+ * retries a few times, briefly, rather than either blocking indefinitely or giving up on the
+ * first empty read.
+ */
+const ADMIN_TOKEN_FILE_READ_ATTEMPTS = 3;
+const ADMIN_TOKEN_FILE_RETRY_DELAY_MS = 50;
+
+/** ADR §5's resolution order: `--token`, then `SIMLOCK_ADMIN_TOKEN`, then the local
+ * `admin.token` file (briefly retried). `undefined` means every source came up empty --
+ * callers fall back to an agent-role connection with a stderr notice. */
+async function resolveAdminCredential(
+  environment: CliEnvironment,
+  tokenFlag: string | undefined,
+): Promise<string | undefined> {
+  if (tokenFlag !== undefined && tokenFlag !== "") return tokenFlag;
+  if (environment.adminTokenFromEnv !== undefined && environment.adminTokenFromEnv !== "") {
+    return environment.adminTokenFromEnv;
+  }
+  for (let attempt = 0; attempt < ADMIN_TOKEN_FILE_READ_ATTEMPTS; attempt++) {
+    const token = await environment.readAdminTokenFile();
+    if (token !== undefined) return token;
+    if (attempt < ADMIN_TOKEN_FILE_READ_ATTEMPTS - 1) {
+      await environment.sleep(ADMIN_TOKEN_FILE_RETRY_DELAY_MS);
+    }
+  }
+  return undefined;
+}
+
+/**
+ * The one connection helper every daemon-touching command uses (ADR §5's "the CLI is the
+ * operator interface"). Resolves the admin credential, writes a stderr notice when none was
+ * found (ADR §5's fallback), then connects -- auto-launching the daemon unless `launch: false`.
+ */
+async function connectDaemonClient(
+  environment: CliEnvironment,
+  tokenFlag: string | undefined,
+  options: { readonly launch?: boolean; readonly heartbeat?: boolean } = {},
+): Promise<SimlockAdminClient> {
+  const credential = await resolveAdminCredential(environment, tokenFlag);
+  if (credential === undefined) {
+    environment.stderr.write(
+      `${JSON.stringify({
+        notice:
+          "admin credential unavailable; connecting as agent (admin-only commands will fail with FORBIDDEN)",
+      })}\n`,
+    );
+  }
+  const connect =
+    options.launch === false ? environment.connectExistingAdmin : environment.connectAdmin;
+  return connect(
+    credential,
+    options.heartbeat === undefined ? {} : { heartbeat: options.heartbeat },
+  );
+}
+
+/** Auto-launches the daemon on a refused/missing socket, mirroring
+ * `daemon-client/startup-coordinator.ts`'s behaviour at the raw `IpcConnector` level instead of
+ * the legacy typed-connection level -- `simlock/admin`'s `connector` option accepts any
+ * `IpcConnector`, so this is the entire seam needed to keep `lease`'s "start the daemon if it
+ * isn't running" behaviour with the typed client. */
+class AutoLaunchIpcConnector implements IpcConnector {
+  constructor(
+    private readonly ipc: IpcConnector,
+    private readonly clock: Clock,
+    private readonly launcher: DaemonLauncher,
+  ) {}
+
+  async connect(endpoint: string): Promise<IpcConnection> {
+    try {
+      return await this.ipc.connect(endpoint);
+    } catch (error: unknown) {
+      if (!isUnavailable(error)) throw error;
+    }
+    await this.launcher.launch();
+    const deadline = this.clock.now() + 5_000;
+    let lastError: unknown;
+    while (this.clock.now() < deadline) {
+      try {
+        return await this.ipc.connect(endpoint);
+      } catch (error: unknown) {
+        if (!isUnavailable(error)) throw error;
+        lastError = error;
+        await new Promise<void>((resolve) => this.clock.setTimer(50, resolve));
+      }
+    }
+    throw new Error(`Timed out starting simlock daemon: ${errorMessage(lastError)}`);
+  }
+}
+
+/** True only for "nothing is listening yet" -- a refused/missing socket -- never for a `hello`
+ * rejection (ADR §6: the client never restarts the daemon on mismatch). */
+function isUnavailable(error: unknown): boolean {
+  return (
+    error instanceof IpcError &&
+    (error.code === "connection-refused" || error.code === "endpoint-not-found")
+  );
+}
+
 function defaultCliEnvironment(env: NodeJS.ProcessEnv = process.env): CliEnvironment {
   const dataDirectory = resolveSimlockHome(env);
   const filesystem = new NodeFilesystem();
   const clock = new SystemClock();
+  const systemStats = new NodeSystemStats();
   const ipc = new NodeIpcTransport();
   const socketPath = join(dataDirectory, "daemon.sock");
   const configPath = join(dataDirectory, "config.json");
   const logPath = join(dataDirectory, "daemon.log");
-  const tokenStore = new TokenStore({
-    clock,
-    filesystem,
-    idGenerator: new CryptoIdGenerator(),
-    path: join(dataDirectory, "tokens.json"),
-    secrets: new CryptoTokenSecrets(),
+  const adminTokenPath = join(dataDirectory, "admin.token");
+  const requesterId = fallbackRequesterId(env);
+  const launcher = new NodeDaemonLauncher({
+    args: [join(dirname(fileURLToPath(import.meta.url)), "../daemon/main.js")],
+    command: process.execPath,
+    logPath,
   });
+  const autoLaunchIpc = new AutoLaunchIpcConnector(ipc, clock, launcher);
+
+  const connect = (
+    connector: IpcConnector,
+    credential: string | undefined,
+    options?: { readonly heartbeat?: boolean },
+  ): Promise<SimlockAdminClient> =>
+    connectSimlockAdmin({
+      ipc: connector,
+      endpoint: socketPath,
+      principal: requesterId,
+      ...(credential === undefined ? {} : { credential }),
+      ...(options?.heartbeat === undefined ? {} : { heartbeat: options.heartbeat }),
+    });
+
   return {
     configPath,
-    connect: (capabilities) =>
-      connectDaemon({
-        ...(capabilities === undefined ? {} : { capabilities }),
-        clock,
-        ipc,
-        launcher: new NodeDaemonLauncher({
-          args: [join(dirname(fileURLToPath(import.meta.url)), "../daemon/main.js")],
-          command: process.execPath,
-          logPath,
-        }),
-        socketPath,
-      }),
-    connectExisting: () => connectExistingDaemon(socketPath, ipc),
+    requesterId,
     now: () => clock.now(),
+    connectAdmin: (credential, options) => connect(autoLaunchIpc, credential, options),
+    connectExistingAdmin: (credential, options) => connect(ipc, credential, options),
+    ...(env.SIMLOCK_ADMIN_TOKEN === undefined
+      ? {}
+      : { adminTokenFromEnv: env.SIMLOCK_ADMIN_TOKEN }),
+    readAdminTokenFile: () => readAdminTokenFile(filesystem, adminTokenPath),
+    sleep: (milliseconds) => new Promise<void>((resolve) => clock.setTimer(milliseconds, resolve)),
     // Captured once at process startup, before anything can reparent this
     // process -- `--bind-pid` overrides it per invocation.
     parentPid: process.ppid,
     parentWatch: new NodeParentWatch(),
-    requesterId: fallbackRequesterId(env),
     readConfigFile: async () => {
       if (!(await filesystem.exists(configPath))) return {};
       return requireObject(JSON.parse(await filesystem.readFile(configPath)) as unknown);
+    },
+    writeConfigFile: async (contents) => {
+      await filesystem.mkdirp(dataDirectory);
+      await filesystem.writeFileAtomic(configPath, `${JSON.stringify(contents, null, 2)}\n`);
+    },
+    validateConfig: async (merged) => {
+      await loadConfig({
+        // Never read: the point is to validate `merged` (the full post-edit file content) as
+        // its own layer, not to re-merge it over whatever is still on disk at `configPath`.
+        configPath: join(dataDirectory, ".config-set-validation-scratch.json"),
+        filesystem,
+        overrides: merged as ConfigOverrides,
+        systemStats,
+      });
     },
     readLogFile: async () => readLogFile(filesystem, logPath),
     signals: process,
     stderr: process.stderr,
     stdout: process.stdout,
     confirm: confirmTerminal,
-    tokenStore,
-    writeConfigFile: async (contents) => {
-      await filesystem.mkdirp(dataDirectory);
-      await filesystem.writeFileAtomic(configPath, `${JSON.stringify(contents, null, 2)}\n`);
-    },
   };
+}
+
+async function readAdminTokenFile(
+  filesystem: Filesystem,
+  path: string,
+): Promise<string | undefined> {
+  try {
+    if (!(await filesystem.exists(path))) return undefined;
+    const contents = (await filesystem.readFile(path)).trim();
+    return contents === "" ? undefined : contents;
+  } catch {
+    return undefined;
+  }
 }
 
 async function loadDefaultMcpStdio(): Promise<McpStdioRunner> {
   return (await import("../mcp/main.js")).runMcpStdio;
+}
+
+/** `--token <secret>` is a global flag (ADR §5's first credential source), recognized anywhere
+ * on the command line rather than per-command, since almost every command can use it. Stripped
+ * before the remaining argv reaches that command's own `parseArgs` call. */
+function extractGlobalToken(argv: readonly string[]): {
+  readonly token: string | undefined;
+  readonly rest: string[];
+} {
+  const rest: string[] = [];
+  let token: string | undefined;
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index] as string;
+    if (arg === "--token") {
+      const value = argv[index + 1];
+      if (value === undefined) throw new UsageError("--token requires a value");
+      token = value;
+      index++;
+      continue;
+    }
+    if (arg.startsWith("--token=")) {
+      token = arg.slice("--token=".length);
+      continue;
+    }
+    rest.push(arg);
+  }
+  return { token, rest };
 }
 
 export async function runCli(
@@ -209,35 +368,36 @@ export async function runCli(
       environment.stdout.write(`${USAGE}\n`);
       return 0;
     }
-    switch (argv[0]) {
+    const { token, rest } = extractGlobalToken(argv);
+    switch (rest[0]) {
       case "lease":
-        return await runLease(argv.slice(1), environment);
+        return await runLease(rest.slice(1), environment, token);
       case "release":
-        return await runRelease(argv.slice(1), environment);
+        return await runRelease(rest.slice(1), environment, token);
       case "status":
-        return await runStatus(argv.slice(1), environment);
+        return await runStatus(rest.slice(1), environment, token);
       case "list":
-        return await runList(argv.slice(1), environment);
+        return await runList(rest.slice(1), environment, token);
       case "catalog":
-        return await runCatalog(argv.slice(1), environment);
+        return await runCatalog(rest.slice(1), environment, token);
       case "cleanup":
-        return await runCleanup(argv.slice(1), environment);
+        return await runCleanup(rest.slice(1), environment, token);
       case "doctor":
-        return await runDoctor(argv.slice(1), environment);
+        return await runDoctor(rest.slice(1), environment, token);
       case "nuke":
-        return await runNuke(argv.slice(1), environment);
+        return await runNuke(rest.slice(1), environment, token);
       case "events":
-        return await runEvents(argv.slice(1), environment);
+        return await runEvents(rest.slice(1), environment, token);
       case "daemon":
-        return await runDaemon(argv.slice(1), environment);
+        return await runDaemon(rest.slice(1), environment, token);
       case "config":
-        return await runConfig(argv.slice(1), environment);
+        return await runConfig(rest.slice(1), environment, token);
       case "token":
-        return await runToken(argv.slice(1), environment);
+        return await runToken(rest.slice(1), environment, token);
       case "mcp":
-        return await runMcp(argv.slice(1), environment);
+        return await runMcp(rest.slice(1), environment);
       default:
-        throw new UsageError(withHelpHint(`Unknown command: ${argv[0]}`));
+        throw new UsageError(withHelpHint(`Unknown command: ${rest[0]}`));
     }
   } catch (error: unknown) {
     writeError(environment, error);
@@ -260,9 +420,17 @@ function writeError(environment: CliEnvironment, error: unknown): void {
 
 function cliErrorCode(error: unknown): string {
   if (error instanceof UsageError) return "USAGE";
-  if (error instanceof DaemonClientError) return error.code;
-  if (error instanceof TokenCliError) return error.code;
+  if (isSimlockError(error)) return error.code;
   return "INTERNAL";
+}
+
+/** ADR §7: "CLI exit codes and HTTP status codes are columns of the same error table, not
+ * second mappings" -- driven from `ERROR_TABLE`'s `cliExitCode` column rather than a second,
+ * CLI-maintained map. */
+export function errorExitCode(error: unknown): number {
+  if (error instanceof UsageError) return 2;
+  if (isSimlockError(error)) return ERROR_TABLE[error.code].cliExitCode;
+  return 1;
 }
 
 async function runMcp(argv: readonly string[], environment: CliEnvironment): Promise<number> {
@@ -275,12 +443,6 @@ async function runMcp(argv: readonly string[], environment: CliEnvironment): Pro
     environment.runMcpStdio ?? (await (environment.loadMcpStdio ?? loadDefaultMcpStdio)());
   await runMcpStdio();
   return 0;
-}
-
-export function errorExitCode(error: unknown): number {
-  if (error instanceof UsageError) return 2;
-  if (error instanceof DaemonClientError) return DAEMON_ERROR_EXIT_CODES[error.code] ?? 1;
-  return 1;
 }
 
 /** Parses user-facing durations only at the CLI boundary. */
@@ -305,8 +467,12 @@ function parseBindPid(value: unknown): number | undefined {
 }
 
 // fallow-ignore-next-line complexity -- CLI command parsing remains intentionally local to its rendering boundary.
-async function runLease(argv: readonly string[], environment: CliEnvironment): Promise<number> {
-  if (argv[0] === "renew") return runRenew(argv.slice(1), environment);
+async function runLease(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
+  if (argv[0] === "renew") return runRenew(argv.slice(1), environment, token);
   const values = commandArgs(argv, {
     "agent-id": { type: "string" },
     "allow-download": { type: "boolean" },
@@ -330,10 +496,11 @@ async function runLease(argv: readonly string[], environment: CliEnvironment): P
   }
   if (values.platform !== "ios" && values.platform !== "android")
     throw new UsageError(withHelpHint("lease requires --platform <ios|android>"));
+  const platform = values.platform as "ios" | "android";
   if (typeof values.device !== "string" || values.device === "")
     throw new UsageError(withHelpHint("lease requires --device <model>"));
   if (values["agent-id"] === "") throw new UsageError("lease --agent-id must not be empty");
-  const requesterId = values["agent-id"] ?? environment.requesterId;
+  const requesterId = (values["agent-id"] as string | undefined) ?? environment.requesterId;
   const detached = values.detach ?? false;
   const timeoutMs = typeof values.timeout === "string" ? parseDuration(values.timeout) : undefined;
   // Held mode watches its parent so a crashed agent's backgrounded holder
@@ -345,73 +512,55 @@ async function runLease(argv: readonly string[], environment: CliEnvironment): P
   const termination = detached
     ? undefined
     : waitForTermination(environment.signals, environment.parentWatch, watchedPid);
-  // Declaring the heartbeat capability opts this connection into the daemon's
-  // sliding TTL -- safe now that a dead-parent holder self-terminates instead
-  // of pinging forever. Detached mode never holds a connection, so it keeps
-  // relying purely on its own TTL.
-  const connection = await environment.connect(detached ? undefined : { heartbeat: true });
+
+  const client = await connectDaemonClient(environment, token, { heartbeat: !detached });
   // Set once the daemon says this connection's lease ended without us asking. ADR 0003 §8:
-  // lease-scoped pushes now go to every live connection sharing the lease's owner, not only
-  // the one holding it -- until the CLI sends a real per-process principal at `hello` (PR 4),
-  // two CLI connections started without `--agent-id`/`SIMLOCK_AGENT_ID` share the daemon's
-  // fallback principal, so a lease-lost push meant for one can reach the other. Filtered by
-  // `leaseId` below against this connection's own granted lease (unset until the grant
-  // response lands, in which case any push is necessarily for someone else's lease -- nothing
-  // this connection holds could have already been lost).
+  // lease-scoped pushes go to every live connection sharing the lease's owner, in either mode
+  // -- filtered below against this connection's own granted lease id, the same way the
+  // pre-typed-client CLI did, since a second CLI invocation sharing this principal (e.g. a
+  // detached lease from an earlier `--detach`) can otherwise deliver a push for a lease this
+  // process never held.
   let leaseLost = false;
   let ourLeaseId: string | undefined;
   let notifyLeaseLost: (() => void) | undefined;
   const leaseLostSignal = new Promise<void>((resolve) => {
     notifyLeaseLost = resolve;
   });
-  const unsubscribe = connection.onPush((kind, payload) => {
-    if (kind === "progress") {
-      environment.stderr.write(`${JSON.stringify(progressLine(payload))}\n`);
-      return;
-    }
-    if (kind === "device-unhealthy") {
-      writeDeviceHealthLine(environment, () => deviceUnhealthyLine(payload));
-      return;
-    }
-    if (kind === "device-recovered") {
-      writeDeviceHealthLine(environment, () => deviceRecoveredLine(payload));
-      return;
-    }
-    if (kind === "lease-lost") {
-      // Parse before deciding the lease is gone: unlike the health lines, acting on
-      // this one ends the process, so a malformed push must be ignored outright
-      // rather than exiting the holder with no explanation of why.
-      let line;
-      try {
-        line = leaseLostLine(payload);
-      } catch {
-        return;
-      }
-      if (line.lease !== ourLeaseId) return;
-      environment.stderr.write(`${JSON.stringify(line)}\n`);
-      leaseLost = true;
-      notifyLeaseLost?.();
-    }
+  const offLeaseLost = client.onLeaseLost((push) => {
+    if (push.leaseId !== ourLeaseId) return;
+    environment.stderr.write(`${JSON.stringify({ push: "lease-lost", ...push })}\n`);
+    leaseLost = true;
+    notifyLeaseLost?.();
+  });
+  const offUnhealthy = client.onDeviceUnhealthy((push) => {
+    environment.stderr.write(`${JSON.stringify({ push: "device-unhealthy", ...push })}\n`);
+  });
+  const offRecovered = client.onDeviceRecovered((push) => {
+    environment.stderr.write(`${JSON.stringify({ push: "device-recovered", ...push })}\n`);
   });
   try {
-    // Flat fields, not the legacy `device`/`os` aliases or a nested `request` wrapper -- the
-    // wire moved to protocol 3 with no compatibility shim (ADR 0003 "Consequences"). Moving
-    // this onto the typed `simlock/client` (ADR 0003 §10-11) is PR 4's job; this is only the
-    // minimal payload-shape fix needed to keep the CLI working against this PR's daemon.
-    const response = await connection.request("lease.request", {
-      allowDownload: values["allow-download"] ?? false,
-      mode: detached ? "detached" : "held",
-      noWait: values["no-wait"] ?? false,
-      requesterId,
-      model: values.device,
-      ...(typeof values.os === "string" ? { osVersion: values.os } : {}),
-      platform: values.platform,
-      ...(values.full === true ? { full: true } : {}),
-      ...(timeoutMs === undefined ? {} : { timeoutMs }),
-    });
-    const result = leaseResult(response);
-    ourLeaseId = result.lease;
-    environment.stdout.write(`${JSON.stringify(result)}\n`);
+    const grant = await client.requestLease(
+      {
+        allowDownload: values["allow-download"] === true,
+        mode: detached ? "detached" : "held",
+        noWait: values["no-wait"] === true,
+        requesterId,
+        model: values.device,
+        ...(typeof values.os === "string" ? { osVersion: values.os } : {}),
+        platform,
+        ...(values.full === true ? { full: true } : {}),
+        ...(timeoutMs === undefined ? {} : { timeoutMs }),
+      },
+      {
+        onProgress: (progress) => {
+          environment.stderr.write(`${JSON.stringify({ push: "progress", ...progress })}\n`);
+        },
+      },
+    );
+    ourLeaseId = grant.lease.id;
+    // ADR §5: "simlock lease output includes the resolved role" -- the one field this CLI
+    // adds on top of the contract's `LeaseGrant` shape, everything else passed through as-is.
+    writeResult(environment, { ...grant, role: client.role });
     if (detached || termination === undefined) return 0;
     await Promise.race([termination.settled, leaseLostSignal]);
     if (leaseLost) {
@@ -419,7 +568,7 @@ async function runLease(argv: readonly string[], environment: CliEnvironment): P
       return LEASE_LOST_EXIT_CODE;
     }
     try {
-      await connection.request("lease.release", { leaseId: result.lease });
+      await client.releaseLease({ leaseId: grant.lease.id });
     } catch (error: unknown) {
       // Non-fatal: the process still exits 0 after a signal, but the release
       // failure is still diagnostic output, so it stays a structured stderr
@@ -429,12 +578,18 @@ async function runLease(argv: readonly string[], environment: CliEnvironment): P
     return 0;
   } finally {
     termination?.dispose();
-    unsubscribe();
-    await connection.close();
+    offLeaseLost();
+    offUnhealthy();
+    offRecovered();
+    await client.close();
   }
 }
 
-async function runRenew(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+async function runRenew(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
   const values = commandArgs(argv, {
     help: { type: "boolean", short: "h" },
     ttl: { type: "string" },
@@ -445,17 +600,26 @@ async function runRenew(argv: readonly string[], environment: CliEnvironment): P
     return 0;
   }
   const leaseId = requiredPositional(positionals, "lease-id");
-  writeResult(
-    environment,
-    await requestOnce(environment, "lease.renew", {
-      leaseId,
-      ...(typeof values.ttl === "string" ? { ttlMs: parseDuration(values.ttl) } : {}),
-    }),
-  );
-  return 0;
+  const client = await connectDaemonClient(environment, token);
+  try {
+    writeResult(
+      environment,
+      await client.renewLease({
+        leaseId,
+        ...(typeof values.ttl === "string" ? { ttlMs: parseDuration(values.ttl) } : {}),
+      }),
+    );
+    return 0;
+  } finally {
+    await client.close();
+  }
 }
 
-async function runRelease(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+async function runRelease(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
   const values = commandArgs(argv, {
     all: { type: "boolean" },
     help: { type: "boolean", short: "h" },
@@ -466,24 +630,31 @@ async function runRelease(argv: readonly string[], environment: CliEnvironment):
     environment.stdout.write("Usage: simlock release <lease-id> | --all [--yes]\n");
     return 0;
   }
-  if (values.all) {
-    if (positionals.length > 0)
-      throw new UsageError("release accepts either a lease id or --all, not both");
-    const confirmed = values.yes ?? (await environment.confirm?.("Release every lease? [y/N] "));
-    if (!confirmed) throw new UsageError("release --all requires confirmation or --yes");
-    writeResult(environment, await requestOnce(environment, "lease.release-all", {}));
+  const client = await connectDaemonClient(environment, token);
+  try {
+    if (values.all) {
+      if (positionals.length > 0)
+        throw new UsageError("release accepts either a lease id or --all, not both");
+      const confirmed = values.yes ?? (await environment.confirm?.("Release every lease? [y/N] "));
+      if (!confirmed) throw new UsageError("release --all requires confirmation or --yes");
+      writeResult(environment, await client.releaseAllLeases());
+      return 0;
+    }
+    writeResult(
+      environment,
+      await client.releaseLease({ leaseId: requiredPositional(positionals, "lease-id") }),
+    );
     return 0;
+  } finally {
+    await client.close();
   }
-  writeResult(
-    environment,
-    await requestOnce(environment, "lease.release", {
-      leaseId: requiredPositional(positionals, "lease-id"),
-    }),
-  );
-  return 0;
 }
 
-async function runStatus(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+async function runStatus(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
   const values = commandArgs(argv, {
     help: { type: "boolean", short: "h" },
     json: { type: "boolean" },
@@ -492,13 +663,22 @@ async function runStatus(argv: readonly string[], environment: CliEnvironment): 
     environment.stdout.write("Usage: simlock status [--json]\n");
     return 0;
   }
-  const status = await requestOnce(environment, "status.get", {});
-  if (values.json) writeResult(environment, status);
-  else environment.stdout.write(`${formatStatus(requireObject(status))}\n`);
-  return 0;
+  const client = await connectDaemonClient(environment, token);
+  try {
+    const status = await client.getStatus();
+    if (values.json) writeResult(environment, status);
+    else environment.stdout.write(`${formatStatus(status)}\n`);
+    return 0;
+  } finally {
+    await client.close();
+  }
 }
 
-async function runList(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+async function runList(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
   const values = commandArgs(argv, {
     devices: { type: "boolean" },
     help: { type: "boolean", short: "h" },
@@ -512,11 +692,20 @@ async function runList(argv: readonly string[], environment: CliEnvironment): Pr
   if ([values.devices, values.leases, values.rules].filter(Boolean).length > 1)
     throw new UsageError("list accepts only one of --devices, --leases, or --rules");
   const kind = values.leases ? "leases" : values.rules ? "rules" : "devices";
-  writeResult(environment, await requestOnce(environment, "list.get", { kind }));
-  return 0;
+  const client = await connectDaemonClient(environment, token);
+  try {
+    writeResult(environment, await client.list({ kind }));
+    return 0;
+  } finally {
+    await client.close();
+  }
 }
 
-async function runCatalog(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+async function runCatalog(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
   const values = commandArgs(argv, {
     help: { type: "boolean", short: "h" },
     json: { type: "boolean" },
@@ -528,17 +717,23 @@ async function runCatalog(argv: readonly string[], environment: CliEnvironment):
   }
   if (values.platform !== undefined && values.platform !== "ios" && values.platform !== "android")
     throw new UsageError("catalog --platform must be ios or android");
-  const response = await requestOnce(
-    environment,
-    "catalog.get",
-    values.platform === undefined ? {} : { platform: values.platform },
-  );
-  if (values.json) writeResult(environment, response);
-  else environment.stdout.write(`${formatCatalog(requireObject(response))}\n`);
-  return 0;
+  const platform = values.platform as "ios" | "android" | undefined;
+  const client = await connectDaemonClient(environment, token);
+  try {
+    const response = await client.getCatalog(platform === undefined ? {} : { platform });
+    if (values.json) writeResult(environment, response);
+    else environment.stdout.write(`${formatCatalog(response)}\n`);
+    return 0;
+  } finally {
+    await client.close();
+  }
 }
 
-async function runCleanup(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+async function runCleanup(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
   const values = commandArgs(argv, {
     "dry-run": { type: "boolean" },
     help: { type: "boolean", short: "h" },
@@ -548,17 +743,26 @@ async function runCleanup(argv: readonly string[], environment: CliEnvironment):
     environment.stdout.write("Usage: simlock cleanup [--dry-run] [--rule <name>]\n");
     return 0;
   }
-  writeResult(
-    environment,
-    await requestOnce(environment, "cleanup.run", {
-      dryRun: values["dry-run"] ?? false,
-      ...(typeof values.rule === "string" ? { rule: values.rule } : {}),
-    }),
-  );
-  return 0;
+  const client = await connectDaemonClient(environment, token);
+  try {
+    writeResult(
+      environment,
+      await client.runCleanup({
+        dryRun: values["dry-run"] === true,
+        ...(typeof values.rule === "string" ? { rule: values.rule } : {}),
+      }),
+    );
+    return 0;
+  } finally {
+    await client.close();
+  }
 }
 
-async function runDoctor(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+async function runDoctor(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
   const values = commandArgs(argv, {
     fix: { type: "boolean" },
     help: { type: "boolean", short: "h" },
@@ -567,10 +771,15 @@ async function runDoctor(argv: readonly string[], environment: CliEnvironment): 
     environment.stdout.write("Usage: simlock doctor [--fix]\n");
     return 0;
   }
-  const response = await requestOnce(environment, "doctor.run", { fix: values.fix ?? false });
-  writeDriverAdvisoryWarnings(environment, response);
-  writeResult(environment, response);
-  return 0;
+  const client = await connectDaemonClient(environment, token);
+  try {
+    const response = await client.runDoctor({ fix: values.fix === true });
+    writeDriverAdvisoryWarnings(environment, response);
+    writeResult(environment, response);
+    return 0;
+  } finally {
+    await client.close();
+  }
 }
 
 /**
@@ -581,21 +790,18 @@ async function runDoctor(argv: readonly string[], environment: CliEnvironment): 
  * every finding kind unmodified via `writeResult`, matching the JSON-passthrough convention
  * `list`/`cleanup`/`nuke` already use, so a scripted consumer of stdout sees no behavior change.
  */
-function writeDriverAdvisoryWarnings(environment: CliEnvironment, response: unknown): void {
-  if (typeof response !== "object" || response === null) return;
-  const findings = (response as Record<string, unknown>).findings;
-  if (!Array.isArray(findings)) return;
-  for (const finding of findings) {
-    if (typeof finding !== "object" || finding === null) continue;
-    const record = finding as Record<string, unknown>;
-    if (record.kind !== "driver-advisory") continue;
-    environment.stderr.write(
-      `Warning [${String(record.platform)}] ${String(record.code)}: ${String(record.message)}\n`,
-    );
+function writeDriverAdvisoryWarnings(environment: CliEnvironment, report: DoctorReport): void {
+  for (const finding of report.findings) {
+    if (finding.kind !== "driver-advisory") continue;
+    environment.stderr.write(`Warning [${finding.platform}] ${finding.code}: ${finding.message}\n`);
   }
 }
 
-async function runNuke(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+async function runNuke(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
   const values = commandArgs(argv, {
     "delete-devices": { type: "boolean" },
     help: { type: "boolean", short: "h" },
@@ -608,16 +814,23 @@ async function runNuke(argv: readonly string[], environment: CliEnvironment): Pr
   const confirmed =
     values.yes ?? (await environment.confirm?.("Nuke Simlock-managed devices? [y/N] "));
   if (!confirmed) throw new UsageError("nuke requires confirmation or --yes");
-  writeResult(
-    environment,
-    await requestOnce(environment, "nuke.run", {
-      deleteDevices: values["delete-devices"] ?? false,
-    }),
-  );
-  return 0;
+  const client = await connectDaemonClient(environment, token);
+  try {
+    writeResult(
+      environment,
+      await client.runNuke({ deleteDevices: values["delete-devices"] === true }),
+    );
+    return 0;
+  } finally {
+    await client.close();
+  }
 }
 
-async function runEvents(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+async function runEvents(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
   const values = commandArgs(argv, {
     follow: { type: "boolean" },
     help: { type: "boolean", short: "h" },
@@ -627,32 +840,32 @@ async function runEvents(argv: readonly string[], environment: CliEnvironment): 
     environment.stdout.write("Usage: simlock events [--follow] [--since <duration>]\n");
     return 0;
   }
-  const connection = await environment.connect();
-  const unsubscribe = connection.onPush((kind, payload) => {
-    if (kind === "event") writeResult(environment, payload);
-  });
+  const client = await connectDaemonClient(environment, token);
   try {
     const sinceTs =
       typeof values.since === "string"
         ? (environment.now ?? Date.now)() - parseDuration(values.since)
         : undefined;
-    const replayPayload = sinceTs === undefined ? {} : { sinceTs };
-    for (const event of requireArray(await connection.request("events.replay", replayPayload)))
+    for (const event of await client.replayEvents(sinceTs === undefined ? {} : { sinceTs })) {
       writeResult(environment, event);
+    }
     if (values.follow) {
-      await connection.request("events.subscribe", {});
+      const unsubscribe = await client.subscribeEvents((event) => writeResult(environment, event));
       await waitForTermination(environment.signals).settled;
-      await connection.request("events.unsubscribe", {});
+      await unsubscribe();
     }
     return 0;
   } finally {
-    unsubscribe();
-    await connection.close();
+    await client.close();
   }
 }
 
 // fallow-ignore-next-line complexity -- daemon subcommand parsing is a single CLI boundary.
-async function runDaemon(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+async function runDaemon(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
   const command = argv[0];
   const values = commandArgs(argv.slice(1), {
     help: { type: "boolean", short: "h" },
@@ -664,17 +877,22 @@ async function runDaemon(argv: readonly string[], environment: CliEnvironment): 
   }
   if (values.positionals.length > 0) throw new UsageError("daemon accepts exactly one subcommand");
   if (command === "start") {
-    await requestOnce(environment, "status.get", {});
+    const client = await connectDaemonClient(environment, token, { launch: true });
+    try {
+      await client.getStatus();
+    } finally {
+      await client.close();
+    }
     if (values.json) writeResult(environment, { status: "running" });
     else environment.stdout.write("Daemon running\n");
     return 0;
   }
   if (command === "stop") {
-    const connection = await (environment.connectExisting ?? environment.connect)();
+    const client = await connectDaemonClient(environment, token, { launch: false });
     try {
-      await connection.request("daemon.stop", {});
+      await client.stopDaemon();
     } finally {
-      await connection.close();
+      await client.close();
     }
     if (values.json) writeResult(environment, { status: "stopping" });
     else environment.stdout.write("Daemon stopping\n");
@@ -682,17 +900,38 @@ async function runDaemon(argv: readonly string[], environment: CliEnvironment): 
   }
   if (command === "status") {
     try {
-      const connection = await (environment.connectExisting ?? environment.connect)();
+      const client = await connectDaemonClient(environment, token, { launch: false });
       try {
-        writeResult(environment, await connection.request("status.get", {}));
+        const status = await client.getStatus();
+        if (values.json) writeResult(environment, status);
+        else environment.stdout.write(`${formatStatus(status)}\n`);
       } finally {
-        await connection.close();
+        await client.close();
       }
-    } catch {
+      return 0;
+    } catch (error: unknown) {
+      // ADR §11: distinguish socket-absent from handshake-refused using the error `kind`,
+      // instead of reporting "stopped" on any error. A `SimlockError` whose `kind` is not
+      // `"transport"` means the socket was reachable and a daemon answered, but the
+      // connection was refused at or after `hello` (bad credential, version mismatch, ...);
+      // anything else (a raw `IpcError`, or a `transport`-kind `SimlockError` such as
+      // `DAEMON_CONNECTION_LOST`) means nothing is listening -- the pre-existing "stopped"
+      // outcome.
+      if (isSimlockError(error) && error.kind !== "transport") {
+        if (values.json) {
+          writeResult(environment, {
+            status: "handshake-refused",
+            error: { code: error.code, message: error.message },
+          });
+        } else {
+          environment.stdout.write(`Daemon handshake refused: ${error.code}: ${error.message}\n`);
+        }
+        return 1;
+      }
       if (values.json) writeResult(environment, { status: "stopped" });
       else environment.stdout.write("Daemon stopped\n");
+      return 0;
     }
-    return 0;
   }
   if (command === "logs") {
     if (environment.readLogFile === undefined) throw new Error("Daemon log reader is unavailable");
@@ -706,19 +945,32 @@ async function runDaemon(argv: readonly string[], environment: CliEnvironment): 
 }
 
 // fallow-ignore-next-line complexity -- config subcommand parsing is a single CLI boundary.
-async function runConfig(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+async function runConfig(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
   const command = argv[0];
   if (command === undefined) {
-    writeResult(environment, await requestOnce(environment, "config.get", {}));
-    return 0;
+    const client = await connectDaemonClient(environment, token);
+    try {
+      writeResult(environment, await client.getConfig());
+      return 0;
+    } finally {
+      await client.close();
+    }
   }
   if (command === "get") {
     const values = commandArgs(argv.slice(1), {});
     const key = requiredPositional(values.positionals, "key");
-    const value = readConfigValue(
-      requireObject(await requestOnce(environment, "config.get", {})),
-      key,
-    );
+    const client = await connectDaemonClient(environment, token);
+    let config: Record<string, unknown>;
+    try {
+      config = await client.getConfig();
+    } finally {
+      await client.close();
+    }
+    const value = readConfigValue(config, key);
     if (value === undefined) throw new UsageError(`Unknown config key: ${key}`);
     writeResult(environment, value);
     return 0;
@@ -730,6 +982,14 @@ async function runConfig(argv: readonly string[], environment: CliEnvironment): 
       throw new UsageError("Usage: simlock config set <key> <value>");
     const config = await environment.readConfigFile();
     writeConfigValue(config, key, parseConfigValue(rawValue));
+    // ADR §11 part D: "config set stays a file write ... but validates the merged file through
+    // the config loader before writing." Any failure here is bad input, same class as a bad
+    // flag -- surfaced as a usage error (exit 2) rather than a new CLI-level error code.
+    try {
+      await environment.validateConfig(config);
+    } catch (error: unknown) {
+      throw new UsageError(`Invalid config after setting ${key}: ${errorMessage(error)}`);
+    }
     await environment.writeConfigFile(config);
     environment.stdout.write(
       `Updated ${key} in ${environment.configPath}; takes effect on daemon restart.\n`,
@@ -743,7 +1003,11 @@ async function runConfig(argv: readonly string[], environment: CliEnvironment): 
   throw new UsageError(`Unknown config command: ${command}`);
 }
 
-async function runToken(argv: readonly string[], environment: CliEnvironment): Promise<number> {
+async function runToken(
+  argv: readonly string[],
+  environment: CliEnvironment,
+  token: string | undefined,
+): Promise<number> {
   const command = argv[0];
   if (command === undefined || isHelp(command)) {
     environment.stdout.write(
@@ -753,21 +1017,20 @@ async function runToken(argv: readonly string[], environment: CliEnvironment): P
     );
     return 0;
   }
-  const tokenStore = requireTokenStore(environment);
-  if (command === "create") return runTokenCreate(argv.slice(1), tokenStore, environment);
-  if (command === "list") return runTokenList(argv.slice(1), tokenStore, environment);
-  if (command === "revoke") return runTokenRevoke(argv.slice(1), tokenStore, environment);
-  throw new UsageError(withHelpHint(`Unknown token command: ${command}`));
-}
-
-function requireTokenStore(environment: CliEnvironment): TokenStore {
-  if (environment.tokenStore === undefined) throw new Error("Token store is unavailable");
-  return environment.tokenStore;
+  const client = await connectDaemonClient(environment, token);
+  try {
+    if (command === "create") return await runTokenCreate(argv.slice(1), client, environment);
+    if (command === "list") return await runTokenList(argv.slice(1), client, environment);
+    if (command === "revoke") return await runTokenRevoke(argv.slice(1), client, environment);
+    throw new UsageError(withHelpHint(`Unknown token command: ${command}`));
+  } finally {
+    await client.close();
+  }
 }
 
 async function runTokenCreate(
   argv: readonly string[],
-  tokenStore: TokenStore,
+  client: SimlockAdminClient,
   environment: CliEnvironment,
 ): Promise<number> {
   const values = commandArgs(argv, {
@@ -784,14 +1047,16 @@ async function runTokenCreate(
   const role = parseTokenRole(values.role);
   const label = typeof values.label === "string" ? values.label : undefined;
   if (label === "") throw new UsageError("token create --label must not be empty");
-  const { record, secret } = await tokenStore.create(role, label);
-  writeResult(environment, { secret, token: serializeToken(record) });
+  writeResult(
+    environment,
+    await client.createToken({ role, ...(label === undefined ? {} : { label }) }),
+  );
   return 0;
 }
 
 async function runTokenList(
   argv: readonly string[],
-  tokenStore: TokenStore,
+  client: SimlockAdminClient,
   environment: CliEnvironment,
 ): Promise<number> {
   const values = commandArgs(argv, { help: { type: "boolean", short: "h" } });
@@ -799,14 +1064,13 @@ async function runTokenList(
     environment.stdout.write("Usage: simlock token list\n");
     return 0;
   }
-  const records = await tokenStore.list();
-  writeResult(environment, { tokens: records.map(serializeToken) });
+  writeResult(environment, await client.listTokens());
   return 0;
 }
 
 async function runTokenRevoke(
   argv: readonly string[],
-  tokenStore: TokenStore,
+  client: SimlockAdminClient,
   environment: CliEnvironment,
 ): Promise<number> {
   const values = commandArgs(argv, { help: { type: "boolean", short: "h" } });
@@ -815,39 +1079,14 @@ async function runTokenRevoke(
     return 0;
   }
   const id = requiredPositional(values.positionals, "token-id");
-  if (!(await tokenStore.revoke(id)))
-    throw new TokenCliError("UNKNOWN_TOKEN", `Unknown token: ${id}`);
-  writeResult(environment, { revoked: true });
+  writeResult(environment, await client.revokeToken({ id }));
   return 0;
 }
 
-function parseTokenRole(value: unknown): TokenRole {
+function parseTokenRole(value: unknown): "agent" | "operator" {
   if (value !== "agent" && value !== "operator")
     throw new UsageError(withHelpHint("token create requires --role <agent|operator>"));
   return value;
-}
-
-/** Drops `hash` -- an implementation detail no CLI output needs to expose. */
-function serializeToken(record: TokenRecord): Record<string, unknown> {
-  return {
-    createdAt: record.createdAt,
-    id: record.id,
-    ...(record.label === undefined ? {} : { label: record.label }),
-    role: record.role,
-  };
-}
-
-async function requestOnce(
-  environment: CliEnvironment,
-  type: string,
-  payload: unknown,
-): Promise<unknown> {
-  const connection = await environment.connect();
-  try {
-    return await connection.request(type, payload);
-  } finally {
-    await connection.close();
-  }
 }
 
 function commandArgs(
@@ -860,181 +1099,6 @@ function commandArgs(
   } catch (error: unknown) {
     throw new UsageError(errorMessage(error));
   }
-}
-
-function leaseResult(value: unknown): Record<string, unknown> & { readonly lease: string } {
-  const grant = parseRawLeaseGrant(value);
-  return {
-    // Optional: undefined only for a device leased straight out of a pre-address `state.json`
-    // without ever rebooting under this daemon -- see `DeviceRecord.address` in domain.ts.
-    ...(grant.device.address === undefined ? {} : { address: grant.device.address }),
-    device: grant.device.spec.model,
-    expires_at_ms: grant.lease.ttlDeadline,
-    lease: grant.lease.id,
-    os: grant.device.spec.osVersion,
-    platform: grant.device.spec.platform,
-    slim: grant.slim,
-    state: "leased",
-    timing: {
-      estimated_boot_ms: grant.timing.estimatedBootMs,
-      estimated_provision_ms: grant.timing.estimatedProvisionMs,
-      estimated_reclaim_ms: grant.timing.estimatedReclaimMs,
-      estimated_ready_ms: grant.timing.estimatedReadyMs,
-    },
-    udid: grant.device.driverDeviceId,
-  };
-}
-
-function progressLine(value: unknown): {
-  readonly event: string;
-  readonly eta_seconds?: number;
-  readonly queue_position?: number;
-} {
-  // ADR 0003 §8: `progress` pushes now wrap the stage payload under `progress`, alongside a
-  // `requestId` this CLI does not yet need (it never has more than one lease request in flight
-  // per connection).
-  const envelope = requireObject(value);
-  const progress = requireObject(envelope.progress);
-  if (progress.stage === "queued" && typeof progress.queuePosition === "number") {
-    return { event: "queued", queue_position: progress.queuePosition };
-  }
-  if (
-    (progress.stage === "provisioning" ||
-      progress.stage === "booting" ||
-      progress.stage === "reclaiming") &&
-    typeof progress.etaMs === "number"
-  ) {
-    return { eta_seconds: Math.ceil(progress.etaMs / 1_000), event: progress.stage };
-  }
-  throw new Error("Daemon returned invalid progress");
-}
-
-/**
- * Writes one structured diagnostic line for a device-unhealthy/device-recovered push, mirroring
- * `progressLine`'s stderr shape. A malformed push is diagnostic noise, not fatal: the CLI's
- * stdout contract (exactly one JSON result line) must survive it, so parse failures are dropped
- * silently rather than thrown.
- */
-function writeDeviceHealthLine(
-  environment: CliEnvironment,
-  build: () => Record<string, unknown>,
-): void {
-  try {
-    environment.stderr.write(`${JSON.stringify(build())}\n`);
-  } catch {
-    // Ignore a malformed push.
-  }
-}
-
-function deviceUnhealthyLine(value: unknown): {
-  readonly device_id: string;
-  readonly event: "device_unhealthy";
-  readonly lease: string;
-} {
-  const notice = parseRawDeviceUnhealthy(value);
-  return { device_id: notice.deviceId, event: "device_unhealthy", lease: notice.leaseId };
-}
-
-function deviceRecoveredLine(value: unknown): {
-  readonly attempts: number;
-  readonly device_id: string;
-  readonly event: "device_recovered";
-  readonly lease: string;
-} {
-  const notice = parseRawDeviceRecovered(value);
-  return {
-    attempts: notice.attempts,
-    device_id: notice.deviceId,
-    event: "device_recovered",
-    lease: notice.leaseId,
-  };
-}
-
-function leaseLostLine(value: unknown): {
-  readonly device_id: string;
-  readonly event: "lease_lost";
-  readonly lease: string;
-  readonly reason: string;
-} {
-  const notice = parseRawLeaseLost(value);
-  return {
-    device_id: notice.deviceId,
-    event: "lease_lost",
-    lease: notice.leaseId,
-    reason: notice.reason,
-  };
-}
-
-// fallow-ignore-next-line complexity -- stable human status rendering is intentionally a single formatter.
-function formatStatus(status: Record<string, unknown>): string {
-  const devices = requireArray(status.devices);
-  const leases = requireArray(status.leases);
-  const queueDepth = typeof status.queueDepth === "number" ? status.queueDepth : 0;
-  const capacity = requireObject(status.capacity ?? {});
-  const global = requireObject(capacity.global ?? {});
-  const globalLine = `Running global: ${String(global.running ?? 0)} + ${String(global.reserved ?? 0)} reserved/${String(global.maxRunning ?? 0)}, warm ${String(global.warm ?? 0)}${global.overLimit === true ? " (over limit)" : ""}`;
-  const capacityLines = ["ios", "android"].map((platform) => {
-    const usage = requireObject(capacity[platform] ?? {});
-    return `Capacity ${platform}: managed ${String(usage.used ?? 0)}/${String(usage.limit ?? 0)}, running ${String(usage.running ?? 0)} + ${String(usage.reserved ?? 0)} reserved/${String(usage.maxRunning ?? 0)}, warm ${String(usage.warm ?? 0)}${usage.overLimit === true ? " (over limit)" : ""}`;
-  });
-  const deviceLines = devices.map((device) => {
-    const record = requireObject(device);
-    const markers = [
-      record.foreignStateDetectedAt === undefined ? undefined : "foreign state change",
-      record.foreignProvenanceDetectedAt === undefined ? undefined : "foreign provenance change",
-      record.state === "quarantined" ? quarantineMarker(record) : undefined,
-      typeof record.transitionAgeMs === "number"
-        ? `mid-transition ${record.transitionAgeMs}ms`
-        : undefined,
-    ].filter((marker) => marker !== undefined);
-    const suffix = markers.length === 0 ? "" : ` (${markers.join(", ")})`;
-    return `Device ${String(record.id)}: ${String(record.state)}${suffix}`;
-  });
-  const leaseLines = leases.map((lease) => {
-    const record = requireObject(lease);
-    const heartbeatSuffix =
-      typeof record.lastHeartbeatAt === "number"
-        ? `, last heartbeat ${String(record.lastHeartbeatAt)}`
-        : "";
-    return `Lease ${String(record.id)}: ${String(record.requesterId)} since ${String(record.grantedAt)}${heartbeatSuffix}`;
-  });
-  return [
-    `Daemon: ${typeof status.health === "string" ? status.health : "running"}`,
-    globalLine,
-    ...capacityLines,
-    ...deviceLines,
-    ...leaseLines,
-    `Queue depth: ${queueDepth}`,
-  ].join("\n");
-}
-
-/** Surfaces retry progress for a quarantined device instead of leaving it as a bare state name. */
-function quarantineMarker(record: Record<string, unknown>): string {
-  const attempts = typeof record.quarantineAttempts === "number" ? record.quarantineAttempts : 0;
-  const nextRetryAt =
-    typeof record.quarantineNextRetryAt === "number"
-      ? `, next retry at ${String(record.quarantineNextRetryAt)}`
-      : "";
-  return `purge retry ${attempts}${nextRetryAt}`;
-}
-
-function formatCatalog(response: Record<string, unknown>): string {
-  const platforms = requireArray(response.platforms);
-  if (platforms.length === 0) return "No platforms available.";
-  return platforms
-    .map((entry) => {
-      const record = requireObject(entry);
-      const models = requireArray(record.models).map(String);
-      const runtimes = requireArray(record.runtimes).map(String);
-      const defaultRuntime =
-        typeof record.defaultRuntime === "string" ? record.defaultRuntime : "(none)";
-      return [
-        `Platform: ${String(record.platform)}`,
-        `  Models: ${models.length > 0 ? models.join(", ") : "(none)"}`,
-        `  Runtimes: ${runtimes.length > 0 ? runtimes.join(", ") : "(none)"} (default: ${defaultRuntime})`,
-      ].join("\n");
-    })
-    .join("\n");
 }
 
 function requiredPositional(positionals: readonly string[], label: string): string {
@@ -1072,6 +1136,7 @@ function parseConfigValue(value: string): unknown {
     return value;
   }
 }
+
 /**
  * Reads the rotated generation (if present) followed by the current log, so a fatal
  * crash written just before rotation is never silently lost. `NodeFileLogSink` keeps
@@ -1092,13 +1157,70 @@ function requireObject(value: unknown): Record<string, unknown> {
     throw new Error("Daemon returned an invalid response");
   return value as Record<string, unknown>;
 }
-function requireArray(value: unknown): unknown[] {
-  if (!Array.isArray(value)) throw new Error("Daemon returned an invalid response");
-  return value;
-}
+
 function writeResult(environment: CliEnvironment, value: unknown): void {
   environment.stdout.write(`${JSON.stringify(value)}\n`);
 }
+
+// fallow-ignore-next-line complexity -- stable human status rendering is intentionally a single formatter.
+function formatStatus(status: StatusGetOutput): string {
+  const { capacity, devices, health, leases, queueDepth } = status;
+  const globalLine = `Running global: ${capacity.global.running} + ${capacity.global.reserved} reserved/${capacity.global.maxRunning}, warm ${capacity.global.warm}${capacity.global.overLimit ? " (over limit)" : ""}`;
+  const capacityLines = (["ios", "android"] as const).map((platform) => {
+    const usage = capacity[platform];
+    return `Capacity ${platform}: managed ${usage.used}/${usage.limit}, running ${usage.running} + ${usage.reserved} reserved/${usage.maxRunning}, warm ${usage.warm}${usage.overLimit ? " (over limit)" : ""}`;
+  });
+  const deviceLines = devices.map((device) => {
+    const markers = [
+      device.foreignStateDetectedAt === undefined ? undefined : "foreign state change",
+      device.foreignProvenanceDetectedAt === undefined ? undefined : "foreign provenance change",
+      device.state === "quarantined" ? quarantineMarker(device) : undefined,
+      device.transitionAgeMs === undefined
+        ? undefined
+        : `mid-transition ${device.transitionAgeMs}ms`,
+    ].filter((marker) => marker !== undefined);
+    const suffix = markers.length === 0 ? "" : ` (${markers.join(", ")})`;
+    return `Device ${device.id}: ${device.state}${suffix}`;
+  });
+  const leaseLines = leases.map((lease) => {
+    const heartbeatSuffix =
+      lease.lastHeartbeatAt === undefined ? "" : `, last heartbeat ${lease.lastHeartbeatAt}`;
+    return `Lease ${lease.id}: ${lease.requesterId} since ${lease.grantedAt}${heartbeatSuffix}`;
+  });
+  return [
+    `Daemon: ${health}`,
+    globalLine,
+    ...capacityLines,
+    ...deviceLines,
+    ...leaseLines,
+    `Queue depth: ${queueDepth}`,
+  ].join("\n");
+}
+
+/** Surfaces retry progress for a quarantined device instead of leaving it as a bare state name. */
+function quarantineMarker(device: StatusGetOutput["devices"][number]): string {
+  const attempts = device.quarantineAttempts ?? 0;
+  const nextRetryAt =
+    device.quarantineNextRetryAt === undefined
+      ? ""
+      : `, next retry at ${device.quarantineNextRetryAt}`;
+  return `purge retry ${attempts}${nextRetryAt}`;
+}
+
+function formatCatalog(response: CatalogGetOutput): string {
+  if (response.platforms.length === 0) return "No platforms available.";
+  return response.platforms
+    .map((entry) => {
+      const defaultRuntime = entry.defaultRuntime ?? "(none)";
+      return [
+        `Platform: ${entry.platform}`,
+        `  Models: ${entry.models.length > 0 ? entry.models.join(", ") : "(none)"}`,
+        `  Runtimes: ${entry.runtimes.length > 0 ? entry.runtimes.join(", ") : "(none)"} (default: ${defaultRuntime})`,
+      ].join("\n");
+    })
+    .join("\n");
+}
+
 /**
  * Resolves on SIGINT, SIGTERM, or (when `parentWatch`/`parentPid` are given)
  * the watched parent dying -- all three converge on the same `finish`, so a

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,0 +1,76 @@
+/**
+ * `simlock/client` (ADR 0003 §10). The one supported way for a host process to allocate
+ * devices over the daemon's unix socket without spawning a command. No reconnect, no retry --
+ * see `../simlock-client/client.ts`'s module comment for why.
+ *
+ * This module (and `simlock/admin`) is the entire public surface: everything it exports is
+ * derived from `src/contract`'s zod schemas, never a core-private type
+ * (`DeviceRecord`/`LeaseRecord`/`LeaseGrant`-the-core-type stay inside the daemon) -- see
+ * `no-core-leak.test.ts`.
+ */
+import { NodeIpcTransport, type IpcConnection, type IpcConnector } from "../ports/index.js";
+import {
+  connectSimlockClient,
+  type ConnectOptions,
+  type SimlockClient,
+} from "../simlock-client/client.js";
+
+export type {
+  AnySimlockError,
+  CatalogGetInput,
+  CatalogGetOutput,
+  DeviceRecoveredPush,
+  DeviceUnhealthyPush,
+  DoctorReport,
+  DoctorRunInput,
+  LeaseCancelInput,
+  LeaseCancelOutput,
+  LeaseGrant,
+  LeaseHeartbeatOutput,
+  LeaseListOutput,
+  LeaseLostPush,
+  LeaseProgress,
+  LeaseReleaseInput,
+  LeaseReleaseOutput,
+  LeaseRenewInput,
+  LeaseRecord,
+  LeaseRequestInput,
+  RequestLeaseOptions,
+  SimlockClient,
+  SimlockErrorCode,
+  StatusGetOutput,
+} from "../simlock-client/client.js";
+export { isSimlockError, SimlockError } from "../simlock-client/client.js";
+
+/** A caller-facing subset of `ConnectOptions` -- `credential` is deliberately not accepted
+ * here (ADR §10: "the split is by import path"). Use `connectSimlockAdmin` from
+ * `simlock/admin` for an admin-role connection. */
+export interface ConnectSimlockOptions {
+  /** A pre-connected transport -- mainly for tests (a scripted `IpcConnection`). Exactly one of
+   * `connection`/`endpoint` must be given. */
+  readonly connection?: IpcConnection;
+  /** The daemon's unix socket path. Connected via `ipc` (defaults to the real
+   * `NodeIpcTransport`) when `connection` is not given directly. */
+  readonly endpoint?: string;
+  readonly ipc?: IpcConnector;
+  readonly principal?: string;
+  readonly heartbeat?: boolean;
+}
+
+/** Opens one connection to the daemon and completes the `hello` handshake as an agent-role
+ * session. Rejects with a `SimlockError` (`PROTOCOL_VERSION_UNSUPPORTED`,
+ * `ADMIN_AUTHENTICATION_FAILED` never applies here since no credential is sent,
+ * `DAEMON_CONNECTION_LOST` if the socket cannot be reached) without ever restarting the
+ * daemon -- see `docs/adr/0003-...md` §6. */
+export async function connectSimlock(options: ConnectSimlockOptions): Promise<SimlockClient> {
+  const resolved: ConnectOptions = {
+    ...(options.connection === undefined ? {} : { connection: options.connection }),
+    ...(options.connection === undefined
+      ? { connector: options.ipc ?? new NodeIpcTransport() }
+      : {}),
+    ...(options.endpoint === undefined ? {} : { endpoint: options.endpoint }),
+    ...(options.principal === undefined ? {} : { principal: options.principal }),
+    ...(options.heartbeat === undefined ? {} : { heartbeat: options.heartbeat }),
+  };
+  return connectSimlockClient(resolved, false);
+}

--- a/src/client/smoke.test.ts
+++ b/src/client/smoke.test.ts
@@ -1,0 +1,62 @@
+/**
+ * ADR 0003 §12: "one smoke test per frontend (CLI, MCP, HTTP, client)". This walks
+ * `connectSimlock` end to end against a scripted connection: handshake, one full lease
+ * lifecycle (request -> grant -> release), and clean disconnect. It deliberately does not
+ * re-walk every operation -- `src/simlock-client/client.test.ts` already covers push routing,
+ * abort, and error mapping in depth; this file only proves the frontend wiring holds together.
+ */
+import { describe, expect, it } from "vitest";
+
+import { completeHello, ScriptedConnection } from "../simlock-client/test-support.js";
+import { connectSimlock } from "./index.js";
+
+describe("simlock/client smoke test", () => {
+  it("connects, requests a lease, and releases it", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection, principal: "agent-smoke" });
+    await Promise.resolve();
+    completeHello(connection, { role: "agent" });
+    const client = await connectPromise;
+    expect(client.role).toBe("agent");
+
+    const leasePromise = client.requestLease({ model: "iPhone 17", platform: "ios" });
+    await Promise.resolve();
+    const requestFrame = connection.lastSentOf("lease.request")!;
+    connection.reply(requestFrame.id, {
+      device: {
+        createdAt: 0,
+        driverData: null,
+        driverDeviceId: "sim-1",
+        id: "device_1",
+        spec: { model: "iPhone 17", osVersion: "18.0", platform: "ios" },
+        state: "leased",
+      },
+      lease: {
+        deviceId: "device_1",
+        grantedAt: 0,
+        id: "lease_1",
+        mode: "held",
+        ownerId: "agent-smoke",
+        requesterId: "agent-smoke",
+        ttlDeadline: 1_000,
+      },
+      timing: {
+        estimatedBootMs: 1,
+        estimatedProvisionMs: 1,
+        estimatedReadyMs: 1,
+        estimatedReclaimMs: 1,
+      },
+    });
+    const grant = await leasePromise;
+    expect(grant.lease.id).toBe("lease_1");
+
+    const releasePromise = client.releaseLease({ leaseId: grant.lease.id });
+    await Promise.resolve();
+    const releaseFrame = connection.lastSentOf("lease.release")!;
+    connection.reply(releaseFrame.id, { leaseId: "lease_1" });
+    await expect(releasePromise).resolves.toEqual({ leaseId: "lease_1" });
+
+    await client.close();
+    expect(connection.closed).toBe(true);
+  });
+});

--- a/src/contract/errors.ts
+++ b/src/contract/errors.ts
@@ -64,6 +64,12 @@ export interface ErrorDetailsMap {
    * daemon) wraps as this instead of throwing a parse failure. Never sent by a daemon this
    * version of the contract can produce -- purely a client-side wrapping target. */
   UNKNOWN_DAEMON_ERROR: { readonly code: string; readonly message: string };
+
+  /** ADR §10: the outcome `requestLease`'s `AbortSignal` surfaces for all four abort paths.
+   * Never sent by the daemon over the wire -- purely a client-side construction, the same way
+   * `UNKNOWN_DAEMON_ERROR` is. Kept in the closed set (rather than a separate ad hoc class) so
+   * callers can `isSimlockError(e) && e.code === "CANCELLED"` exactly like any other outcome. */
+  CANCELLED: Record<string, never>;
 }
 
 export type SimlockErrorCode = keyof ErrorDetailsMap;
@@ -156,6 +162,10 @@ export const ERROR_TABLE: { readonly [Code in SimlockErrorCode]: ErrorTableEntry
     cliExitCode: 1,
     httpStatus: 500,
   },
+  // Never sent over the wire (see the field comment on `ErrorDetailsMap.CANCELLED`); the
+  // `httpStatus` follows the conventional "client closed request" code even though HTTP never
+  // actually produces this error today.
+  CANCELLED: { code: "CANCELLED", kind: "domain", cliExitCode: 1, httpStatus: 499 },
 };
 
 /**

--- a/src/contract/operations.ts
+++ b/src/contract/operations.ts
@@ -124,6 +124,20 @@ export const leaseRequest = defineOperation({
   role: "agent",
   input: leaseRequestInputSchema,
   output: leaseGrantSchema,
+  /**
+   * Deliberately no `authorize` hook, and not an oversight to pair with `lease.cancel`'s: ADR
+   * §4 is explicit that any agent session may request a lease under an arbitrary
+   * `requesterId` -- that is the whole mechanism behind "one connection (the host, acting as
+   * a proxy for many agents) holds many leases by passing one requester id per session". The
+   * lease's actual `ownerId` is never client-supplied (always `session.principal`, see the
+   * dispatcher's `#leaseRequest`), so this does not let one session take over another's
+   * lease -- only choose the attribution label on a lease it will itself own. `lease.cancel`
+   * used to look inconsistent next to this (forbidding a `requesterId` that did not equal the
+   * principal, on an operation that has none of `lease.request`'s ownership protection to
+   * begin with) -- fixed by gating `lease.cancel` on the pending request's recorded owner
+   * (`pendingRequestOwner`, see its own `authorize` hook below) instead, which is consistent
+   * with this operation's design rather than in tension with it.
+   */
 });
 
 // ---- lease.cancel (new, ADR §9) --------------------------------------------------------------
@@ -135,16 +149,25 @@ export const leaseCancel = defineOperation({
   input: z.object({ requesterId: z.string().optional() }),
   output: z.object({ result: z.enum(["cancelled", "not-found", "not-cancellable"]) }),
   /**
-   * ADR §9: "cancels this principal's pending request by requester id" -- not any pending
-   * request, keyed by a `requesterId` the caller can pass arbitrarily. Deliberately not
-   * `ownsLease` (that hook resolves a *lease's* recorded `ownerId` from the registry; a
-   * pending, not-yet-granted request has no lease yet to look up). `requesterId` defaults to
-   * the principal the same way the handler's own default does (see `dispatcher.ts`'s
-   * `#leaseCancel`), so an omitted `requesterId` always passes -- only an explicit, *different*
-   * `requesterId` is gated, and only admin may supply one.
+   * ADR §9: "cancels this principal's pending request by requester id". Gated on the pending
+   * request's *recorded owner* (`pendingRequestOwner`, ADR §4's `ownerId` -- always the
+   * creating session's principal, never the caller-suppliable `requesterId`), not on comparing
+   * `requesterId` to the principal directly -- that comparison would forbid exactly the case
+   * ADR §4 exists for: one connection (`principal: "host"`) proxying many agents, each under
+   * its own `requesterId` (`"agent-7"`). Deliberately not `ownsLease` (that hook resolves a
+   * *lease's* recorded `ownerId` from the registry; a pending, not-yet-granted request has no
+   * lease yet to look up -- `pendingRequestOwner` is the wait-queue equivalent). An omitted
+   * `requesterId` defaults to the principal the same way the handler's own default does (see
+   * `dispatcher.ts`'s `#leaseCancel`), so it always resolves to a request this principal owns.
+   * A `requesterId` with no pending request resolves `pendingRequestOwner` to `undefined`,
+   * which is treated as authorized (same convention as `ownsLease`) so the handler's own
+   * `not-found` surfaces instead of a misleading `FORBIDDEN`.
    */
-  authorize: (input, context) =>
-    context.role === "admin" || (input.requesterId ?? context.principal) === context.principal,
+  authorize: (input, context) => {
+    if (context.role === "admin") return true;
+    const owner = context.pendingRequestOwner(input.requesterId ?? context.principal);
+    return owner === undefined || owner === context.principal;
+  },
 });
 
 // ---- lease.renew ----------------------------------------------------------------------------

--- a/src/contract/protocol.ts
+++ b/src/contract/protocol.ts
@@ -86,10 +86,17 @@ export const helloRequestSchema = z
  * What the daemon replies with. `role` is declared now (every field a client will eventually
  * need to assert it got what it asked for, per ADR §5) but is a fixed value until PR 2 resolves
  * it from a real credential -- see `DaemonServer#handleHello`.
+ *
+ * `principal` is the connection's resolved, fixed-for-its-lifetime identity (ADR §4): what a
+ * `hello` request supplied, or the daemon's own default (today: `defaultRequesterId`) when it
+ * omitted one. Without this the client cannot learn its own principal in that fallback case, and
+ * would otherwise have to guess -- see the abort-authorization defect this closes in
+ * `simlock-client/client.ts`.
  */
 export const helloReplySchema = z.object({
   protocolVersion: z.number().int(),
   daemonProtocolRange: protocolRangeSchema,
   version: z.string(),
   role: z.enum(["agent", "admin"]),
+  principal: z.string(),
 });

--- a/src/contract/roles.ts
+++ b/src/contract/roles.ts
@@ -20,6 +20,16 @@ export interface AuthorizeContext {
   readonly principal: string;
   readonly role: Role;
   readonly ownerId: (id: string) => string | undefined;
+  /** ADR §4/§9: the session principal that created the pending request identified by
+   * `requesterId` -- looked up against the live wait queue, the same "lookup, not a value"
+   * shape as `ownerId` above and for the same reason (the only identifier available at
+   * `authorize` time is whatever the input schema already validated). Used by `lease.cancel`
+   * so a proxy connection (one principal, many `requesterId`s) can cancel what it created,
+   * rather than comparing the caller-suppliable `requesterId` to the principal directly.
+   * Returns `undefined` for a `requesterId` with no pending request, which `lease.cancel`'s
+   * `authorize` hook treats as authorized on purpose -- same convention as `ownsLease` -- so
+   * the handler's own `not-found` surfaces instead of a misleading `FORBIDDEN`. */
+  readonly pendingRequestOwner: (requesterId: string) => string | undefined;
 }
 
 /**

--- a/src/contract/schemas.test.ts
+++ b/src/contract/schemas.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import { grantedDeviceSchema, leaseGrantSchema } from "./schemas.js";
+
+/**
+ * Regression coverage for the defect fixed alongside ADR 0003 §1: a lease grant's device must
+ * never carry core-private, driver-internal, or quarantine/recovery bookkeeping fields --
+ * `driverData`, `state`, `createdAt`, any `quarantine*` field, any `foreign*` field, or
+ * `recovering*`/`recoveryAttempts`. Those stay exclusive to `deviceRecordSchema`, used only by
+ * the admin-only `list.get`/`status.get` operations.
+ *
+ * This asserts the behavior a caller of `simlock/client`/`simlock/admin` actually sees, not an
+ * implementation detail: `leaseGrantSchema.parse` is exactly what `DaemonDispatcher#dispatch`'s
+ * `#parseOutput` runs a grant through before it reaches any transport, and zod's default
+ * "strip unknown keys" object mode is what performs the core-record -> contract-type mapping
+ * for the device on a grant.
+ */
+describe("leaseGrantSchema's device projection", () => {
+  const internalDeviceFields = [
+    "driverData",
+    "state",
+    "createdAt",
+    "lastLeaseEndedAt",
+    "foreignStateDetectedAt",
+    "foreignProvenanceDetectedAt",
+    "recoveringSince",
+    "recoveryAttempts",
+    "quarantinedAt",
+    "quarantineAttempts",
+    "quarantineNextRetryAt",
+    "transitionAgeMs",
+  ] as const;
+
+  /** A device shaped like a full core `DeviceRecord` mid-quarantine, exactly the kind of
+   * payload a real `LeaseGrant` from `core`'s lease engine would carry into `#parseOutput`. */
+  function fullCoreShapedDevice(): Record<string, unknown> {
+    return {
+      id: "device-1",
+      driverDeviceId: "SIM-1",
+      spec: { platform: "ios", model: "iPhone 17 Pro", osVersion: "26.5" },
+      state: "quarantined",
+      driverData: { udid: "SIM-1", secretDriverInternals: true },
+      createdAt: 0,
+      lastLeaseEndedAt: 10,
+      foreignStateDetectedAt: 20,
+      foreignProvenanceDetectedAt: 30,
+      recoveringSince: 40,
+      recoveryAttempts: 2,
+      quarantinedAt: 50,
+      quarantineAttempts: 3,
+      quarantineNextRetryAt: 60,
+      address: "127.0.0.1:1234",
+      featureProfile: "reduced",
+      transitionAgeMs: 70,
+    };
+  }
+
+  it("strips every internal DeviceRecord field off a grant's device", () => {
+    const grant = leaseGrantSchema.parse({
+      device: fullCoreShapedDevice(),
+      lease: {
+        id: "lease-1",
+        deviceId: "device-1",
+        requesterId: "req",
+        ownerId: "req",
+        mode: "held",
+        grantedAt: 0,
+        ttlDeadline: 1000,
+      },
+      timing: {
+        estimatedProvisionMs: 0,
+        estimatedBootMs: 0,
+        estimatedReclaimMs: 0,
+        estimatedReadyMs: 0,
+      },
+    });
+
+    for (const field of internalDeviceFields) {
+      expect(grant.device).not.toHaveProperty(field);
+    }
+    expect(grant.device).toEqual({
+      id: "device-1",
+      driverDeviceId: "SIM-1",
+      spec: { platform: "ios", model: "iPhone 17 Pro", osVersion: "26.5" },
+      address: "127.0.0.1:1234",
+      featureProfile: "reduced",
+    });
+  });
+
+  it("rejects a device object that is missing the fields a grant must keep", () => {
+    expect(() => grantedDeviceSchema.parse({ id: "device-1" })).toThrow();
+  });
+
+  it("keeps id, driverDeviceId, spec, and the optional address/featureProfile", () => {
+    const parsed = grantedDeviceSchema.parse({
+      id: "device-1",
+      driverDeviceId: "SIM-1",
+      spec: { platform: "android", model: "Pixel 8", osVersion: "34" },
+    });
+    expect(parsed).toEqual({
+      id: "device-1",
+      driverDeviceId: "SIM-1",
+      spec: { platform: "android", model: "Pixel 8", osVersion: "34" },
+    });
+  });
+});

--- a/src/contract/schemas.ts
+++ b/src/contract/schemas.ts
@@ -5,7 +5,11 @@
  * `DeviceRecord`, `LeaseRecord`, `Config`, `DoctorFinding`, `Proposal`, `EventEnvelope`, and so
  * on are core-private types. Re-declaring their fields here, by hand, is exactly what keeps
  * private domain records off the public package surface (the daemon maps its own records onto
- * these shapes in exactly one place -- `src/daemon/server.ts`). If a core type's shape changes
+ * these shapes in exactly one place -- `DaemonDispatcher#dispatch`'s `#parseOutput` call in
+ * `src/daemon/dispatcher.ts`, which parses every handler's result through the operation's
+ * output schema before it reaches a transport, stripping any field (such as `DeviceRecord`'s
+ * quarantine/foreign/recovery bookkeeping) that a narrower output schema like
+ * `grantedDeviceSchema` does not declare). If a core type's shape changes
  * without a matching edit here, that is a compile-time or (for shapes structurally compatible
  * but semantically different) a runtime output-validation failure at the daemon boundary --
  * see `DaemonServer`'s output parsing -- not a silent drift.
@@ -60,6 +64,45 @@ export const deviceRecordSchema = z.object({
   transitionAgeMs: z.number().optional(),
 });
 
+/**
+ * The device a `lease.request`/`lease.renew` grant carries -- deliberately narrower than
+ * `deviceRecordSchema` (ADR 0003 §1: "the daemon maps [core records] onto contract types in
+ * exactly one place"). A grant is agent-facing, not an admin inspection of the registry, so it
+ * carries only what a caller needs to drive the device it was just handed:
+ *
+ * - `id`: the lease-facing device identity (what `lease.list`/`lease.renew` correlate against).
+ * - `driverDeviceId`: the driver address a caller actually drives (simctl UDID / adb serial).
+ * - `spec`, `address`, `featureProfile`: same meanings as on `DeviceRecord` (src/core/domain.ts).
+ *
+ * Everything else on `DeviceRecord` -- `driverData` (opaque driver-private blob), `state`,
+ * `createdAt`, every `quarantine*`/`foreign*`/`recovering*` field, and the `status`/`list`
+ * decoration's `transitionAgeMs` -- is internal reclamation/health bookkeeping a grant recipient
+ * has no business seeing, and stays off this shape. `list.get`/`status.get` (admin-only) still
+ * return the full `deviceRecordSchema` -- an operator inspecting the registry legitimately wants
+ * the whole record.
+ */
+export const grantedDeviceSchema = z.object({
+  id: z.string(),
+  driverDeviceId: z.string(),
+  spec: deviceSpecSchema,
+  /**
+   * The driver-reported address (see `DriverDevice.address`), current as of this device's
+   * last `ready` transition. Undefined for a device still `provisioning` (never made ready
+   * yet) and, as an upgrade path, for a record written by a pre-address daemon -- `state.json`
+   * from before this field existed loads without one rather than failing to start. It becomes
+   * defined the next time the device is made ready (`boot`/`readyProvisioned`); nothing here
+   * ever guesses at a value it wasn't told.
+   */
+  address: z.string().optional(),
+  /**
+   * Mirrors `DriverDevice.featureProfile` (see `driver.ts`), current as of this device's last
+   * `ready` transition. Undefined for a device still `provisioning` (never made ready yet)
+   * and for any driver that does not reduce anything -- today's behaviour, and every non-iOS
+   * driver.
+   */
+  featureProfile: featureProfileSchema.optional(),
+});
+
 export const leaseModeSchema = z.enum(["held", "detached"]);
 
 /**
@@ -87,7 +130,7 @@ const leaseTimingSchema = z.object({
 });
 
 export const leaseGrantSchema = z.object({
-  device: deviceRecordSchema,
+  device: grantedDeviceSchema,
   lease: leaseRecordSchema,
   timing: leaseTimingSchema,
 });

--- a/src/core/lease-acquisition-coordinator.ts
+++ b/src/core/lease-acquisition-coordinator.ts
@@ -124,6 +124,21 @@ export class LeaseAcquisitionCoordinator implements AcquisitionMaintenance {
     return this.options.queue.depth;
   }
 
+  /**
+   * The session principal a pending request was created under (ADR §4: `ownerId` on
+   * `LeaseRequestOptions`, always the session principal, never the caller-suppliable
+   * `requesterId`). `undefined` when no pending request exists for this requester id --
+   * `cancelPending`'s own `not-found` outcome is what surfaces that, not this lookup, so a
+   * caller cancelling a request that already settled (or never existed) is not authorized on
+   * a manufactured owner. A synchronous read like `queueDepth`, not routed through
+   * `decisions.run`: no state is asserted or mutated, and `#leaseCancel`'s contract-level
+   * `authorize` hook (ADR §2 step 3) runs before the handler, so it cannot go through the
+   * handler's own serialized decision anyway.
+   */
+  pendingRequestOwner(requesterId: string): string | undefined {
+    return this.options.queue.findPendingWaiter(requesterId)?.options.ownerId;
+  }
+
   get queueHeadSpec(): DeviceSpec | undefined {
     return (this.options.queue.head as AcquisitionWaiter | undefined)?.spec;
   }

--- a/src/core/lease-engine.ts
+++ b/src/core/lease-engine.ts
@@ -321,6 +321,13 @@ export class LeaseEngine {
     return this.#acquisition.cancelPending(requesterId);
   }
 
+  /** The session principal that owns a pending request, for `lease.cancel`'s owner-aware
+   * `authorize` hook (ADR §4). See the coordinator method's own comment. */
+  // fallow-ignore-next-line unused-class-member -- reached through the QueueControl port by the dispatcher's authorize context (same as the sibling cancelPending).
+  pendingRequestOwner(requesterId: string): string | undefined {
+    return this.#acquisition.pendingRequestOwner(requesterId);
+  }
+
   // fallow-ignore-next-line unused-class-member -- reached through the LeaseCommands port by DaemonServer (same as the sibling heartbeat).
   async renew(leaseId: string, ttlMs?: number): Promise<LeaseRecord> {
     return this.#releaseCoordinator.renew(leaseId, ttlMs);

--- a/src/core/lease-ports.ts
+++ b/src/core/lease-ports.ts
@@ -22,6 +22,12 @@ export interface QueueControl {
   readonly queueDepth: number;
   detachQueuedProgress(requesterId: string): Promise<void>;
   cancelPending(requesterId: string): Promise<"cancelled" | "not-found" | "not-cancellable">;
+  /** ADR §4: the session principal a pending request was created under -- always the creating
+   * session's principal (`LeaseRequestOptions.ownerId`), never the caller-suppliable
+   * `requesterId`. `undefined` when no pending request exists for this requester id. Used by
+   * `lease.cancel`'s `authorize` hook so a proxy connection (one principal, many
+   * `requesterId`s) can cancel what it created, per ADR §4/§9. */
+  pendingRequestOwner(requesterId: string): string | undefined;
 }
 
 /** Read-only capacity view used by daemon status. */

--- a/src/daemon/dispatcher.test.ts
+++ b/src/daemon/dispatcher.test.ts
@@ -9,7 +9,13 @@ import {
   Registry,
   type Config,
 } from "../core/index.js";
-import { FakeClock, FakeSystemStats, MemoryFilesystem } from "../ports/index.js";
+import {
+  CryptoTokenSecrets,
+  FakeClock,
+  FakeSystemStats,
+  MemoryFilesystem,
+} from "../ports/index.js";
+import { TokenStore } from "../http/token-store.js";
 import type { DispatchSession } from "./dispatcher.js";
 import { Dispatcher, DispatchError } from "./dispatcher.js";
 
@@ -74,6 +80,13 @@ async function buildDispatcher(
     quarantine: engine,
     registry,
   });
+  const tokens = new TokenStore({
+    clock,
+    filesystem,
+    idGenerator: sequence(),
+    path: "/tokens.json",
+    secrets: new CryptoTokenSecrets(),
+  });
   const dispatcher = new Dispatcher({
     awaitReady: overrides.awaitReady ?? (() => Promise.resolve()),
     capacity: engine,
@@ -87,8 +100,9 @@ async function buildDispatcher(
     queue: engine,
     reaper,
     registry,
+    tokens,
   });
-  return { clock, dispatcher, driver, engine, eventBus, registry };
+  return { clock, dispatcher, driver, engine, eventBus, registry, tokens };
 }
 
 function session(overrides: Partial<DispatchSession> = {}): DispatchSession {
@@ -123,11 +137,48 @@ describe("Dispatcher: parsing", () => {
 
   it("rejects an operation this dispatcher has no handler for with UNKNOWN_REQUEST", async () => {
     const { dispatcher } = await buildDispatcher();
-    // "token.create" is a declared contract operation (ADR §11) with no daemon-side handler
-    // yet -- see `dispatcher.ts`'s class doc.
+    // "daemon.stop" is ADR §6's frozen exception -- `DaemonServer#dispatchLine` intercepts it
+    // before it ever reaches a `Dispatcher`, so this dispatcher genuinely has no handler for it.
     await expect(
-      dispatcher.dispatch("token.create", { role: "agent" }, session({ role: "admin" })),
+      dispatcher.dispatch("daemon.stop", {}, session({ role: "admin" })),
     ).rejects.toMatchObject({ code: "UNKNOWN_REQUEST" });
+  });
+});
+
+describe("Dispatcher: token.create | token.list | token.revoke", () => {
+  it("creates a token, lists it, then revokes it -- admin only", async () => {
+    const { dispatcher, tokens } = await buildDispatcher();
+    const admin = session({ role: "admin" });
+
+    await expect(
+      dispatcher.dispatch("token.create", { role: "agent" }, session({ role: "agent" })),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+    const created = await dispatcher.dispatch(
+      "token.create",
+      { role: "operator", label: "ci" },
+      admin,
+    );
+    expect(created.token.role).toBe("operator");
+    expect(created.token.label).toBe("ci");
+    expect(typeof created.secret).toBe("string");
+
+    const listed = await dispatcher.dispatch("token.list", {}, admin);
+    expect(listed.tokens.map((token) => token.id)).toEqual([created.token.id]);
+
+    const revoked = await dispatcher.dispatch("token.revoke", { id: created.token.id }, admin);
+    expect(revoked.revoked).toBe(true);
+    expect((await tokens.list()).length).toBe(0);
+  });
+
+  it("revoking an unknown token id returns revoked: false rather than throwing", async () => {
+    const { dispatcher } = await buildDispatcher();
+    const result = await dispatcher.dispatch(
+      "token.revoke",
+      { id: "tok_does-not-exist" },
+      session({ role: "admin" }),
+    );
+    expect(result.revoked).toBe(false);
   });
 });
 

--- a/src/daemon/dispatcher.test.ts
+++ b/src/daemon/dispatcher.test.ts
@@ -282,16 +282,19 @@ describe("Dispatcher: ownership", () => {
     expect(admin.leases).toHaveLength(1);
   });
 
-  it("lease.cancel: rejects an agent naming a different requesterId with FORBIDDEN, admits an admin", async () => {
+  it("lease.cancel: naming a requesterId with no pending request always passes (not-found), admin bypasses too", async () => {
     const { dispatcher } = await buildDispatcher();
 
+    // A requesterId nobody has a pending request under: not gated, since there is no owner to
+    // compare against -- `pendingRequestOwner` resolves `undefined`, and `not-found` is what
+    // surfaces (the same convention `ownsLease` uses for an unknown lease id).
     await expect(
       dispatcher.dispatch(
         "lease.cancel",
         { requesterId: "tok_other" },
         session({ principal: "tok_agent", role: "agent" }),
       ),
-    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    ).resolves.toMatchObject({ result: "not-found" });
 
     // An omitted requesterId always passes (defaults to the principal) -- see the operation's
     // `authorize` hook doc in `operations.ts`.
@@ -306,6 +309,74 @@ describe("Dispatcher: ownership", () => {
         session({ principal: "tok_admin", role: "admin" }),
       ),
     ).resolves.toMatchObject({ result: "not-found" });
+  });
+
+  it("lease.cancel: gated on the pending request's recorded owner (ADR §4), not the requesterId -- so a proxy connection can cancel what it created", async () => {
+    const { dispatcher, engine } = await buildDispatcher();
+
+    // Fill iOS capacity (maxRunning: 2, see testConfig) so a third request queues instead of
+    // granting immediately -- cancellability requires a still-`queued` waiter.
+    await dispatcher.dispatch(
+      "lease.request",
+      {
+        model: "iPhone 17 Pro",
+        mode: "detached",
+        requesterId: "tok_owner1",
+        osVersion: "26.5",
+        platform: "ios",
+      },
+      session({ principal: "tok_owner1" }),
+    );
+    await dispatcher.dispatch(
+      "lease.request",
+      {
+        model: "iPhone 17 Pro",
+        mode: "detached",
+        requesterId: "tok_owner2",
+        osVersion: "26.5",
+        platform: "ios",
+      },
+      session({ principal: "tok_owner2" }),
+    );
+
+    // ADR §4's proxy case: one connection, principal "host", requesting under a different
+    // requesterId ("agent-7") than its own principal.
+    const queuedRequest = dispatcher.dispatch(
+      "lease.request",
+      {
+        model: "iPhone 17 Pro",
+        mode: "held",
+        requesterId: "agent-7",
+        osVersion: "26.5",
+        platform: "ios",
+      },
+      session({ principal: "host" }),
+    );
+    await expect.poll(() => engine.queueDepth).toBe(1);
+
+    // Naming "agent-7" from a session that is neither "host" (the recorded owner) nor admin is
+    // FORBIDDEN, even though "agent-7" is the pending request's own requesterId -- the ADR
+    // incoherence this fixes: `lease.cancel` is no longer gated on `requesterId === principal`.
+    await expect(
+      dispatcher.dispatch(
+        "lease.cancel",
+        { requesterId: "agent-7" },
+        session({ principal: "tok_other", role: "agent" }),
+      ),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+    // The owning principal ("host") cancels what it created, under the requesterId it created
+    // it with -- this is the case the old `requesterId === principal` comparison forbade
+    // outright.
+    await expect(
+      dispatcher.dispatch(
+        "lease.cancel",
+        { requesterId: "agent-7" },
+        session({ principal: "host", role: "agent" }),
+      ),
+    ).resolves.toMatchObject({ result: "cancelled" });
+
+    await expect(queuedRequest).rejects.toThrow();
   });
 });
 

--- a/src/daemon/dispatcher.ts
+++ b/src/daemon/dispatcher.ts
@@ -221,6 +221,7 @@ export class Dispatcher {
       const context: AuthorizeContext = {
         ownerId: (leaseId) =>
           this.options.registry.snapshot.leases.find((lease) => lease.id === leaseId)?.ownerId,
+        pendingRequestOwner: (requesterId) => this.options.queue.pendingRequestOwner(requesterId),
         principal: session.principal,
         role: session.role,
       };

--- a/src/daemon/dispatcher.ts
+++ b/src/daemon/dispatcher.ts
@@ -31,6 +31,7 @@ import {
   type AuthorizeContext,
   type Role,
 } from "../contract/index.js";
+import type { TokenStore } from "../http/token-store.js";
 
 /**
  * ADR 0003 §2's "session" argument to `dispatch`. Constructed fresh per call by the transport
@@ -102,6 +103,13 @@ export interface DispatcherOptions {
   readonly queue: QueueControl;
   readonly reaper: CleanupReaper;
   readonly registry: Registry;
+  /**
+   * ADR 0003 §11: "token create|list|revoke become daemon operations. The daemon is the only
+   * owner of tokens.json." Optional so tests that don't exercise `token.*` (the overwhelming
+   * majority) don't need to fabricate one -- `#tokenCreate`/`#tokenList`/`#tokenRevoke` throw a
+   * clear `DispatchError` when it is missing rather than crashing on `undefined.create(...)`.
+   */
+  readonly tokens?: TokenStore;
   /** Reports current daemon health for `status.get`. */
   readonly health: () => "starting" | "running" | "failed";
   /**
@@ -174,8 +182,11 @@ export class Dispatcher {
       "events.replay": this.#eventsReplay,
       "events.subscribe": this.#eventsSubscribe,
       "events.unsubscribe": this.#eventsUnsubscribe,
-      // "daemon.stop" and "token.*" deliberately absent -- see the class comment; `DaemonServer`
-      // never calls `dispatch()` for a frame type this map has no entry for.
+      "token.create": this.#tokenCreate,
+      "token.list": this.#tokenList,
+      "token.revoke": this.#tokenRevoke,
+      // "daemon.stop" deliberately absent -- see the class comment; `DaemonServer` never calls
+      // `dispatch()` for a frame type this map has no entry for.
     };
   }
 
@@ -391,6 +402,29 @@ export class Dispatcher {
   };
 
   #configGet: Handler<"config.get"> = () => this.options.config;
+
+  /**
+   * ADR §11: the daemon is the only owner of `tokens.json` -- `TokenStore.create` never
+   * persists the plaintext `secret`, only its hash, exactly as it did when the CLI called it
+   * directly.
+   */
+  #tokenCreate: Handler<"token.create"> = async (input) => {
+    const { record, secret } = await this.#requireTokens().create(input.role, input.label);
+    return { secret, token: record };
+  };
+
+  #tokenList: Handler<"token.list"> = async () => ({ tokens: await this.#requireTokens().list() });
+
+  #tokenRevoke: Handler<"token.revoke"> = async (input) => ({
+    revoked: await this.#requireTokens().revoke(input.id),
+  });
+
+  #requireTokens(): TokenStore {
+    if (this.options.tokens === undefined) {
+      throw new DispatchError("INTERNAL", "Token store is unavailable");
+    }
+    return this.options.tokens;
+  }
 
   /**
    * Adds a derived `lastHeartbeatAt` for held leases, without a new `LeaseRecord` field: since

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -207,6 +207,7 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
     registry,
     resolveRole,
     adminSecret,
+    tokens,
     version: options.version ?? "1.0.0",
     // Runs after the socket is claimed (see DaemonServer#start): reachability no
     // longer depends on doctor reconciliation or running-capacity convergence.

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -1431,6 +1431,27 @@ describe("DaemonServer roles and ownership (ADR 0003 §2-4)", () => {
     await client.close();
   });
 
+  it("hello reports the resolved principal: the client-supplied one verbatim, or the daemon's default when omitted (ADR §4)", async () => {
+    const harness = await createHarness();
+
+    const explicit = await createClient(harness.socketPath);
+    const explicitReply = await explicit.request("hello", {
+      clientVersion: "test",
+      protocolVersion: DAEMON_PROTOCOL_VERSION,
+      principal: "host",
+    });
+    expect(explicitReply.payload).toMatchObject({ principal: "host" });
+    await explicit.close();
+
+    const omitted = await createClient(harness.socketPath);
+    const omittedReply = await omitted.request("hello", {
+      clientVersion: "test",
+      protocolVersion: DAEMON_PROTOCOL_VERSION,
+    });
+    expect(omittedReply.payload).toMatchObject({ principal: "test-process" });
+    await omitted.close();
+  });
+
   it("allows an admin session to call the same admin-only operation", async () => {
     const harness = await createHarness({ resolveRole: { resolve: () => "admin" } });
     const client = await createClient(harness.socketPath);

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -43,6 +43,7 @@ import {
   type Role,
 } from "../contract/index.js";
 import type { ConnectionHost } from "./connection-host.js";
+import type { TokenStore } from "../http/token-store.js";
 import {
   Dispatcher,
   DispatchError,
@@ -124,6 +125,8 @@ export interface DaemonServerOptions {
   readonly healthMonitor?: LeaseHealthMonitor;
   readonly nuke?: Nuke;
   readonly registry: Registry;
+  /** ADR 0003 §11: threaded straight into the `Dispatcher` for `token.create|list|revoke`. */
+  readonly tokens?: TokenStore;
   readonly version: string;
   /** ADR §5's seam (see `session.ts`): resolves a session's role from `hello`'s payload.
    * Defaults to `resolveAgentRole` (every session is "agent") -- PR 2's credential handshake
@@ -224,6 +227,7 @@ export class DaemonServer {
       queue: options.queue,
       reaper: options.reaper,
       registry: options.registry,
+      ...(options.tokens === undefined ? {} : { tokens: options.tokens }),
     });
   }
 
@@ -827,6 +831,16 @@ export class DaemonServer {
           frame.payload ?? {},
           this.#session(connection),
         );
+      case "token.create":
+        return this.#dispatcher.dispatch("token.create", frame.payload, this.#session(connection));
+      case "token.list":
+        return this.#dispatcher.dispatch(
+          "token.list",
+          frame.payload ?? {},
+          this.#session(connection),
+        );
+      case "token.revoke":
+        return this.#dispatcher.dispatch("token.revoke", frame.payload, this.#session(connection));
       // "daemon.stop" is deliberately absent from this switch: `#dispatchLine` intercepts it
       // itself, ahead of the protocol-mismatch and `#stopping` gates (ADR §6's frozen exception,
       // scoped to protocol version only -- still gated on a completed handshake and the `admin`

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -696,6 +696,11 @@ export class DaemonServer {
         daemonProtocolRange: this.#protocolRange,
         version: this.options.version,
         role: connection.role,
+        // ADR §4: report the resolved principal back -- see `helloReplySchema`'s comment. Read
+        // from `connection.principal`, set a few lines above from `payload.principal` or the
+        // daemon's own default, so this is always the same value every subsequent dispatched
+        // request is authorized against.
+        principal: connection.principal,
       },
       "hello",
     );

--- a/src/mcp/connect.ts
+++ b/src/mcp/connect.ts
@@ -1,0 +1,91 @@
+/**
+ * MCP's connection-lifecycle-only auto-launch (ADR 0003 §11: MCP keeps "connection lifecycle
+ * (lazy reconnect, tool-call serialization)"). `simlock/client`'s `connectSimlock` deliberately
+ * does not start the daemon itself -- it only ever connects to an already-listening socket
+ * (ADR §10: the client "does not reconnect and does not retry"). MCP is the one frontend spawned
+ * with no separate "start the daemon first" step, so it is the frontend that needs this, the
+ * same way `src/daemon-client/startup-coordinator.ts`'s `DaemonStartupCoordinator` gives the
+ * (now superseded, daemon-client-based) old MCP client this behaviour. That coordinator is not
+ * reused directly -- it is typed against `daemon-client`'s `DaemonConnector`/`DaemonConnection`,
+ * not `simlock-client`'s connection-less `connectSimlock` -- so the same launch-then-retry
+ * policy is re-implemented here, against the typed client, instead.
+ */
+import {
+  connectSimlock,
+  isSimlockError,
+  SimlockError,
+  type SimlockClient,
+} from "../client/index.js";
+import { IpcError, type Clock, type DaemonLauncher, type IpcConnector } from "../ports/index.js";
+
+export interface ConnectWithAutoLaunchOptions {
+  readonly clock: Clock;
+  readonly heartbeat?: boolean;
+  readonly ipc: IpcConnector;
+  readonly launcher: DaemonLauncher;
+  readonly principal: string;
+  readonly retryIntervalMs?: number;
+  readonly socketPath: string;
+  readonly startupTimeoutMs?: number;
+}
+
+/**
+ * Connects to the daemon, launching it first if nothing is listening yet. Never launches on
+ * any other failure -- a version mismatch or a refused handshake is not "nothing is running",
+ * and launching there would risk starting a second daemon instance or masking a real
+ * incompatibility (mirrors `DaemonStartupCoordinator#isUnavailable`'s reasoning: "the client
+ * never restarts the daemon on mismatch", ADR §6).
+ */
+export async function connectWithAutoLaunch(
+  options: ConnectWithAutoLaunchOptions,
+): Promise<SimlockClient> {
+  try {
+    return await attempt(options);
+  } catch (error: unknown) {
+    if (!isUnavailable(error)) throw error;
+  }
+  await options.launcher.launch();
+  const deadline = options.clock.now() + (options.startupTimeoutMs ?? 5_000);
+  let lastError: unknown;
+  while (options.clock.now() < deadline) {
+    try {
+      return await attempt(options);
+    } catch (error: unknown) {
+      if (!isUnavailable(error)) throw error;
+      lastError = error;
+      await delay(options.clock, options.retryIntervalMs ?? 50);
+    }
+  }
+  throw new SimlockError(
+    "DAEMON_STARTUP_FAILED",
+    "transport",
+    `Timed out starting simlock daemon: ${errorMessage(lastError)}`,
+    {},
+  );
+}
+
+function attempt(options: ConnectWithAutoLaunchOptions): Promise<SimlockClient> {
+  return connectSimlock({
+    endpoint: options.socketPath,
+    heartbeat: options.heartbeat ?? true,
+    ipc: options.ipc,
+    principal: options.principal,
+  });
+}
+
+/** True only for "nothing is listening yet" -- a refused/missing socket. */
+function isUnavailable(error: unknown): boolean {
+  return (
+    error instanceof IpcError &&
+    (error.code === "connection-refused" || error.code === "endpoint-not-found")
+  );
+}
+
+function delay(clock: Clock, milliseconds: number): Promise<void> {
+  return new Promise((resolve) => clock.setTimer(milliseconds, resolve));
+}
+
+function errorMessage(error: unknown): string {
+  if (isSimlockError(error)) return error.message;
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/mcp/contracts.test.ts
+++ b/src/mcp/contracts.test.ts
@@ -1,66 +1,75 @@
 import { describe, expect, it } from "vitest";
 
+import { OPERATIONS } from "../contract/index.js";
 import {
   leaseSimulatorInputSchema,
   leaseSimulatorOutputSchema,
-  MAX_TIMEOUT_SECONDS,
+  leaseStatusOutputSchema,
   releaseSimulatorInputSchema,
   releaseSimulatorOutputSchema,
 } from "./contracts.js";
 
 describe("MCP contracts", () => {
-  it("applies safe lease input defaults", () => {
-    expect(leaseSimulatorInputSchema.parse({ device: "iPhone 17 Pro", platform: "ios" })).toEqual({
-      allow_download: false,
-      device: "iPhone 17 Pro",
-      full: false,
-      no_wait: false,
+  it("accepts a minimal lease input and omits the session-controlled fields", () => {
+    expect(leaseSimulatorInputSchema.parse({ model: "iPhone 17 Pro", platform: "ios" })).toEqual({
+      model: "iPhone 17 Pro",
       platform: "ios",
     });
   });
 
-  it("accepts an explicit full: true lease input", () => {
-    expect(
-      leaseSimulatorInputSchema.parse({ device: "iPhone 17 Pro", full: true, platform: "ios" }),
-    ).toMatchObject({ full: true });
+  it("rejects requesterId, mode, and ttlMs -- those are the session's job, not the caller's", () => {
+    for (const extra of [{ requesterId: "someone-else" }, { mode: "detached" }, { ttlMs: 1_000 }]) {
+      expect(() =>
+        leaseSimulatorInputSchema.parse({ model: "iPhone 17 Pro", platform: "ios", ...extra }),
+      ).toThrow();
+    }
   });
 
-  it.each([
-    [{ device: "", platform: "ios" }],
-    [{ device: "Pixel", os: "", platform: "android" }],
-    [{ device: "Pixel", platform: "android", timeout_seconds: -1 }],
-    [{ device: "Pixel", platform: "android", timeout_seconds: Number.POSITIVE_INFINITY }],
-    [{ device: "Pixel", platform: "android", timeout_seconds: MAX_TIMEOUT_SECONDS + 1 }],
-  ])("rejects invalid lease inputs", (input) => {
-    expect(() => leaseSimulatorInputSchema.parse(input)).toThrow();
+  it("is the same schema the contract validates lease.request input against, minus those fields", () => {
+    const full = OPERATIONS["lease.request"].input.innerType();
+    expect(Object.keys(leaseSimulatorInputSchema.shape).sort()).toEqual(
+      Object.keys(full.shape)
+        .filter((key) => !["mode", "requesterId", "ttlMs"].includes(key))
+        .sort(),
+    );
   });
 
-  it("validates public success results", () => {
-    expect(
-      leaseSimulatorOutputSchema.parse({
-        device: "iPhone 17 Pro",
-        device_id: "ABCD",
-        expires_at_ms: 61_000,
-        lease_id: "lse_9f2c",
-        mode: "held",
-        os: "26.5",
-        platform: "ios",
-        slim: false,
+  it("validates a lease grant, release, and lease-status shape using contract field names", () => {
+    const grant = leaseSimulatorOutputSchema.parse({
+      device: {
+        createdAt: 0,
+        driverData: null,
+        driverDeviceId: "SIM-1",
+        id: "device-1",
+        spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
         state: "leased",
-        timing: {
-          estimated_boot_ms: 20,
-          estimated_provision_ms: 10,
-          estimated_reclaim_ms: 0,
-          estimated_ready_ms: 30,
-        },
-      }),
-    ).toMatchObject({ lease_id: "lse_9f2c", slim: false, state: "leased" });
-    expect(releaseSimulatorInputSchema.parse({ lease_id: "lse_9f2c" })).toEqual({
-      lease_id: "lse_9f2c",
+      },
+      lease: {
+        deviceId: "device-1",
+        grantedAt: 0,
+        id: "lease-1",
+        mode: "held",
+        ownerId: "mcp:1",
+        requesterId: "mcp:1",
+        ttlDeadline: 61_000,
+      },
+      timing: {
+        estimatedBootMs: 20,
+        estimatedProvisionMs: 10,
+        estimatedReadyMs: 30,
+        estimatedReclaimMs: 0,
+      },
     });
-    expect(releaseSimulatorOutputSchema.parse({ lease_id: "lse_9f2c", released: true })).toEqual({
-      lease_id: "lse_9f2c",
+    expect(grant.lease.id).toBe("lease-1");
+
+    expect(releaseSimulatorInputSchema.parse({ leaseId: "lease-1" })).toEqual({
+      leaseId: "lease-1",
+    });
+    expect(releaseSimulatorOutputSchema.parse({ leaseId: "lease-1", released: true })).toEqual({
+      leaseId: "lease-1",
       released: true,
     });
+
+    expect(leaseStatusOutputSchema.parse({ held: false })).toEqual({ held: false });
   });
 });

--- a/src/mcp/contracts.ts
+++ b/src/mcp/contracts.ts
@@ -1,106 +1,69 @@
+/**
+ * MCP tool schemas, derived from the contract's operation schemas (ADR 0003 §11: "MCP tool
+ * schemas are derived from the contract schemas. Tool names stay."). Nothing here hand-declares
+ * a field the contract already declares -- each schema below is the contract's own zod object
+ * for that operation, or a small `.omit()`/`.extend()`/`.partial()` composition of it. A
+ * contract schema change is a compile-time (or, for a structurally-compatible-but-different
+ * shape, a test) change here too, not a silent drift.
+ *
+ * Field names follow the contract's own vocabulary (camelCase: `leaseId`, `deviceId`,
+ * `allowDownload`, ...), not the snake_case this module used before PR 4. This is a deliberate
+ * break (0.x, ADR "Alternatives considered": "one vocabulary everywhere is the point") -- see
+ * the PR report for the tradeoffs.
+ */
 import { z } from "zod";
 
-const nonEmptyString = z.string().min(1);
-const finiteNumber = z.number().finite();
-export const MAX_TIMEOUT_SECONDS = Number.MAX_SAFE_INTEGER / 1_000;
+import { leaseRecordSchema, OPERATIONS } from "../contract/index.js";
 
-export const leaseSimulatorInputSchema = z.object({
-  allow_download: z.boolean().default(false),
-  device: nonEmptyString,
-  // Platform-neutral: "give me a device with no driver-side resource reduction". The iOS
-  // driver implements this as "do not slim"; other drivers ignore it.
-  full: z.boolean().default(false),
-  no_wait: z.boolean().default(false),
-  os: nonEmptyString.optional(),
-  platform: z.enum(["ios", "android"]),
-  timeout_seconds: finiteNumber
-    .nonnegative()
-    .max(MAX_TIMEOUT_SECONDS, "timeout_seconds is too large to convert safely to milliseconds")
-    .optional(),
-});
+// ---- lease_simulator ---------------------------------------------------------------------
 
-export const leaseSimulatorOutputSchema = z.object({
-  // Optional: undefined only for a device leased straight out of a pre-address `state.json`
-  // without ever rebooting under this daemon -- see `DeviceRecord.address` in domain.ts.
-  address: nonEmptyString.optional(),
-  device: nonEmptyString,
-  device_id: nonEmptyString,
-  expires_at_ms: finiteNumber,
-  lease_id: nonEmptyString,
-  mode: z.literal("held"),
-  os: nonEmptyString,
-  platform: z.enum(["ios", "android"]),
-  /** Whether the granted device had its feature set reduced -- see `RawLeaseGrant.slim`. */
-  slim: z.boolean(),
-  state: z.literal("leased"),
-  timing: z.object({
-    estimated_boot_ms: finiteNumber,
-    estimated_provision_ms: finiteNumber,
-    estimated_reclaim_ms: finiteNumber,
-    estimated_ready_ms: finiteNumber,
-  }),
-});
+/**
+ * `lease.request`'s input, minus the three fields this tool never lets the caller set:
+ * `requesterId` (session-controlled -- see `session.ts`'s `#requesterId`, never caller-supplied,
+ * for the same reason the daemon never lets a request rename its own principal), `mode` (this
+ * tool always leases `"held"`), and `ttlMs` (only meaningful for a detached lease, which this
+ * tool never requests -- and is `BAD_REQUEST` for a held one per the contract's own
+ * `superRefine`). `.innerType()` unwraps the contract schema's `superRefine` wrapper down to
+ * the plain (still `.strict()`) object so `.omit()` is available -- see zod's `ZodEffects`.
+ */
+export const leaseSimulatorInputSchema = OPERATIONS["lease.request"].input
+  .innerType()
+  .omit({ mode: true, requesterId: true, ttlMs: true });
 
-export const releaseSimulatorInputSchema = z.object({
-  lease_id: nonEmptyString,
-});
+/** `lease.request`'s output verbatim -- the device/lease/timing grant. */
+export const leaseSimulatorOutputSchema = OPERATIONS["lease.request"].output;
 
-export const releaseSimulatorOutputSchema = z.object({
-  lease_id: nonEmptyString,
+// ---- list_devices -------------------------------------------------------------------------
+
+export const listDevicesInputSchema = OPERATIONS["catalog.get"].input;
+export const listDevicesOutputSchema = OPERATIONS["catalog.get"].output;
+
+// ---- release_simulator ---------------------------------------------------------------------
+
+export const releaseSimulatorInputSchema = OPERATIONS["lease.release"].input;
+/** `lease.release`'s output (`{leaseId}`) plus a friendly `released: true` literal -- an
+ * addition on top of the contract shape, not a hand duplicate of it. */
+export const releaseSimulatorOutputSchema = OPERATIONS["lease.release"].output.extend({
   released: z.literal(true),
 });
 
-export const listDevicesInputSchema = z.object({
-  platform: z.enum(["ios", "android"]).optional(),
-});
+// ---- lease_status -------------------------------------------------------------------------
 
-export const listDevicesOutputSchema = z.object({
-  platforms: z.array(
-    z.object({
-      default_runtime: nonEmptyString.optional(),
-      models: z.array(nonEmptyString),
-      platform: z.enum(["ios", "android"]),
-      runtimes: z.array(nonEmptyString),
-    }),
-  ),
-});
+/** `lease_status` is one `lease.list` call (ADR §9), not a session-local cache read. */
+export const leaseStatusInputSchema = OPERATIONS["lease.list"].input;
 
-export const leaseStatusInputSchema = z.object({});
-
-// Flat and all-optional (rather than a discriminated union) because the MCP SDK
-// validates structuredContent against outputSchema as a plain object shape.
-export const leaseStatusOutputSchema = z.object({
-  device: nonEmptyString.optional(),
-  device_id: nonEmptyString.optional(),
-  expires_at_ms: finiteNumber.optional(),
-  held: z.boolean(),
-  lease_id: nonEmptyString.optional(),
-  os: nonEmptyString.optional(),
-  platform: z.enum(["ios", "android"]).optional(),
-  state: z.literal("leased").optional(),
-});
+/**
+ * `lease.list` returns `{leases: LeaseRecord[]}`; this session ever holds at most one lease (one
+ * requester id, always `mode: "held"`), so the tool flattens that array's first entry (or none)
+ * onto a `held` discriminant. Flat and all-optional -- not a discriminated union -- because the
+ * MCP SDK validates `structuredContent` against `outputSchema` as a plain object shape.
+ */
+export const leaseStatusOutputSchema = leaseRecordSchema.partial().extend({ held: z.boolean() });
 
 export type LeaseSimulatorInput = z.infer<typeof leaseSimulatorInputSchema>;
 export type LeaseSimulatorOutput = z.infer<typeof leaseSimulatorOutputSchema>;
-export type ReleaseSimulatorInput = z.infer<typeof releaseSimulatorInputSchema>;
-export type ReleaseSimulatorOutput = z.infer<typeof releaseSimulatorOutputSchema>;
 export type ListDevicesInput = z.infer<typeof listDevicesInputSchema>;
 export type ListDevicesOutput = z.infer<typeof listDevicesOutputSchema>;
+export type ReleaseSimulatorInput = z.infer<typeof releaseSimulatorInputSchema>;
+export type ReleaseSimulatorOutput = z.infer<typeof releaseSimulatorOutputSchema>;
 export type LeaseStatusOutput = z.infer<typeof leaseStatusOutputSchema>;
-
-/** The `lease_status` result when this session currently holds a lease. */
-export interface HeldLeaseStatus {
-  readonly device: string;
-  readonly device_id: string;
-  readonly expires_at_ms: number;
-  readonly held: true;
-  readonly lease_id: string;
-  readonly os: string;
-  readonly platform: "android" | "ios";
-  readonly state: "leased";
-}
-
-/** The `lease_status` result when this session holds nothing. */
-export interface NoLeaseStatus {
-  readonly held: false;
-}

--- a/src/mcp/main.test.ts
+++ b/src/mcp/main.test.ts
@@ -2,10 +2,13 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import type { DaemonConnection } from "../daemon-client/protocol.js";
+import { FakeSimlockClient, sampleGrant } from "./test-support.js";
 import { startMcpStdio, type McpTransport } from "./main.js";
+
+const { connectWithAutoLaunch } = vi.hoisted(() => ({ connectWithAutoLaunch: vi.fn() }));
+vi.mock("./connect.js", () => ({ connectWithAutoLaunch }));
 
 describe("MCP stdio lifecycle", () => {
   it.each(["transport", "SIGINT", "SIGTERM"])("closes once on %s", async (cause) => {
@@ -66,78 +69,79 @@ describe("MCP stdio lifecycle", () => {
     expect(transport.closeCalls).toBe(1);
   });
 
-  it("closes the lease-owning session when its transport ends", async () => {
-    const connection = new LeaseConnection();
+  it("closes the lease-owning session's client when its transport ends", async () => {
+    const client = new FakeSimlockClient();
+    client.requestLeaseImpl = () => Promise.resolve(sampleGrant());
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     const runner = await startMcpStdio({
-      connect: async () => connection,
+      connect: async () => client,
       createTransport: () => serverTransport,
       requesterId: "mcp-test",
       signals: new FakeSignals(),
     });
-    const client = new Client({ name: "test", version: "1.0.0" });
-    await client.connect(clientTransport);
-    await client.request(
+    const mcpClient = new Client({ name: "test", version: "1.0.0" });
+    await mcpClient.connect(clientTransport);
+    await mcpClient.request(
       {
         method: "tools/call",
-        params: { arguments: { device: "iPhone", platform: "ios" }, name: "lease_simulator" },
+        params: { arguments: { model: "iPhone", platform: "ios" }, name: "lease_simulator" },
       },
       CallToolResultSchema,
     );
 
     serverTransport.onclose?.();
     await runner.finished;
-    expect(connection.closeCalls).toBe(1);
-    await client.close();
+    expect(client.closeCalls).toBe(1);
+    await mcpClient.close();
   });
 
-  it("sources the requester id from SIMLOCK_AGENT_ID when none is given explicitly", async () => {
-    const connection = new LeaseConnection();
+  it("sources the connection principal from SIMLOCK_AGENT_ID when no requesterId is given explicitly", async () => {
+    connectWithAutoLaunch.mockReset().mockResolvedValue(new FakeSimlockClient());
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     const runner = await startMcpStdio({
-      connect: async () => connection,
       createTransport: () => serverTransport,
       env: { SIMLOCK_AGENT_ID: "agent-from-env" },
       signals: new FakeSignals(),
     });
-    const client = new Client({ name: "test", version: "1.0.0" });
-    await client.connect(clientTransport);
-    await client.request(
-      {
-        method: "tools/call",
-        params: { arguments: { device: "iPhone", platform: "ios" }, name: "lease_simulator" },
-      },
-      CallToolResultSchema,
-    );
+    const mcpClient = new Client({ name: "test", version: "1.0.0" });
+    await mcpClient.connect(clientTransport);
+    await mcpClient
+      .request(
+        { method: "tools/call", params: { arguments: {}, name: "lease_status" } },
+        CallToolResultSchema,
+      )
+      .catch(() => undefined);
 
-    expect(connection.lastRequesterId).toBe("agent-from-env");
+    expect(connectWithAutoLaunch).toHaveBeenCalledWith(
+      expect.objectContaining({ principal: "agent-from-env" }),
+    );
+    await mcpClient.close();
     await runner.shutdown();
-    await client.close();
   });
 
   it("prefers an explicit requesterId over SIMLOCK_AGENT_ID", async () => {
-    const connection = new LeaseConnection();
+    connectWithAutoLaunch.mockReset().mockResolvedValue(new FakeSimlockClient());
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     const runner = await startMcpStdio({
-      connect: async () => connection,
       createTransport: () => serverTransport,
       env: { SIMLOCK_AGENT_ID: "agent-from-env" },
       requesterId: "explicit-agent",
       signals: new FakeSignals(),
     });
-    const client = new Client({ name: "test", version: "1.0.0" });
-    await client.connect(clientTransport);
-    await client.request(
-      {
-        method: "tools/call",
-        params: { arguments: { device: "iPhone", platform: "ios" }, name: "lease_simulator" },
-      },
-      CallToolResultSchema,
-    );
+    const mcpClient = new Client({ name: "test", version: "1.0.0" });
+    await mcpClient.connect(clientTransport);
+    await mcpClient
+      .request(
+        { method: "tools/call", params: { arguments: {}, name: "lease_status" } },
+        CallToolResultSchema,
+      )
+      .catch(() => undefined);
 
-    expect(connection.lastRequesterId).toBe("explicit-agent");
+    expect(connectWithAutoLaunch).toHaveBeenCalledWith(
+      expect.objectContaining({ principal: "explicit-agent" }),
+    );
+    await mcpClient.close();
     await runner.shutdown();
-    await client.close();
   });
 
   it("closes once when stdin reaches EOF", async () => {
@@ -239,37 +243,6 @@ class FakeSignals {
   }
   emit(signal: string): void {
     this.listeners.get(signal)?.();
-  }
-}
-
-class LeaseConnection implements DaemonConnection {
-  closeCalls = 0;
-  lastRequesterId: unknown;
-  async close(): Promise<void> {
-    this.closeCalls += 1;
-  }
-  onPush(): () => void {
-    return () => undefined;
-  }
-
-  onClose(): () => void {
-    return () => undefined;
-  }
-  async request(_type: string, payload: unknown): Promise<unknown> {
-    this.lastRequesterId = (payload as { readonly requesterId?: unknown }).requesterId;
-    return {
-      device: {
-        driverDeviceId: "SIM-1",
-        spec: { model: "iPhone", osVersion: "26", platform: "ios" },
-      },
-      lease: { id: "lease-1", mode: "held", ttlDeadline: 10 },
-      timing: {
-        estimatedBootMs: 1,
-        estimatedProvisionMs: 1,
-        estimatedReclaimMs: 0,
-        estimatedReadyMs: 2,
-      },
-    };
   }
 }
 

--- a/src/mcp/main.ts
+++ b/src/mcp/main.ts
@@ -3,14 +3,14 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import type { SimlockClient } from "../client/index.js";
 import {
   NodeDaemonLauncher,
   NodeIpcTransport,
   resolveSimlockHome,
   SystemClock,
 } from "../ports/index.js";
-import { connectDaemon } from "../daemon-client/client.js";
-import type { DaemonConnection } from "../daemon-client/protocol.js";
+import { connectWithAutoLaunch } from "./connect.js";
 import { McpSession } from "./session.js";
 import { createMcpServer } from "./server.js";
 
@@ -32,7 +32,7 @@ export interface McpTransport {
 }
 
 export interface McpStdioEnvironment {
-  readonly connect?: () => Promise<DaemonConnection>;
+  readonly connect?: () => Promise<SimlockClient>;
   readonly createServer?: (session: McpSession) => McpServer;
   readonly createTransport?: () => McpTransport;
   /** Source for `SIMLOCK_AGENT_ID` when `requesterId` is not given explicitly. */
@@ -62,11 +62,11 @@ export async function runMcpStdio(environment: McpStdioEnvironment = {}): Promis
 export async function startMcpStdio(
   environment: McpStdioEnvironment = {},
 ): Promise<McpStdioRunner> {
-  const defaults = defaultEnvironment();
   const env = environment.env ?? process.env;
+  const requesterId = environment.requesterId ?? env.SIMLOCK_AGENT_ID ?? `mcp:${process.pid}`;
+  const defaults = defaultEnvironment(requesterId);
   const session = new McpSession({
     connect: environment.connect ?? defaults.connect,
-    requesterId: environment.requesterId ?? env.SIMLOCK_AGENT_ID ?? `mcp:${process.pid}`,
   });
   const server = (environment.createServer ?? createMcpServer)(session);
   const transport = (environment.createTransport ?? defaults.createTransport)();
@@ -137,7 +137,9 @@ export async function startMcpStdio(
   return { finished, shutdown };
 }
 
-function defaultEnvironment(): Required<Pick<McpStdioEnvironment, "connect" | "createTransport">> {
+function defaultEnvironment(
+  requesterId: string,
+): Required<Pick<McpStdioEnvironment, "connect" | "createTransport">> {
   const dataDirectory = resolveSimlockHome();
   const clock = new SystemClock();
   const ipc = new NodeIpcTransport();
@@ -145,18 +147,19 @@ function defaultEnvironment(): Required<Pick<McpStdioEnvironment, "connect" | "c
   const logPath = join(dataDirectory, "daemon.log");
   return {
     connect: () =>
-      connectDaemon({
+      connectWithAutoLaunch({
+        clock,
         // MCP's holder process dies with its agent (stdin EOF -> session.close()), so a
         // sliding TTL is safe here. CLI held mode declares the same capability now that
         // it self-terminates on parent death too — see docs/known-pitfalls.md.
-        capabilities: { heartbeat: true },
-        clock,
+        heartbeat: true,
         ipc,
         launcher: new NodeDaemonLauncher({
           args: [join(dirname(fileURLToPath(import.meta.url)), "../daemon/main.js")],
           command: process.execPath,
           logPath,
         }),
+        principal: requesterId,
         socketPath,
       }),
     createTransport: () => new StdioServerTransport(),

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -8,139 +8,168 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { describe, expect, it } from "vitest";
 
-import { DaemonClientError, type DaemonConnection } from "../daemon-client/protocol.js";
-import {
-  leaseSimulatorOutputSchema,
-  leaseStatusOutputSchema,
-  listDevicesOutputSchema,
-  releaseSimulatorOutputSchema,
-} from "./contracts.js";
+import { SimlockError } from "../client/index.js";
+import { FakeSimlockClient, sampleGrant } from "./test-support.js";
 import { McpSession } from "./session.js";
 import { createMcpServer } from "./server.js";
 
-const grant = {
-  device: {
-    driverDeviceId: "SIM-1",
-    spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" as const },
-  },
-  lease: { id: "lease-1", mode: "held" as const, ttlDeadline: 12_345 },
-  timing: {
-    estimatedBootMs: 3,
-    estimatedProvisionMs: 2,
-    estimatedReclaimMs: 1,
-    estimatedReadyMs: 6,
-  },
-};
-
-const catalog = {
-  platforms: [
-    {
-      defaultRuntime: "26.5",
-      models: ["iPhone 17 Pro"],
-      platform: "ios" as const,
-      runtimes: ["26.5"],
-    },
-  ],
-};
-
-describe("MCP server", () => {
-  it("advertises exactly the lease, catalog, and status tools and returns dual schema-valid results", async () => {
-    const connection = new StubConnection([grant, catalog, { leaseId: "lease-1" }]);
-    const { client, close } = await connectedServer(connection);
-    try {
-      const listed = await client.request({ method: "tools/list" }, ListToolsResultSchema);
-      expect(listed.tools.map((tool) => tool.name)).toEqual([
-        "lease_simulator",
-        "list_devices",
-        "release_simulator",
-        "lease_status",
-      ]);
-      for (const tool of listed.tools) {
-        expect(tool.title).toEqual(expect.any(String));
-        expect(tool.description).toEqual(expect.any(String));
-        expect(tool.inputSchema).toEqual(expect.any(Object));
-        expect(tool.outputSchema).toEqual(expect.any(Object));
-      }
-
-      const noLease = await call(client, "lease_status", {});
-      expect(noLease.isError).not.toBe(true);
-      leaseStatusOutputSchema.parse(noLease.structuredContent);
-      expect(noLease.structuredContent).toEqual({ held: false });
-
-      const lease = await call(client, "lease_simulator", {
-        device: "iPhone 17 Pro",
-        platform: "ios",
-      });
-      expect(lease.isError).not.toBe(true);
-      leaseSimulatorOutputSchema.parse(lease.structuredContent);
-      expect(lease.structuredContent).toMatchObject({ lease_id: "lease-1", mode: "held" });
-      expect(JSON.parse(text(lease))).toEqual(lease.structuredContent);
-
-      const devices = await call(client, "list_devices", {});
-      expect(devices.isError).not.toBe(true);
-      listDevicesOutputSchema.parse(devices.structuredContent);
-      expect(devices.structuredContent).toEqual({
+describe("MCP server (smoke)", () => {
+  it("advertises exactly the lease, catalog, and status tools, and walks lease -> list -> status -> release", async () => {
+    const client = new FakeSimlockClient();
+    const grant = sampleGrant();
+    client.requestLeaseImpl = () => Promise.resolve(grant);
+    client.getCatalogImpl = () =>
+      Promise.resolve({
         platforms: [
           {
-            default_runtime: "26.5",
+            defaultRuntime: "26.5",
             models: ["iPhone 17 Pro"],
             platform: "ios",
             runtimes: ["26.5"],
           },
         ],
       });
-      expect(JSON.parse(text(devices))).toEqual(devices.structuredContent);
+    client.releaseLeaseImpl = (input) => Promise.resolve({ leaseId: input.leaseId });
+    let listed = false;
+    client.listLeasesImpl = () => {
+      const wasListed = listed;
+      listed = true;
+      return Promise.resolve({
+        leases: wasListed
+          ? []
+          : [
+              {
+                deviceId: grant.device.id,
+                grantedAt: grant.lease.grantedAt,
+                id: grant.lease.id,
+                mode: grant.lease.mode,
+                ownerId: grant.lease.ownerId,
+                requesterId: grant.lease.requesterId,
+                ttlDeadline: grant.lease.ttlDeadline,
+              },
+            ],
+      });
+    };
+    const { mcpClient, close } = await connectedServer(client);
+    try {
+      const tools = await mcpClient.request({ method: "tools/list" }, ListToolsResultSchema);
+      expect(tools.tools.map((tool) => tool.name)).toEqual([
+        "lease_simulator",
+        "list_devices",
+        "release_simulator",
+        "lease_status",
+      ]);
+      for (const tool of tools.tools) {
+        expect(tool.inputSchema).toEqual(expect.any(Object));
+        expect(tool.outputSchema).toEqual(expect.any(Object));
+      }
 
-      const held = await call(client, "lease_status", {});
-      expect(held.isError).not.toBe(true);
-      leaseStatusOutputSchema.parse(held.structuredContent);
-      expect(held.structuredContent).toEqual({
-        device: "iPhone 17 Pro",
-        device_id: "SIM-1",
-        expires_at_ms: 12_345,
-        held: true,
-        lease_id: "lease-1",
-        os: "26.5",
+      const lease = await call(mcpClient, "lease_simulator", {
+        model: "iPhone 17 Pro",
         platform: "ios",
-        state: "leased",
+      });
+      expect(lease.isError).not.toBe(true);
+      expect(lease.structuredContent).toMatchObject({ lease: { id: "lease-1", mode: "held" } });
+
+      const devices = await call(mcpClient, "list_devices", {});
+      expect(devices.isError).not.toBe(true);
+      expect(devices.structuredContent).toEqual({
+        platforms: [
+          {
+            defaultRuntime: "26.5",
+            models: ["iPhone 17 Pro"],
+            platform: "ios",
+            runtimes: ["26.5"],
+          },
+        ],
       });
 
-      const release = await call(client, "release_simulator", { lease_id: "lease-1" });
-      expect(release.isError).not.toBe(true);
-      releaseSimulatorOutputSchema.parse(release.structuredContent);
-      expect(release.structuredContent).toEqual({ lease_id: "lease-1", released: true });
-      expect(JSON.parse(text(release))).toEqual(release.structuredContent);
+      const status = await call(mcpClient, "lease_status", {});
+      expect(status.isError).not.toBe(true);
+      expect(status.structuredContent).toMatchObject({ held: true, id: "lease-1" });
 
-      const afterRelease = await call(client, "lease_status", {});
+      const release = await call(mcpClient, "release_simulator", { leaseId: "lease-1" });
+      expect(release.isError).not.toBe(true);
+      expect(release.structuredContent).toEqual({ leaseId: "lease-1", released: true });
+
+      const afterRelease = await call(mcpClient, "lease_status", {});
       expect(afterRelease.structuredContent).toEqual({ held: false });
     } finally {
       await close();
     }
   });
 
-  it("relays a daemon lease-lost push as an MCP logging notification and forgets the lease", async () => {
-    const connection = new StubConnection([grant]);
-    const { client, close, session } = await connectedServer(connection);
+  it("surfaces a daemon FORBIDDEN as-is when releasing a lease this session does not own -- no client-side pre-check", async () => {
+    const client = new FakeSimlockClient();
+    client.releaseLeaseImpl = () =>
+      Promise.reject(new SimlockError("FORBIDDEN", "protocol", "not your lease", {}));
+    const { mcpClient, close } = await connectedServer(client);
+    try {
+      const result = await call(mcpClient, "release_simulator", { leaseId: "not-mine" });
+      expect(result.isError).toBe(true);
+      expect(JSON.parse(text(result))).toEqual({ code: "FORBIDDEN", message: "not your lease" });
+    } finally {
+      await close();
+    }
+  });
+
+  it("sanitizes an unexpected error without leaking its message", async () => {
+    const client = new FakeSimlockClient();
+    client.requestLeaseImpl = () => Promise.reject(new Error("/private/secret-stack-path"));
+    const { mcpClient, close } = await connectedServer(client);
+    try {
+      const result = await call(mcpClient, "lease_simulator", {
+        model: "iPhone 17 Pro",
+        platform: "ios",
+      });
+      expect(result.isError).toBe(true);
+      expect(JSON.parse(text(result))).toEqual({
+        code: "INTERNAL",
+        message: "Simlock could not complete the request",
+      });
+      expect(text(result)).not.toContain("private");
+    } finally {
+      await close();
+    }
+  });
+
+  it("rejects invalid tool arguments through the registered schema before touching the client", async () => {
+    const client = new FakeSimlockClient();
+    const { mcpClient, close } = await connectedServer(client);
+    try {
+      const result = await call(mcpClient, "lease_simulator", { model: "", platform: "desktop" });
+      expect(result.isError).toBe(true);
+      expect(text(result)).toContain("Input validation error");
+      expect(client.calls).toEqual([]);
+    } finally {
+      await close();
+    }
+  });
+
+  it("relays a lease-lost push as an MCP logging notification (MCP-only relay)", async () => {
+    const client = new FakeSimlockClient();
+    client.requestLeaseImpl = () => Promise.resolve(sampleGrant());
+    const { mcpClient, close } = await connectedServer(client);
     try {
       const notifications: unknown[] = [];
-      client.setNotificationHandler(LoggingMessageNotificationSchema, (notification) => {
+      mcpClient.setNotificationHandler(LoggingMessageNotificationSchema, (notification) => {
         notifications.push(notification.params);
       });
 
-      const lease = await call(client, "lease_simulator", {
-        device: "iPhone 17 Pro",
+      const lease = await call(mcpClient, "lease_simulator", {
+        model: "iPhone 17 Pro",
         platform: "ios",
       });
       expect(lease.isError).not.toBe(true);
 
-      connection.pushLeaseLost({ deviceId: "SIM-1", leaseId: "lease-1", reason: "expired" });
+      client.emitLeaseLost({ deviceId: "SIM-1", leaseId: "lease-1", reason: "expired" });
       await expect
         .poll(() => notifications)
         .toEqual([
           {
             data: {
-              device_id: "SIM-1",
-              lease_id: "lease-1",
+              deviceId: "SIM-1",
+              leaseId: "lease-1",
               message: "Simlock lease ended; this session no longer holds the device.",
               reason: "expired",
             },
@@ -148,88 +177,77 @@ describe("MCP server", () => {
             logger: "simlock",
           },
         ]);
-
-      expect(session.status()).toEqual({ held: false });
-      const releaseAfterLost = await call(client, "release_simulator", { lease_id: "lease-1" });
-      expect(releaseAfterLost.isError).toBe(true);
-      expect(JSON.parse(text(releaseAfterLost))).toEqual({
-        code: "LEASE_NOT_OWNED",
-        message: "This session does not own that lease",
-      });
     } finally {
       await close();
     }
   });
 
-  it("relays device-unhealthy and device-recovered pushes as MCP logging notifications, keeping the lease held", async () => {
-    const connection = new StubConnection([grant]);
-    const { client, close, session } = await connectedServer(connection);
+  it("relays device-unhealthy and device-recovered pushes as MCP logging notifications (MCP-only relay)", async () => {
+    const client = new FakeSimlockClient();
+    client.requestLeaseImpl = () => Promise.resolve(sampleGrant());
+    const { mcpClient, close } = await connectedServer(client);
     try {
       const notifications: unknown[] = [];
-      client.setNotificationHandler(LoggingMessageNotificationSchema, (notification) => {
+      mcpClient.setNotificationHandler(LoggingMessageNotificationSchema, (notification) => {
         notifications.push(notification.params);
       });
 
-      const lease = await call(client, "lease_simulator", {
-        device: "iPhone 17 Pro",
+      const lease = await call(mcpClient, "lease_simulator", {
+        model: "iPhone 17 Pro",
         platform: "ios",
       });
       expect(lease.isError).not.toBe(true);
 
-      connection.pushDeviceUnhealthy({ deviceId: "SIM-1", leaseId: "lease-1", reason: "crashed" });
-      connection.pushDeviceRecovered({ attempts: 2, deviceId: "SIM-1", leaseId: "lease-1" });
+      client.emitDeviceUnhealthy({ deviceId: "SIM-1", leaseId: "lease-1" });
+      client.emitDeviceRecovered({ attempts: 2, deviceId: "SIM-1", leaseId: "lease-1" });
       await expect.poll(() => notifications).toHaveLength(2);
 
       expect(notifications).toEqual([
         expect.objectContaining({
-          data: expect.objectContaining({
-            device_id: "SIM-1",
-            lease_id: "lease-1",
-            reason: "crashed",
-          }),
+          data: expect.objectContaining({ deviceId: "SIM-1", leaseId: "lease-1" }),
           level: "warning",
         }),
         expect.objectContaining({
-          data: expect.objectContaining({
-            attempts: 2,
-            device_id: "SIM-1",
-            lease_id: "lease-1",
-          }),
+          data: expect.objectContaining({ attempts: 2, deviceId: "SIM-1", leaseId: "lease-1" }),
           level: "info",
         }),
       ]);
-
-      // The lease is still owned: unlike a lease-lost push, device health notices never
-      // clear it.
-      expect(session.status()).toMatchObject({ held: true, lease_id: "lease-1" });
     } finally {
       await close();
     }
   });
 
-  it("relays queued/provisioning/booting/reclaiming progress as notifications/progress when a token is supplied", async () => {
-    const deferredGrant = deferredResponse();
-    const connection = new StubConnection([deferredGrant.promise]);
-    const { client, close } = await connectedServer(connection);
+  it("relays queued/provisioning/booting/reclaiming progress as notifications/progress when a token is supplied (MCP-only relay)", async () => {
+    const client = new FakeSimlockClient();
+    let onProgress: ((progress: unknown) => void) | undefined;
+    let resolveGrant!: (grant: ReturnType<typeof sampleGrant>) => void;
+    const grantPromise = new Promise<ReturnType<typeof sampleGrant>>((resolve) => {
+      resolveGrant = resolve;
+    });
+    client.requestLeaseImpl = (_input, options) => {
+      onProgress = options.onProgress as ((progress: unknown) => void) | undefined;
+      return grantPromise;
+    };
+    const { mcpClient, close } = await connectedServer(client);
     try {
       const progressEvents: unknown[] = [];
-      const leaseCall = client.request(
+      const leaseCall = mcpClient.request(
         {
           method: "tools/call",
           params: {
-            arguments: { device: "iPhone 17 Pro", platform: "ios" },
+            arguments: { model: "iPhone 17 Pro", platform: "ios" },
             name: "lease_simulator",
           },
         },
         CallToolResultSchema,
         { onprogress: (progress) => progressEvents.push(progress) },
       );
-      await waitFor(() => connection.calls.length === 1);
+      await waitFor(() => onProgress !== undefined);
 
-      connection.pushProgress({ queuePosition: 2, stage: "queued" });
-      connection.pushProgress({ etaMs: 9_000, stage: "provisioning" });
-      connection.pushProgress({ etaMs: 4_000, stage: "booting" });
-      connection.pushProgress({ etaMs: 1_000, stage: "reclaiming" });
+      onProgress!({ queuePosition: 2, stage: "queued" });
+      onProgress!({ etaMs: 9_000, stage: "provisioning" });
+      onProgress!({ etaMs: 4_000, stage: "booting" });
+      onProgress!({ etaMs: 1_000, stage: "reclaiming" });
       await waitFor(() => progressEvents.length === 4);
 
       expect(progressEvents).toEqual([
@@ -242,7 +260,7 @@ describe("MCP server", () => {
       expect(values).toEqual([...values].sort((a, b) => a - b));
       expect(new Set(values).size).toBe(values.length);
 
-      deferredGrant.resolve(grant);
+      resolveGrant(sampleGrant());
       const lease = await leaseCall;
       expect(lease.isError).not.toBe(true);
     } finally {
@@ -250,102 +268,40 @@ describe("MCP server", () => {
     }
   });
 
-  it("emits nothing when the client supplied no progress token", async () => {
-    const deferredGrant = deferredResponse();
-    const connection = new StubConnection([deferredGrant.promise]);
-    const { client, close } = await connectedServer(connection);
+  it("emits nothing when the client supplied no progress token (MCP-only relay)", async () => {
+    const client = new FakeSimlockClient();
+    let onProgress: ((progress: unknown) => void) | undefined;
+    client.requestLeaseImpl = (_input, options) => {
+      onProgress = options.onProgress as ((progress: unknown) => void) | undefined;
+      return Promise.resolve(sampleGrant());
+    };
+    const { mcpClient, close } = await connectedServer(client);
     try {
       const progressEvents: unknown[] = [];
-      client.setNotificationHandler(ProgressNotificationSchema, (notification) => {
+      mcpClient.setNotificationHandler(ProgressNotificationSchema, (notification) => {
         progressEvents.push(notification.params);
       });
 
-      const leaseCall = call(client, "lease_simulator", {
-        device: "iPhone 17 Pro",
-        platform: "ios",
-      });
-      await waitFor(() => connection.calls.length === 1);
-
-      connection.pushProgress({ queuePosition: 1, stage: "queued" });
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      await call(mcpClient, "lease_simulator", { model: "iPhone 17 Pro", platform: "ios" });
+      expect(onProgress).toBeUndefined();
       expect(progressEvents).toEqual([]);
-
-      deferredGrant.resolve(grant);
-      await leaseCall;
-      expect(progressEvents).toEqual([]);
-    } finally {
-      await close();
-    }
-  });
-
-  it("forwards the platform filter for list_devices and never triggers a lease request", async () => {
-    const connection = new StubConnection([catalog]);
-    const { client, close } = await connectedServer(connection);
-    try {
-      const devices = await call(client, "list_devices", { platform: "ios" });
-      expect(devices.isError).not.toBe(true);
-      expect(connection.calls).toEqual([{ payload: { platform: "ios" }, type: "catalog.get" }]);
-    } finally {
-      await close();
-    }
-  });
-
-  it("returns stable, sanitized errors without invalid structured output", async () => {
-    const connection = new StubConnection([
-      new DaemonClientError("NO_CAPACITY", "No matching devices are available"),
-      new Error("/private/secret-stack-path"),
-    ]);
-    const { client, close } = await connectedServer(connection);
-    try {
-      const expected = await call(client, "lease_simulator", {
-        device: "iPhone 17 Pro",
-        platform: "ios",
-      });
-      expect(expected).toMatchObject({ isError: true });
-      expect(JSON.parse(text(expected))).toEqual({
-        code: "NO_CAPACITY",
-        message: "No matching devices are available",
-      });
-      expect(expected.structuredContent).toBeUndefined();
-
-      const unexpected = await call(client, "lease_simulator", {
-        device: "iPhone 17 Pro",
-        platform: "ios",
-      });
-      expect(JSON.parse(text(unexpected))).toEqual({
-        code: "INTERNAL",
-        message: "Simlock could not complete the request",
-      });
-      expect(text(unexpected)).not.toContain("private");
-    } finally {
-      await close();
-    }
-  });
-
-  it("rejects invalid tool arguments through the registered schema", async () => {
-    const { client, close } = await connectedServer(new StubConnection([]));
-    try {
-      const result = await call(client, "lease_simulator", { device: "", platform: "desktop" });
-      expect(result.isError).toBe(true);
-      expect(text(result)).toContain("Input validation error");
     } finally {
       await close();
     }
   });
 });
 
-async function connectedServer(connection: StubConnection) {
-  const session = new McpSession({ connect: async () => connection, requesterId: "mcp-test" });
+async function connectedServer(client: FakeSimlockClient) {
+  const session = new McpSession({ connect: async () => client });
   const server = createMcpServer(session);
-  const client = new Client({ name: "mcp-test-client", version: "1.0.0" });
+  const mcpClient = new Client({ name: "mcp-test-client", version: "1.0.0" });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+  await Promise.all([mcpClient.connect(clientTransport), server.connect(serverTransport)]);
   return {
-    client,
     close: async () => {
-      await Promise.all([client.close(), server.close(), session.close()]);
+      await Promise.all([mcpClient.close(), server.close(), session.close()]);
     },
-    session,
+    mcpClient,
   };
 }
 
@@ -362,60 +318,6 @@ function text(result: { content: Array<{ type: string; text?: string }> }): stri
   return first.text;
 }
 
-function deferredResponse(): { promise: Promise<unknown>; resolve: (value: unknown) => void } {
-  let resolve!: (value: unknown) => void;
-  const promise = new Promise<unknown>((next) => {
-    resolve = next;
-  });
-  return { promise, resolve };
-}
-
 async function waitFor(predicate: () => boolean): Promise<void> {
   while (!predicate()) await new Promise((resolve) => setTimeout(resolve, 0));
-}
-
-class StubConnection implements DaemonConnection {
-  closeCalls = 0;
-  readonly calls: Array<{ readonly payload: unknown; readonly type: string }> = [];
-  readonly #listeners = new Set<(kind: string, payload: unknown) => void>();
-  constructor(private readonly responses: unknown[]) {}
-  async close(): Promise<void> {
-    this.closeCalls += 1;
-  }
-  onPush(listener: (kind: string, payload: unknown) => void): () => void {
-    this.#listeners.add(listener);
-    return () => this.#listeners.delete(listener);
-  }
-
-  onClose(): () => void {
-    return () => undefined;
-  }
-  pushLeaseLost(payload: {
-    readonly deviceId: string;
-    readonly leaseId: string;
-    readonly reason: string;
-  }): void {
-    for (const listener of this.#listeners) listener("lease-lost", payload);
-  }
-
-  /** Wraps the given stage payload under `{requestId, progress}` -- ADR 0003 §8's push
-   * correlation shape -- so callers can keep passing the bare stage object. */
-  pushProgress(payload: unknown): void {
-    for (const listener of this.#listeners)
-      listener("progress", { progress: payload, requestId: "test-request" });
-  }
-
-  pushDeviceUnhealthy(payload: unknown): void {
-    for (const listener of this.#listeners) listener("device-unhealthy", payload);
-  }
-
-  pushDeviceRecovered(payload: unknown): void {
-    for (const listener of this.#listeners) listener("device-recovered", payload);
-  }
-  async request(type: string, payload: unknown): Promise<unknown> {
-    this.calls.push({ payload, type });
-    const response = this.responses.shift();
-    if (response instanceof Error) throw response;
-    return response;
-  }
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -166,9 +166,9 @@ export function createMcpServer(session: McpSession): McpServer {
       inputSchema: leaseStatusInputSchema,
       outputSchema: leaseStatusOutputSchema,
     },
-    () => {
+    async () => {
       try {
-        return success(session.status());
+        return success(await session.status());
       } catch (error: unknown) {
         return failure(error);
       }
@@ -178,8 +178,8 @@ export function createMcpServer(session: McpSession): McpServer {
   session.onLeaseLost((notice) => {
     void server.server.sendLoggingMessage({
       data: {
-        device_id: notice.deviceId,
-        lease_id: notice.leaseId,
+        deviceId: notice.deviceId,
+        leaseId: notice.leaseId,
         message: "Simlock lease ended; this session no longer holds the device.",
         reason: notice.reason,
       },
@@ -208,8 +208,8 @@ function deviceHealthLoggingMessage(notice: DeviceHealthNotice): {
   if (notice.kind === "unhealthy") {
     return {
       data: {
-        device_id: notice.deviceId,
-        lease_id: notice.leaseId,
+        deviceId: notice.deviceId,
+        leaseId: notice.leaseId,
         message:
           "Simlock's device crashed outside simlock; anything running inside it (apps, log streams, automation sessions, port forwards) is gone. Recovery is in progress under the same lease.",
         reason: notice.reason,
@@ -221,8 +221,8 @@ function deviceHealthLoggingMessage(notice: DeviceHealthNotice): {
   return {
     data: {
       attempts: notice.attempts,
-      device_id: notice.deviceId,
-      lease_id: notice.leaseId,
+      deviceId: notice.deviceId,
+      leaseId: notice.leaseId,
       message: "Simlock's device was rebooted and is ready again under the same lease.",
     },
     level: "info",

--- a/src/mcp/session.test.ts
+++ b/src/mcp/session.test.ts
@@ -1,1096 +1,229 @@
 import { describe, expect, it } from "vitest";
 
-import { DaemonClientError, type DaemonConnection } from "../daemon-client/protocol.js";
-import { leaseSimulatorInputSchema } from "./contracts.js";
+import { SimlockError } from "../client/index.js";
+import { FakeSimlockClient, sampleGrant } from "./test-support.js";
 import { McpSession, toMcpErrorResult } from "./session.js";
 
-const input = leaseSimulatorInputSchema.parse({ device: "iPhone 17 Pro", platform: "ios" });
-const rawGrant = {
-  device: {
-    driverDeviceId: "ABCD",
-    spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" as const },
-  },
-  lease: { id: "lse_9f2c", mode: "held" as const, ttlDeadline: 61_000 },
-  timing: {
-    estimatedBootMs: 20,
-    estimatedProvisionMs: 10,
-    estimatedReclaimMs: 0,
-    estimatedReadyMs: 30,
-  },
-};
-
 describe("McpSession", () => {
-  it("maps safe defaults and grants to the public result", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
+  it("requests a held lease with the tool input as-is, and returns the grant unchanged", async () => {
+    const client = new FakeSimlockClient();
+    let seenInput: unknown;
+    let seenOptions: unknown;
+    const grant = sampleGrant();
+    client.requestLeaseImpl = (input, options) => {
+      seenInput = input;
+      seenOptions = options;
+      return Promise.resolve(grant);
+    };
+    const session = new McpSession({ connect: async () => client });
 
-    await expect(session.lease(input)).resolves.toEqual({
-      device: "iPhone 17 Pro",
-      device_id: "ABCD",
-      expires_at_ms: 61_000,
-      lease_id: "lse_9f2c",
-      mode: "held",
-      os: "26.5",
-      platform: "ios",
-      slim: false,
-      state: "leased",
-      timing: {
-        estimated_boot_ms: 20,
-        estimated_provision_ms: 10,
-        estimated_reclaim_ms: 0,
-        estimated_ready_ms: 30,
-      },
+    const signal = new AbortController().signal;
+    const onProgress = () => undefined;
+    const result = await session.lease(
+      { model: "iPhone 17 Pro", platform: "ios" },
+      signal,
+      onProgress,
+    );
+
+    expect(result).toBe(grant);
+    expect(seenInput).toEqual({ model: "iPhone 17 Pro", mode: "held", platform: "ios" });
+    expect(seenOptions).toEqual({ onProgress, signal });
+  });
+
+  it("releases without any client-side ownership check -- a FORBIDDEN from the daemon passes straight through", async () => {
+    const client = new FakeSimlockClient();
+    client.releaseLeaseImpl = () =>
+      Promise.reject(new SimlockError("FORBIDDEN", "protocol", "not your lease", {}));
+    const session = new McpSession({ connect: async () => client });
+
+    await expect(session.release({ leaseId: "someone-elses-lease" })).rejects.toMatchObject({
+      code: "FORBIDDEN",
     });
-    expect(connection.requests).toEqual([
-      {
-        payload: {
-          allowDownload: false,
-          mode: "held",
-          model: "iPhone 17 Pro",
-          noWait: false,
-          platform: "ios",
-          requesterId: "mcp-session-1",
-        },
-        type: "lease.request",
-      },
+    expect(client.calls).toEqual([
+      { input: { leaseId: "someone-elses-lease" }, method: "releaseLease" },
     ]);
   });
 
-  it("sends full: true on the request when full is set, and slim: true when the grant reports a reduced feature profile", async () => {
-    const connection = new StubConnection();
-    connection.responses.push({
-      ...rawGrant,
-      device: { ...rawGrant.device, featureProfile: "reduced" },
-    });
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
+  it("adds released: true to a successful release without otherwise reshaping the result", async () => {
+    const client = new FakeSimlockClient();
+    client.releaseLeaseImpl = (input) => Promise.resolve({ leaseId: input.leaseId });
+    const session = new McpSession({ connect: async () => client });
 
-    await expect(
-      session.lease(leaseSimulatorInputSchema.parse({ ...input, full: true })),
-    ).resolves.toMatchObject({ slim: true });
-    expect(connection.requests).toEqual([
-      {
-        payload: {
-          allowDownload: false,
-          full: true,
-          mode: "held",
-          model: "iPhone 17 Pro",
-          noWait: false,
-          platform: "ios",
-          requesterId: "mcp-session-1",
-        },
-        type: "lease.request",
-      },
+    await expect(session.release({ leaseId: "lease-1" })).resolves.toEqual({
+      leaseId: "lease-1",
+      released: true,
+    });
+  });
+
+  it("forwards list_devices straight to getCatalog", async () => {
+    const client = new FakeSimlockClient();
+    client.getCatalogImpl = () => Promise.resolve({ platforms: [] });
+    const session = new McpSession({ connect: async () => client });
+
+    await session.listDevices({ platform: "ios" });
+    expect(client.calls).toEqual([{ input: { platform: "ios" }, method: "getCatalog" }]);
+  });
+
+  it("answers lease_status with one lease.list call each time, not a cache", async () => {
+    const client = new FakeSimlockClient();
+    let call = 0;
+    client.listLeasesImpl = () => {
+      call += 1;
+      return Promise.resolve(
+        call === 1
+          ? { leases: [] }
+          : {
+              leases: [
+                {
+                  deviceId: "device-1",
+                  grantedAt: 0,
+                  id: "lease-1",
+                  mode: "held" as const,
+                  ownerId: "mcp-test",
+                  requesterId: "mcp-test",
+                  ttlDeadline: 5_000,
+                },
+              ],
+            },
+      );
+    };
+    const session = new McpSession({ connect: async () => client });
+
+    await expect(session.status()).resolves.toEqual({ held: false });
+    await expect(session.status()).resolves.toEqual({
+      deviceId: "device-1",
+      grantedAt: 0,
+      held: true,
+      id: "lease-1",
+      mode: "held",
+      ownerId: "mcp-test",
+      requesterId: "mcp-test",
+      ttlDeadline: 5_000,
+    });
+    expect(client.calls.filter((c) => c.method === "listLeases")).toHaveLength(2);
+  });
+
+  it("reconnects lazily: builds a new client only after the current one's connection is lost", async () => {
+    const clients: FakeSimlockClient[] = [];
+    let connectCalls = 0;
+    const connect = async () => {
+      connectCalls += 1;
+      const client = new FakeSimlockClient();
+      client.getCatalogImpl = () => Promise.resolve({ platforms: [] });
+      clients.push(client);
+      return client;
+    };
+    const session = new McpSession({ connect });
+
+    await session.listDevices({});
+    await session.listDevices({});
+    expect(connectCalls).toBe(1);
+
+    clients[0]!.emitConnectionLost();
+    await session.listDevices({});
+    expect(connectCalls).toBe(2);
+    expect(clients[1]).not.toBe(clients[0]);
+  });
+
+  it("serializes tool calls: a slower lease still completes before a release issued after it", async () => {
+    const client = new FakeSimlockClient();
+    const order: string[] = [];
+    let releaseGrant: (() => void) | undefined;
+    client.requestLeaseImpl = () =>
+      new Promise((resolve) => {
+        releaseGrant = () => {
+          order.push("lease");
+          resolve(sampleGrant());
+        };
+      });
+    client.releaseLeaseImpl = (input) => {
+      order.push("release");
+      return Promise.resolve({ leaseId: input.leaseId });
+    };
+    const session = new McpSession({ connect: async () => client });
+
+    const leaseCall = session.lease({ model: "iPhone 17 Pro", platform: "ios" });
+    const releaseCall = session.release({ leaseId: "lease-1" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(order).toEqual([]); // release is queued behind the still-pending lease
+    releaseGrant?.();
+    await Promise.all([leaseCall, releaseCall]);
+
+    expect(order).toEqual(["lease", "release"]);
+  });
+
+  it("closes the current client exactly once, and closes a client that finishes connecting after close", async () => {
+    let resolveConnect!: (client: FakeSimlockClient) => void;
+    const pendingClient = new Promise<FakeSimlockClient>((resolve) => {
+      resolveConnect = resolve;
+    });
+    const session = new McpSession({ connect: () => pendingClient });
+
+    const listDevicesCall = session.listDevices({});
+    await Promise.resolve(); // let the queued mutation reach #clientForUse() and start connecting
+    const closeCall = session.close();
+    const client = new FakeSimlockClient();
+    client.getCatalogImpl = () => Promise.resolve({ platforms: [] });
+    resolveConnect(client);
+
+    await closeCall;
+    await expect(listDevicesCall).rejects.toBeTruthy();
+    expect(client.closeCalls).toBe(1);
+
+    await session.close();
+    expect(client.closeCalls).toBe(1);
+  });
+
+  it("rejects every tool call with SESSION_CLOSED, without contacting the client, once closed", async () => {
+    const client = new FakeSimlockClient();
+    const session = new McpSession({ connect: async () => client });
+    await session.close();
+
+    await expect(session.lease({ model: "x", platform: "ios" })).rejects.toMatchObject({
+      code: "SESSION_CLOSED",
+    });
+    await expect(session.release({ leaseId: "l" })).rejects.toMatchObject({
+      code: "SESSION_CLOSED",
+    });
+    await expect(session.listDevices({})).rejects.toMatchObject({ code: "SESSION_CLOSED" });
+    await expect(session.status()).rejects.toMatchObject({ code: "SESSION_CLOSED" });
+    expect(client.calls).toEqual([]);
+  });
+
+  it("relays the client's lease-lost, device-unhealthy, and device-recovered pushes to session listeners", async () => {
+    const client = new FakeSimlockClient();
+    client.getCatalogImpl = () => Promise.resolve({ platforms: [] });
+    const session = new McpSession({ connect: async () => client });
+    await session.listDevices({}); // forces the client to connect and wire up push relays
+
+    const leaseLost: unknown[] = [];
+    const deviceHealth: unknown[] = [];
+    session.onLeaseLost((notice) => leaseLost.push(notice));
+    session.onDeviceHealth((notice) => deviceHealth.push(notice));
+
+    client.emitLeaseLost({ deviceId: "SIM-1", leaseId: "lease-1", reason: "expired" });
+    client.emitDeviceUnhealthy({ deviceId: "SIM-1", leaseId: "lease-1" });
+    client.emitDeviceRecovered({ attempts: 2, deviceId: "SIM-1", leaseId: "lease-1" });
+
+    expect(leaseLost).toEqual([{ deviceId: "SIM-1", leaseId: "lease-1", reason: "expired" }]);
+    expect(deviceHealth).toEqual([
+      { deviceId: "SIM-1", kind: "unhealthy", leaseId: "lease-1", reason: "crashed" },
+      { attempts: 2, deviceId: "SIM-1", kind: "recovered", leaseId: "lease-1" },
     ]);
   });
+});
 
-  it("converts timeout seconds and optional fields for the daemon", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(
-      leaseSimulatorInputSchema.parse({
-        allow_download: true,
-        device: "iPhone 17 Pro",
-        no_wait: true,
-        os: "26.5",
-        platform: "ios",
-        timeout_seconds: 1.25,
-      }),
-    );
-    expect(connection.requests[0]?.payload).toEqual({
-      allowDownload: true,
-      mode: "held",
-      model: "iPhone 17 Pro",
-      noWait: true,
-      osVersion: "26.5",
-      platform: "ios",
-      requesterId: "mcp-session-1",
-      timeoutMs: 1_250,
-    });
-  });
-
-  it("rejects timeout values that would overflow milliseconds before requesting the daemon", async () => {
-    const connection = new StubConnection();
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-
-    await expect(
-      session.lease({ ...input, timeout_seconds: Number.MAX_VALUE }),
-    ).rejects.toMatchObject({ code: "INVALID_TIMEOUT" });
-    expect(connection.requests).toEqual([]);
-  });
-
-  it("rejects releases that this session does not own without calling the daemon", async () => {
-    const connection = new StubConnection();
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await expect(session.release({ lease_id: "other" })).rejects.toMatchObject({
-      code: "LEASE_NOT_OWNED",
-    });
-    expect(connection.requests).toEqual([]);
-  });
-
-  it("preserves expected daemon errors and sanitizes unexpected ones", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(
-      new DaemonClientError("NO_CAPACITY", "No matching devices are available"),
-    );
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await expect(session.lease(input)).rejects.toBeInstanceOf(DaemonClientError);
+describe("toMcpErrorResult", () => {
+  it("maps a SimlockError to its code and message", () => {
     expect(
-      toMcpErrorResult(new DaemonClientError("NO_CAPACITY", "No matching devices are available")),
-    ).toEqual({
-      code: "NO_CAPACITY",
-      message: "No matching devices are available",
-    });
-    expect(toMcpErrorResult(new Error("/private/secret"))).toEqual({
+      toMcpErrorResult(new SimlockError("NO_CAPACITY", "domain", "No matching devices", {})),
+    ).toEqual({ code: "NO_CAPACITY", message: "No matching devices" });
+  });
+
+  it("sanitizes any other error to a generic INTERNAL result", () => {
+    expect(toMcpErrorResult(new Error("/private/secret-stack-path"))).toEqual({
       code: "INTERNAL",
       message: "Simlock could not complete the request",
     });
   });
-
-  it("defers repeat lease ownership decisions to the daemon and replaces stale local ownership", async () => {
-    const connection = new StubConnection();
-    const activeError = new DaemonClientError("REQUESTER_ALREADY_LEASED", "Lease is active");
-    const replacementGrant = {
-      ...rawGrant,
-      lease: { ...rawGrant.lease, id: "lse_replacement" },
-    };
-    connection.responses.push(rawGrant, activeError, replacementGrant, {
-      leaseId: "lse_replacement",
-    });
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-
-    await session.lease(input);
-    await expect(session.lease(input)).rejects.toBe(activeError);
-    await expect(session.lease(input)).resolves.toMatchObject({ lease_id: "lse_replacement" });
-    await session.release({ lease_id: "lse_replacement" });
-    expect(connection.requests.map((request) => request.type)).toEqual([
-      "lease.request",
-      "lease.request",
-      "lease.request",
-      "lease.release",
-    ]);
-  });
-
-  it("rejects malformed and non-held daemon grants", async () => {
-    const malformed = new StubConnection();
-    malformed.responses.push({ nope: true });
-    await expect(
-      new McpSession({ connect: async () => malformed, requesterId: "mcp-session-1" }).lease(input),
-    ).rejects.toThrow("Daemon returned an invalid lease grant");
-    expect(malformed.closeCalls).toBe(1);
-
-    const detached = new StubConnection();
-    detached.responses.push(
-      { ...rawGrant, lease: { ...rawGrant.lease, mode: "detached" } },
-      new DaemonClientError("UNKNOWN_LEASE", "Lease was already gone"),
-    );
-    await expect(
-      new McpSession({ connect: async () => detached, requesterId: "mcp-session-1" }).lease(input),
-    ).rejects.toMatchObject({ code: "INVALID_LEASE_GRANT" });
-    expect(detached.requests).toEqual([
-      expect.objectContaining({ type: "lease.request" }),
-      { payload: { leaseId: "lse_9f2c" }, type: "lease.release" },
-    ]);
-    expect(detached.closeCalls).toBe(1);
-  });
-
-  it("closes the active connection when cancelled so a late grant cannot be orphaned", async () => {
-    const connection = new StubConnection();
-    const lateGrant = deferred<unknown>();
-    connection.responses.push(lateGrant.promise);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    const controller = new AbortController();
-    const unhandled: unknown[] = [];
-    const recordUnhandled = (reason: unknown) => unhandled.push(reason);
-    process.on("unhandledRejection", recordUnhandled);
-    try {
-      const lease = session.lease(input, controller.signal);
-      await waitFor(() => connection.requests.length === 1);
-      controller.abort();
-      await expect(lease).rejects.toMatchObject({ code: "CANCELLED" });
-      expect(connection.closeCalls).toBe(1);
-      lateGrant.resolve(rawGrant);
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      expect(connection.closeCalls).toBe(1);
-      expect(unhandled).toEqual([]);
-    } finally {
-      process.off("unhandledRejection", recordUnhandled);
-    }
-  });
-
-  it("closes promptly during a pending lease and makes the session terminal", async () => {
-    const connection = new StubConnection();
-    const lateGrant = deferred<unknown>();
-    connection.responses.push(lateGrant.promise);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    const unhandled: unknown[] = [];
-    const recordUnhandled = (reason: unknown) => unhandled.push(reason);
-    process.on("unhandledRejection", recordUnhandled);
-    try {
-      const lease = session.lease(input);
-      await waitFor(() => connection.requests.length === 1);
-      await session.close();
-      expect(connection.closeCalls).toBe(1);
-      await expect(lease).rejects.toMatchObject({ code: "SESSION_CLOSED" });
-      await expect(session.lease(input)).rejects.toMatchObject({ code: "SESSION_CLOSED" });
-      await expect(session.release({ lease_id: "lse_9f2c" })).rejects.toMatchObject({
-        code: "SESSION_CLOSED",
-      });
-      lateGrant.resolve(rawGrant);
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      expect(unhandled).toEqual([]);
-    } finally {
-      process.off("unhandledRejection", recordUnhandled);
-    }
-  });
-
-  it("closes a connection that finishes establishing after session shutdown", async () => {
-    const connection = new StubConnection();
-    const connectionDeferred = deferred<DaemonConnection>();
-    let connectCalls = 0;
-    const session = new McpSession({
-      connect: async () => {
-        connectCalls += 1;
-        return connectionDeferred.promise;
-      },
-      requesterId: "mcp-session-1",
-    });
-    const lease = session.lease(input);
-
-    await waitFor(() => connectCalls === 1);
-    await session.close();
-    connectionDeferred.resolve(connection);
-    await expect(lease).rejects.toMatchObject({ code: "SESSION_CLOSED" });
-    await waitFor(() => connection.closeCalls === 1);
-    expect(connection.requests).toEqual([]);
-  });
-
-  it("serializes lease and release mutations", async () => {
-    const connection = new StubConnection();
-    const grant = deferred<unknown>();
-    connection.responses.push(grant.promise, { leaseId: "lse_9f2c" });
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    const lease = session.lease(input);
-    const release = session.release({ lease_id: "lse_9f2c" });
-
-    await waitFor(() => connection.requests.length === 1);
-    expect(connection.requests).toHaveLength(1);
-    grant.resolve(rawGrant);
-    await lease;
-    await release;
-    expect(connection.requests.map((request) => request.type)).toEqual([
-      "lease.request",
-      "lease.release",
-    ]);
-  });
-
-  it("releases explicitly, clears expired ownership, and closes idempotently", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant, { leaseId: "lse_9f2c" });
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-    await expect(session.release({ lease_id: "lse_9f2c" })).resolves.toEqual({
-      lease_id: "lse_9f2c",
-      released: true,
-    });
-    await expect(session.release({ lease_id: "lse_9f2c" })).rejects.toMatchObject({
-      code: "LEASE_NOT_OWNED",
-    });
-    await Promise.all([session.close(), session.close(), session.close()]);
-    expect(connection.closeCalls).toBe(1);
-  });
-
-  it("forgets ownership when the daemon says a lease is unknown or expired", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant, new DaemonClientError("UNKNOWN_LEASE", "Lease expired"));
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-    await expect(session.release({ lease_id: "lse_9f2c" })).rejects.toMatchObject({
-      code: "UNKNOWN_LEASE",
-    });
-    await expect(session.release({ lease_id: "lse_9f2c" })).rejects.toMatchObject({
-      code: "LEASE_NOT_OWNED",
-    });
-  });
-
-  it("maps the daemon catalog to snake_case tool output", async () => {
-    const connection = new StubConnection();
-    connection.responses.push({
-      platforms: [
-        {
-          defaultRuntime: "26.5",
-          models: ["iPhone 16"],
-          platform: "ios",
-          runtimes: ["18.4", "26.5"],
-        },
-        { defaultRuntime: undefined, models: ["Pixel 8"], platform: "android", runtimes: [] },
-      ],
-    });
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-
-    await expect(session.listDevices({})).resolves.toEqual({
-      platforms: [
-        {
-          default_runtime: "26.5",
-          models: ["iPhone 16"],
-          platform: "ios",
-          runtimes: ["18.4", "26.5"],
-        },
-        { default_runtime: undefined, models: ["Pixel 8"], platform: "android", runtimes: [] },
-      ],
-    });
-    expect(connection.requests).toEqual([{ payload: {}, type: "catalog.get" }]);
-  });
-
-  it("forwards the platform filter without leasing or releasing anything", async () => {
-    const connection = new StubConnection();
-    connection.responses.push({ platforms: [] });
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-
-    await expect(session.listDevices({ platform: "android" })).resolves.toEqual({ platforms: [] });
-    expect(connection.requests).toEqual([
-      { payload: { platform: "android" }, type: "catalog.get" },
-    ]);
-  });
-
-  it("rejects listDevices after the session is closed without contacting the daemon", async () => {
-    const connection = new StubConnection();
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.close();
-
-    await expect(session.listDevices({})).rejects.toMatchObject({ code: "SESSION_CLOSED" });
-    expect(connection.requests).toEqual([]);
-  });
-
-  it("reports no lease held until a lease is granted, and the held lease's details after", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant, { leaseId: "lse_9f2c" });
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    expect(session.status()).toEqual({ held: false });
-
-    await session.lease(input);
-    expect(session.status()).toEqual({
-      device: "iPhone 17 Pro",
-      device_id: "ABCD",
-      expires_at_ms: 61_000,
-      held: true,
-      lease_id: "lse_9f2c",
-      os: "26.5",
-      platform: "ios",
-      state: "leased",
-    });
-
-    await session.release({ lease_id: "lse_9f2c" });
-    expect(session.status()).toEqual({ held: false });
-  });
-
-  it("reports the slid expiry after a heartbeat ack, with no daemon round-trip from status() itself", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-    expect(session.status()).toMatchObject({ expires_at_ms: 61_000, held: true });
-
-    const requestsBeforeStatus = connection.requests.length;
-    connection.pushHeartbeatAck({ leases: [{ leaseId: "lse_9f2c", ttlDeadline: 65_000 }] });
-
-    expect(session.status()).toMatchObject({ expires_at_ms: 65_000, held: true });
-    // status() is a synchronous local read; the ack refreshed the cache, not a round-trip.
-    expect(connection.requests).toHaveLength(requestsBeforeStatus);
-  });
-
-  it("ignores a heartbeat ack for a lease id this session does not currently own", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-
-    connection.pushHeartbeatAck({ leases: [{ leaseId: "some-other-lease", ttlDeadline: 99_999 }] });
-    expect(session.status()).toMatchObject({ expires_at_ms: 61_000, held: true });
-  });
-
-  it("tolerates a malformed heartbeat ack without throwing", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-
-    expect(() => connection.pushHeartbeatAck({ leases: "not-an-array" })).not.toThrow();
-    expect(() => connection.pushHeartbeatAck(null)).not.toThrow();
-    expect(session.status()).toMatchObject({ expires_at_ms: 61_000, held: true });
-  });
-
-  it("throws when status is queried on a closed session", async () => {
-    const connection = new StubConnection();
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.close();
-    expect(() => session.status()).toThrowError(
-      expect.objectContaining({ code: "SESSION_CLOSED" }),
-    );
-  });
-
-  it("clears ownership and notifies listeners when the daemon pushes a lease-lost fact", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-
-    const notices: unknown[] = [];
-    session.onLeaseLost((notice) => notices.push(notice));
-    connection.pushLeaseLost({ deviceId: "ABCD", leaseId: "lse_9f2c", reason: "expired" });
-
-    expect(session.status()).toEqual({ held: false });
-    expect(notices).toEqual([{ deviceId: "ABCD", leaseId: "lse_9f2c", reason: "expired" }]);
-    await expect(session.release({ lease_id: "lse_9f2c" })).rejects.toMatchObject({
-      code: "LEASE_NOT_OWNED",
-    });
-  });
-
-  it("ignores a lease-lost push for a lease id this session does not currently own", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-
-    const notices: unknown[] = [];
-    session.onLeaseLost((notice) => notices.push(notice));
-    connection.pushLeaseLost({ deviceId: "other", leaseId: "some-other-lease", reason: "killed" });
-
-    expect(notices).toEqual([]);
-    expect(session.status()).toMatchObject({ held: true, lease_id: "lse_9f2c" });
-  });
-
-  it("ignores malformed lease-lost pushes without throwing", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-
-    const notices: unknown[] = [];
-    session.onLeaseLost((notice) => notices.push(notice));
-    expect(() => connection.pushLeaseLost({} as never)).not.toThrow();
-
-    expect(notices).toEqual([]);
-    expect(session.status()).toMatchObject({ held: true, lease_id: "lse_9f2c" });
-  });
-
-  it("ignores a lease-lost push that arrives for a lease this session already released itself", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant, { leaseId: "lse_9f2c" });
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-    await session.release({ lease_id: "lse_9f2c" });
-
-    const notices: unknown[] = [];
-    session.onLeaseLost((notice) => notices.push(notice));
-    // The daemon suppresses this in practice (issue #15), but the client stays
-    // defensive: a stale push for an id this session no longer owns is a no-op.
-    connection.pushLeaseLost({ deviceId: "ABCD", leaseId: "lse_9f2c", reason: "expired" });
-    expect(notices).toEqual([]);
-  });
-
-  it("notifies onDeviceHealth without ending the lease when the daemon pushes device-unhealthy", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-
-    const notices: unknown[] = [];
-    session.onDeviceHealth((notice) => notices.push(notice));
-    connection.pushDeviceUnhealthy({ deviceId: "ABCD", leaseId: "lse_9f2c", reason: "crashed" });
-
-    expect(notices).toEqual([
-      { deviceId: "ABCD", kind: "unhealthy", leaseId: "lse_9f2c", reason: "crashed" },
-    ]);
-    // Still owned: unlike a lease-lost push, this does not end the lease.
-    expect(session.status()).toMatchObject({ held: true, lease_id: "lse_9f2c" });
-  });
-
-  it("notifies onDeviceHealth without ending the lease when the daemon pushes device-recovered", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-
-    const notices: unknown[] = [];
-    session.onDeviceHealth((notice) => notices.push(notice));
-    connection.pushDeviceRecovered({ attempts: 2, deviceId: "ABCD", leaseId: "lse_9f2c" });
-
-    expect(notices).toEqual([
-      { attempts: 2, deviceId: "ABCD", kind: "recovered", leaseId: "lse_9f2c" },
-    ]);
-    expect(session.status()).toMatchObject({ held: true, lease_id: "lse_9f2c" });
-  });
-
-  it("ignores device-unhealthy/device-recovered pushes for a lease id this session does not currently own", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-
-    const notices: unknown[] = [];
-    session.onDeviceHealth((notice) => notices.push(notice));
-    connection.pushDeviceUnhealthy({
-      deviceId: "other",
-      leaseId: "some-other-lease",
-      reason: "crashed",
-    });
-    connection.pushDeviceRecovered({ attempts: 1, deviceId: "other", leaseId: "some-other-lease" });
-
-    expect(notices).toEqual([]);
-  });
-
-  it("ignores malformed device-unhealthy/device-recovered pushes without throwing", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-
-    const notices: unknown[] = [];
-    session.onDeviceHealth((notice) => notices.push(notice));
-    expect(() => connection.pushDeviceUnhealthy({} as never)).not.toThrow();
-    expect(() => connection.pushDeviceRecovered(null)).not.toThrow();
-
-    expect(notices).toEqual([]);
-    expect(session.status()).toMatchObject({ held: true, lease_id: "lse_9f2c" });
-  });
-
-  it("stops delivering onDeviceHealth notices once the session is closed", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-
-    const notices: unknown[] = [];
-    session.onDeviceHealth((notice) => notices.push(notice));
-    await session.close();
-
-    // Closing unsubscribes the push listener, so a push arriving after close (a race
-    // between shutdown and an in-flight daemon message) is simply never delivered.
-    connection.pushDeviceUnhealthy({ deviceId: "ABCD", leaseId: "lse_9f2c", reason: "crashed" });
-    expect(notices).toEqual([]);
-  });
-
-  it("relays progress pushes to the in-flight lease request's onProgress callback", async () => {
-    const connection = new StubConnection();
-    const grant = deferred<unknown>();
-    connection.responses.push(grant.promise);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-
-    const progressEvents: unknown[] = [];
-    const lease = session.lease(input, undefined, (progress) => progressEvents.push(progress));
-    await waitFor(() => connection.requests.length === 1);
-
-    connection.pushProgress({ queuePosition: 2, stage: "queued" });
-    connection.pushProgress({ etaMs: 9_000, stage: "provisioning" });
-
-    expect(progressEvents).toEqual([
-      { queuePosition: 2, stage: "queued" },
-      { etaMs: 9_000, stage: "provisioning" },
-    ]);
-
-    grant.resolve(rawGrant);
-    await lease;
-  });
-
-  it("does nothing when a lease request has no onProgress callback", async () => {
-    const connection = new StubConnection();
-    const grant = deferred<unknown>();
-    connection.responses.push(grant.promise);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-
-    const lease = session.lease(input);
-    await waitFor(() => connection.requests.length === 1);
-    expect(() => connection.pushProgress({ queuePosition: 3, stage: "queued" })).not.toThrow();
-
-    grant.resolve(rawGrant);
-    await lease;
-  });
-
-  it("stops relaying progress once the lease request has settled", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-
-    const progressEvents: unknown[] = [];
-    await session.lease(input, undefined, (progress) => progressEvents.push(progress));
-    connection.pushProgress({ etaMs: 5_000, stage: "booting" });
-
-    expect(progressEvents).toEqual([]);
-  });
-
-  it("scopes the progress listener to one request: no leakage across sequential lease calls", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant, { leaseId: "lse_9f2c" });
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-
-    const firstProgress: unknown[] = [];
-    await session.lease(input, undefined, (progress) => firstProgress.push(progress));
-    await session.release({ lease_id: "lse_9f2c" });
-
-    const secondGrant = deferred<unknown>();
-    connection.responses.push(secondGrant.promise);
-    const secondProgress: unknown[] = [];
-    const secondLease = session.lease(input, undefined, (progress) =>
-      secondProgress.push(progress),
-    );
-    await waitFor(() => connection.requests.length === 3);
-
-    connection.pushProgress({ etaMs: 1_000, stage: "booting" });
-
-    expect(firstProgress).toEqual([]);
-    expect(secondProgress).toEqual([{ etaMs: 1_000, stage: "booting" }]);
-
-    secondGrant.resolve({ ...rawGrant, lease: { ...rawGrant.lease, id: "lse_second" } });
-    await secondLease;
-  });
-
-  it("stops relaying progress once a cancelled lease request tears down", async () => {
-    const connection = new StubConnection();
-    const grant = deferred<unknown>();
-    connection.responses.push(grant.promise);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    const controller = new AbortController();
-    const progressEvents: unknown[] = [];
-    const lease = session.lease(input, controller.signal, (progress) =>
-      progressEvents.push(progress),
-    );
-    await waitFor(() => connection.requests.length === 1);
-
-    controller.abort();
-    await expect(lease).rejects.toMatchObject({ code: "CANCELLED" });
-    connection.pushProgress({ etaMs: 1_000, stage: "booting" });
-
-    expect(progressEvents).toEqual([]);
-    grant.resolve(rawGrant);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  });
-
-  it("stops relaying progress once the session closes", async () => {
-    const connection = new StubConnection();
-    const grant = deferred<unknown>();
-    connection.responses.push(grant.promise);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-
-    const progressEvents: unknown[] = [];
-    const lease = session.lease(input, undefined, (progress) => progressEvents.push(progress));
-    await waitFor(() => connection.requests.length === 1);
-
-    await session.close();
-    connection.pushProgress({ queuePosition: 1, stage: "queued" });
-
-    expect(progressEvents).toEqual([]);
-    await expect(lease).rejects.toMatchObject({ code: "SESSION_CLOSED" });
-    grant.resolve(rawGrant);
-  });
-
-  it("ignores malformed progress pushes without throwing", async () => {
-    const connection = new StubConnection();
-    const grant = deferred<unknown>();
-    connection.responses.push(grant.promise);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-
-    const progressEvents: unknown[] = [];
-    const lease = session.lease(input, undefined, (progress) => progressEvents.push(progress));
-    await waitFor(() => connection.requests.length === 1);
-
-    expect(() => connection.pushProgress({ stage: "not-a-stage" })).not.toThrow();
-    expect(() => connection.pushProgress({ stage: "queued" })).not.toThrow();
-    expect(() => connection.pushProgress({ stage: "provisioning" })).not.toThrow();
-    expect(() => connection.pushProgress(null)).not.toThrow();
-
-    expect(progressEvents).toEqual([]);
-    grant.resolve(rawGrant);
-    await lease;
-  });
-
-  it("reconnects lazily after a daemon restart between two calls", async () => {
-    const connectionA = new StubConnection();
-    connectionA.responses.push({ platforms: [] });
-    const connectionB = new StubConnection();
-    connectionB.responses.push({ platforms: [] });
-    const connections = [connectionA, connectionB];
-    let connectCalls = 0;
-    const session = new McpSession({
-      connect: async () => {
-        connectCalls += 1;
-        return connections.shift()!;
-      },
-      requesterId: "mcp-session-1",
-    });
-
-    await expect(session.listDevices({})).resolves.toEqual({ platforms: [] });
-    expect(connectCalls).toBe(1);
-
-    // The daemon restarts: the socket underneath the cached connection dies.
-    connectionA.emitClose();
-
-    await expect(session.listDevices({})).resolves.toEqual({ platforms: [] });
-    expect(connectCalls).toBe(2);
-    expect(connectionA.requests).toEqual([{ payload: {}, type: "catalog.get" }]);
-    expect(connectionB.requests).toEqual([{ payload: {}, type: "catalog.get" }]);
-  });
-
-  it("surfaces DAEMON_CONNECTION_LOST, without retrying, when the connection dies mid lease request", async () => {
-    const connection = new StubConnection();
-    const grant = deferred<unknown>();
-    connection.responses.push(grant.promise);
-    let connectCalls = 0;
-    const session = new McpSession({
-      connect: async () => {
-        connectCalls += 1;
-        return connection;
-      },
-      requesterId: "mcp-session-1",
-    });
-
-    const lease = session.lease(input);
-    await waitFor(() => connection.requests.length === 1);
-
-    // The socket dies while the daemon is still deciding on the lease request.
-    connection.emitClose();
-    grant.reject(new DaemonClientError("DAEMON_CONNECTION_LOST", "Daemon connection closed"));
-
-    await expect(lease).rejects.toMatchObject({ code: "DAEMON_CONNECTION_LOST" });
-    // A retry here could provision and grant a second device -- must never happen.
-    expect(connectCalls).toBe(1);
-    expect(connection.requests).toHaveLength(1);
-    expect(session.status()).toEqual({ held: false });
-  });
-
-  it("retries a read-only catalog.get once after the connection dies mid-request", async () => {
-    const connection = new StubConnection();
-    const firstResponse = deferred<unknown>();
-    connection.responses.push(firstResponse.promise);
-    connection.responses.push({ platforms: [] });
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-
-    const listing = session.listDevices({});
-    await waitFor(() => connection.requests.length === 1);
-    connection.emitClose();
-    firstResponse.reject(
-      new DaemonClientError("DAEMON_CONNECTION_LOST", "Daemon connection closed"),
-    );
-
-    await expect(listing).resolves.toEqual({ platforms: [] });
-    expect(connection.requests).toEqual([
-      { payload: {}, type: "catalog.get" },
-      { payload: {}, type: "catalog.get" },
-    ]);
-  });
-
-  it("forces a fresh connection on retry when DAEMON_CONNECTION_LOST arrives without #connection having been cleared yet", async () => {
-    // This pins the ordering IpcDaemonConnection.request() also rejects synchronously once it
-    // observes the transport already closed, which can race ahead of the underlying `onClose`
-    // propagating back to `#handleConnectionClosed`. `connectionA` here rejects the same way but
-    // deliberately never calls `emitClose()`, so `#connection` is still set to it when the retry
-    // runs -- the retry must not just hand back the same dead connection.
-    const connectionA = new StubConnection();
-    connectionA.responses.push(
-      new DaemonClientError("DAEMON_CONNECTION_LOST", "Daemon connection is closed"),
-    );
-    const connectionB = new StubConnection();
-    connectionB.responses.push({ platforms: [] });
-    const connections = [connectionA, connectionB];
-    let connectCalls = 0;
-    const session = new McpSession({
-      connect: async () => {
-        connectCalls += 1;
-        return connections.shift()!;
-      },
-      requesterId: "mcp-session-1",
-    });
-
-    await expect(session.listDevices({})).resolves.toEqual({ platforms: [] });
-    expect(connectCalls).toBe(2);
-    expect(connectionA.requests).toEqual([{ payload: {}, type: "catalog.get" }]);
-    expect(connectionB.requests).toEqual([{ payload: {}, type: "catalog.get" }]);
-  });
-
-  it("clears an owned lease and notifies onLeaseLost when the connection dies across a restart", async () => {
-    const connection = new StubConnection();
-    connection.responses.push(rawGrant);
-    const session = new McpSession({
-      connect: async () => connection,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-    expect(session.status()).toMatchObject({ held: true, lease_id: "lse_9f2c" });
-
-    const notices: unknown[] = [];
-    session.onLeaseLost((notice) => notices.push(notice));
-
-    // A graceful stop or an ungraceful crash both release the held lease daemon-side (see
-    // DaemonServer#stop / the startup path's orphan sweep) -- the reconnect never asks.
-    connection.emitClose();
-
-    expect(notices).toEqual([
-      { deviceId: "ABCD", leaseId: "lse_9f2c", reason: "daemon-connection-lost" },
-    ]);
-    expect(session.status()).toEqual({ held: false });
-  });
-
-  it("keeps an onDeviceHealth listener registered across a reconnect after the connection dies", async () => {
-    const connectionA = new StubConnection();
-    connectionA.responses.push(rawGrant);
-    const connectionB = new StubConnection();
-    const connections = [connectionA, connectionB];
-    const session = new McpSession({
-      connect: async () => connections.shift()!,
-      requesterId: "mcp-session-1",
-    });
-    await session.lease(input);
-
-    const notices: unknown[] = [];
-    session.onDeviceHealth((notice) => notices.push(notice));
-
-    // The connection dies (daemon restart); `#handleConnectionClosed` drops the push
-    // subscription along with the owned lease, so a stale push on the dead connection
-    // must not reach the listener.
-    connectionA.emitClose();
-    connectionA.pushDeviceUnhealthy({ deviceId: "ABCD", leaseId: "lse_9f2c", reason: "crashed" });
-    expect(notices).toEqual([]);
-
-    // A fresh lease through the lazily-reconnected session (connectionB) is owned
-    // again, and the *same* onDeviceHealth listener -- never re-registered by this
-    // test -- still fires for it: registration survives the reconnect without leaking.
-    connectionB.responses.push({
-      ...rawGrant,
-      lease: { ...rawGrant.lease, id: "lse_after_reconnect" },
-    });
-    await session.lease(input);
-    connectionB.pushDeviceUnhealthy({
-      deviceId: "ABCD",
-      leaseId: "lse_after_reconnect",
-      reason: "crashed",
-    });
-
-    expect(notices).toEqual([
-      { deviceId: "ABCD", kind: "unhealthy", leaseId: "lse_after_reconnect", reason: "crashed" },
-    ]);
-  });
-
-  it("surfaces DAEMON_UNAVAILABLE when reconnecting after a restart fails", async () => {
-    const connection = new StubConnection();
-    connection.responses.push({ platforms: [] });
-    let connectCalls = 0;
-    const session = new McpSession({
-      connect: async () => {
-        connectCalls += 1;
-        if (connectCalls === 1) return connection;
-        throw new Error("ECONNREFUSED");
-      },
-      requesterId: "mcp-session-1",
-    });
-
-    await expect(session.listDevices({})).resolves.toEqual({ platforms: [] });
-    connection.emitClose();
-
-    await expect(session.listDevices({})).rejects.toMatchObject({
-      code: "DAEMON_UNAVAILABLE",
-    });
-    expect(connectCalls).toBe(2);
-  });
 });
-
-class StubConnection implements DaemonConnection {
-  readonly requests: Array<{ readonly payload: unknown; readonly type: string }> = [];
-  readonly responses: unknown[] = [];
-  closeCalls = 0;
-  #closed = false;
-  readonly #listeners = new Set<(kind: string, payload: unknown) => void>();
-  readonly #closeListeners = new Set<() => void>();
-
-  async request(type: string, payload: unknown): Promise<unknown> {
-    this.requests.push({ payload, type });
-    const response = this.responses.shift();
-    if (response instanceof Error) throw response;
-    return response instanceof Promise ? response : response;
-  }
-
-  onPush(listener: (kind: string, payload: unknown) => void): () => void {
-    this.#listeners.add(listener);
-    return () => this.#listeners.delete(listener);
-  }
-
-  onClose(listener: () => void): () => void {
-    this.#closeListeners.add(listener);
-    return () => this.#closeListeners.delete(listener);
-  }
-
-  /** Simulates the socket dying under this connection (daemon restart/crash). */
-  emitClose(): void {
-    if (this.#closed) return;
-    this.#closed = true;
-    for (const listener of this.#closeListeners) listener();
-  }
-
-  pushLeaseLost(payload: {
-    readonly deviceId: string;
-    readonly leaseId: string;
-    readonly reason: string;
-  }): void {
-    for (const listener of this.#listeners) listener("lease-lost", payload);
-  }
-
-  pushDeviceUnhealthy(payload: unknown): void {
-    for (const listener of this.#listeners) listener("device-unhealthy", payload);
-  }
-
-  pushDeviceRecovered(payload: unknown): void {
-    for (const listener of this.#listeners) listener("device-recovered", payload);
-  }
-
-  /**
-   * Wraps the given stage payload under `{requestId, progress}` -- ADR 0003 §8's push
-   * correlation shape (see `DaemonServer#pushProgress`) -- so callers can keep passing the bare
-   * stage object `parseRawLeaseProgress` ultimately unwraps this back to.
-   */
-  pushProgress(payload: unknown): void {
-    for (const listener of this.#listeners)
-      listener("progress", { progress: payload, requestId: "test-request" });
-  }
-
-  /**
-   * Simulates the ack `IpcDaemonConnection` re-surfaces as a push after it auto-answers the
-   * server's `lease.heartbeat` push (see `src/daemon-client/connection.ts`).
-   */
-  pushHeartbeatAck(payload: unknown): void {
-    for (const listener of this.#listeners) listener("lease.heartbeat", payload);
-  }
-
-  async close(): Promise<void> {
-    this.closeCalls += 1;
-  }
-}
-
-function deferred<T>(): {
-  promise: Promise<T>;
-  reject: (error: unknown) => void;
-  resolve: (value: T) => void;
-} {
-  let resolve!: (value: T) => void;
-  let reject!: (error: unknown) => void;
-  const promise = new Promise<T>((nextResolve, nextReject) => {
-    resolve = nextResolve;
-    reject = nextReject;
-  });
-  promise.catch(() => undefined);
-  return { promise, reject, resolve };
-}
-
-async function waitFor(predicate: () => boolean): Promise<void> {
-  while (!predicate()) await new Promise((resolve) => setTimeout(resolve, 0));
-}

--- a/src/mcp/session.ts
+++ b/src/mcp/session.ts
@@ -1,35 +1,28 @@
 import {
-  parseRawCatalog,
-  parseRawDeviceRecovered,
-  parseRawDeviceUnhealthy,
-  parseRawLeaseGrant,
-  parseRawLeaseHeartbeatAck,
-  parseRawLeaseLost,
-  parseRawLeaseProgress,
-  type RawLeaseGrant,
-  type RawLeaseProgress,
-} from "../daemon-client/contracts.js";
-import { DaemonClientError, type DaemonConnection } from "../daemon-client/protocol.js";
+  isSimlockError,
+  SimlockError,
+  type LeaseProgress,
+  type LeaseRequestInput,
+  type SimlockClient,
+} from "../client/index.js";
 import type {
-  HeldLeaseStatus,
   LeaseSimulatorInput,
   LeaseSimulatorOutput,
   LeaseStatusOutput,
   ListDevicesInput,
   ListDevicesOutput,
-  NoLeaseStatus,
   ReleaseSimulatorInput,
   ReleaseSimulatorOutput,
 } from "./contracts.js";
-import {
-  leaseSimulatorOutputSchema,
-  listDevicesOutputSchema,
-  MAX_TIMEOUT_SECONDS,
-} from "./contracts.js";
 
 export interface McpSessionOptions {
-  readonly connect: () => Promise<DaemonConnection>;
-  readonly requesterId: string;
+  /**
+   * Opens one connection and completes the `hello` handshake, fixing this session's principal
+   * for the connection's lifetime (ADR §4). Called again -- building a brand new client, never
+   * reusing or repairing the dead one -- on lazy reconnect: the typed client "does not
+   * reconnect and does not retry" (ADR §10), so that policy has to live here.
+   */
+  readonly connect: () => Promise<SimlockClient>;
 }
 
 export interface McpErrorResult {
@@ -64,22 +57,7 @@ export type DeviceHealthNotice =
     };
 
 /** Delivered to a `lease()` call's own `onProgress` callback while that request is in flight. */
-export type LeaseProgressNotice = RawLeaseProgress;
-
-interface OwnedLease {
-  readonly device: string;
-  readonly deviceId: string;
-  readonly expiresAtMs: number;
-  readonly leaseId: string;
-  readonly os: string;
-  readonly platform: "android" | "ios";
-}
-
-interface LeaseAbortWatch {
-  readonly cancelled: Promise<never>;
-  cleanup(): Promise<void> | undefined;
-  dispose(): void;
-}
+export type LeaseProgressNotice = LeaseProgress;
 
 class McpSessionError extends Error {
   constructor(
@@ -92,100 +70,84 @@ class McpSessionError extends Error {
 }
 
 export function toMcpErrorResult(error: unknown): McpErrorResult {
-  if (error instanceof DaemonClientError || error instanceof McpSessionError) {
-    return { code: error.code, message: error.message };
-  }
+  if (isSimlockError(error)) return { code: error.code, message: error.message };
+  if (error instanceof McpSessionError) return { code: error.code, message: error.message };
   return { code: "INTERNAL", message: "Simlock could not complete the request" };
 }
 
+/**
+ * MCP's own connection lifecycle and tool surface (ADR §11: "MCP keeps only connection
+ * lifecycle (lazy reconnect, tool-call serialization) and its MCP-only relays"). Everything
+ * that used to be hand-built payload construction, response parsing, and a session-local
+ * owned-lease cache is gone -- `#client` (a `SimlockClient`, ADR §10) does all of that now.
+ * `lease_status` is one `lease.list` call, not a cache read (ADR §9); releasing a lease this
+ * session does not own surfaces the daemon's own `FORBIDDEN` rather than a client-side guard
+ * pre-empting it (ADR §11).
+ */
 export class McpSession {
-  readonly #connect: () => Promise<DaemonConnection>;
-  readonly #requesterId: string;
-  #connection: DaemonConnection | undefined;
-  #connecting: Promise<DaemonConnection> | undefined;
+  readonly #connect: () => Promise<SimlockClient>;
+  #client: SimlockClient | undefined;
+  #connecting: Promise<SimlockClient> | undefined;
   #closed = false;
-  #closedConnections = new Set<DaemonConnection>();
+  readonly #closedClients = new Set<SimlockClient>();
   #closePromise: Promise<void> | undefined;
-  #rejectClosed!: (reason: McpSessionError) => void;
-  #sessionClosed: Promise<never>;
-  #ownedLease: OwnedLease | undefined;
-  #pushUnsubscribe: (() => void) | undefined;
-  #closeUnsubscribe: (() => void) | undefined;
-  /** Scoped to the in-flight `lease()` call; cleared once that call settles or the session closes. */
-  #leaseProgressListener: ((progress: LeaseProgressNotice) => void) | undefined;
+  #clientUnsubscribers: Array<() => void> = [];
   readonly #leaseLostListeners = new Set<(notice: LeaseLostNotice) => void>();
   readonly #deviceHealthListeners = new Set<(notice: DeviceHealthNotice) => void>();
+  /** Serializes every mutating (and `listDevices`/`status`, for simplicity) tool call on this
+   * session so concurrent `lease_simulator`/`release_simulator` calls never interleave. */
   #mutations: Promise<void> = Promise.resolve();
 
   constructor(options: McpSessionOptions) {
     this.#connect = options.connect;
-    this.#requesterId = options.requesterId;
-    this.#sessionClosed = new Promise<never>((_resolve, reject) => {
-      this.#rejectClosed = reject;
-    });
-    void this.#sessionClosed.catch(() => undefined);
   }
 
-  /**
-   * `onProgress` is scoped to this call only: it receives queue/provisioning/boot updates for
-   * this request while it is in flight, and is torn down on completion, error, cancellation, or
-   * session close. It never leaks across sequential lease requests.
-   */
   lease(
     input: LeaseSimulatorInput,
     signal?: AbortSignal,
     onProgress?: (progress: LeaseProgressNotice) => void,
   ): Promise<LeaseSimulatorOutput> {
-    return this.#mutate(() => {
+    return this.#mutate(async () => {
       this.#throwIfClosed();
-      return this.#lease(input, signal, onProgress);
+      const client = await this.#clientForUse();
+      const request: LeaseRequestInput = { ...input, mode: "held" };
+      return client.requestLease(request, {
+        ...(onProgress === undefined ? {} : { onProgress }),
+        ...(signal === undefined ? {} : { signal }),
+      });
     });
   }
 
   release(input: ReleaseSimulatorInput): Promise<ReleaseSimulatorOutput> {
     return this.#mutate(async () => {
       this.#throwIfClosed();
-      if (this.#ownedLease?.leaseId !== input.lease_id) {
-        throw new McpSessionError("LEASE_NOT_OWNED", "This session does not own that lease");
-      }
-      const connection = await this.#connectionForUse();
-      try {
-        await Promise.race([
-          connection.request("lease.release", { leaseId: input.lease_id }),
-          this.#sessionClosed,
-        ]);
-      } catch (error: unknown) {
-        if (isNoLongerActiveLease(error)) this.#ownedLease = undefined;
-        throw error;
-      }
-      this.#ownedLease = undefined;
-      return { lease_id: input.lease_id, released: true };
+      const client = await this.#clientForUse();
+      const result = await client.releaseLease(input);
+      return { ...result, released: true };
     });
   }
 
   listDevices(input: ListDevicesInput): Promise<ListDevicesOutput> {
     return this.#mutate(async () => {
       this.#throwIfClosed();
-      const response = await this.#requestReadOnly(
-        "catalog.get",
-        input.platform === undefined ? {} : { platform: input.platform },
-      );
-      const catalog = parseRawCatalog(response);
-      return listDevicesOutputSchema.parse({
-        platforms: catalog.platforms.map((entry) => ({
-          default_runtime: entry.defaultRuntime,
-          models: entry.models,
-          platform: entry.platform,
-          runtimes: entry.runtimes,
-        })),
-      });
+      const client = await this.#clientForUse();
+      return client.getCatalog(input);
     });
   }
 
-  /** This session's current lease, or an explicit "no lease held" result. Cheap, local, and safe to poll. */
-  status(): LeaseStatusOutput {
-    this.#throwIfClosed();
-    return this.#ownedLease === undefined ? noLeaseStatus() : heldLeaseStatus(this.#ownedLease);
+  /**
+   * This session's current lease, or an explicit "no lease held" result -- one `lease.list`
+   * call (ADR §9), never a local cache. This session only ever requests `mode: "held"` leases
+   * under one requester id (its fixed principal), so `leases` holds at most one entry.
+   */
+  status(): Promise<LeaseStatusOutput> {
+    return this.#mutate(async () => {
+      this.#throwIfClosed();
+      const client = await this.#clientForUse();
+      const { leases } = await client.listLeases();
+      const lease = leases[0];
+      return lease === undefined ? { held: false } : { ...lease, held: true };
+    });
   }
 
   /** Notifies when this session's held lease ends elsewhere (expiry or a force-release). */
@@ -206,334 +168,103 @@ export class McpSession {
   close(): Promise<void> {
     if (this.#closePromise !== undefined) return this.#closePromise;
     this.#closed = true;
-    this.#ownedLease = undefined;
-    this.#leaseProgressListener = undefined;
-    this.#pushUnsubscribe?.();
-    this.#pushUnsubscribe = undefined;
-    this.#closeUnsubscribe?.();
-    this.#closeUnsubscribe = undefined;
-    this.#rejectClosed(new McpSessionError("SESSION_CLOSED", "MCP session is closed"));
-    const connection = this.#connection;
-    this.#connection = undefined;
+    this.#unwireClient();
+    const client = this.#client;
+    this.#client = undefined;
     if (this.#connecting !== undefined) {
-      void this.#connecting
-        .then((nextConnection) => this.#closeDaemonConnection(nextConnection))
-        .catch(noop);
+      void this.#connecting.then((next) => this.#closeClient(next)).catch(noop);
     }
-    this.#closePromise =
-      connection === undefined ? Promise.resolve() : this.#closeDaemonConnection(connection);
+    this.#closePromise = client === undefined ? Promise.resolve() : this.#closeClient(client);
     return this.#closePromise;
   }
 
-  async #lease(
-    input: LeaseSimulatorInput,
-    signal?: AbortSignal,
-    onProgress?: (progress: LeaseProgressNotice) => void,
-  ): Promise<LeaseSimulatorOutput> {
-    throwIfAborted(signal);
-
-    const abortWatch = this.#watchLeaseAbort(signal);
-    this.#leaseProgressListener = onProgress;
-    let responseReceived = false;
-    try {
-      const connection = await this.#connectionForUse();
-      await this.#throwIfCancelledBeforeRequest(signal);
-      const response = await this.#requestLease(connection, input, abortWatch.cancelled);
-      responseReceived = true;
-      return await this.#mapLeaseResponse(connection, response, signal, abortWatch);
-    } catch (error: unknown) {
-      await this.#cleanupFailedLease(responseReceived, abortWatch.cleanup());
-      throw error;
-    } finally {
-      this.#leaseProgressListener = undefined;
-      abortWatch.dispose();
-    }
-  }
-
-  #watchLeaseAbort(signal: AbortSignal | undefined): LeaseAbortWatch {
-    let cleanup: Promise<void> | undefined;
-    let reject: ((reason: McpSessionError) => void) | undefined;
-    const cancelled = new Promise<never>((_resolve, nextReject) => {
-      reject = nextReject;
-    });
-    void cancelled.catch(() => undefined);
-    const abort = () => {
-      cleanup ??= this.#closeConnection().catch(() => undefined);
-      reject?.(new McpSessionError("CANCELLED", "Lease request cancelled"));
-    };
-    signal?.addEventListener("abort", abort, { once: true });
-    return {
-      cancelled,
-      cleanup: () => cleanup,
-      dispose: () => signal?.removeEventListener("abort", abort),
-    };
-  }
-
-  async #throwIfCancelledBeforeRequest(signal: AbortSignal | undefined): Promise<void> {
-    if (!signal?.aborted) return;
-    await this.#closeConnection().catch(() => undefined);
-    throw new McpSessionError("CANCELLED", "Lease request cancelled");
-  }
-
-  #requestLease(
-    connection: DaemonConnection,
-    input: LeaseSimulatorInput,
-    cancelled: Promise<never>,
-  ): Promise<unknown> {
-    return Promise.race([
-      connection.request("lease.request", daemonLeaseRequest(input, this.#requesterId)),
-      cancelled,
-      this.#sessionClosed,
-    ]);
-  }
-
-  async #mapLeaseResponse(
-    connection: DaemonConnection,
-    response: unknown,
-    signal: AbortSignal | undefined,
-    abortWatch: LeaseAbortWatch,
-  ): Promise<LeaseSimulatorOutput> {
-    const grant = parseRawLeaseGrant(response);
-    this.#throwIfClosed();
-    if (signal?.aborted) {
-      await abortWatch.cleanup();
-      throw new McpSessionError("CANCELLED", "Lease request cancelled");
-    }
-    if (grant.lease.mode !== "held") {
-      await this.#releaseUnexpectedLease(connection, grant.lease.id);
-      throw new McpSessionError("INVALID_LEASE_GRANT", "Daemon returned a non-held lease grant");
-    }
-    const output = leaseSimulatorOutputSchema.parse(leaseSimulatorOutput(grant));
-    this.#ownedLease = {
-      device: output.device,
-      deviceId: output.device_id,
-      expiresAtMs: output.expires_at_ms,
-      leaseId: output.lease_id,
-      os: output.os,
-      platform: output.platform,
-    };
-    return output;
-  }
-
-  async #releaseUnexpectedLease(connection: DaemonConnection, leaseId: string): Promise<void> {
-    try {
-      await connection.request("lease.release", { leaseId });
-    } catch {
-      // The connection close below remains the daemon-side held-lease cleanup fallback.
-    } finally {
-      await this.#closeConnection().catch(() => undefined);
-    }
-  }
-
-  async #cleanupFailedLease(
-    responseReceived: boolean,
-    abortCleanup: Promise<void> | undefined,
-  ): Promise<void> {
-    if (abortCleanup !== undefined) await abortCleanup;
-    else if (responseReceived) await this.#closeConnection().catch(() => undefined);
-  }
-
   /**
-   * Reconnects lazily: a dead `#connection` (cleared by `#handleConnectionClosed`, below) makes
-   * the next call re-run `#connect()`, which auto-starts the daemon exactly as the CLI does and
-   * re-negotiates capabilities (e.g. the heartbeat) at `hello`, free of charge.
+   * Reconnects lazily: a dead `#client` (cleared by the client's own `onConnectionLost`, below)
+   * makes the next call re-run `#connect()`, building a brand new `SimlockClient` -- the typed
+   * client itself never reconnects (ADR §10), so constructing a fresh one here on every dead
+   * connection is what keeps MCP's process-outlives-a-connection lifecycle working.
    */
-  async #connectionForUse(): Promise<DaemonConnection> {
-    if (this.#connection !== undefined) return this.#connection;
+  async #clientForUse(): Promise<SimlockClient> {
+    if (this.#client !== undefined) return this.#client;
     this.#connecting ??= this.#connect();
     const connecting = this.#connecting;
     try {
-      const connection = await connecting;
+      const client = await connecting;
       if (this.#closed) {
-        await this.#closeDaemonConnection(connection);
+        await this.#closeClient(client);
         this.#throwIfClosed();
       }
-      this.#connection = connection;
-      this.#pushUnsubscribe = connection.onPush((kind, payload) => this.#handlePush(kind, payload));
-      this.#closeUnsubscribe = connection.onClose(() => this.#handleConnectionClosed(connection));
-      return connection;
+      this.#client = client;
+      this.#wireClient(client);
+      return client;
     } catch (error: unknown) {
       this.#throwIfClosed();
-      if (error instanceof DaemonClientError || error instanceof McpSessionError) throw error;
-      throw new DaemonClientError("DAEMON_UNAVAILABLE", errorMessage(error));
+      // `#connect` is expected to reject with a `SimlockError` (the real implementation always
+      // does -- see `main.ts`'s `connectWithAutoLaunch`), but this is a defensive fallback for
+      // any other injected `connect` so a caller never sees a bare, un-coded exception.
+      throw isSimlockError(error)
+        ? error
+        : new SimlockError(
+            "DAEMON_CONNECTION_LOST",
+            "transport",
+            error instanceof Error ? error.message : String(error),
+            {},
+          );
     } finally {
       if (this.#connecting === connecting) this.#connecting = undefined;
     }
   }
 
-  async #closeConnection(): Promise<void> {
-    const connection = this.#connection;
-    this.#connection = undefined;
-    this.#pushUnsubscribe?.();
-    this.#pushUnsubscribe = undefined;
-    this.#closeUnsubscribe?.();
-    this.#closeUnsubscribe = undefined;
-    if (connection !== undefined) await this.#closeDaemonConnection(connection);
-  }
-
   /**
-   * The invariant this relies on: a dead connection means the held lease is already gone
-   * daemon-side, by one of three paths — a graceful `daemon stop` releases held leases before
-   * exiting, an ordinary connection close releases that connection's held leases the same way,
-   * and an ungraceful death leaves the lease persisted for the startup path to release as
-   * `orphaned`. So this never asks the daemon; it just stops believing the lease is ours and
-   * tells the agent (#15's `onLeaseLost` channel) so it can decide whether to re-lease.
+   * Relays a freshly-connected client's pushes to this session's own listeners (which survive
+   * across a reconnect, unlike the client itself), and drops `#client` the moment this
+   * connection dies so the next call reconnects. The client already synthesizes `onLeaseLost`
+   * for every lease it held when its connection dies (ADR §10), so nothing extra is needed
+   * here for that case.
    */
-  #handleConnectionClosed(connection: DaemonConnection): void {
-    if (this.#connection !== connection) return;
-    this.#connection = undefined;
-    this.#pushUnsubscribe?.();
-    this.#pushUnsubscribe = undefined;
-    this.#closeUnsubscribe = undefined;
-    if (this.#ownedLease === undefined) return;
-    const lease = this.#ownedLease;
-    this.#ownedLease = undefined;
-    for (const listener of this.#leaseLostListeners) {
-      listener({
-        deviceId: lease.deviceId,
-        leaseId: lease.leaseId,
-        reason: "daemon-connection-lost",
-      });
-    }
+  #wireClient(client: SimlockClient): void {
+    this.#clientUnsubscribers = [
+      client.onLeaseLost((push) => {
+        for (const listener of this.#leaseLostListeners) listener(push);
+      }),
+      client.onDeviceUnhealthy((push) => {
+        for (const listener of this.#deviceHealthListeners) {
+          listener({
+            deviceId: push.deviceId,
+            kind: "unhealthy",
+            leaseId: push.leaseId,
+            reason: "crashed",
+          });
+        }
+      }),
+      client.onDeviceRecovered((push) => {
+        for (const listener of this.#deviceHealthListeners) {
+          listener({
+            attempts: push.attempts,
+            deviceId: push.deviceId,
+            kind: "recovered",
+            leaseId: push.leaseId,
+          });
+        }
+      }),
+      client.onConnectionLost(() => {
+        if (this.#client === client) {
+          this.#client = undefined;
+          this.#unwireClient();
+        }
+      }),
+    ];
   }
 
-  /**
-   * Retries at most once, and only for idempotent, read-only requests. A `lease.request` must
-   * never go through here: retrying it after a mid-request connection death could provision and
-   * grant a *second* device, which would violate "reconnecting never implicitly acquires one".
-   */
-  async #requestReadOnly(type: string, payload: unknown): Promise<unknown> {
-    const connection = await this.#connectionForUse();
-    try {
-      return await Promise.race([connection.request(type, payload), this.#sessionClosed]);
-    } catch (error: unknown) {
-      if (!(error instanceof DaemonClientError) || error.code !== "DAEMON_CONNECTION_LOST") {
-        throw error;
-      }
-      // The close listener may not have run yet -- `IpcDaemonConnection.request()` also
-      // rejects synchronously once it observes the transport already closed, ahead of the
-      // underlying `onClose` propagating back to `#handleConnectionClosed`. Don't trust that
-      // ordering: if this is still the connection that just failed, drop it explicitly so
-      // `#connectionForUse()` is forced to build a fresh one instead of handing back the same
-      // dead connection.
-      if (this.#connection === connection) await this.#closeConnection().catch(() => undefined);
-      const retryConnection = await this.#connectionForUse();
-      return await Promise.race([retryConnection.request(type, payload), this.#sessionClosed]);
-    }
+  #unwireClient(): void {
+    for (const unsubscribe of this.#clientUnsubscribers) unsubscribe();
+    this.#clientUnsubscribers = [];
   }
 
-  /**
-   * Relays a daemon push to this session's own listeners (lease-lost facts, in-flight lease
-   * progress, and the heartbeat ack that keeps `#ownedLease.expiresAtMs` truthful under the
-   * sliding TTL — see `IpcDaemonConnection`, which turns the server's `lease.heartbeat` push
-   * into an answered request and re-surfaces its ack here under the same push kind).
-   */
-  #handlePush(kind: string, payload: unknown): void {
-    switch (kind) {
-      case "progress":
-        this.#handleLeaseProgress(payload);
-        return;
-      case "lease.heartbeat":
-        this.#handleHeartbeatAck(payload);
-        return;
-      case "lease-lost":
-        this.#handleLeaseLost(payload);
-        return;
-      case "device-unhealthy":
-        this.#handleDeviceUnhealthy(payload);
-        return;
-      case "device-recovered":
-        this.#handleDeviceRecovered(payload);
-        return;
-    }
-  }
-
-  /** Relays a lease-lost push to `#leaseLostListeners`, if it names this session's own lease. */
-  #handleLeaseLost(payload: unknown): void {
-    let notice: LeaseLostNotice;
-    try {
-      notice = parseRawLeaseLost(payload);
-    } catch {
-      return;
-    }
-    if (this.#ownedLease === undefined || this.#ownedLease.leaseId !== notice.leaseId) return;
-    this.#ownedLease = undefined;
-    for (const listener of this.#leaseLostListeners) listener(notice);
-  }
-
-  /** Relays a device-unhealthy push to `#deviceHealthListeners`, if it names this session's lease. */
-  #handleDeviceUnhealthy(payload: unknown): void {
-    let raw: ReturnType<typeof parseRawDeviceUnhealthy>;
-    try {
-      raw = parseRawDeviceUnhealthy(payload);
-    } catch {
-      return;
-    }
-    if (this.#ownedLease === undefined || this.#ownedLease.leaseId !== raw.leaseId) return;
-    for (const listener of this.#deviceHealthListeners) {
-      listener({
-        deviceId: raw.deviceId,
-        kind: "unhealthy",
-        leaseId: raw.leaseId,
-        reason: "crashed",
-      });
-    }
-  }
-
-  /** Relays a device-recovered push to `#deviceHealthListeners`, if it names this session's lease. */
-  #handleDeviceRecovered(payload: unknown): void {
-    let raw: ReturnType<typeof parseRawDeviceRecovered>;
-    try {
-      raw = parseRawDeviceRecovered(payload);
-    } catch {
-      return;
-    }
-    if (this.#ownedLease === undefined || this.#ownedLease.leaseId !== raw.leaseId) return;
-    for (const listener of this.#deviceHealthListeners) {
-      listener({
-        attempts: raw.attempts,
-        deviceId: raw.deviceId,
-        kind: "recovered",
-        leaseId: raw.leaseId,
-      });
-    }
-  }
-
-  /**
-   * `lease_status` reads `#ownedLease.expiresAtMs` locally, with no daemon round-trip
-   * (deliberate — see PR #25). Under a sliding TTL that cache would otherwise go stale the
-   * moment a heartbeat renews the lease elsewhere; this keeps it truthful without adding a
-   * round-trip to `status()` itself.
-   */
-  #handleHeartbeatAck(payload: unknown): void {
-    if (this.#ownedLease === undefined) return;
-    let ack: ReturnType<typeof parseRawLeaseHeartbeatAck>;
-    try {
-      ack = parseRawLeaseHeartbeatAck(payload);
-    } catch {
-      return;
-    }
-    const slid = ack.leases.find((lease) => lease.leaseId === this.#ownedLease?.leaseId);
-    if (slid === undefined) return;
-    this.#ownedLease = { ...this.#ownedLease, expiresAtMs: slid.ttlDeadline };
-  }
-
-  /** Relays a daemon progress push to the in-flight `lease()` call's own `onProgress`, if any. */
-  #handleLeaseProgress(payload: unknown): void {
-    if (this.#leaseProgressListener === undefined) return;
-    let progress: LeaseProgressNotice;
-    try {
-      progress = parseRawLeaseProgress(payload);
-    } catch {
-      return;
-    }
-    this.#leaseProgressListener(progress);
-  }
-
-  async #closeDaemonConnection(connection: DaemonConnection): Promise<void> {
-    if (this.#closedConnections.has(connection)) return;
-    this.#closedConnections.add(connection);
-    await connection.close();
+  async #closeClient(client: SimlockClient): Promise<void> {
+    if (this.#closedClients.has(client)) return;
+    this.#closedClients.add(client);
+    await client.close();
   }
 
   #throwIfClosed(): void {
@@ -550,97 +281,4 @@ export class McpSession {
   }
 }
 
-function isNoLongerActiveLease(error: unknown): boolean {
-  return (
-    error instanceof DaemonClientError &&
-    (error.code === "UNKNOWN_LEASE" || error.code === "LEASE_EXPIRED")
-  );
-}
-
-function throwIfAborted(signal: AbortSignal | undefined): void {
-  if (signal?.aborted) throw new McpSessionError("CANCELLED", "Lease request cancelled");
-}
-
 function noop(): void {}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
-/**
- * Flat fields, not the legacy `device`/`os` aliases or a nested `request` wrapper -- the wire
- * moved to protocol 3 with no compatibility shim (ADR 0003 "Consequences"). Deriving this from
- * the contract's `lease.request` input schema (ADR 0003 §11: "MCP tool schemas are derived from
- * the contract schemas") is PR 4's job; this is only the minimal payload-shape fix needed to
- * keep MCP working against this PR's daemon.
- */
-function daemonLeaseRequest(
-  input: LeaseSimulatorInput,
-  requesterId: string,
-): Record<string, unknown> {
-  return {
-    allowDownload: input.allow_download,
-    mode: "held",
-    noWait: input.no_wait,
-    requesterId,
-    model: input.device,
-    ...(input.os === undefined ? {} : { osVersion: input.os }),
-    platform: input.platform,
-    ...(input.full ? { full: true } : {}),
-    ...(input.timeout_seconds === undefined
-      ? {}
-      : { timeoutMs: timeoutMilliseconds(input.timeout_seconds) }),
-  };
-}
-
-function timeoutMilliseconds(timeoutSeconds: number): number {
-  if (
-    !Number.isFinite(timeoutSeconds) ||
-    timeoutSeconds < 0 ||
-    timeoutSeconds > MAX_TIMEOUT_SECONDS
-  ) {
-    throw new McpSessionError(
-      "INVALID_TIMEOUT",
-      "timeout_seconds is too large to convert safely to milliseconds",
-    );
-  }
-  return timeoutSeconds * 1_000;
-}
-
-function noLeaseStatus(): NoLeaseStatus {
-  return { held: false };
-}
-
-function heldLeaseStatus(lease: OwnedLease): HeldLeaseStatus {
-  return {
-    device: lease.device,
-    device_id: lease.deviceId,
-    expires_at_ms: lease.expiresAtMs,
-    held: true,
-    lease_id: lease.leaseId,
-    os: lease.os,
-    platform: lease.platform,
-    state: "leased",
-  };
-}
-
-function leaseSimulatorOutput(grant: RawLeaseGrant): LeaseSimulatorOutput {
-  return {
-    address: grant.device.address,
-    device: grant.device.spec.model,
-    device_id: grant.device.driverDeviceId,
-    expires_at_ms: grant.lease.ttlDeadline,
-    lease_id: grant.lease.id,
-    mode: "held",
-    os: grant.device.spec.osVersion,
-    platform: grant.device.spec.platform,
-    slim: grant.slim,
-    state: "leased",
-    timing: {
-      estimated_boot_ms: grant.timing.estimatedBootMs,
-      estimated_provision_ms: grant.timing.estimatedProvisionMs,
-      estimated_reclaim_ms: grant.timing.estimatedReclaimMs,
-      estimated_ready_ms: grant.timing.estimatedReadyMs,
-    },
-  };
-}

--- a/src/mcp/test-support.ts
+++ b/src/mcp/test-support.ts
@@ -1,0 +1,207 @@
+/**
+ * A scripted `SimlockClient` double for MCP's own unit tests. MCP no longer talks to the
+ * daemon directly (PR 4 moved it onto `simlock/client`), so its tests script the typed
+ * client's surface instead of a raw `DaemonConnection`/`IpcConnection`.
+ */
+import {
+  SimlockError,
+  type AnySimlockError,
+  type CatalogGetInput,
+  type CatalogGetOutput,
+  type DeviceRecoveredPush,
+  type DeviceUnhealthyPush,
+  type DoctorReport,
+  type DoctorRunInput,
+  type LeaseCancelInput,
+  type LeaseCancelOutput,
+  type LeaseGrant,
+  type LeaseHeartbeatOutput,
+  type LeaseListOutput,
+  type LeaseLostPush,
+  type LeaseReleaseInput,
+  type LeaseReleaseOutput,
+  type LeaseRenewInput,
+  type LeaseRecord,
+  type LeaseRequestInput,
+  type RequestLeaseOptions,
+  type SimlockClient,
+  type StatusGetOutput,
+} from "../client/index.js";
+import type { Role } from "../contract/index.js";
+
+export interface FakeSimlockClientOptions {
+  readonly daemonVersion?: string;
+  readonly principal?: string;
+  readonly role?: Role;
+}
+
+function notStubbed(method: string): () => never {
+  return () => {
+    throw new Error(`FakeSimlockClient.${method} was not stubbed for this test`);
+  };
+}
+
+/** Records every call and lets a test script each method's response and fire pushes on demand. */
+export class FakeSimlockClient implements SimlockClient {
+  readonly principal: string;
+  readonly role: Role;
+  readonly daemonVersion: string;
+  closeCalls = 0;
+  readonly calls: Array<{ readonly method: string; readonly input: unknown }> = [];
+
+  getCatalogImpl: (input: CatalogGetInput) => Promise<CatalogGetOutput> = notStubbed("getCatalog");
+  getStatusImpl: () => Promise<StatusGetOutput> = notStubbed("getStatus");
+  requestLeaseImpl: (
+    input: LeaseRequestInput,
+    options: RequestLeaseOptions,
+  ) => Promise<LeaseGrant> = notStubbed("requestLease");
+  cancelLeaseImpl: (input: LeaseCancelInput) => Promise<LeaseCancelOutput> =
+    notStubbed("cancelLease");
+  renewLeaseImpl: (input: LeaseRenewInput) => Promise<LeaseRecord> = notStubbed("renewLease");
+  releaseLeaseImpl: (input: LeaseReleaseInput) => Promise<LeaseReleaseOutput> =
+    notStubbed("releaseLease");
+  listLeasesImpl: () => Promise<LeaseListOutput> = notStubbed("listLeases");
+  heartbeatImpl: () => Promise<LeaseHeartbeatOutput> = notStubbed("heartbeat");
+  runDoctorImpl: (input: DoctorRunInput) => Promise<DoctorReport> = notStubbed("runDoctor");
+
+  readonly #leaseLostListeners = new Set<(push: LeaseLostPush) => void>();
+  readonly #deviceUnhealthyListeners = new Set<(push: DeviceUnhealthyPush) => void>();
+  readonly #deviceRecoveredListeners = new Set<(push: DeviceRecoveredPush) => void>();
+  readonly #connectionLostListeners = new Set<(error: AnySimlockError) => void>();
+
+  constructor(options: FakeSimlockClientOptions = {}) {
+    this.principal = options.principal ?? "mcp-test";
+    this.role = options.role ?? "agent";
+    this.daemonVersion = options.daemonVersion ?? "test";
+  }
+
+  getCatalog(input: CatalogGetInput = {}): Promise<CatalogGetOutput> {
+    this.calls.push({ input, method: "getCatalog" });
+    return this.getCatalogImpl(input);
+  }
+
+  // fallow-ignore-next-line unused-class-member -- part of the SimlockClient interface this fake implements; MCP itself never calls status.get.
+  getStatus(): Promise<StatusGetOutput> {
+    this.calls.push({ input: undefined, method: "getStatus" });
+    return this.getStatusImpl();
+  }
+
+  requestLease(input: LeaseRequestInput, options: RequestLeaseOptions = {}): Promise<LeaseGrant> {
+    this.calls.push({ input, method: "requestLease" });
+    return this.requestLeaseImpl(input, options);
+  }
+
+  // fallow-ignore-next-line unused-class-member -- part of the SimlockClient interface this fake implements; MCP itself never calls lease.cancel.
+  cancelLease(input: LeaseCancelInput = {}): Promise<LeaseCancelOutput> {
+    this.calls.push({ input, method: "cancelLease" });
+    return this.cancelLeaseImpl(input);
+  }
+
+  // fallow-ignore-next-line unused-class-member -- part of the SimlockClient interface this fake implements; MCP itself never calls lease.renew.
+  renewLease(input: LeaseRenewInput): Promise<LeaseRecord> {
+    this.calls.push({ input, method: "renewLease" });
+    return this.renewLeaseImpl(input);
+  }
+
+  releaseLease(input: LeaseReleaseInput): Promise<LeaseReleaseOutput> {
+    this.calls.push({ input, method: "releaseLease" });
+    return this.releaseLeaseImpl(input);
+  }
+
+  listLeases(): Promise<LeaseListOutput> {
+    this.calls.push({ input: undefined, method: "listLeases" });
+    return this.listLeasesImpl();
+  }
+
+  // fallow-ignore-next-line unused-class-member -- part of the SimlockClient interface this fake implements; MCP itself never calls lease.heartbeat (the client handles it internally).
+  heartbeat(): Promise<LeaseHeartbeatOutput> {
+    this.calls.push({ input: undefined, method: "heartbeat" });
+    return this.heartbeatImpl();
+  }
+
+  // fallow-ignore-next-line unused-class-member -- part of the SimlockClient interface this fake implements; MCP itself never calls doctor.run.
+  runDoctor(input: DoctorRunInput = {}): Promise<DoctorReport> {
+    this.calls.push({ input, method: "runDoctor" });
+    return this.runDoctorImpl(input);
+  }
+
+  onLeaseLost(listener: (push: LeaseLostPush) => void): () => void {
+    this.#leaseLostListeners.add(listener);
+    return () => this.#leaseLostListeners.delete(listener);
+  }
+
+  onDeviceUnhealthy(listener: (push: DeviceUnhealthyPush) => void): () => void {
+    this.#deviceUnhealthyListeners.add(listener);
+    return () => this.#deviceUnhealthyListeners.delete(listener);
+  }
+
+  onDeviceRecovered(listener: (push: DeviceRecoveredPush) => void): () => void {
+    this.#deviceRecoveredListeners.add(listener);
+    return () => this.#deviceRecoveredListeners.delete(listener);
+  }
+
+  onConnectionLost(listener: (error: AnySimlockError) => void): () => void {
+    this.#connectionLostListeners.add(listener);
+    return () => this.#connectionLostListeners.delete(listener);
+  }
+
+  emitLeaseLost(push: LeaseLostPush): void {
+    for (const listener of this.#leaseLostListeners) listener(push);
+  }
+
+  emitDeviceUnhealthy(push: DeviceUnhealthyPush): void {
+    for (const listener of this.#deviceUnhealthyListeners) listener(push);
+  }
+
+  emitDeviceRecovered(push: DeviceRecoveredPush): void {
+    for (const listener of this.#deviceRecoveredListeners) listener(push);
+  }
+
+  /** Simulates the connection dying (a crash, not `close()`) without marking this fake closed. */
+  emitConnectionLost(
+    error: AnySimlockError = new SimlockError(
+      "DAEMON_CONNECTION_LOST",
+      "transport",
+      "Daemon connection lost",
+      {},
+    ),
+  ): void {
+    for (const listener of this.#connectionLostListeners) listener(error);
+  }
+
+  async close(): Promise<void> {
+    this.closeCalls += 1;
+    this.emitConnectionLost(
+      new SimlockError("DAEMON_CONNECTION_LOST", "transport", "Client closed the connection", {}),
+    );
+  }
+}
+
+export function sampleGrant(overrides: { readonly leaseId?: string } = {}): LeaseGrant {
+  const leaseId = overrides.leaseId ?? "lease-1";
+  return {
+    device: {
+      createdAt: 0,
+      driverData: null,
+      driverDeviceId: "SIM-1",
+      id: "device-1",
+      spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
+      state: "leased",
+    },
+    lease: {
+      deviceId: "device-1",
+      grantedAt: 0,
+      id: leaseId,
+      mode: "held",
+      ownerId: "mcp-test",
+      requesterId: "mcp-test",
+      ttlDeadline: 12_345,
+    },
+    timing: {
+      estimatedBootMs: 3,
+      estimatedProvisionMs: 2,
+      estimatedReadyMs: 6,
+      estimatedReclaimMs: 1,
+    },
+  };
+}

--- a/src/mcp/test-support.ts
+++ b/src/mcp/test-support.ts
@@ -181,12 +181,9 @@ export function sampleGrant(overrides: { readonly leaseId?: string } = {}): Leas
   const leaseId = overrides.leaseId ?? "lease-1";
   return {
     device: {
-      createdAt: 0,
-      driverData: null,
       driverDeviceId: "SIM-1",
       id: "device-1",
       spec: { model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
-      state: "leased",
     },
     lease: {
       deviceId: "device-1",

--- a/src/simlock-client/client.test.ts
+++ b/src/simlock-client/client.test.ts
@@ -1,0 +1,403 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { connectSimlockAdmin } from "../admin/index.js";
+import { connectSimlock } from "../client/index.js";
+import type { LeaseGrant } from "./types.js";
+import { completeHello, ScriptedConnection } from "./test-support.js";
+
+async function flushMicrotasks(times = 10): Promise<void> {
+  for (let index = 0; index < times; index += 1) await Promise.resolve();
+}
+
+function sampleGrant(
+  overrides: {
+    readonly leaseId?: string;
+    readonly deviceId?: string;
+    readonly mode?: "held" | "detached";
+  } = {},
+): LeaseGrant {
+  const leaseId = overrides.leaseId ?? "lease_1";
+  const deviceId = overrides.deviceId ?? "device_1";
+  return {
+    device: {
+      createdAt: 0,
+      driverData: null,
+      driverDeviceId: "sim-1",
+      id: deviceId,
+      spec: { model: "iPhone 17", osVersion: "18.0", platform: "ios" },
+      state: "leased",
+    },
+    lease: {
+      deviceId,
+      grantedAt: 0,
+      id: leaseId,
+      mode: overrides.mode ?? "held",
+      ownerId: "agent-1",
+      requesterId: "agent-1",
+      ttlDeadline: 1_000,
+    },
+    timing: {
+      estimatedBootMs: 1,
+      estimatedProvisionMs: 1,
+      estimatedReadyMs: 1,
+      estimatedReclaimMs: 1,
+    },
+  };
+}
+
+describe("connectSimlock: handshake", () => {
+  it("rejects a version mismatch before any other request is sent", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    const hello = connection.lastSentOf("hello");
+    expect(hello).toBeDefined();
+    connection.fail(hello!.id, "PROTOCOL_VERSION_UNSUPPORTED", "no overlap", {
+      client: { max: 3, min: 3 },
+      daemon: { max: 5, min: 5 },
+      daemonVersion: "9.9.9",
+    });
+
+    await expect(connectPromise).rejects.toMatchObject({
+      code: "PROTOCOL_VERSION_UNSUPPORTED",
+      details: { daemon: { max: 5, min: 5 }, daemonVersion: "9.9.9" },
+    });
+    expect(connection.sent).toHaveLength(1);
+  });
+
+  it("maps a legacy protocol-2 daemon's mismatch code onto the contract's shape", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    const hello = connection.lastSentOf("hello")!;
+    connection.fail(hello.id, "PROTOCOL_VERSION_MISMATCH", "old daemon says no");
+
+    await expect(connectPromise).rejects.toMatchObject({
+      code: "PROTOCOL_VERSION_UNSUPPORTED",
+      details: { daemon: { max: 2, min: 2 }, daemonVersion: "unknown" },
+    });
+    expect(connection.sent).toHaveLength(1);
+  });
+
+  it("a bad admin credential causes zero requests after hello", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlockAdmin({ connection, credential: "wrong" });
+    await flushMicrotasks();
+    const hello = connection.lastSentOf("hello")!;
+    expect((hello.payload as { credential?: string }).credential).toBe("wrong");
+    connection.fail(hello.id, "ADMIN_AUTHENTICATION_FAILED", "nope");
+
+    await expect(connectPromise).rejects.toMatchObject({ code: "ADMIN_AUTHENTICATION_FAILED" });
+    expect(connection.sent).toHaveLength(1);
+  });
+
+  it("agent role: a FORBIDDEN reply from the daemon surfaces as a typed error", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection, { role: "agent" });
+    const client = await connectPromise;
+
+    const callPromise = client.cancelLease();
+    await flushMicrotasks();
+    const call = connection.lastSentOf("lease.cancel")!;
+    connection.fail(call.id, "FORBIDDEN", "agents cannot do this");
+
+    await expect(callPromise).rejects.toMatchObject({ code: "FORBIDDEN", kind: "protocol" });
+  });
+
+  it("rejects client-side invalid input without sending a frame", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const before = connection.sent.length;
+    // `model` is required and non-empty per the contract's input schema.
+    await expect(client.requestLease({ model: "", platform: "ios" })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    });
+    expect(connection.sent).toHaveLength(before);
+  });
+
+  it("wraps a malformed daemon response instead of throwing a raw parse failure", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const callPromise = client.getCatalog();
+    await flushMicrotasks();
+    const call = connection.lastSentOf("catalog.get")!;
+    connection.reply(call.id, { notPlatforms: true });
+
+    await expect(callPromise).rejects.toMatchObject({ code: "BAD_FRAME" });
+  });
+
+  it("wraps an error code it does not recognize as UNKNOWN_DAEMON_ERROR", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const callPromise = client.getStatus();
+    await flushMicrotasks();
+    const call = connection.lastSentOf("status.get")!;
+    connection.fail(call.id, "SOME_FUTURE_CODE", "a newer daemon said so");
+
+    await expect(callPromise).rejects.toMatchObject({
+      code: "UNKNOWN_DAEMON_ERROR",
+      details: { code: "SOME_FUTURE_CODE" },
+    });
+  });
+});
+
+describe("connection death", () => {
+  it("rejects in-flight calls and fires onLeaseLost for held leases", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const leaseLost = vi.fn();
+    client.onLeaseLost(leaseLost);
+    const connectionLost = vi.fn();
+    client.onConnectionLost(connectionLost);
+
+    const grantPromise = client.requestLease({ model: "iPhone 17", platform: "ios" });
+    await flushMicrotasks();
+    const requestCall = connection.lastSentOf("lease.request")!;
+    connection.reply(requestCall.id, sampleGrant({ leaseId: "lease_held" }));
+    await grantPromise;
+
+    const statusPromise = client.getStatus();
+    await flushMicrotasks();
+
+    connection.simulateDeath();
+
+    await expect(statusPromise).rejects.toMatchObject({ code: "DAEMON_CONNECTION_LOST" });
+    expect(leaseLost).toHaveBeenCalledWith({
+      deviceId: "device_1",
+      leaseId: "lease_held",
+      reason: "daemon-connection-lost",
+    });
+    expect(connectionLost).toHaveBeenCalledTimes(1);
+
+    await expect(client.getStatus()).rejects.toMatchObject({ code: "DAEMON_CONNECTION_LOST" });
+    expect(connection.sent.filter((f) => f.type === "status.get")).toHaveLength(1);
+  });
+});
+
+describe("pushes", () => {
+  it("routes progress to the originating call and drops it once the call is no longer tracked", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const onProgress = vi.fn();
+    const grantPromise = client.requestLease(
+      { model: "iPhone 17", platform: "ios" },
+      { onProgress },
+    );
+    await flushMicrotasks();
+    const requestCall = connection.lastSentOf("lease.request")!;
+
+    // A push can arrive before the response to the request that caused it (ADR §8).
+    connection.push("progress", {
+      progress: { etaMs: 500, stage: "provisioning" },
+      requestId: requestCall.id,
+    });
+    connection.reply(requestCall.id, sampleGrant());
+    await grantPromise;
+
+    expect(onProgress).toHaveBeenCalledWith({ etaMs: 500, stage: "provisioning" });
+
+    // Dropped: no call is tracked under this id any more.
+    connection.push("progress", {
+      progress: { etaMs: 1, stage: "booting" },
+      requestId: requestCall.id,
+    });
+    expect(onProgress).toHaveBeenCalledTimes(1);
+  });
+
+  it("de-duplicates lease-scoped pushes by lease id", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const unhealthy = vi.fn();
+    client.onDeviceUnhealthy(unhealthy);
+
+    connection.push("device-unhealthy", {
+      deviceId: "device_1",
+      leaseId: "lease_1",
+      reason: "crashed",
+    });
+    connection.push("device-unhealthy", {
+      deviceId: "device_1",
+      leaseId: "lease_1",
+      reason: "crashed",
+    });
+
+    expect(unhealthy).toHaveBeenCalledTimes(1);
+  });
+
+  it("never fires onLeaseLost for a release this client itself asked for", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const leaseLost = vi.fn();
+    client.onLeaseLost(leaseLost);
+
+    const grantPromise = client.requestLease({ model: "iPhone 17", platform: "ios" });
+    await flushMicrotasks();
+    connection.reply(
+      connection.lastSentOf("lease.request")!.id,
+      sampleGrant({ leaseId: "lease_1" }),
+    );
+    await grantPromise;
+
+    const releasePromise = client.releaseLease({ leaseId: "lease_1" });
+    await flushMicrotasks();
+    const releaseCall = connection.lastSentOf("lease.release")!;
+    // The daemon pushes lease-lost for the same release the client itself just asked for --
+    // this must be swallowed, not surfaced.
+    connection.push("lease-lost", { deviceId: "device_1", leaseId: "lease_1", reason: "explicit" });
+    connection.reply(releaseCall.id, { leaseId: "lease_1" });
+    await releasePromise;
+
+    expect(leaseLost).not.toHaveBeenCalled();
+  });
+});
+
+describe("requestLease abort (ADR §10)", () => {
+  it("before the request is sent: rejects CANCELLED, nothing sent", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const controller = new AbortController();
+    controller.abort();
+    const before = connection.sent.length;
+
+    await expect(
+      client.requestLease({ model: "iPhone 17", platform: "ios" }, { signal: controller.signal }),
+    ).rejects.toMatchObject({ code: "CANCELLED" });
+    expect(connection.sent).toHaveLength(before);
+  });
+
+  it("while queued: sends lease.cancel, waits for the original to reject, surfaces CANCELLED", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const controller = new AbortController();
+    const leasePromise = client.requestLease(
+      { model: "iPhone 17", platform: "ios" },
+      { signal: controller.signal },
+    );
+    await flushMicrotasks();
+    const requestCall = connection.lastSentOf("lease.request")!;
+
+    controller.abort();
+    await flushMicrotasks();
+    const cancelCall = connection.lastSentOf("lease.cancel")!;
+    expect(cancelCall).toBeDefined();
+
+    connection.reply(cancelCall.id, { result: "cancelled" });
+    await flushMicrotasks();
+    connection.fail(requestCall.id, "QUEUE_TIMEOUT", "cancelled by request", { requestId: "r1" });
+
+    await expect(leasePromise).rejects.toMatchObject({ code: "CANCELLED" });
+  });
+
+  it("while device work is in flight: releases a grant that still arrives, then rejects CANCELLED", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const controller = new AbortController();
+    const leasePromise = client.requestLease(
+      { model: "iPhone 17", platform: "ios" },
+      { signal: controller.signal },
+    );
+    await flushMicrotasks();
+    const requestCall = connection.lastSentOf("lease.request")!;
+
+    controller.abort();
+    await flushMicrotasks();
+    const cancelCall = connection.lastSentOf("lease.cancel")!;
+    connection.reply(cancelCall.id, { result: "not-cancellable" });
+    await flushMicrotasks();
+
+    connection.reply(requestCall.id, sampleGrant({ leaseId: "lease_abandoned" }));
+    await flushMicrotasks();
+    const releaseCall = connection.lastSentOf("lease.release")!;
+    expect(releaseCall).toBeDefined();
+    expect((releaseCall.payload as { leaseId: string }).leaseId).toBe("lease_abandoned");
+    connection.reply(releaseCall.id, { leaseId: "lease_abandoned" });
+
+    await expect(leasePromise).rejects.toMatchObject({ code: "CANCELLED" });
+  });
+
+  it("after the grant resolved: abort is ignored", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const controller = new AbortController();
+    const leasePromise = client.requestLease(
+      { model: "iPhone 17", platform: "ios" },
+      { signal: controller.signal },
+    );
+    await flushMicrotasks();
+    const requestCall = connection.lastSentOf("lease.request")!;
+    connection.reply(requestCall.id, sampleGrant({ leaseId: "lease_kept" }));
+
+    const grant = await leasePromise;
+    expect(grant.lease.id).toBe("lease_kept");
+
+    const before = connection.sent.length;
+    controller.abort();
+    await flushMicrotasks();
+
+    // No lease.cancel was ever sent for an already-resolved request.
+    expect(connection.sent).toHaveLength(before);
+  });
+});
+
+describe("simlock/admin", () => {
+  it("exposes the admin operations and sends daemon.stop like any other request", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlockAdmin({ connection, credential: "operator-secret" });
+    await flushMicrotasks();
+    completeHello(connection, { role: "admin" });
+    const admin = await connectPromise;
+    expect(admin.role).toBe("admin");
+
+    const stopPromise = admin.stopDaemon();
+    await flushMicrotasks();
+    const stopCall = connection.lastSentOf("daemon.stop")!;
+    connection.reply(stopCall.id, { stopping: true });
+    await expect(stopPromise).resolves.toEqual({ stopping: true });
+  });
+});

--- a/src/simlock-client/client.test.ts
+++ b/src/simlock-client/client.test.ts
@@ -20,12 +20,9 @@ function sampleGrant(
   const deviceId = overrides.deviceId ?? "device_1";
   return {
     device: {
-      createdAt: 0,
-      driverData: null,
       driverDeviceId: "sim-1",
       id: deviceId,
       spec: { model: "iPhone 17", osVersion: "18.0", platform: "ios" },
-      state: "leased",
     },
     lease: {
       deviceId,

--- a/src/simlock-client/client.test.ts
+++ b/src/simlock-client/client.test.ts
@@ -43,9 +43,9 @@ function sampleGrant(
 }
 
 describe("connectSimlock: handshake", () => {
-  it("rejects a version mismatch before any other request is sent", async () => {
+  it("a version mismatch leaves the connection open and usable for stopDaemon() only (ADR §6)", async () => {
     const connection = new ScriptedConnection();
-    const connectPromise = connectSimlock({ connection });
+    const connectPromise = connectSimlockAdmin({ connection, credential: "operator-secret" });
     await flushMicrotasks();
     const hello = connection.lastSentOf("hello");
     expect(hello).toBeDefined();
@@ -55,28 +55,56 @@ describe("connectSimlock: handshake", () => {
       daemonVersion: "9.9.9",
     });
 
-    await expect(connectPromise).rejects.toMatchObject({
+    // The daemon deliberately keeps this connection open after a failed range negotiation
+    // (ADR §6, see the comments in `daemon/server.ts#handleHello`) so an admin client can
+    // still send `daemon.stop` on it instead of restarting the daemon -- closing here, what
+    // this client used to do unconditionally, made that escape hatch dead on arrival.
+    const client = await connectPromise;
+    expect(connection.closed).toBe(false);
+
+    // Every other operation rejects with the captured mismatch error, never reaching the wire.
+    const before = connection.sent.length;
+    await expect(client.getStatus()).rejects.toMatchObject({
       code: "PROTOCOL_VERSION_UNSUPPORTED",
-      details: { daemon: { max: 5, min: 5 }, daemonVersion: "9.9.9" },
     });
-    expect(connection.sent).toHaveLength(1);
+    await expect(client.runCleanup()).rejects.toMatchObject({
+      code: "PROTOCOL_VERSION_UNSUPPORTED",
+    });
+    expect(connection.sent).toHaveLength(before);
+
+    const stopPromise = client.stopDaemon();
+    await flushMicrotasks();
+    const stopCall = connection.lastSentOf("daemon.stop")!;
+    expect(stopCall).toBeDefined();
+    connection.reply(stopCall.id, { stopping: true });
+    await expect(stopPromise).resolves.toEqual({ stopping: true });
+
+    await client.close();
+    expect(connection.closed).toBe(true);
   });
 
-  it("maps a legacy protocol-2 daemon's mismatch code onto the contract's shape", async () => {
+  it("maps a legacy protocol-2 daemon's mismatch code onto the contract's shape, and still leaves the connection open (ADR §6)", async () => {
     const connection = new ScriptedConnection();
     const connectPromise = connectSimlock({ connection });
     await flushMicrotasks();
     const hello = connection.lastSentOf("hello")!;
     connection.fail(hello.id, "PROTOCOL_VERSION_MISMATCH", "old daemon says no");
 
-    await expect(connectPromise).rejects.toMatchObject({
+    // Resolves rather than rejects: this maps onto the same `PROTOCOL_VERSION_UNSUPPORTED`
+    // code as a modern range mismatch, so it gets the same ADR §6 treatment -- the connection
+    // stays open, and the returned client's every operation rejects with the mapped error.
+    const client = await connectPromise;
+    expect(connection.closed).toBe(false);
+    expect(connection.sent).toHaveLength(1);
+
+    await expect(client.getStatus()).rejects.toMatchObject({
       code: "PROTOCOL_VERSION_UNSUPPORTED",
       details: { daemon: { max: 2, min: 2 }, daemonVersion: "unknown" },
     });
     expect(connection.sent).toHaveLength(1);
   });
 
-  it("a bad admin credential causes zero requests after hello", async () => {
+  it("a bad admin credential causes zero requests after hello, and closes the connection", async () => {
     const connection = new ScriptedConnection();
     const connectPromise = connectSimlockAdmin({ connection, credential: "wrong" });
     await flushMicrotasks();
@@ -86,6 +114,9 @@ describe("connectSimlock: handshake", () => {
 
     await expect(connectPromise).rejects.toMatchObject({ code: "ADMIN_AUTHENTICATION_FAILED" });
     expect(connection.sent).toHaveLength(1);
+    // Unlike a protocol-version mismatch (ADR §6's frozen exception), a bad credential is not
+    // the escape hatch -- the connection closes and serves nothing.
+    expect(connection.closed).toBe(true);
   });
 
   it("agent role: a FORBIDDEN reply from the daemon surfaces as a typed error", async () => {
@@ -379,6 +410,146 @@ describe("requestLease abort (ADR §10)", () => {
 
     // No lease.cancel was ever sent for an already-resolved request.
     expect(connection.sent).toHaveLength(before);
+  });
+});
+
+describe("principal resolution (ADR §4, B3)", () => {
+  it('adopts the daemon-resolved principal from hello\'s reply, never defaulting to ""', async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    const hello = connection.lastSentOf("hello")!;
+    // No principal was supplied -- the daemon resolves its own default (a pid, in practice).
+    expect((hello.payload as { principal?: string }).principal).toBeUndefined();
+    connection.reply(hello.id, {
+      daemonProtocolRange: { max: 3, min: 3 },
+      principal: "48213",
+      protocolVersion: 3,
+      role: "agent",
+      version: "0.3.0",
+    });
+    const client = await connectPromise;
+
+    expect(client.principal).toBe("48213");
+  });
+});
+
+describe("requestLease abort: ADR §4 identity cases (B3)", () => {
+  it("no principal supplied: abort while queued cancels with the daemon-resolved principal, and leaves no lease held", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    const hello = connection.lastSentOf("hello")!;
+    connection.reply(hello.id, {
+      daemonProtocolRange: { max: 3, min: 3 },
+      principal: "48213",
+      protocolVersion: 3,
+      role: "agent",
+      version: "0.3.0",
+    });
+    const client = await connectPromise;
+
+    const controller = new AbortController();
+    const leasePromise = client.requestLease(
+      { model: "iPhone 17", platform: "ios" },
+      { signal: controller.signal },
+    );
+    await flushMicrotasks();
+    const requestCall = connection.lastSentOf("lease.request")!;
+
+    controller.abort();
+    await flushMicrotasks();
+    const cancelCall = connection.lastSentOf("lease.cancel")!;
+    // Before this fix, this was always "" -- the daemon fixes the connection's principal to
+    // its own default, and the client had no way to learn it. Sent as the resolved principal
+    // now, never "".
+    expect((cancelCall.payload as { requesterId?: string }).requesterId).toBe("48213");
+
+    connection.reply(cancelCall.id, { result: "cancelled" });
+    await flushMicrotasks();
+    connection.fail(requestCall.id, "QUEUE_TIMEOUT", "cancelled by request");
+
+    await expect(leasePromise).rejects.toMatchObject({ code: "CANCELLED" });
+
+    // No lease is held: connection death fires no onLeaseLost for anything.
+    const leaseLost = vi.fn();
+    client.onLeaseLost(leaseLost);
+    connection.simulateDeath();
+    await flushMicrotasks();
+    expect(leaseLost).not.toHaveBeenCalled();
+  });
+
+  it('ADR §4 proxy case (principal "host", requesterId "agent-7"): abort in flight releases the grant and leaves no lease held', async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection, principal: "host" });
+    await flushMicrotasks();
+    completeHello(connection, { principal: "host" });
+    const client = await connectPromise;
+    expect(client.principal).toBe("host");
+
+    const controller = new AbortController();
+    const leasePromise = client.requestLease(
+      { model: "iPhone 17", platform: "ios", requesterId: "agent-7" },
+      { signal: controller.signal },
+    );
+    await flushMicrotasks();
+    const requestCall = connection.lastSentOf("lease.request")!;
+
+    controller.abort();
+    await flushMicrotasks();
+    const cancelCall = connection.lastSentOf("lease.cancel")!;
+    // Before this fix, the daemon's `authorize` hook compared this `requesterId` straight to
+    // the principal and rejected FORBIDDEN outright -- exactly ADR §4's proxy case. The
+    // request is still sent with the proxied requesterId (attribution); the daemon now
+    // authorizes the cancel against the pending request's recorded *owner* instead.
+    expect((cancelCall.payload as { requesterId?: string }).requesterId).toBe("agent-7");
+    connection.reply(cancelCall.id, { result: "not-cancellable" });
+    await flushMicrotasks();
+
+    connection.reply(requestCall.id, sampleGrant({ leaseId: "lease_proxy_abandoned" }));
+    await flushMicrotasks();
+    const releaseCall = connection.lastSentOf("lease.release")!;
+    expect((releaseCall.payload as { leaseId: string }).leaseId).toBe("lease_proxy_abandoned");
+    connection.reply(releaseCall.id, { leaseId: "lease_proxy_abandoned" });
+
+    await expect(leasePromise).rejects.toMatchObject({ code: "CANCELLED" });
+
+    // Already released via the abandoned-grant path -- not tracked as held any more.
+    const leaseLost = vi.fn();
+    client.onLeaseLost(leaseLost);
+    connection.simulateDeath();
+    await flushMicrotasks();
+    expect(leaseLost).not.toHaveBeenCalled();
+  });
+
+  it("a FORBIDDEN from the abort's lease.cancel surfaces instead of being read as a dead connection", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const controller = new AbortController();
+    const leasePromise = client.requestLease(
+      { model: "iPhone 17", platform: "ios" },
+      { signal: controller.signal },
+    );
+    await flushMicrotasks();
+
+    controller.abort();
+    await flushMicrotasks();
+    const cancelCall = connection.lastSentOf("lease.cancel")!;
+    connection.fail(cancelCall.id, "FORBIDDEN", "not authorized");
+
+    await expect(leasePromise).rejects.toMatchObject({ code: "FORBIDDEN" });
+    // Not misread as the connection dying -- it's still alive and usable for another call.
+    expect(connection.closed).toBe(false);
+    const anotherCall = client.cancelLease();
+    await flushMicrotasks();
+    const anotherCancelCall = connection.lastSentOf("lease.cancel")!;
+    expect(anotherCancelCall.id).not.toBe(cancelCall.id);
+    connection.reply(anotherCancelCall.id, { result: "not-found" });
+    await expect(anotherCall).resolves.toMatchObject({ result: "not-found" });
   });
 });
 

--- a/src/simlock-client/client.ts
+++ b/src/simlock-client/client.ts
@@ -207,16 +207,102 @@ export async function connectSimlockClient(
       capabilities: { heartbeat: options.heartbeat ?? true },
     });
   } catch (error: unknown) {
+    // ADR §6: a `PROTOCOL_VERSION_UNSUPPORTED` `hello` rejection is the one handshake failure
+    // the daemon deliberately keeps the connection open for -- an admin client whose range
+    // does not overlap the daemon's must still be able to send `daemon.stop` on *this*
+    // connection instead of restarting it (see the comments around the mismatch reply in
+    // `daemon/server.ts#handleHello`, and `#dispatchLine`'s `daemon.stop`-ahead-of-the-mismatch-
+    // gate check). Closing here -- every other handshake failure, a bad credential
+    // (`ADMIN_AUTHENTICATION_FAILED`) included -- still closes and serves nothing.
+    if (isSimlockError(error) && error.code === "PROTOCOL_VERSION_UNSUPPORTED") {
+      return buildDegradedClient(wire, error, options.principal ?? "", admin);
+    }
     await connection.close();
     throw error;
   }
-  const impl = new SimlockClientImpl(
-    wire,
-    hello.role,
-    options.principal ?? "",
-    hello.daemonVersion,
-  );
+  const impl = new SimlockClientImpl(wire, hello.role, hello.principal, hello.daemonVersion);
   return admin ? impl.asAdmin() : impl;
+}
+
+/**
+ * ADR §6's escape hatch, on the client side: everything but `stopDaemon()` and `close()`
+ * rejects with the captured `PROTOCOL_VERSION_UNSUPPORTED` error (never sent to the daemon --
+ * every other operation requires a completed handshake this connection never got); `close()`
+ * still works so a caller that decides not to stop the daemon can tidy up. `stopDaemon()` calls
+ * straight through the wire: the daemon accepts `daemon.stop` "at any protocol version it has
+ * ever spoken" (ADR §6), ahead of its own mismatch gate, specifically so this is reachable.
+ *
+ * `role`/`principal` cannot be the connection's real resolved values -- the daemon resolves
+ * them before the mismatch check but the failed `hello` never reports them back (see the PR
+ * report's weak-spots list) -- so `role` reflects which entry point the caller used
+ * (`connectSimlock` vs. `connectSimlockAdmin`) rather than a verified fact, and `principal` is
+ * whatever the caller supplied (or `""` when it supplied none). Neither is load-bearing here:
+ * the only operation this client permits (`daemon.stop`) is gated by the daemon's own role
+ * check on the credential it already verified, not by anything this object reports about
+ * itself.
+ */
+function buildDegradedClient(
+  wire: SimlockWire,
+  error: SimlockError<"PROTOCOL_VERSION_UNSUPPORTED">,
+  principal: string,
+  admin: boolean,
+): SimlockClient | SimlockAdminClient {
+  const rejected = <T>(): Promise<T> => Promise.reject(error);
+  const client: SimlockAdminClient = {
+    principal,
+    role: admin ? "admin" : "agent",
+    daemonVersion: error.details.daemonVersion,
+
+    getCatalog: () => rejected(),
+    getStatus: () => rejected(),
+    requestLease: () => rejected(),
+    cancelLease: () => rejected(),
+    renewLease: () => rejected(),
+    releaseLease: () => rejected(),
+    listLeases: () => rejected(),
+    heartbeat: () => rejected(),
+    runDoctor: () => rejected(),
+
+    onLeaseLost: () => () => {},
+    onDeviceUnhealthy: () => () => {},
+    onDeviceRecovered: () => () => {},
+    // The one live fact this connection can still report: it can still die later even though
+    // `hello` never fully succeeded (e.g. the daemon exits while this degraded client sits
+    // idle).
+    onConnectionLost: (listener) => wire.onDeath(listener),
+
+    close: () => wire.close(),
+
+    releaseAllLeases: () => rejected(),
+    list: () => rejected(),
+    runCleanup: () => rejected(),
+    runNuke: () => rejected(),
+    getConfig: () => rejected(),
+    stopDaemon: () =>
+      wire.call("daemon.stop", {}).then(
+        (payload) => {
+          const result = OPERATIONS["daemon.stop"].output.safeParse(payload);
+          if (!result.success) {
+            throw new SimlockError(
+              "BAD_FRAME",
+              "protocol",
+              "Daemon's daemon.stop response did not match the contract output schema",
+              {},
+            );
+          }
+          return result.data;
+        },
+        (callError: unknown) => {
+          throw toSimlockError(callError);
+        },
+      ),
+    replayEvents: () => rejected(),
+    subscribeEvents: () => rejected(),
+    createToken: () => rejected(),
+    listTokens: () => rejected(),
+    revokeToken: () => rejected(),
+  };
+  return client;
 }
 
 async function resolveConnection(options: ConnectOptions): Promise<IpcConnection> {
@@ -451,12 +537,18 @@ class SimlockClientImpl {
     let outcome: LeaseCancelOutput["result"];
     try {
       outcome = (await this.#call("lease.cancel", { requesterId })).result;
-    } catch {
-      // The connection itself may have died mid-cancel; fall through and let awaiting
+    } catch (error: unknown) {
+      // Only a connection that actually died mid-cancel falls through to let awaiting
       // `requestPromise` below surface whatever that produces (most likely
-      // `DAEMON_CONNECTION_LOST`, which is a more accurate rejection than a manufactured
-      // `CANCELLED` would be here).
-      return requestPromise;
+      // `DAEMON_CONNECTION_LOST`, a more accurate rejection than a manufactured `CANCELLED`
+      // would be here). Every other rejection -- `FORBIDDEN`, `BAD_REQUEST` -- is a real
+      // answer from the daemon and must surface as-is: this `catch` used to swallow those
+      // unconditionally, which is what let an aborted `requestLease` silently resolve with a
+      // real grant instead of `CANCELLED` (see the PR report's B3).
+      if (isSimlockError(error) && error.kind === "transport") {
+        return requestPromise;
+      }
+      throw error;
     }
 
     if (outcome === "not-found") {

--- a/src/simlock-client/client.ts
+++ b/src/simlock-client/client.ts
@@ -1,0 +1,598 @@
+/**
+ * The typed client (ADR 0003 §10): one connection, methods derived from the contract, and one
+ * stateful behaviour -- abort. `connectSimlock`/`connectSimlockAdmin` (the two public entry
+ * points, `../client/index.ts` and `../admin/index.ts`) both funnel through
+ * `connectSimlockClient` here; the split between them is only which type the caller gets back
+ * and whether a `credential` is accepted, exactly as the ADR specifies ("the split is by
+ * import path; the enforcement is the daemon's role check").
+ *
+ * This class does not reconnect and does not retry, not even for reads (ADR §10): a dead
+ * connection ends the client for good, and every in-flight call rejects with
+ * `DAEMON_CONNECTION_LOST` rather than being silently queued for a retry that would need a
+ * whole second policy (and would make "reconnecting never implicitly acquires a device" a
+ * claim this module could no longer prove).
+ */
+import type { z } from "zod";
+
+import {
+  fromWireError,
+  isSimlockError,
+  OPERATIONS,
+  SimlockError,
+  type AnySimlockError,
+  type OperationName,
+  type Role,
+} from "../contract/index.js";
+import type { IpcConnection, IpcConnector } from "../ports/index.js";
+import { SimlockWire, WireCallError, type LeaseScopedPush } from "./wire.js";
+import type {
+  CatalogGetInput,
+  CatalogGetOutput,
+  CleanupRunInput,
+  CleanupRunOutput,
+  DaemonStopOutput,
+  DeviceRecoveredPush,
+  DeviceUnhealthyPush,
+  DoctorReport,
+  DoctorRunInput,
+  EventPush,
+  EventsReplayInput,
+  EventsReplayOutput,
+  LeaseCancelInput,
+  LeaseCancelOutput,
+  LeaseGrant,
+  LeaseHeartbeatOutput,
+  LeaseListOutput,
+  LeaseLostPush,
+  LeaseProgress,
+  LeaseReleaseAllOutput,
+  LeaseReleaseInput,
+  LeaseReleaseOutput,
+  LeaseRenewInput,
+  LeaseRecord,
+  LeaseRequestInput,
+  ListGetInput,
+  ListGetOutput,
+  NukeReport,
+  NukeRunInput,
+  RequestLeaseOptions,
+  SimlockConfig,
+  StatusGetOutput,
+  TokenCreateInput,
+  TokenCreateOutput,
+  TokenListOutput,
+  TokenRevokeInput,
+  TokenRevokeOutput,
+} from "./types.js";
+
+export type {
+  CatalogGetInput,
+  CatalogGetOutput,
+  CleanupRunInput,
+  CleanupRunOutput,
+  DaemonStopOutput,
+  DeviceRecoveredPush,
+  DeviceUnhealthyPush,
+  DoctorReport,
+  DoctorRunInput,
+  EventPush,
+  EventsReplayInput,
+  EventsReplayOutput,
+  EventsSubscribeOutput,
+  EventsUnsubscribeOutput,
+  LeaseCancelInput,
+  LeaseCancelOutput,
+  LeaseGrant,
+  LeaseHeartbeatOutput,
+  LeaseListOutput,
+  LeaseLostPush,
+  LeaseProgress,
+  LeaseReleaseAllOutput,
+  LeaseReleaseInput,
+  LeaseReleaseOutput,
+  LeaseRenewInput,
+  LeaseRecord,
+  LeaseRequestInput,
+  ListGetInput,
+  ListGetOutput,
+  NukeReport,
+  NukeRunInput,
+  RequestLeaseOptions,
+  SimlockConfig,
+  StatusGetOutput,
+  TokenCreateInput,
+  TokenCreateOutput,
+  TokenListOutput,
+  TokenRevokeInput,
+  TokenRevokeOutput,
+} from "./types.js";
+export {
+  isSimlockError,
+  SimlockError,
+  type AnySimlockError,
+  type SimlockErrorCode,
+} from "../contract/index.js";
+
+export interface ConnectOptions {
+  /** Pre-connected transport (a scripted `IpcConnection` in tests, or the real result of an
+   * `IpcConnector`). Exactly one of `connection`/`connector` must be given. */
+  readonly connection?: IpcConnection;
+  /** A connector plus its endpoint -- the normal production path (`NodeIpcTransport` +
+   * a socket path). */
+  readonly connector?: IpcConnector;
+  readonly endpoint?: string;
+  /** ADR §4: the connection's fixed principal. Defaults to whatever the daemon assigns when
+   * omitted (today: its own default requester id). */
+  readonly principal?: string;
+  /** ADR §5's first credential source in the resolution order: "the `credential` connect
+   * option (programmatic client)". Only meaningful via `connectSimlockAdmin` -- the base
+   * `connectSimlock` does not accept one, by design (ADR §10: "the split is by import path"). */
+  readonly credential?: string;
+  /** Declares heartbeat support at `hello`; defaults to `true` so held leases keep sliding
+   * without the caller doing anything. */
+  readonly heartbeat?: boolean;
+}
+
+/** The full agent-visible method surface (ADR §3's operation matrix, `agent` rows) plus the
+ * pushes and lifecycle every frontend needs. `simlock/admin`'s `SimlockAdminClient` extends
+ * this with the `admin` rows. */
+export interface SimlockClient {
+  readonly principal: string;
+  readonly role: Role;
+  readonly daemonVersion: string;
+
+  getCatalog(input?: CatalogGetInput): Promise<CatalogGetOutput>;
+  getStatus(): Promise<StatusGetOutput>;
+  requestLease(input: LeaseRequestInput, options?: RequestLeaseOptions): Promise<LeaseGrant>;
+  cancelLease(input?: LeaseCancelInput): Promise<LeaseCancelOutput>;
+  renewLease(input: LeaseRenewInput): Promise<LeaseRecord>;
+  releaseLease(input: LeaseReleaseInput): Promise<LeaseReleaseOutput>;
+  listLeases(): Promise<LeaseListOutput>;
+  heartbeat(): Promise<LeaseHeartbeatOutput>;
+  runDoctor(input?: DoctorRunInput): Promise<DoctorReport>;
+
+  onLeaseLost(listener: (push: LeaseLostPush) => void): () => void;
+  onDeviceUnhealthy(listener: (push: DeviceUnhealthyPush) => void): () => void;
+  onDeviceRecovered(listener: (push: DeviceRecoveredPush) => void): () => void;
+  /** Fires exactly once, when the connection dies for any reason (including a deliberate
+   * `close()`). Every in-flight call has already rejected `DAEMON_CONNECTION_LOST` and every
+   * `onLeaseLost` for a held lease has already fired by the time this listener runs. */
+  onConnectionLost(listener: (error: AnySimlockError) => void): () => void;
+
+  close(): Promise<void>;
+}
+
+/** `simlock/admin`'s extension: the `admin` rows of ADR §3's matrix. */
+export interface SimlockAdminClient extends SimlockClient {
+  releaseAllLeases(): Promise<LeaseReleaseAllOutput>;
+  list(input?: ListGetInput): Promise<ListGetOutput>;
+  runCleanup(input?: CleanupRunInput): Promise<CleanupRunOutput>;
+  runNuke(input?: NukeRunInput): Promise<NukeReport>;
+  getConfig(): Promise<SimlockConfig>;
+  /** ADR §6's frozen exception: accepted by the daemon at any protocol version it has ever
+   * spoken, even before `hello`/role resolve. Exposed here rather than on the base client
+   * purely as an API-surface choice matching the ADR's operation matrix (the daemon itself
+   * does not gate this operation by role at all -- see the caveat in the PR report). */
+  stopDaemon(): Promise<DaemonStopOutput>;
+  replayEvents(input?: EventsReplayInput): Promise<EventsReplayOutput>;
+  subscribeEvents(listener: (event: EventPush) => void): Promise<() => Promise<void>>;
+  createToken(input: TokenCreateInput): Promise<TokenCreateOutput>;
+  listTokens(): Promise<TokenListOutput>;
+  revokeToken(input: TokenRevokeInput): Promise<TokenRevokeOutput>;
+}
+
+/** Internal: builds either client. `admin` toggles only which methods the returned object
+ * carries (an object literal with/without the extra methods) -- the daemon's own role check is
+ * what actually stops an agent-role session from calling one of them; this flag exists purely
+ * so `simlock/client` doesn't even show the admin methods in a caller's editor. */
+export async function connectSimlockClient(
+  options: ConnectOptions,
+  admin: false,
+): Promise<SimlockClient>;
+export async function connectSimlockClient(
+  options: ConnectOptions,
+  admin: true,
+): Promise<SimlockAdminClient>;
+export async function connectSimlockClient(
+  options: ConnectOptions,
+  admin: boolean,
+): Promise<SimlockClient | SimlockAdminClient> {
+  const connection = await resolveConnection(options);
+  const wire = new SimlockWire(connection);
+  let hello: Awaited<ReturnType<SimlockWire["hello"]>>;
+  try {
+    hello = await wire.hello({
+      ...(options.principal === undefined ? {} : { principal: options.principal }),
+      ...(options.credential === undefined ? {} : { credential: options.credential }),
+      capabilities: { heartbeat: options.heartbeat ?? true },
+    });
+  } catch (error: unknown) {
+    await connection.close();
+    throw error;
+  }
+  const impl = new SimlockClientImpl(
+    wire,
+    hello.role,
+    options.principal ?? "",
+    hello.daemonVersion,
+  );
+  return admin ? impl.asAdmin() : impl;
+}
+
+async function resolveConnection(options: ConnectOptions): Promise<IpcConnection> {
+  if (options.connection !== undefined) return options.connection;
+  if (options.connector !== undefined && options.endpoint !== undefined) {
+    return options.connector.connect(options.endpoint);
+  }
+  throw new Error(
+    "connectSimlock requires either `connection` (a pre-connected transport) or both `connector` and `endpoint`",
+  );
+}
+
+/**
+ * The single implementation both `SimlockClient` and `SimlockAdminClient` are backed by --
+ * `asAdmin()` returns the same instance typed with the extra methods, since every admin
+ * operation is a plain operation call like any other and there is nothing role-specific to
+ * duplicate. Held-lease bookkeeping (`#heldLeaseIds`) exists for exactly one reason: so a
+ * connection death can synthesize `onLeaseLost` for each lease this client held, per ADR §10.
+ */
+class SimlockClientImpl {
+  readonly #wire: SimlockWire;
+  readonly #heldLeaseIds = new Map<string, string>(); // leaseId -> deviceId
+  readonly #leaseLostListeners = new Set<(push: LeaseLostPush) => void>();
+  readonly #deviceUnhealthyListeners = new Set<(push: DeviceUnhealthyPush) => void>();
+  readonly #deviceRecoveredListeners = new Set<(push: DeviceRecoveredPush) => void>();
+  readonly #connectionLostListeners = new Set<(error: AnySimlockError) => void>();
+  #eventSubscriptionId: string | undefined;
+
+  constructor(
+    wire: SimlockWire,
+    readonly role: Role,
+    readonly principal: string,
+    readonly daemonVersion: string,
+  ) {
+    this.#wire = wire;
+    wire.onLeaseScopedPush((push) => this.#handleLeaseScopedPush(push));
+    wire.onDeath((error) => this.#handleConnectionLost(error));
+  }
+
+  asAdmin(): SimlockAdminClient {
+    // `this` already implements every method the interface below needs (see the class body) --
+    // this cast documents that the split is purely at the type layer.
+    return this as unknown as SimlockAdminClient;
+  }
+
+  // ---- agent-visible operations --------------------------------------------------------------
+
+  getCatalog(input: CatalogGetInput = {}): Promise<CatalogGetOutput> {
+    return this.#call("catalog.get", input);
+  }
+
+  getStatus(): Promise<StatusGetOutput> {
+    return this.#call("status.get", {});
+  }
+
+  async requestLease(
+    input: LeaseRequestInput,
+    options: RequestLeaseOptions = {},
+  ): Promise<LeaseGrant> {
+    const parsed = this.#parseInput("lease.request", input);
+    const requesterId = parsed.requesterId ?? this.principal;
+    const { signal, onProgress } = options;
+
+    if (signal?.aborted === true) throw cancelledError();
+
+    const requestPromise = this.#callRaw("lease.request", parsed, onProgress).then((grant) => {
+      this.#trackGrant(grant as LeaseGrant);
+      return grant as LeaseGrant;
+    });
+
+    if (signal === undefined) return requestPromise;
+    return this.#requestLeaseWithAbort(requestPromise, signal, requesterId);
+  }
+
+  cancelLease(input: LeaseCancelInput = {}): Promise<LeaseCancelOutput> {
+    return this.#call("lease.cancel", input);
+  }
+
+  renewLease(input: LeaseRenewInput): Promise<LeaseRecord> {
+    return this.#call("lease.renew", input);
+  }
+
+  async releaseLease(input: LeaseReleaseInput): Promise<LeaseReleaseOutput> {
+    const parsed = this.#parseInput("lease.release", input);
+    this.#wire.markSelfInitiatedRelease(parsed.leaseId);
+    const result = await this.#call("lease.release", parsed);
+    this.#heldLeaseIds.delete(parsed.leaseId);
+    return result;
+  }
+
+  listLeases(): Promise<LeaseListOutput> {
+    return this.#call("lease.list", {});
+  }
+
+  heartbeat(): Promise<LeaseHeartbeatOutput> {
+    return this.#call("lease.heartbeat", {});
+  }
+
+  runDoctor(input: DoctorRunInput = {}): Promise<DoctorReport> {
+    return this.#call("doctor.run", input);
+  }
+
+  onLeaseLost(listener: (push: LeaseLostPush) => void): () => void {
+    this.#leaseLostListeners.add(listener);
+    return () => this.#leaseLostListeners.delete(listener);
+  }
+
+  onDeviceUnhealthy(listener: (push: DeviceUnhealthyPush) => void): () => void {
+    this.#deviceUnhealthyListeners.add(listener);
+    return () => this.#deviceUnhealthyListeners.delete(listener);
+  }
+
+  onDeviceRecovered(listener: (push: DeviceRecoveredPush) => void): () => void {
+    this.#deviceRecoveredListeners.add(listener);
+    return () => this.#deviceRecoveredListeners.delete(listener);
+  }
+
+  onConnectionLost(listener: (error: AnySimlockError) => void): () => void {
+    this.#connectionLostListeners.add(listener);
+    return () => this.#connectionLostListeners.delete(listener);
+  }
+
+  async close(): Promise<void> {
+    await this.#wire.close();
+  }
+
+  // ---- admin-only operations ------------------------------------------------------------------
+
+  releaseAllLeases(): Promise<LeaseReleaseAllOutput> {
+    for (const leaseId of this.#heldLeaseIds.keys()) this.#wire.markSelfInitiatedRelease(leaseId);
+    return this.#call("lease.release-all", {}).then((result) => {
+      this.#heldLeaseIds.clear();
+      return result;
+    });
+  }
+
+  list(input: ListGetInput = {}): Promise<ListGetOutput> {
+    return this.#call("list.get", input);
+  }
+
+  runCleanup(input: CleanupRunInput = {}): Promise<CleanupRunOutput> {
+    return this.#call("cleanup.run", input);
+  }
+
+  runNuke(input: NukeRunInput = {}): Promise<NukeReport> {
+    return this.#call("nuke.run", input);
+  }
+
+  getConfig(): Promise<SimlockConfig> {
+    return this.#call("config.get", {});
+  }
+
+  stopDaemon(): Promise<DaemonStopOutput> {
+    return this.#call("daemon.stop", {});
+  }
+
+  replayEvents(input: EventsReplayInput = {}): Promise<EventsReplayOutput> {
+    return this.#call("events.replay", input);
+  }
+
+  async subscribeEvents(listener: (event: EventPush) => void): Promise<() => Promise<void>> {
+    const unsubscribePush = this.#wire.onEvent((payload) => listener(payload as EventPush));
+    const result = await this.#call("events.subscribe", {});
+    this.#eventSubscriptionId = result.subscriptionId;
+    return async () => {
+      unsubscribePush();
+      if (this.#eventSubscriptionId === undefined) return;
+      this.#eventSubscriptionId = undefined;
+      await this.#call("events.unsubscribe", {});
+    };
+  }
+
+  createToken(input: TokenCreateInput): Promise<TokenCreateOutput> {
+    return this.#call("token.create", input);
+  }
+
+  listTokens(): Promise<TokenListOutput> {
+    return this.#call("token.list", {});
+  }
+
+  revokeToken(input: TokenRevokeInput): Promise<TokenRevokeOutput> {
+    return this.#call("token.revoke", input);
+  }
+
+  // ---- abort (ADR §10) ------------------------------------------------------------------------
+
+  /**
+   * The four behaviours, all funneled through one function once we know the request was sent
+   * and a signal was given:
+   *
+   * - already resolved by the time abort fires -> `#requestDone` guards the raw promise's own
+   *   `.then` from resolving twice; the abort handler itself never runs any cancellation logic
+   *   because `#requestDone` is also checked there.
+   * - queued / in-flight / not-found are all resolved by `#cancelOnAbort`, driven entirely by
+   *   `lease.cancel`'s own three-way result.
+   */
+  #requestLeaseWithAbort(
+    requestPromise: Promise<LeaseGrant>,
+    signal: AbortSignal,
+    requesterId: string,
+  ): Promise<LeaseGrant> {
+    return new Promise((resolve, reject) => {
+      let requestDone = false;
+      let aborted = false;
+
+      const onAbort = (): void => {
+        if (requestDone) return; // after the grant resolved (or it already failed) -> ignored.
+        aborted = true;
+        void this.#cancelOnAbort(requestPromise, requesterId).then(resolve, reject);
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+
+      requestPromise.then(
+        (grant) => {
+          requestDone = true;
+          signal.removeEventListener("abort", onAbort);
+          if (!aborted) resolve(grant);
+        },
+        (error: unknown) => {
+          requestDone = true;
+          signal.removeEventListener("abort", onAbort);
+          if (!aborted) reject(error as Error);
+        },
+      );
+    });
+  }
+
+  async #cancelOnAbort(
+    requestPromise: Promise<LeaseGrant>,
+    requesterId: string,
+  ): Promise<LeaseGrant> {
+    let outcome: LeaseCancelOutput["result"];
+    try {
+      outcome = (await this.#call("lease.cancel", { requesterId })).result;
+    } catch {
+      // The connection itself may have died mid-cancel; fall through and let awaiting
+      // `requestPromise` below surface whatever that produces (most likely
+      // `DAEMON_CONNECTION_LOST`, which is a more accurate rejection than a manufactured
+      // `CANCELLED` would be here).
+      return requestPromise;
+    }
+
+    if (outcome === "not-found") {
+      // Either genuinely never existed, or -- per ADR §10's fourth case -- the grant already
+      // resolved before the cancel reached the daemon: "after the grant resolved -> ignored".
+      // Both cases defer entirely to the original outcome.
+      return requestPromise;
+    }
+
+    if (outcome === "cancelled") {
+      // Queued: the daemon rejects the original waiter; wait for that, then surface CANCELLED
+      // regardless of the rejection's own code/message.
+      await requestPromise.catch(() => undefined);
+      throw cancelledError();
+    }
+
+    // "not-cancellable": device work already in flight. Wait for the outcome; a grant that
+    // still arrives is abandoned immediately so the caller never holds a lease it walked away
+    // from, then CANCELLED is surfaced either way.
+    try {
+      const grant = await requestPromise;
+      await this.#releaseAbandonedGrant(grant);
+    } catch {
+      // The request failed on its own (e.g. ran out of capacity mid-flight) -- nothing to
+      // release, and CANCELLED is still the right thing to tell a caller who asked to abort.
+    }
+    throw cancelledError();
+  }
+
+  async #releaseAbandonedGrant(grant: LeaseGrant): Promise<void> {
+    try {
+      await this.releaseLease({ leaseId: grant.lease.id });
+    } catch {
+      // Best-effort: the caller already gets CANCELLED either way. A failed release here means
+      // the daemon may still show the lease held -- see the PR report's weak-spots list.
+    }
+  }
+
+  // ---- pushes -----------------------------------------------------------------------------
+
+  #handleLeaseScopedPush(push: LeaseScopedPush): void {
+    switch (push.kind) {
+      case "lease-lost":
+        this.#heldLeaseIds.delete(push.leaseId);
+        for (const listener of this.#leaseLostListeners) {
+          listener({ deviceId: push.deviceId, leaseId: push.leaseId, reason: push.reason });
+        }
+        return;
+      case "device-unhealthy":
+        for (const listener of this.#deviceUnhealthyListeners) {
+          listener({ deviceId: push.deviceId, leaseId: push.leaseId });
+        }
+        return;
+      case "device-recovered":
+        for (const listener of this.#deviceRecoveredListeners) {
+          listener({ attempts: push.attempts, deviceId: push.deviceId, leaseId: push.leaseId });
+        }
+        return;
+    }
+  }
+
+  #handleConnectionLost(error: AnySimlockError): void {
+    const held = [...this.#heldLeaseIds.entries()];
+    this.#heldLeaseIds.clear();
+    for (const [leaseId, deviceId] of held) {
+      for (const listener of this.#leaseLostListeners) {
+        listener({ deviceId, leaseId, reason: "daemon-connection-lost" });
+      }
+    }
+    for (const listener of this.#connectionLostListeners) listener(error);
+  }
+
+  #trackGrant(grant: LeaseGrant): void {
+    if (grant.lease.mode === "held") this.#heldLeaseIds.set(grant.lease.id, grant.lease.deviceId);
+  }
+
+  // ---- call plumbing --------------------------------------------------------------------------
+
+  #parseInput<Name extends OperationName>(
+    name: Name,
+    input: unknown,
+  ): z.infer<(typeof OPERATIONS)[Name]["input"]> {
+    const result = OPERATIONS[name].input.safeParse(input);
+    if (result.success) return result.data;
+    const description = result.error.issues
+      .map((issue) => `${issue.path.length > 0 ? `${issue.path.join(".")}: ` : ""}${issue.message}`)
+      .join("; ");
+    throw new SimlockError("BAD_REQUEST", "protocol", description, {});
+  }
+
+  #parseOutput<Name extends OperationName>(
+    name: Name,
+    payload: unknown,
+  ): z.infer<(typeof OPERATIONS)[Name]["output"]> {
+    const result = OPERATIONS[name].output.safeParse(payload);
+    if (result.success) return result.data;
+    throw new SimlockError(
+      "BAD_FRAME",
+      "protocol",
+      `Daemon's ${name} response did not match the contract output schema`,
+      {},
+    );
+  }
+
+  async #call<Name extends OperationName>(
+    name: Name,
+    input: z.infer<(typeof OPERATIONS)[Name]["input"]>,
+  ): Promise<z.infer<(typeof OPERATIONS)[Name]["output"]>> {
+    const payload = await this.#callRaw(name, input);
+    return this.#parseOutput(name, payload);
+  }
+
+  #callRaw(
+    name: OperationName,
+    input: unknown,
+    onProgress?: (progress: LeaseProgress) => void,
+  ): Promise<unknown> {
+    const parsed = this.#parseInput(name, input);
+    return this.#wire.call(name, parsed, onProgress).catch((error: unknown) => {
+      throw toSimlockError(error);
+    });
+  }
+}
+
+function cancelledError(): SimlockError<"CANCELLED"> {
+  return new SimlockError("CANCELLED", "domain", "Lease request was cancelled", {});
+}
+
+function toSimlockError(error: unknown): AnySimlockError {
+  if (isSimlockError(error)) return error;
+  if (error instanceof WireCallError)
+    return fromWireError(error.code, error.message, error.details);
+  return new SimlockError(
+    "DAEMON_CONNECTION_LOST",
+    "transport",
+    error instanceof Error ? error.message : String(error),
+    {},
+  );
+}

--- a/src/simlock-client/no-core-leak.test.ts
+++ b/src/simlock-client/no-core-leak.test.ts
@@ -1,0 +1,112 @@
+/**
+ * ADR 0003 §10/PR description: "the public surface must expose contract types only -- core
+ * domain records (`DeviceRecord`, `LeaseRecord`, `LeaseGrant`) stay private". This compiles
+ * `simlock/client`'s and `simlock/admin`'s entry points with declaration-only emit (via a
+ * throwaway `tsc -p` invocation restricted to just those two root files, so only their actual
+ * import closure gets emitted -- not a shelled-out `pnpm run build` of the whole package, and
+ * not dependent on one having already run) and asserts none of the emitted `.d.ts` files ever
+ * import from `src/core`, `src/daemon`, `src/drivers`, `src/http`, `src/cli`, or `src/mcp`.
+ * Mirrors `src/contract/boundary.test.ts`'s source-text approach, but checked at the compiled
+ * public-surface boundary instead of the contract module's own imports -- the actual guarantee
+ * this test exists to prove is about what a *consumer* of the published package sees, which is
+ * the emitted declarations, not the source.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..", "..");
+
+const FORBIDDEN_IMPORT_SUBSTRINGS = [
+  "/core/",
+  "/daemon/",
+  "/daemon.js",
+  "/drivers/",
+  "/http/",
+  "/cli/",
+  "/mcp/",
+];
+
+let outDir: string;
+let dtsFiles: Array<{ readonly path: string; readonly contents: string }>;
+
+describe("public package surface (simlock/client, simlock/admin)", () => {
+  let tmpTsconfigPath: string;
+
+  beforeAll(() => {
+    outDir = mkdtempSync(join(tmpdir(), "simlock-surface-"));
+    // Written inside the repo root (not the tmp outDir) so `"types": ["node"]` and everything
+    // else in the extended `tsconfig.json` still resolves against this project's own
+    // `node_modules` -- TS resolves package/type-root lookups relative to the config file's own
+    // directory, not the directory of the config it extends.
+    tmpTsconfigPath = join(repoRoot, ".simlock-surface-tsconfig.json");
+    writeFileSync(
+      tmpTsconfigPath,
+      JSON.stringify({
+        extends: "./tsconfig.json",
+        compilerOptions: { declaration: true, emitDeclarationOnly: true, outDir },
+        files: ["src/client/index.ts", "src/admin/index.ts"],
+        include: [],
+      }),
+    );
+    const tscBin = join(repoRoot, "node_modules", ".bin", "tsc");
+    execFileSync(tscBin, ["-p", tmpTsconfigPath], { cwd: repoRoot, stdio: "pipe" });
+    dtsFiles = collectDtsFiles(outDir).map((path) => ({
+      contents: readFileSync(path, "utf8"),
+      path,
+    }));
+  }, 60_000);
+
+  afterAll(() => {
+    rmSync(outDir, { force: true, recursive: true });
+    rmSync(tmpTsconfigPath, { force: true });
+  });
+
+  it("compiles both entry points and emits declarations for each", () => {
+    expect(dtsFiles.some((file) => file.path.endsWith(join("client", "index.d.ts")))).toBe(true);
+    expect(dtsFiles.some((file) => file.path.endsWith(join("admin", "index.d.ts")))).toBe(true);
+  });
+
+  it("never imports a core/daemon/drivers-private module from the compiled public surface", () => {
+    expect(dtsFiles.length).toBeGreaterThan(0);
+    for (const file of dtsFiles) {
+      for (const specifier of importSpecifiers(file.contents)) {
+        for (const forbidden of FORBIDDEN_IMPORT_SUBSTRINGS) {
+          expect(
+            specifier.includes(forbidden),
+            `${file.path} imports "${specifier}", which references forbidden "${forbidden}"`,
+          ).toBe(false);
+        }
+      }
+    }
+  });
+});
+
+/** Import/re-export specifiers only -- e.g. from `import("../core/index.js").Foo` or
+ * `export * from "./x.js"` -- deliberately not a plain substring scan of the whole file, which
+ * would false-positive on prose in a carried-over JSDoc comment (e.g. a `.d.ts` comment that
+ * merely *mentions* `src/http/errors.ts` in passing, as `errors.ts` does today). */
+function importSpecifiers(contents: string): string[] {
+  const specifiers: string[] = [];
+  const pattern = /(?:from\s+["']([^"']+)["']|import\(["']([^"']+)["']\))/g;
+  for (const match of contents.matchAll(pattern)) {
+    const specifier = match[1] ?? match[2];
+    if (specifier !== undefined) specifiers.push(specifier);
+  }
+  return specifiers;
+}
+
+function collectDtsFiles(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) results.push(...collectDtsFiles(full));
+    else if (entry.name.endsWith(".d.ts")) results.push(full);
+  }
+  return results;
+}

--- a/src/simlock-client/test-support.ts
+++ b/src/simlock-client/test-support.ts
@@ -1,0 +1,109 @@
+/**
+ * A scripted `IpcConnection` double for the typed client's unit tests (ADR §12: "client unit
+ * tests against a scripted connection"). Records every frame the client writes (so a test can
+ * assert exactly what was/wasn't sent -- the "zero requests after hello" and "mismatch rejected
+ * before any request" conditions need this) and lets a test script arbitrary success/error/push
+ * replies keyed by request id, or drive the connection dead on demand.
+ */
+import type { IpcConnection } from "../ports/index.js";
+
+export interface SentFrame {
+  readonly id: number | string;
+  readonly type: string;
+  readonly payload: unknown;
+}
+
+export class ScriptedConnection implements IpcConnection {
+  readonly sent: SentFrame[] = [];
+  #closed = false;
+  readonly #dataListeners = new Set<(chunk: string) => void>();
+  readonly #closeListeners = new Set<() => void>();
+  readonly #errorListeners = new Set<(error: Error) => void>();
+
+  get closed(): boolean {
+    return this.#closed;
+  }
+
+  onData(listener: (chunk: string) => void): () => void {
+    this.#dataListeners.add(listener);
+    return () => this.#dataListeners.delete(listener);
+  }
+
+  onClose(listener: () => void): () => void {
+    this.#closeListeners.add(listener);
+    return () => this.#closeListeners.delete(listener);
+  }
+
+  onError(listener: (error: Error) => void): () => void {
+    this.#errorListeners.add(listener);
+    return () => this.#errorListeners.delete(listener);
+  }
+
+  write(contents: string): Promise<void> {
+    for (const line of contents.split("\n")) {
+      if (line.trim() === "") continue;
+      const frame = JSON.parse(line) as { id: number | string; type: string; payload: unknown };
+      this.sent.push(frame);
+    }
+    return Promise.resolve();
+  }
+
+  close(): Promise<void> {
+    this.#simulateClose();
+    return Promise.resolve();
+  }
+
+  /** Feeds one JSON line to the client as if the daemon sent it. */
+  receive(frame: unknown): void {
+    for (const listener of this.#dataListeners) listener(`${JSON.stringify(frame)}\n`);
+  }
+
+  /** Replies success to the most recent (or a specific) sent frame id. */
+  reply(id: number | string, payload: unknown): void {
+    this.receive({ id, ok: true, payload });
+  }
+
+  fail(id: number | string, code: string, message = code, details?: unknown): void {
+    this.receive({ error: { code, details, message }, id, ok: false });
+  }
+
+  push(kind: string, payload: unknown): void {
+    this.receive({ payload, push: kind });
+  }
+
+  /** Finds the most recent sent frame of a given type, e.g. for auto-replying to `hello`. */
+  lastSentOf(type: string): SentFrame | undefined {
+    for (let index = this.sent.length - 1; index >= 0; index -= 1) {
+      const frame = this.sent[index];
+      if (frame !== undefined && frame.type === type) return frame;
+    }
+    return undefined;
+  }
+
+  /** Simulates the socket dying (not a graceful `close()`). */
+  simulateDeath(): void {
+    this.#simulateClose();
+  }
+
+  #simulateClose(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    for (const listener of this.#closeListeners) listener();
+  }
+}
+
+/** Replies to the connection's `hello` frame with a normal, matching-protocol, given-role
+ * response -- the common setup step for every test that needs a connected client. */
+export function completeHello(
+  connection: ScriptedConnection,
+  options: { readonly role?: "agent" | "admin"; readonly version?: string } = {},
+): void {
+  const hello = connection.lastSentOf("hello");
+  if (hello === undefined) throw new Error("Expected the client to have sent hello already");
+  connection.reply(hello.id, {
+    daemonProtocolRange: { max: 3, min: 3 },
+    protocolVersion: 3,
+    role: options.role ?? "agent",
+    version: options.version ?? "0.3.0",
+  });
+}

--- a/src/simlock-client/test-support.ts
+++ b/src/simlock-client/test-support.ts
@@ -93,15 +93,24 @@ export class ScriptedConnection implements IpcConnection {
 }
 
 /** Replies to the connection's `hello` frame with a normal, matching-protocol, given-role
- * response -- the common setup step for every test that needs a connected client. */
+ * response -- the common setup step for every test that needs a connected client.
+ * `principal` defaults to whatever the client itself sent (ADR §4: the daemon's default when
+ * `hello` omits one is out of this test double's scope, so a test exercising that specific
+ * fallback -- see `server.test.ts` -- passes an explicit `principal` here instead). */
 export function completeHello(
   connection: ScriptedConnection,
-  options: { readonly role?: "agent" | "admin"; readonly version?: string } = {},
+  options: {
+    readonly role?: "agent" | "admin";
+    readonly version?: string;
+    readonly principal?: string;
+  } = {},
 ): void {
   const hello = connection.lastSentOf("hello");
   if (hello === undefined) throw new Error("Expected the client to have sent hello already");
+  const sentPrincipal = (hello.payload as { principal?: string }).principal;
   connection.reply(hello.id, {
     daemonProtocolRange: { max: 3, min: 3 },
+    principal: options.principal ?? sentPrincipal ?? "default-principal",
     protocolVersion: 3,
     role: options.role ?? "agent",
     version: options.version ?? "0.3.0",

--- a/src/simlock-client/types.ts
+++ b/src/simlock-client/types.ts
@@ -1,0 +1,92 @@
+/**
+ * Public types for `simlock/client` and `simlock/admin` (ADR 0003 §10). Every type here is
+ * `z.infer`red from a contract schema (`src/contract/operations.ts`, `schemas.ts`, `pushes.ts`)
+ * rather than hand-declared, so a schema change is a compile-time type change here too, never a
+ * silent drift. Nothing in this file imports from `src/core`, `src/daemon`, or `src/drivers` --
+ * see `no-core-leak.test.ts`, which asserts the compiled `.d.ts` for these two entry points
+ * never mentions a core-private type name.
+ */
+import type { z } from "zod";
+
+import type { OPERATIONS, OperationName, PUSH_SCHEMAS } from "../contract/index.js";
+import type { leaseProgressSchema } from "../contract/schemas.js";
+
+type OpInput<Name extends OperationName> = z.infer<(typeof OPERATIONS)[Name]["input"]>;
+type OpOutput<Name extends OperationName> = z.infer<(typeof OPERATIONS)[Name]["output"]>;
+
+// ---- agent-visible operations -------------------------------------------------------------
+
+export type CatalogGetInput = OpInput<"catalog.get">;
+export type CatalogGetOutput = OpOutput<"catalog.get">;
+export type StatusGetOutput = OpOutput<"status.get">;
+export type LeaseRequestInput = OpInput<"lease.request">;
+/** `lease.request`'s output -- deliberately not named `LeaseRequestOutput` since it is the
+ * thing every frontend actually calls a "grant" (device + lease + timing estimates). */
+export type LeaseGrant = OpOutput<"lease.request">;
+export type LeaseCancelInput = OpInput<"lease.cancel">;
+export type LeaseCancelOutput = OpOutput<"lease.cancel">;
+export type LeaseRenewInput = OpInput<"lease.renew">;
+/** Also `lease.renew`'s output, and the element type of `lease.list`'s array -- one shape,
+ * reused wherever the contract reuses `leaseRecordSchema`. */
+export type LeaseRecord = OpOutput<"lease.renew">;
+export type LeaseReleaseInput = OpInput<"lease.release">;
+export type LeaseReleaseOutput = OpOutput<"lease.release">;
+export type LeaseListOutput = OpOutput<"lease.list">;
+export type LeaseHeartbeatOutput = OpOutput<"lease.heartbeat">;
+export type DoctorRunInput = OpInput<"doctor.run">;
+export type DoctorReport = OpOutput<"doctor.run">;
+
+// ---- admin-only operations ------------------------------------------------------------------
+
+export type LeaseReleaseAllOutput = OpOutput<"lease.release-all">;
+export type ListGetInput = OpInput<"list.get">;
+export type ListGetOutput = OpOutput<"list.get">;
+export type CleanupRunInput = OpInput<"cleanup.run">;
+export type CleanupRunOutput = OpOutput<"cleanup.run">;
+export type NukeRunInput = OpInput<"nuke.run">;
+export type NukeReport = OpOutput<"nuke.run">;
+export type SimlockConfig = OpOutput<"config.get">;
+export type DaemonStopOutput = OpOutput<"daemon.stop">;
+export type EventsReplayInput = OpInput<"events.replay">;
+export type EventsReplayOutput = OpOutput<"events.replay">;
+export type EventsSubscribeOutput = OpOutput<"events.subscribe">;
+export type EventsUnsubscribeOutput = OpOutput<"events.unsubscribe">;
+export type TokenCreateInput = OpInput<"token.create">;
+export type TokenCreateOutput = OpOutput<"token.create">;
+export type TokenListOutput = OpOutput<"token.list">;
+export type TokenRevokeInput = OpInput<"token.revoke">;
+export type TokenRevokeOutput = OpOutput<"token.revoke">;
+
+// ---- pushes ---------------------------------------------------------------------------------
+
+export type LeaseProgress = z.infer<typeof leaseProgressSchema>;
+export type EventPush = z.infer<(typeof PUSH_SCHEMAS)["event"]>;
+
+export interface LeaseLostPush {
+  readonly leaseId: string;
+  readonly deviceId: string;
+  /** A server-reported reason (`"expired"`, `"explicit"`, `"closed"`, ...) or, when this
+   * client's own connection died, the client-synthesized `"daemon-connection-lost"` (ADR
+   * §10). Not a closed enum on the wire, so kept as `string` here rather than invented. */
+  readonly reason: string;
+}
+
+export interface DeviceUnhealthyPush {
+  readonly leaseId: string;
+  readonly deviceId: string;
+}
+
+export interface DeviceRecoveredPush {
+  readonly leaseId: string;
+  readonly deviceId: string;
+  readonly attempts: number;
+}
+
+// ---- connect options --------------------------------------------------------------------------
+
+export interface RequestLeaseOptions {
+  /** ADR §10's one stateful client behaviour -- see `client.ts`'s `#requestLeaseWithAbort` for
+   * the four distinct behaviours this drives. */
+  readonly signal?: AbortSignal;
+  readonly onProgress?: (progress: LeaseProgress) => void;
+}

--- a/src/simlock-client/wire.ts
+++ b/src/simlock-client/wire.ts
@@ -37,6 +37,9 @@ export interface HelloResult {
   readonly daemonProtocolRange: ProtocolRange;
   readonly daemonVersion: string;
   readonly role: Role;
+  /** ADR §4: the connection's resolved, fixed-for-its-lifetime principal -- see
+   * `helloReplySchema`'s comment. */
+  readonly principal: string;
 }
 
 interface PendingCall {
@@ -128,6 +131,7 @@ export class SimlockWire {
     return {
       daemonProtocolRange: parsed.data.daemonProtocolRange,
       daemonVersion: parsed.data.version,
+      principal: parsed.data.principal,
       protocolVersion: parsed.data.protocolVersion,
       role: parsed.data.role,
     };

--- a/src/simlock-client/wire.ts
+++ b/src/simlock-client/wire.ts
@@ -1,0 +1,367 @@
+/**
+ * The typed client's wire layer (ADR 0003 §10). One connection, one frame-id space, no
+ * reconnect and no retry -- see the module comment on `client.ts` for the policy this
+ * implements. This file owns only framing, push routing, and connection-death handling; every
+ * typed method surface lives in `client.ts`.
+ */
+import type { IpcConnection } from "../ports/index.js";
+import {
+  fromWireError,
+  mapLegacyProtocolMismatch,
+  normalizeProtocolVersion,
+  PROTOCOL_VERSION_RANGE,
+  PUSH_SCHEMAS,
+  SimlockError,
+  helloReplySchema,
+  type AnySimlockError,
+  type ProtocolRange,
+  type Role,
+} from "../contract/index.js";
+import { parseDaemonResponse, serializeFrame } from "../daemon-protocol/index.js";
+import type { LeaseProgress } from "./types.js";
+
+/** The one legacy code a protocol-2 daemon answers `hello` with (see
+ * `src/daemon-client/startup-coordinator.ts`'s comment, the only place in this repo that names
+ * it -- there is no live protocol-2 daemon to negotiate with, so this constant documents a
+ * historical fact rather than something exercised against a real peer). */
+const LEGACY_MISMATCH_CODE = "PROTOCOL_VERSION_MISMATCH";
+
+export interface HelloOptions {
+  readonly principal?: string;
+  readonly credential?: string;
+  readonly capabilities?: { readonly heartbeat?: boolean };
+}
+
+export interface HelloResult {
+  readonly protocolVersion: number;
+  readonly daemonProtocolRange: ProtocolRange;
+  readonly daemonVersion: string;
+  readonly role: Role;
+}
+
+interface PendingCall {
+  readonly resolve: (payload: unknown) => void;
+  readonly reject: (error: Error) => void;
+  readonly onProgress?: ((progress: LeaseProgress) => void) | undefined;
+}
+
+export type LeaseScopedPush =
+  | {
+      readonly kind: "lease-lost";
+      readonly leaseId: string;
+      readonly deviceId: string;
+      readonly reason: string;
+    }
+  | { readonly kind: "device-unhealthy"; readonly leaseId: string; readonly deviceId: string }
+  | {
+      readonly kind: "device-recovered";
+      readonly leaseId: string;
+      readonly deviceId: string;
+      readonly attempts: number;
+    };
+
+/**
+ * Everything below `client.ts`'s typed method surface: frame ids, pending-call bookkeeping,
+ * push routing and de-duplication, and connection-death fan-out. Deliberately has no idea what
+ * a "lease" or a "grant" is beyond the push correlation keys the contract declares -- that
+ * vocabulary lives in `client.ts`.
+ */
+export class SimlockWire {
+  readonly #connection: IpcConnection;
+  readonly #pending = new Map<number, PendingCall>();
+  readonly #leaseScopedListeners = new Set<(push: LeaseScopedPush) => void>();
+  readonly #eventListeners = new Set<(payload: unknown) => void>();
+  readonly #closeListeners = new Set<(error: AnySimlockError) => void>();
+  /** Lease ids this client itself asked to release -- suppresses the matching `lease-lost`
+   * push exactly once (ADR §8: "never fires onLeaseLost for a release the same client asked
+   * for"), then is removed so a *later*, unrelated crash for a reused lease id is not silently
+   * eaten forever. */
+  readonly #selfInitiatedReleases = new Set<string>();
+  /** De-dup key (`${kind}:${leaseId}`) for lease-scoped pushes already delivered, so a
+   * redundant re-push (the owner-routed fan-out can in principle reach the same connection
+   * twice for one fact) does not fire a listener twice for the same fact. */
+  readonly #deliveredLeaseScoped = new Set<string>();
+  #buffer = "";
+  #nextId = 1;
+  #dead: AnySimlockError | undefined;
+
+  constructor(connection: IpcConnection) {
+    this.#connection = connection;
+    connection.onData((chunk) => this.#read(chunk));
+    connection.onError(() =>
+      this.#die(
+        new SimlockError("DAEMON_CONNECTION_LOST", "transport", "Daemon connection is closed", {}),
+      ),
+    );
+    connection.onClose(() =>
+      this.#die(
+        new SimlockError("DAEMON_CONNECTION_LOST", "transport", "Daemon connection closed", {}),
+      ),
+    );
+  }
+
+  /** Sends `hello` and returns its reply, or throws the contract's typed mismatch/auth error.
+   * Called exactly once, before any other frame -- see `client.ts`'s `connect*` functions. */
+  async hello(options: HelloOptions): Promise<HelloResult> {
+    let raw: unknown;
+    try {
+      raw = await this.#send("hello", {
+        clientVersion: "1.0.0",
+        protocolVersion: PROTOCOL_VERSION_RANGE.max,
+        protocolRange: PROTOCOL_VERSION_RANGE,
+        ...(options.principal === undefined ? {} : { principal: options.principal }),
+        ...(options.credential === undefined ? {} : { credential: options.credential }),
+        ...(options.capabilities === undefined ? {} : { capabilities: options.capabilities }),
+      });
+    } catch (error: unknown) {
+      throw this.#toHelloError(error);
+    }
+    const parsed = helloReplySchema.safeParse(raw);
+    if (!parsed.success) {
+      throw new SimlockError(
+        "BAD_FRAME",
+        "protocol",
+        "Daemon's hello reply did not match the protocol contract",
+        {},
+      );
+    }
+    return {
+      daemonProtocolRange: parsed.data.daemonProtocolRange,
+      daemonVersion: parsed.data.version,
+      protocolVersion: parsed.data.protocolVersion,
+      role: parsed.data.role,
+    };
+  }
+
+  #toHelloError(error: unknown): AnySimlockError {
+    if (!(error instanceof WireCallError)) {
+      return new SimlockError(
+        "DAEMON_CONNECTION_LOST",
+        "transport",
+        error instanceof Error ? error.message : String(error),
+        {},
+      );
+    }
+    if (error.code === LEGACY_MISMATCH_CODE) {
+      return mapLegacyProtocolMismatch(PROTOCOL_VERSION_RANGE, error.message);
+    }
+    if (error.code === "PROTOCOL_VERSION_UNSUPPORTED") {
+      const details = asRecord(error.details);
+      const client = asProtocolRange(details.client) ?? PROTOCOL_VERSION_RANGE;
+      const daemon = asProtocolRange(details.daemon);
+      if (daemon !== undefined) {
+        return new SimlockError("PROTOCOL_VERSION_UNSUPPORTED", "protocol", error.message, {
+          client,
+          daemon,
+          daemonVersion:
+            typeof details.daemonVersion === "string" ? details.daemonVersion : "unknown",
+        });
+      }
+    }
+    return fromWireError(error.code, error.message, error.details);
+  }
+
+  /** One request/response round trip for an already role/shape-agnostic operation name.
+   * `client.ts` is responsible for input/output schema validation; this only moves bytes and
+   * correlates frame ids. */
+  call(
+    type: string,
+    payload: unknown,
+    onProgress?: (progress: LeaseProgress) => void,
+  ): Promise<unknown> {
+    if (this.#dead !== undefined) return Promise.reject(this.#dead);
+    return this.#send(type, payload, onProgress);
+  }
+
+  onLeaseScopedPush(listener: (push: LeaseScopedPush) => void): () => void {
+    this.#leaseScopedListeners.add(listener);
+    return () => this.#leaseScopedListeners.delete(listener);
+  }
+
+  onEvent(listener: (payload: unknown) => void): () => void {
+    this.#eventListeners.add(listener);
+    return () => this.#eventListeners.delete(listener);
+  }
+
+  /** Fires exactly once, when this connection dies (socket close/error, or `close()`). */
+  onDeath(listener: (error: AnySimlockError) => void): () => void {
+    this.#closeListeners.add(listener);
+    return () => this.#closeListeners.delete(listener);
+  }
+
+  /** A lease this client itself is releasing: the next matching `lease-lost` push is
+   * swallowed rather than surfaced as a loss. */
+  markSelfInitiatedRelease(leaseId: string): void {
+    this.#selfInitiatedReleases.add(leaseId);
+  }
+
+  async close(): Promise<void> {
+    this.#die(
+      new SimlockError("DAEMON_CONNECTION_LOST", "transport", "Client closed the connection", {}),
+    );
+    await this.#connection.close();
+  }
+
+  #send(
+    type: string,
+    payload: unknown,
+    onProgress?: (progress: LeaseProgress) => void,
+  ): Promise<unknown> {
+    const id = this.#nextId++;
+    return new Promise((resolve, reject) => {
+      this.#pending.set(id, { onProgress, reject, resolve });
+      void this.#connection.write(serializeFrame({ id, payload, type })).catch((error: unknown) => {
+        this.#pending.delete(id);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      });
+    });
+  }
+
+  #read(chunk: string): void {
+    this.#buffer += chunk;
+    for (;;) {
+      const newline = this.#buffer.indexOf("\n");
+      if (newline < 0) return;
+      const line = this.#buffer.slice(0, newline);
+      this.#buffer = this.#buffer.slice(newline + 1);
+      if (line.trim() === "") continue;
+      let value: unknown;
+      try {
+        value = JSON.parse(line) as unknown;
+      } catch {
+        continue; // A malformed line from the daemon is not this client's problem to crash over.
+      }
+      this.#dispatch(value);
+    }
+  }
+
+  // fallow-ignore-next-line complexity -- one frame-kind switch, deliberately not split further.
+  #dispatch(value: unknown): void {
+    const frame = parseDaemonResponse(value);
+    if (frame === undefined) return;
+    if (frame.kind === "push") {
+      this.#dispatchPush(frame.push, frame.payload);
+      return;
+    }
+    const pending = this.#pending.get(frame.id);
+    if (pending === undefined) return; // ADR §8: drop pushes/replies for ids no longer tracked.
+    this.#pending.delete(frame.id);
+    if (frame.kind === "success") {
+      pending.resolve(frame.payload);
+    } else {
+      const details = asRecord(frame.error);
+      pending.reject(
+        new WireCallError(
+          typeof details.code === "string" ? details.code : "INTERNAL",
+          typeof details.message === "string" ? details.message : "Daemon request failed",
+          details.details,
+        ),
+      );
+    }
+  }
+
+  // fallow-ignore-next-line complexity -- one push-kind switch, deliberately not split further (matches DaemonServer/Dispatcher's own single-switch dispatch style elsewhere).
+  #dispatchPush(push: string, payload: unknown): void {
+    switch (push) {
+      case "progress": {
+        const parsed = PUSH_SCHEMAS.progress.safeParse(payload);
+        if (!parsed.success) return;
+        const requestId = parsed.data.requestId;
+        const id = typeof requestId === "number" ? requestId : Number(requestId);
+        const pending = this.#pending.get(id);
+        pending?.onProgress?.(parsed.data.progress);
+        return;
+      }
+      case "lease-lost": {
+        const parsed = PUSH_SCHEMAS["lease-lost"].safeParse(payload);
+        if (!parsed.success) return;
+        const suppressed = this.#selfInitiatedReleases.delete(parsed.data.leaseId);
+        if (suppressed) return;
+        this.#emitLeaseScoped({
+          deviceId: parsed.data.deviceId,
+          kind: "lease-lost",
+          leaseId: parsed.data.leaseId,
+          reason: parsed.data.reason,
+        });
+        return;
+      }
+      case "device-unhealthy": {
+        const parsed = PUSH_SCHEMAS["device-unhealthy"].safeParse(payload);
+        if (!parsed.success) return;
+        this.#emitLeaseScoped({
+          deviceId: parsed.data.deviceId,
+          kind: "device-unhealthy",
+          leaseId: parsed.data.leaseId,
+        });
+        return;
+      }
+      case "device-recovered": {
+        const parsed = PUSH_SCHEMAS["device-recovered"].safeParse(payload);
+        if (!parsed.success) return;
+        this.#emitLeaseScoped({
+          attempts: parsed.data.attempts,
+          deviceId: parsed.data.deviceId,
+          kind: "device-recovered",
+          leaseId: parsed.data.leaseId,
+        });
+        return;
+      }
+      case "lease.heartbeat": {
+        // Reactive pong, same behavior as today's `daemon-client/connection.ts`: answer with
+        // an ordinary request frame carrying the same payload (nonce), fire-and-forget.
+        void this.#send("lease.heartbeat", payload).catch(() => undefined);
+        return;
+      }
+      case "event": {
+        const parsed = PUSH_SCHEMAS.event.safeParse(payload);
+        if (!parsed.success) return;
+        for (const listener of this.#eventListeners) listener(parsed.data);
+        return;
+      }
+      default:
+        return;
+    }
+  }
+
+  #emitLeaseScoped(push: LeaseScopedPush): void {
+    const key = `${push.kind}:${push.leaseId}`;
+    if (this.#deliveredLeaseScoped.has(key)) return;
+    this.#deliveredLeaseScoped.add(key);
+    for (const listener of this.#leaseScopedListeners) listener(push);
+  }
+
+  #die(error: AnySimlockError): void {
+    if (this.#dead !== undefined) return;
+    this.#dead = error;
+    for (const pending of this.#pending.values()) pending.reject(error);
+    this.#pending.clear();
+    for (const listener of this.#closeListeners) listener(error);
+  }
+}
+
+/** Internal wire-level rejection: `{code, message, details}` straight off the wire, not yet
+ * mapped through the contract's error table. `client.ts`/`hello()` do that mapping -- kept
+ * separate from `SimlockError` so a mid-mapping bug cannot masquerade as a real contract error. */
+export class WireCallError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+    readonly details?: unknown,
+  ) {
+    super(message);
+    this.name = "WireCallError";
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asProtocolRange(value: unknown): ProtocolRange | undefined {
+  const record = asRecord(value);
+  return typeof record.min === "number" && typeof record.max === "number"
+    ? normalizeProtocolVersion({ max: record.max, min: record.min })
+    : undefined;
+}


### PR DESCRIPTION
**Stacked on #100.** Three blocking defects from the adversarial review.

## A stale `admin.token` bricked every command, including agent-role ones

The daemon removes `admin.token` only on a graceful stop, so a `kill -9` or a power loss leaves it behind. The next invocation read the stale secret, auto-launched a fresh daemon that minted a **new** one, and `hello` failed `ADMIN_AUTHENTICATION_FAILED` — the daemon closed the socket, and nothing in the CLI handled that code. Every subsequent command died, including plain `simlock lease`, which needs no admin at all. The user was locked out until they deleted the file by hand.

ADR §5 designs for graceful degradation — *"falling back to an agent session with a stderr notice"* — but that fallback existed only for "file absent", never "file present but wrong". Now an `ADMIN_AUTHENTICATION_FAILED` retries once with no credential and emits the notice, naming `admin.token` specifically when that was the rejected source.

## The CLI was never admin on a cold start

The credential was resolved *before* connecting, and the daemon is auto-launched *inside* connect. So on a fresh machine, or after `simlock daemon stop`, the file could not exist yet — the 3×50 ms retry was racing a daemon that had not been spawned. Every admin command (`nuke`, `list`, `cleanup`, `config get`, `events`, `token *`, `doctor --fix`, `release --all`) got `FORBIDDEN` on its first invocation. ADR §5's headline — *"the CLI connects as admin whenever the local file is readable"* — held only from the **second** run onward.

Credential resolution now happens **after** the socket is reachable: the environment takes a `resolveCredential` thunk, the raw connection (including any auto-launch) is established first, and only then is the file read. The brief retry now races only the narrow socket-claim-to-persist window that §5 actually describes.

## `config set` accepted any mistyped key

`validateConfigLayer` warns and drops unknown keys rather than throwing, and no `warn` collector was passed — so `simlock config set lease.heldTtlBackstop 60000` (missing `Ms`) validated clean, wrote the file, printed "Updated …", and the daemon ignored the key forever. ADR §11 requires validation *through the config loader* before writing; the mechanism was present but toothless. It now collects warnings and rejects on any unknown key.

The validation pass also moves off the sentinel path inside the real data directory and onto an in-memory filesystem, so a stray file there can no longer cause a false pass or fail — and the "never read" comment is now true.

Both existing `config set` tests injected a fake validator, which is why this survived; they now exercise the real one. New coverage includes a cold-start test against a real in-memory daemon with a genuine credential handshake, asserting admin on the very first invocation.

## Note for reviewers

The stale-token retry degrades to agent uniformly, including for a mistyped `--token`. A user-supplied credential that is wrong could arguably deserve a hard failure rather than a quiet downgrade; the notice is worded differently for that case, but the behaviour is the same. Worth a second opinion.