### PR TITLE
fix(daemon,http): one error table for both transports; fail a bind failure loudly

### DIFF
--- a/src/daemon/error-code.ts
+++ b/src/daemon/error-code.ts
@@ -1,0 +1,112 @@
+/**
+ * The single place that turns a thrown core/daemon error into a `SimlockErrorCode`. ADR 0003
+ * §7: "CLI exit codes and HTTP status codes are columns of the same error table, not second
+ * mappings." Both transports -- `DaemonServer`'s socket frame handling (`errorCode` in
+ * `server.ts`) and the HTTP gateway (`mapError` in `../http/errors.ts`) -- call `classifyError`
+ * to get the *code*, then read whichever column they need (`cliExitCode`/`httpStatus`) off
+ * `ERROR_TABLE` themselves. Before this module existed, each transport hand-wrote its own
+ * `instanceof` chain for these errors and the two silently drifted (see the ADR 0003-09 review,
+ * finding B5): `InsufficientDiskSpaceError`, `LicenseNotAcceptedError`, `StartupFailedError`,
+ * `DoctorUnavailableError`, and `NukeUnavailableError` all mapped correctly over the socket but
+ * fell through to `INTERNAL` over HTTP. Adding a new core error now means adding one branch
+ * here, not one in each transport.
+ *
+ * `DispatchError`'s own `code` is used verbatim (trusted by construction -- see `dispatcher.ts`,
+ * every call site passes a real `SimlockErrorCode`) rather than re-classified, since it is
+ * already the shared dispatcher's own protocol-shaped rejection.
+ *
+ * Deliberately excludes anything that is socket-framing-specific (`ProtocolError`, thrown only
+ * while parsing a request frame before a `Session` exists -- it never reaches the shared
+ * dispatcher, so it never reaches HTTP either) -- that stays local to `server.ts`.
+ */
+import {
+  InsufficientDiskSpaceError,
+  LicenseNotAcceptedError,
+  NoCapacityError,
+  NoDriverError,
+  QueueTimeoutError,
+  RequesterAlreadyLeasedError,
+  RuntimeMissingError,
+  UnknownLeaseError,
+  UnknownModelError,
+} from "../core/index.js";
+import type { SimlockErrorCode } from "../contract/index.js";
+import { DispatchError, DoctorUnavailableError, NukeUnavailableError } from "./dispatcher.js";
+import { AdminAuthenticationFailedError } from "./session.js";
+
+/**
+ * Thrown to a request parked on startup readiness (ADR §2 step 4's `awaitReady`) when
+ * convergence rejected. Lives here (not `server.ts`) so both transports can recognize it:
+ * `DaemonServer#awaitReady` throws it directly into the shared dispatcher's `dispatch()`, which
+ * neither socket nor HTTP request handling wraps -- so an HTTP route can catch this exact class
+ * just as `errorCode` does for a socket response.
+ */
+export class StartupFailedError extends Error {
+  constructor() {
+    super("Daemon failed to start");
+    this.name = "StartupFailedError";
+  }
+}
+
+/**
+ * Classifies a thrown error into the contract's closed `SimlockErrorCode` set. Every branch
+ * here has a matching row in `ERROR_TABLE` (`src/contract/errors.ts`) by construction; a caller
+ * that needs a transport-specific column (HTTP status, CLI exit code) looks the returned code
+ * up in that table itself rather than this function guessing a transport's own representation.
+ *
+ * Returns `undefined` -- deliberately, rather than defaulting to `"INTERNAL"` itself -- for
+ * anything unrecognized, so each transport decides its own `INTERNAL` handling (the socket
+ * transport always echoes the real error message; the HTTP gateway deliberately does not, to
+ * avoid leaking implementation detail into a response body -- see `mapError`). A caller that
+ * doesn't care about that distinction can just do `classifyError(error) ?? "INTERNAL"`.
+ */
+// fallow-ignore-next-line complexity -- one exhaustive classifier is the point (ADR §7).
+export function classifyError(error: unknown): SimlockErrorCode | undefined {
+  // `DispatchError` is `Dispatcher`'s own protocol-shaped rejection (bad input, role/authorize
+  // failure, unknown operation, a rejected credential) -- its `code` is already a
+  // `SimlockErrorCode` by construction (see `dispatcher.ts`), so it is used verbatim rather than
+  // re-derived.
+  if (error instanceof DispatchError) {
+    return error.code as SimlockErrorCode;
+  }
+  if (error instanceof AdminAuthenticationFailedError) {
+    return "ADMIN_AUTHENTICATION_FAILED";
+  }
+  if (error instanceof NoCapacityError) {
+    return "NO_CAPACITY";
+  }
+  if (error instanceof QueueTimeoutError) {
+    return "QUEUE_TIMEOUT";
+  }
+  if (error instanceof RequesterAlreadyLeasedError) {
+    return "REQUESTER_ALREADY_LEASED";
+  }
+  if (error instanceof NoDriverError) {
+    return "NO_DRIVER";
+  }
+  if (error instanceof RuntimeMissingError) {
+    return "RUNTIME_MISSING";
+  }
+  if (error instanceof UnknownModelError) {
+    return "UNKNOWN_MODEL";
+  }
+  if (error instanceof InsufficientDiskSpaceError) {
+    return "INSUFFICIENT_DISK_SPACE";
+  }
+  if (error instanceof LicenseNotAcceptedError) {
+    return "LICENSE_NOT_ACCEPTED";
+  }
+  if (error instanceof UnknownLeaseError) {
+    return "UNKNOWN_LEASE";
+  }
+  if (error instanceof StartupFailedError) {
+    return "DAEMON_STARTUP_FAILED";
+  }
+  if (error instanceof DoctorUnavailableError) {
+    return "DOCTOR_UNAVAILABLE";
+  }
+  if (error instanceof NukeUnavailableError) {
+    return "NUKE_UNAVAILABLE";
+  }
+  return undefined;
+}

--- a/src/daemon/main.test.ts
+++ b/src/daemon/main.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { connect } from "node:net";
+import { connect, createServer } from "node:net";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { EventBus } from "../bus/index.js";
@@ -220,6 +220,54 @@ describe("startDaemon HTTP gateway startup readiness", () => {
 
     const parkedResponse = await parkedStatusPromise;
     expect(parkedResponse.status).toBe(200);
+  });
+});
+
+describe("startDaemon HTTP gateway bind failure", () => {
+  // Review finding B6: before this fix, an HTTP bind failure (occupied port) logged and
+  // stopped the daemon from inside `onSocketClaimed`'s handler without `startDaemon()` itself
+  // ever seeing it -- the daemon's own `start()` would go on to resolve successfully once
+  // convergence finished, so the CLI reported success (exit code 0) with no socket, no HTTP,
+  // and no daemon actually running. This proves `startDaemon()` now rejects instead, and that
+  // the daemon never reports having started after it already reported stopping.
+  it("rejects startDaemon() when the configured HTTP port is already in use, without emitting a started record after a stopping one", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "simlock-main-http-bind-"));
+    temporaryDirectories.push(directory);
+    const clock = new FakeClock(1_000);
+    const sink = new MemoryLogSink();
+    const logger = new JsonLinesLogger({ clock, level: "debug", sink });
+    const filesystem = new MemoryFilesystem();
+    const port = 47_012;
+
+    const occupier = createServer();
+    await new Promise<void>((resolve) => occupier.listen(port, "127.0.0.1", resolve));
+    try {
+      await expect(
+        startDaemon({
+          clock,
+          configOverrides: { http: { enabled: true, host: "127.0.0.1", port } },
+          dataDirectory: directory,
+          drivers: [new FakeDriver({ availableOsVersions: ["26.5"], clock, platform: "ios" })],
+          filesystem,
+          logger,
+          statePath: join(directory, "state.json"),
+          version: "1.2.3",
+        } as StartDaemonOptions),
+      ).rejects.toThrow(/EADDRINUSE|address already in use/i);
+    } finally {
+      await new Promise((resolve) => occupier.close(resolve));
+    }
+
+    const startedIndex = sink.records.findIndex((record) => record.message === "Daemon started");
+    const stoppingIndex = sink.records.findIndex((record) => record.message === "Daemon stopping");
+    expect(stoppingIndex).toBeGreaterThanOrEqual(0);
+    // Either "Daemon started" never appears (the common case: the bind failure is discovered
+    // and the whole thing torn down without convergence ever seeing readiness), or -- if
+    // convergence happened to finish first -- it appears strictly before "Daemon stopping",
+    // never after (ADR events rule 3: a fact must be true when emitted).
+    if (startedIndex >= 0) {
+      expect(startedIndex).toBeLessThan(stoppingIndex);
+    }
   });
 });
 

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -182,6 +182,20 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
   // of leaking a listening HTTP server past a daemon that has already torn everything else down.
   let stopHttpGateway: (() => Promise<void>) | undefined;
   let httpStopRequested = false;
+  // Settles once the HTTP gateway either finishes starting or fails to -- resolved/rejected from
+  // inside `onSocketClaimed`'s handler below. `startDaemon()` awaits this alongside
+  // `daemon.start()` itself (see the bottom of this function) so a bind failure (occupied port,
+  // invalid host) makes `startDaemon()` reject and the entrypoint report a non-zero exit code,
+  // the way it did before the gateway moved to firing concurrently with convergence. When HTTP
+  // is disabled there is nothing to wait for, so this resolves immediately.
+  let resolveGatewayStarted: (() => void) | undefined;
+  let rejectGatewayStarted: ((error: unknown) => void) | undefined;
+  const gatewayStarted: Promise<void> = config.http.enabled
+    ? new Promise<void>((resolve, reject) => {
+        resolveGatewayStarted = resolve;
+        rejectGatewayStarted = reject;
+      })
+    : Promise.resolve();
   const daemon = new DaemonServer({
     capacity: leaseEngine,
     catalog: leaseEngine,
@@ -231,19 +245,22 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
     },
     // ADR 0003 §2: "an HTTP request during startup now waits like a socket request instead of
     // being refused". Firing the gateway's own `start()` from here (not after `daemon.start()`
-    // resolves, as before this PR) is what makes that true: the gateway is listening, and every
-    // route calls `daemon.dispatch(...)`, which parks on the same startup-readiness gate a
-    // socket request does. A bind failure (occupied port, invalid host) here can no longer fail
-    // `startDaemon()` itself the way it used to -- by the time it's discovered, `daemon.start()`
-    // may already have resolved to its caller -- so it's logged and the daemon is stopped
-    // best-effort instead; see this PR's report for this as a known behavioural narrowing.
+    // resolves) is what makes that true: the gateway is listening, and every route calls
+    // `daemon.dispatch(...)`, which parks on the same startup-readiness gate a socket request
+    // does. A bind failure (occupied port, invalid host) is reported through `gatewayStarted`
+    // rather than acted on immediately here -- see the bottom of this function for why: calling
+    // `daemon.stop()` right away, while `daemon.start()` may still be awaiting convergence, is
+    // what let a stale "Daemon started" log/event follow "Daemon stopping" (review finding B6).
     ...(config.http.enabled
       ? {
           onSocketClaimed: () => {
-            void startHttpGateway().catch((error: unknown) => {
-              logger.error("HTTP gateway failed to start", { message: errorMessage(error) });
-              void daemon.stop("http-start-failed").catch(() => undefined);
-            });
+            void startHttpGateway().then(
+              () => resolveGatewayStarted?.(),
+              (error: unknown) => {
+                logger.error("HTTP gateway failed to start", { message: errorMessage(error) });
+                rejectGatewayStarted?.(error);
+              },
+            );
           },
         }
       : {}),
@@ -278,7 +295,23 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
     if (httpStopRequested) await stopHttpGateway();
   }
 
-  await daemon.start();
+  // Awaited together, not `daemon.start()` alone: `gatewayStarted` is the promise
+  // `onSocketClaimed`'s handler above settles once the concurrently-started HTTP gateway either
+  // finishes starting or fails to. Both are already running concurrently by the time this line
+  // is reached (the gateway since `onSocketClaimed` fired partway through `daemon.start()`), so
+  // this changes nothing about when either finishes -- only what `startDaemon()` itself reports.
+  const [daemonResult, gatewayResult] = await Promise.allSettled([daemon.start(), gatewayStarted]);
+  if (gatewayResult.status === "rejected" && daemonResult.status === "fulfilled") {
+    // The daemon itself came all the way up -- convergence succeeded, `daemon.started` was
+    // already emitted -- but its HTTP gateway never bound. Tear the whole thing down now,
+    // *after* that success is a settled fact, so `daemon.stopping` never precedes (or follows
+    // out of order) `daemon.started`; see this function's own comment above `onSocketClaimed`
+    // and review finding B6. `stop()` is idempotent/dedups concurrent callers, so this is safe
+    // even if `stopAuxiliary`'s own path already ran one.
+    await daemon.stop("http-start-failed").catch(() => undefined);
+  }
+  if (daemonResult.status === "rejected") throw daemonResult.reason;
+  if (gatewayResult.status === "rejected") throw gatewayResult.reason;
   return daemon;
 }
 

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -3,16 +3,8 @@ import { z } from "zod";
 import { type EventBus, type EventEnvelope } from "../bus/index.js";
 import {
   type Config,
-  InsufficientDiskSpaceError,
   type LeaseProgress,
-  LicenseNotAcceptedError,
-  NoCapacityError,
-  NoDriverError,
-  QueueTimeoutError,
   type Registry,
-  RequesterAlreadyLeasedError,
-  RuntimeMissingError,
-  UnknownModelError,
   type CleanupReaper,
   type Doctor,
   type LeaseHealthMonitor,
@@ -44,20 +36,11 @@ import {
 } from "../contract/index.js";
 import type { ConnectionHost } from "./connection-host.js";
 import type { TokenStore } from "../http/token-store.js";
-import {
-  Dispatcher,
-  DispatchError,
-  DoctorUnavailableError,
-  NukeUnavailableError,
-  type DispatchSession,
-} from "./dispatcher.js";
-import {
-  AdminAuthenticationFailedError,
-  resolveAgentRole,
-  type SessionRoleResolver,
-} from "./session.js";
+import { Dispatcher, type DispatchSession } from "./dispatcher.js";
+import { resolveAgentRole, type SessionRoleResolver } from "./session.js";
 import type { AdminSecretManager } from "./admin-secret.js";
 import { OwnerRoutedFactBus, type OwnerRoutedFacts } from "./owner-routed-facts.js";
+import { classifyError, StartupFailedError } from "./error-code.js";
 
 type RequestId = string | number;
 
@@ -1189,14 +1172,6 @@ class ProtocolError extends Error {
   }
 }
 
-/** Thrown to a parked request when startup convergence rejected; see `#awaitReady`. */
-class StartupFailedError extends Error {
-  constructor() {
-    super("Daemon failed to start");
-    this.name = "StartupFailedError";
-  }
-}
-
 /** Parses a request payload through its contract input schema, translating a validation
  * failure into the daemon's own `ProtocolError("BAD_REQUEST", ...)` rather than letting a raw
  * `ZodError` escape (its shape is not part of the wire contract). */
@@ -1209,58 +1184,19 @@ function parseInput<Output>(schema: z.ZodType<Output>, value: unknown): Output {
   throw new ProtocolError("BAD_REQUEST", description);
 }
 
-// fallow-ignore-next-line complexity -- preserves stable protocol error mapping.
+/**
+ * Resolves the wire `code` for a socket response. `ProtocolError` is socket-framing-specific
+ * (thrown only while parsing a request frame, before a `Session` exists -- see its own doc) and
+ * stays local to this file; every other error this daemon can throw is classified by the one
+ * shared table both transports read -- see `./error-code.js`'s module doc (ADR 0003 §7, review
+ * finding B5: this used to be its own hand-written `instanceof` chain that silently drifted
+ * from HTTP's).
+ */
 function errorCode(error: unknown): string {
   if (error instanceof ProtocolError) {
     return error.code;
   }
-  // `DispatchError` is `Dispatcher`'s own protocol-shaped rejection (BAD_REQUEST from input
-  // parsing, FORBIDDEN from the role/authorize check, UNKNOWN_REQUEST, INTERNAL) -- same
-  // `{code, message}` shape as `ProtocolError`, deliberately a separate class rather than the
-  // same one so `dispatcher.ts` does not need to import a `DaemonServer`-private type.
-  if (error instanceof DispatchError) {
-    return error.code;
-  }
-  if (error instanceof AdminAuthenticationFailedError) {
-    return "ADMIN_AUTHENTICATION_FAILED";
-  }
-  if (error instanceof NoCapacityError) {
-    return "NO_CAPACITY";
-  }
-  if (error instanceof QueueTimeoutError) {
-    return "QUEUE_TIMEOUT";
-  }
-  if (error instanceof RequesterAlreadyLeasedError) {
-    return "REQUESTER_ALREADY_LEASED";
-  }
-  if (error instanceof NoDriverError) {
-    return "NO_DRIVER";
-  }
-  if (error instanceof RuntimeMissingError) {
-    return "RUNTIME_MISSING";
-  }
-  if (error instanceof UnknownModelError) {
-    return "UNKNOWN_MODEL";
-  }
-  if (error instanceof InsufficientDiskSpaceError) {
-    return "INSUFFICIENT_DISK_SPACE";
-  }
-  if (error instanceof LicenseNotAcceptedError) {
-    return "LICENSE_NOT_ACCEPTED";
-  }
-  if (error instanceof UnknownLeaseError) {
-    return "UNKNOWN_LEASE";
-  }
-  if (error instanceof StartupFailedError) {
-    return "DAEMON_STARTUP_FAILED";
-  }
-  if (error instanceof DoctorUnavailableError) {
-    return "DOCTOR_UNAVAILABLE";
-  }
-  if (error instanceof NukeUnavailableError) {
-    return "NUKE_UNAVAILABLE";
-  }
-  return "INTERNAL";
+  return classifyError(error) ?? "INTERNAL";
 }
 
 function errorMessage(error: unknown): string {

--- a/src/http/app.test.ts
+++ b/src/http/app.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from "vitest";
 
 import { EventBus } from "../bus/index.js";
-import { NoCapacityError, RequesterAlreadyLeasedError } from "../core/index.js";
-import { DispatchError } from "../daemon/dispatcher.js";
+import {
+  InsufficientDiskSpaceError,
+  LicenseNotAcceptedError,
+  NoCapacityError,
+  RequesterAlreadyLeasedError,
+} from "../core/index.js";
+import { DispatchError, DoctorUnavailableError } from "../daemon/dispatcher.js";
+import { StartupFailedError } from "../daemon/error-code.js";
 import { OwnerRoutedFactBus } from "../daemon/owner-routed-facts.js";
 import { FakeClock, JsonLinesLogger, MemoryLogSink } from "../ports/index.js";
 import { createHttpApp, type HttpGatewayDeps } from "./app.js";
@@ -296,6 +302,60 @@ describe("POST /v1/lease-requests", () => {
 
     expect(response.status).toBe(503);
     expect(response.headers.get("Retry-After")).toBeTruthy();
+  });
+
+  // Review finding B5: HTTP collapsed these four thrown-from-`lease.request` codes to a bare
+  // 500 INTERNAL while the socket transport reported the real code and `ERROR_TABLE`'s own
+  // status -- because `mapError` (this file's target) kept its own hand-written `instanceof`
+  // chain instead of reading the one shared table `errorCode` (in `daemon/server.ts`) already
+  // used. Each of these now goes through `classifyError` + `ERROR_TABLE`, the same as the
+  // socket transport.
+  it("maps a fast InsufficientDiskSpaceError to 422 INSUFFICIENT_DISK_SPACE, not 500 INTERNAL", async () => {
+    const { app, dispatcher } = buildHarness();
+    const responsePromise = postLeaseRequest(app, defaultBody);
+    const call = await waitForDispatch(dispatcher, "lease.request");
+    call.reject(new InsufficientDiskSpaceError("ios", 8 * 1024 ** 3, 0));
+    const response = await responsePromise;
+
+    expect(response.status).toBe(422);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("INSUFFICIENT_DISK_SPACE");
+  });
+
+  it("maps a fast LicenseNotAcceptedError to 422 LICENSE_NOT_ACCEPTED, not 500 INTERNAL", async () => {
+    const { app, dispatcher } = buildHarness();
+    const responsePromise = postLeaseRequest(app, defaultBody);
+    const call = await waitForDispatch(dispatcher, "lease.request");
+    call.reject(new LicenseNotAcceptedError("android", "system-images;android-35;google_apis"));
+    const response = await responsePromise;
+
+    expect(response.status).toBe(422);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("LICENSE_NOT_ACCEPTED");
+  });
+
+  it("maps a fast StartupFailedError to 503 DAEMON_STARTUP_FAILED, not 500 INTERNAL", async () => {
+    const { app, dispatcher } = buildHarness();
+    const responsePromise = postLeaseRequest(app, defaultBody);
+    const call = await waitForDispatch(dispatcher, "lease.request");
+    call.reject(new StartupFailedError());
+    const response = await responsePromise;
+
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("DAEMON_STARTUP_FAILED");
+  });
+
+  it("maps a fast DoctorUnavailableError to 503 DOCTOR_UNAVAILABLE, not 500 INTERNAL", async () => {
+    const { app, dispatcher } = buildHarness();
+    const responsePromise = postLeaseRequest(app, defaultBody);
+    const call = await waitForDispatch(dispatcher, "lease.request");
+    call.reject(new DoctorUnavailableError());
+    const response = await responsePromise;
+
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("DOCTOR_UNAVAILABLE");
   });
 
   it("replays an identical Idempotency-Key without a second dispatch call", async () => {

--- a/src/http/errors.test.ts
+++ b/src/http/errors.test.ts
@@ -2,6 +2,8 @@ import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
 
 import {
+  InsufficientDiskSpaceError,
+  LicenseNotAcceptedError,
   NoCapacityError,
   NoDriverError,
   RequesterAlreadyLeasedError,
@@ -9,6 +11,9 @@ import {
   UnknownLeaseError,
   UnknownModelError,
 } from "../core/index.js";
+import { classifyError, StartupFailedError } from "../daemon/error-code.js";
+import { DoctorUnavailableError, NukeUnavailableError } from "../daemon/dispatcher.js";
+import { ERROR_TABLE } from "../contract/index.js";
 import {
   errorResponse,
   HttpApiError,
@@ -61,6 +66,32 @@ describe("mapError", () => {
       code: "UNKNOWN_LEASE",
       status: 404,
     });
+  });
+
+  // Review finding B5: these four previously fell through `mapError`'s own hand-written
+  // `instanceof` chain (which didn't have branches for them) to 500 INTERNAL, while the socket
+  // transport's `errorCode` (now `classifyError`, shared by both) reported the real code. Each
+  // assertion below is checked against `ERROR_TABLE` directly -- the single source both
+  // transports now read -- rather than a hardcoded status, so this test would fail if the table
+  // and `mapError` ever drifted again.
+  it("agrees with the socket transport's classifyError for every core error it recognizes, reading ERROR_TABLE for the HTTP status", () => {
+    const cases: readonly [unknown, string][] = [
+      [new InsufficientDiskSpaceError("ios", 8 * 1024 ** 3, 0), "INSUFFICIENT_DISK_SPACE"],
+      [
+        new LicenseNotAcceptedError("android", "system-images;android-35;google_apis"),
+        "LICENSE_NOT_ACCEPTED",
+      ],
+      [new StartupFailedError(), "DAEMON_STARTUP_FAILED"],
+      [new DoctorUnavailableError(), "DOCTOR_UNAVAILABLE"],
+      [new NukeUnavailableError(), "NUKE_UNAVAILABLE"],
+    ];
+    for (const [error, expectedCode] of cases) {
+      expect(classifyError(error)).toBe(expectedCode);
+      const mapped = mapError(error);
+      expect(mapped.code).toBe(expectedCode);
+      expect(mapped.status).toBe(ERROR_TABLE[expectedCode as keyof typeof ERROR_TABLE].httpStatus);
+      expect(mapped.status).not.toBe(500);
+    }
   });
 
   it("collapses an unrecognized error to 500 INTERNAL without leaking its message", () => {

--- a/src/http/errors.ts
+++ b/src/http/errors.ts
@@ -1,15 +1,7 @@
 import type { Context } from "hono";
 
-import {
-  NoCapacityError,
-  NoDriverError,
-  QueueTimeoutError,
-  RequestCancelledError,
-  RequesterAlreadyLeasedError,
-  RuntimeMissingError,
-  UnknownLeaseError,
-  UnknownModelError,
-} from "../core/index.js";
+import { RequestCancelledError, RequesterAlreadyLeasedError } from "../core/index.js";
+import { classifyError } from "../daemon/error-code.js";
 import { DispatchError } from "../daemon/dispatcher.js";
 import { ERROR_TABLE, type SimlockErrorCode } from "../contract/index.js";
 
@@ -70,12 +62,32 @@ export interface MappedError {
   readonly extra?: Record<string, unknown>;
 }
 
+/** Looks a code up in `ERROR_TABLE`, defensively -- every code `classifyError` returns is a
+ * real key by construction, except `DispatchError`'s (a runtime-supplied string, trusted but
+ * not verified -- see `dispatcher.ts`); this is the one guard against that ever indexing to
+ * `undefined` and throwing instead of degrading to `INTERNAL`. */
+function tableEntry(code: SimlockErrorCode): (typeof ERROR_TABLE)[SimlockErrorCode] {
+  return (
+    (ERROR_TABLE as Record<string, (typeof ERROR_TABLE)[SimlockErrorCode]>)[code] ??
+    ERROR_TABLE.INTERNAL
+  );
+}
+
 /**
  * Maps a thrown error to the response shape the issue's error table specifies. Never echoes
  * a stack trace; an error this function doesn't recognize collapses to 500 `INTERNAL` with a
  * generic message rather than leaking implementation detail into the response body.
+ *
+ * ADR 0003 §7: "CLI exit codes and HTTP status codes are columns of the same error table, not
+ * second mappings." `classifyError` (shared with the socket transport's `errorCode` in
+ * `daemon/server.ts`) is the one place that turns a thrown error into a `SimlockErrorCode`; this
+ * function's own job is only to read `ERROR_TABLE`'s `httpStatus` column for whatever code comes
+ * back -- never a second, HTTP-only guess. Review finding B5: before `classifyError` existed,
+ * this function had its own hand-written `instanceof` chain for the core domain errors, and it
+ * silently drifted from the socket transport's -- `InsufficientDiskSpaceError`,
+ * `LicenseNotAcceptedError`, a startup-convergence failure, and doctor/nuke unavailability all
+ * fell through to `INTERNAL` here while the socket reported the real code.
  */
-// fallow-ignore-next-line complexity -- one exhaustive table beats scattering this mapping across routes.
 export function mapError(error: unknown): MappedError {
   if (error instanceof HttpApiError) {
     return {
@@ -85,59 +97,26 @@ export function mapError(error: unknown): MappedError {
       ...(error.extra === undefined ? {} : { extra: error.extra }),
     };
   }
-  // ADR 0003 §7: "CLI exit codes and HTTP status codes are columns of the same error table, not
-  // second mappings". `DispatchError` is the shared dispatcher's own protocol-shaped rejection
-  // (bad input, role/`authorize` failure, unknown operation, a rejected credential) -- every
-  // code it can carry is declared in the contract's closed `ERROR_TABLE`, so its HTTP status
-  // comes from that table's `httpStatus` column rather than a second HTTP-only guess. Falls
-  // back to 500 `INTERNAL` only for a code this table somehow doesn't recognize, which would
-  // itself be a contract bug (every `DispatchError` code is a `SimlockErrorCode` by construction
-  // -- see `dispatcher.ts`).
-  if (error instanceof DispatchError) {
-    const entry = (ERROR_TABLE as Record<string, (typeof ERROR_TABLE)[SimlockErrorCode]>)[
-      error.code
-    ];
-    return {
-      status: (entry?.httpStatus ?? 500) as HttpStatus,
-      code: error.code,
-      message: error.message,
-    };
-  }
-  if (error instanceof RequesterAlreadyLeasedError) {
-    return {
-      status: 409,
-      code: "REQUESTER_ALREADY_LEASED",
-      message: error.message,
-      ...(error.existingLeaseId === undefined
-        ? {}
-        : { extra: { existingLeaseId: error.existingLeaseId } }),
-    };
-  }
-  if (error instanceof NoCapacityError) {
-    return { status: 503, code: "NO_CAPACITY", message: error.message };
-  }
-  if (error instanceof UnknownModelError) {
-    return { status: 422, code: "UNKNOWN_MODEL", message: error.message };
-  }
-  if (error instanceof RuntimeMissingError) {
-    return { status: 422, code: "RUNTIME_MISSING", message: error.message };
-  }
-  if (error instanceof NoDriverError) {
-    return { status: 422, code: "NO_DRIVER", message: error.message };
-  }
-  if (error instanceof UnknownLeaseError) {
-    return { status: 404, code: "UNKNOWN_LEASE", message: error.message };
-  }
-  // Neither of these is expected to reach a route handler as a live rejection -- the tracker
-  // consumes both internally and turns them into a terminal request state -- but map them
-  // rather than falling through to INTERNAL if that invariant is ever wrong.
-  if (error instanceof QueueTimeoutError) {
-    return { status: 500, code: "QUEUE_TIMEOUT", message: error.message };
-  }
+  // Never sent over the wire (see `wait-queue.ts`) and has no `ERROR_TABLE` row of its own --
+  // the tracker consumes it internally and turns it into a terminal request state, so this is
+  // purely defensive: map it rather than falling through to a generic `INTERNAL` if that
+  // invariant is ever wrong.
   if (error instanceof RequestCancelledError) {
     return { status: 500, code: "REQUEST_CANCELLED", message: error.message };
   }
-  return { status: 500, code: "INTERNAL", message: "Internal error" };
+  const code = classifyError(error) ?? "INTERNAL";
+  const recognized = code !== "INTERNAL" || error instanceof DispatchError;
+  const entry = tableEntry(code);
+  const extra =
+    error instanceof RequesterAlreadyLeasedError && error.existingLeaseId !== undefined
+      ? { existingLeaseId: error.existingLeaseId }
+      : undefined;
+  return {
+    status: entry.httpStatus as HttpStatus,
+    code: entry.code,
+    message: recognized && error instanceof Error ? error.message : "Internal error",
+    ...(extra === undefined ? {} : { extra }),
+  };
 }
 
 /** Writes `mapError`'s result as the standard `{"error":{...}}` body, plus `Retry-After` for NO_CAPACITY. */


### PR DESCRIPTION
**Stacked on #101.** Two blocking defects from the adversarial review.

## HTTP collapsed four error codes to `500 INTERNAL` while the socket mapped them properly

ADR §7: *"CLI exit codes and HTTP status codes are columns of the same error table, **not second mappings**."* They were second mappings — `src/http/errors.ts` kept a hand-written core-error table and `server.ts`'s `errorCode()` kept another, and the two sets differed:

| thrown from `lease.request` | socket | HTTP (before) | table |
|---|---|---|---|
| `InsufficientDiskSpaceError` | `INSUFFICIENT_DISK_SPACE` | 500 `INTERNAL` | **422** |
| `LicenseNotAcceptedError` | `LICENSE_NOT_ACCEPTED` | 500 `INTERNAL` | **422** |
| `StartupFailedError` | `DAEMON_STARTUP_FAILED` | 500 `INTERNAL` | **503** |
| `Doctor`/`NukeUnavailableError` | mapped | 500 `INTERNAL` | **503** |

A `POST /v1/lease-requests` needing a download on a short disk settled as `{code:"INTERNAL", message:"Internal error"}`, while the identical request over the socket got `INSUFFICIENT_DISK_SPACE` with an actionable message. Deleting exactly this divergence was the point of the shared dispatcher — it had survived one branch deeper.

A new `src/daemon/error-code.ts` owns the single `classifyError()` chain; both transports call it and read `ERROR_TABLE`. It returns `undefined` rather than a default, so each transport still decides its own `INTERNAL` fallback. `StartupFailedError` moves there too — it was private to `server.ts` and unreachable from HTTP, which is why HTTP could never map it. Adding a core error is now one edit, not two. Tests assert the two transports agree, end to end through real HTTP routes.

## An HTTP bind failure reported a *successful* `daemon start`

With the gateway now starting concurrently with convergence, `EADDRINUSE` rejected in milliseconds and triggered a **full** teardown — releasing every held lease, disposing, removing the socket — while convergence was still running. `start()` then resumed with no `stopping` check: it subscribed to a disposed bus, emitted `daemon.started` *after* `daemon.stopping`, logged "Daemon started", and `startDaemon()` resolved. The CLI reported success with exit code 0, with no socket, no HTTP, and no daemon.

Emitting `daemon.started` after `daemon.stopping` on a disposed bus also violates events rule 3 — a fact must be true when emitted.

`startDaemon()` now settles both the daemon and the gateway before deciding, stops only after `start()` has settled, and **rethrows**, so the entrypoint sets a non-zero exit code. Tested by occupying the port for real and asserting both the rejection and the log ordering.

Critically, this preserves what the concurrent start was *for*: an HTTP request arriving during convergence still parks on readiness rather than being refused (ADR §2). The existing readiness test is untouched and still passes.

## Note for reviewers

The fix defers the stop rather than adding the missing `stopping` check inside `DaemonServer.start()` itself, because that region belonged to a sibling agent in this round. The structural gap in `start()` remains; this guards the outcome. Worth closing at the root in a follow-up — if it is, this logic becomes redundant but stays harmless, since `stop()` is idempotent.