### PR TITLE
fix(client): stop swallowing a second crash on the same lease

### DIFF
--- a/src/simlock-client/client.test.ts
+++ b/src/simlock-client/client.test.ts
@@ -254,7 +254,7 @@ describe("pushes", () => {
     expect(onProgress).toHaveBeenCalledTimes(1);
   });
 
-  it("de-duplicates lease-scoped pushes by lease id", async () => {
+  it("de-duplicates a repeated device-unhealthy push for the same lease (same state twice in a row)", async () => {
     const connection = new ScriptedConnection();
     const connectPromise = connectSimlock({ connection });
     await flushMicrotasks();
@@ -278,7 +278,76 @@ describe("pushes", () => {
     expect(unhealthy).toHaveBeenCalledTimes(1);
   });
 
-  it("never fires onLeaseLost for a release this client itself asked for", async () => {
+  it("delivers a second device-unhealthy for the same lease once a device-recovered came between the two (S2: a second crash is not a duplicate)", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const unhealthy = vi.fn();
+    const recovered = vi.fn();
+    client.onDeviceUnhealthy(unhealthy);
+    client.onDeviceRecovered(recovered);
+
+    connection.push("device-unhealthy", {
+      deviceId: "device_1",
+      leaseId: "lease_1",
+      reason: "crashed",
+    });
+    connection.push("device-recovered", { attempts: 1, deviceId: "device_1", leaseId: "lease_1" });
+    // A genuine second crash on the same lease -- `LeaseHealthMonitor` clears its recovery
+    // bookkeeping after a successful recovery, so this is a real, distinct fact, not a
+    // redundant re-push of the first one.
+    connection.push("device-unhealthy", {
+      deviceId: "device_1",
+      leaseId: "lease_1",
+      reason: "crashed",
+    });
+
+    expect(unhealthy).toHaveBeenCalledTimes(2);
+    expect(recovered).toHaveBeenCalledTimes(1);
+  });
+
+  it("still de-duplicates a repeated device-recovered push for the same lease", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const recovered = vi.fn();
+    client.onDeviceRecovered(recovered);
+
+    connection.push("device-unhealthy", {
+      deviceId: "device_1",
+      leaseId: "lease_1",
+      reason: "crashed",
+    });
+    connection.push("device-recovered", { attempts: 1, deviceId: "device_1", leaseId: "lease_1" });
+    // The owner-routed fan-out re-delivering the same recovered fact must still be suppressed.
+    connection.push("device-recovered", { attempts: 1, deviceId: "device_1", leaseId: "lease_1" });
+
+    expect(recovered).toHaveBeenCalledTimes(1);
+  });
+
+  it("de-duplicates a repeated lease-lost push for the same lease (permanent -- loss is terminal)", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const leaseLost = vi.fn();
+    client.onLeaseLost(leaseLost);
+
+    connection.push("lease-lost", { deviceId: "device_1", leaseId: "lease_1", reason: "crashed" });
+    connection.push("lease-lost", { deviceId: "device_1", leaseId: "lease_1", reason: "crashed" });
+
+    expect(leaseLost).toHaveBeenCalledTimes(1);
+  });
+
+  it("a successful release never fires onLeaseLost, because the daemon suppresses the push at the source (ADR §8)", async () => {
     const connection = new ScriptedConnection();
     const connectPromise = connectSimlock({ connection });
     await flushMicrotasks();
@@ -299,13 +368,94 @@ describe("pushes", () => {
     const releasePromise = client.releaseLease({ leaseId: "lease_1" });
     await flushMicrotasks();
     const releaseCall = connection.lastSentOf("lease.release")!;
-    // The daemon pushes lease-lost for the same release the client itself just asked for --
-    // this must be swallowed, not surfaced.
-    connection.push("lease-lost", { deviceId: "device_1", leaseId: "lease_1", reason: "explicit" });
+    // Unlike the real daemon (which never sends this push to the releasing connection), the
+    // scripted connection sends nothing here either -- this asserts the client does not
+    // itself need to remember and swallow a self-initiated release.
     connection.reply(releaseCall.id, { leaseId: "lease_1" });
     await releasePromise;
 
     expect(leaseLost).not.toHaveBeenCalled();
+  });
+
+  it("S3: a lease-lost push for a lease id whose earlier release attempt failed is still delivered, not permanently muted", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const leaseLost = vi.fn();
+    client.onLeaseLost(leaseLost);
+
+    const grantPromise = client.requestLease({ model: "iPhone 17", platform: "ios" });
+    await flushMicrotasks();
+    connection.reply(
+      connection.lastSentOf("lease.request")!.id,
+      sampleGrant({ leaseId: "lease_1" }),
+    );
+    await grantPromise;
+
+    // The release itself fails -- e.g. an agent-role client hitting FORBIDDEN.
+    const releasePromise = client.releaseLease({ leaseId: "lease_1" });
+    await flushMicrotasks();
+    const releaseCall = connection.lastSentOf("lease.release")!;
+    connection.fail(releaseCall.id, "FORBIDDEN", "not authorized");
+    await expect(releasePromise).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+    // The lease later genuinely expires/crashes -- this is a real loss the client must
+    // still surface, not residue from the earlier failed release attempt.
+    connection.push("lease-lost", {
+      deviceId: "device_1",
+      leaseId: "lease_1",
+      reason: "expired",
+    });
+
+    expect(leaseLost).toHaveBeenCalledWith({
+      deviceId: "device_1",
+      leaseId: "lease_1",
+      reason: "expired",
+    });
+  });
+
+  it("answers a lease.heartbeat push with a fire-and-forget request frame carrying the same payload", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    await connectPromise;
+
+    connection.push("lease.heartbeat", { nonce: 12345 });
+    await flushMicrotasks();
+
+    const pong = connection.lastSentOf("lease.heartbeat")!;
+    expect(pong).toBeDefined();
+    expect(pong.payload).toEqual({ nonce: 12345 });
+  });
+
+  it("silently drops malformed lease-scoped and event pushes instead of throwing", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    completeHello(connection);
+    const client = await connectPromise;
+
+    const leaseLost = vi.fn();
+    const unhealthy = vi.fn();
+    const recovered = vi.fn();
+    client.onLeaseLost(leaseLost);
+    client.onDeviceUnhealthy(unhealthy);
+    client.onDeviceRecovered(recovered);
+
+    expect(() => connection.push("lease-lost", { leaseId: "lease_1" })).not.toThrow();
+    expect(() => connection.push("device-unhealthy", { leaseId: "lease_1" })).not.toThrow();
+    expect(() =>
+      connection.push("device-recovered", { deviceId: "device_1", leaseId: "lease_1" }),
+    ).not.toThrow();
+    expect(() => connection.push("event", { not: "a valid event shape" })).not.toThrow();
+
+    expect(leaseLost).not.toHaveBeenCalled();
+    expect(unhealthy).not.toHaveBeenCalled();
+    expect(recovered).not.toHaveBeenCalled();
   });
 });
 
@@ -567,5 +717,45 @@ describe("simlock/admin", () => {
     const stopCall = connection.lastSentOf("daemon.stop")!;
     connection.reply(stopCall.id, { stopping: true });
     await expect(stopPromise).resolves.toEqual({ stopping: true });
+  });
+
+  it("releaseAllLeases clears every held lease id and connection death afterwards fires no onLeaseLost", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlockAdmin({ connection, credential: "operator-secret" });
+    await flushMicrotasks();
+    completeHello(connection, { role: "admin" });
+    const admin = await connectPromise;
+
+    const firstGrant = admin.requestLease({ model: "iPhone 17", platform: "ios" });
+    await flushMicrotasks();
+    connection.reply(
+      connection.lastSentOf("lease.request")!.id,
+      sampleGrant({ leaseId: "lease_a" }),
+    );
+    await firstGrant;
+
+    const secondGrant = admin.requestLease({ model: "iPhone 17", platform: "ios" });
+    await flushMicrotasks();
+    connection.reply(
+      connection.lastSentOf("lease.request")!.id,
+      sampleGrant({ leaseId: "lease_b" }),
+    );
+    await secondGrant;
+
+    const releaseAllPromise = admin.releaseAllLeases();
+    await flushMicrotasks();
+    const releaseAllCall = connection.lastSentOf("lease.release-all")!;
+    connection.reply(releaseAllCall.id, { leaseIds: ["lease_a", "lease_b"] });
+    await expect(releaseAllPromise).resolves.toMatchObject({
+      leaseIds: ["lease_a", "lease_b"],
+    });
+
+    // Both leases are no longer tracked as held -- a later connection death synthesizes no
+    // onLeaseLost for either of them.
+    const leaseLost = vi.fn();
+    admin.onLeaseLost(leaseLost);
+    connection.simulateDeath();
+    await flushMicrotasks();
+    expect(leaseLost).not.toHaveBeenCalled();
   });
 });

--- a/src/simlock-client/client.ts
+++ b/src/simlock-client/client.ts
@@ -387,7 +387,8 @@ class SimlockClientImpl {
 
   async releaseLease(input: LeaseReleaseInput): Promise<LeaseReleaseOutput> {
     const parsed = this.#parseInput("lease.release", input);
-    this.#wire.markSelfInitiatedRelease(parsed.leaseId);
+    // The daemon suppresses the matching `lease-lost` push to this connection itself (ADR
+    // §8) -- see the comment on `SimlockWire`'s `#deliveredLeaseLost`. Nothing to mark here.
     const result = await this.#call("lease.release", parsed);
     this.#heldLeaseIds.delete(parsed.leaseId);
     return result;
@@ -432,7 +433,6 @@ class SimlockClientImpl {
   // ---- admin-only operations ------------------------------------------------------------------
 
   releaseAllLeases(): Promise<LeaseReleaseAllOutput> {
-    for (const leaseId of this.#heldLeaseIds.keys()) this.#wire.markSelfInitiatedRelease(leaseId);
     return this.#call("lease.release-all", {}).then((result) => {
       this.#heldLeaseIds.clear();
       return result;

--- a/src/simlock-client/wire.ts
+++ b/src/simlock-client/wire.ts
@@ -75,15 +75,27 @@ export class SimlockWire {
   readonly #leaseScopedListeners = new Set<(push: LeaseScopedPush) => void>();
   readonly #eventListeners = new Set<(payload: unknown) => void>();
   readonly #closeListeners = new Set<(error: AnySimlockError) => void>();
-  /** Lease ids this client itself asked to release -- suppresses the matching `lease-lost`
-   * push exactly once (ADR §8: "never fires onLeaseLost for a release the same client asked
-   * for"), then is removed so a *later*, unrelated crash for a reused lease id is not silently
-   * eaten forever. */
-  readonly #selfInitiatedReleases = new Set<string>();
-  /** De-dup key (`${kind}:${leaseId}`) for lease-scoped pushes already delivered, so a
-   * redundant re-push (the owner-routed fan-out can in principle reach the same connection
-   * twice for one fact) does not fire a listener twice for the same fact. */
-  readonly #deliveredLeaseScoped = new Set<string>();
+  /** Lease ids for which a `lease-lost` push has already been delivered -- kept forever
+   * because loss is terminal (ADR §8): a lease id is never reused, and the owner-routed
+   * fan-out can in principle reach this connection twice for the same fact.
+   *
+   * Suppressing the `lease-lost` push for a release *this* client itself asked for (ADR §8:
+   * "never fires onLeaseLost for a release the same client asked for") is the daemon's job,
+   * not this class's: `DaemonServer` marks the lease id in its own per-connection
+   * `selfInitiatedReleases` set right before dispatching `lease.release`/`lease.release-all`
+   * and clears it in a `finally` regardless of outcome (`daemon/server.ts` around
+   * `#notifyLeaseLost`), so the push is never sent to the releasing connection in the first
+   * place. Mirroring that bookkeeping here too was redundant on a successful release and
+   * actively harmful on a failed one: marked before the call and never rolled back, it
+   * permanently muted the real `lease-lost` push that arrives when the lease later expires
+   * for real. */
+  readonly #deliveredLeaseLost = new Set<string>();
+  /** Last lease-scoped health kind delivered per lease id, so `device-unhealthy` and
+   * `device-recovered` toggle: delivering one clears the other's suppression, so an
+   * unhealthy → recovered → unhealthy cycle (a real second crash) delivers all three, while a
+   * duplicate push of the *same* state in a row (the owner-routed fan-out re-delivering one
+   * fact) is still suppressed. */
+  readonly #lastHealthKind = new Map<string, "device-unhealthy" | "device-recovered">();
   #buffer = "";
   #nextId = 1;
   #dead: AnySimlockError | undefined;
@@ -193,12 +205,6 @@ export class SimlockWire {
     return () => this.#closeListeners.delete(listener);
   }
 
-  /** A lease this client itself is releasing: the next matching `lease-lost` push is
-   * swallowed rather than surfaced as a loss. */
-  markSelfInitiatedRelease(leaseId: string): void {
-    this.#selfInitiatedReleases.add(leaseId);
-  }
-
   async close(): Promise<void> {
     this.#die(
       new SimlockError("DAEMON_CONNECTION_LOST", "transport", "Client closed the connection", {}),
@@ -279,8 +285,6 @@ export class SimlockWire {
       case "lease-lost": {
         const parsed = PUSH_SCHEMAS["lease-lost"].safeParse(payload);
         if (!parsed.success) return;
-        const suppressed = this.#selfInitiatedReleases.delete(parsed.data.leaseId);
-        if (suppressed) return;
         this.#emitLeaseScoped({
           deviceId: parsed.data.deviceId,
           kind: "lease-lost",
@@ -329,9 +333,13 @@ export class SimlockWire {
   }
 
   #emitLeaseScoped(push: LeaseScopedPush): void {
-    const key = `${push.kind}:${push.leaseId}`;
-    if (this.#deliveredLeaseScoped.has(key)) return;
-    this.#deliveredLeaseScoped.add(key);
+    if (push.kind === "lease-lost") {
+      if (this.#deliveredLeaseLost.has(push.leaseId)) return;
+      this.#deliveredLeaseLost.add(push.leaseId);
+    } else {
+      if (this.#lastHealthKind.get(push.leaseId) === push.kind) return;
+      this.#lastHealthKind.set(push.leaseId, push.kind);
+    }
     for (const listener of this.#leaseScopedListeners) listener(push);
   }
 


### PR DESCRIPTION
**Stacked on #103.** Two client-side push-bookkeeping defects from the adversarial review.

## A second crash on the same lease was silently dropped

`#deliveredLeaseScoped` was a `Set` keyed `${kind}:${leaseId}` that was **never pruned**. This was self-reported as merely swallowing a duplicate `device-recovered`; it also swallowed a second **`device-unhealthy`**, which is the dangerous direction. `LeaseHealthMonitor` clears its recovery bookkeeping after a successful recovery, so a second crash on the same lease genuinely re-emits `device.crash-detected` — and the client dropped it. Neither the CLI's stderr lines nor MCP's health notifications reported the second cycle, so **the agent kept driving a dead simulator**.

The test that supposedly covered this pushed two identical `device-unhealthy` frames with **no intervening `device-recovered`**, so it passed under both the correct and the broken semantics.

Now split in two:

- `lease-lost` keeps a permanent per-lease key — loss is genuinely terminal.
- Device health is a **toggle**: delivering one kind clears the other's eligibility, so `unhealthy → recovered → unhealthy` delivers all three, while two identical pushes in a row are still suppressed.

The misleading test is fixed and a full-cycle test added.

## Self-initiated release marks leaked permanently and muted genuine losses

The client-side `#selfInitiatedReleases` set was add-only, cleared only by a matching `lease-lost` push. The daemon already suppresses that push to the releasing connection (and clears its own bookkeeping in a `finally`), so on a healthy release the client entry was never consumed — pure residue. On a **failed** release it was a permanent mute: mark `L1`/`L2`, have the release reject, and when `L1` later expires the real `lease-lost` is swallowed. The client then believes it holds a lease the daemon has already reclaimed.

Dropped the client-side set entirely rather than wrapping it in a `finally` — the daemon's suppression already implements ADR §8's rule, and one mechanism is better than two that must agree. A regression test proves a real `lease-lost` after a *failed* release is still delivered.

## Coverage added

The heartbeat pong, the four malformed-push `safeParse` drop branches, and `releaseAllLeases`'s held-lease bookkeeping — none had any coverage.

## Note

The health-state map is still unpruned per lease, so it grows with distinct leases seen over a connection's life — the same bound as before, not a new leak, but unbounded in principle on a very long-lived connection with heavy churn.