### PR TITLE
fix(contract,daemon): narrow status.get, close the stop-during-start window

### DIFF
--- a/src/contract/operations.ts
+++ b/src/contract/operations.ts
@@ -25,6 +25,7 @@ import {
   platformSchema,
   proposalSchema,
   statusCapacitySchema,
+  statusDeviceSchema,
   tokenRecordSchema,
   tokenRoleSchema,
 } from "./schemas.js";
@@ -72,7 +73,11 @@ export const statusGet = defineOperation({
   role: "agent",
   input: z.object({}),
   output: z.object({
-    devices: z.array(deviceRecordSchema),
+    // Agent-role, no ownership check (ADR §3) -- every device in the registry, not just ones
+    // the caller leases. `statusDeviceSchema`, not `deviceRecordSchema`, is what keeps
+    // `driverData` and reclamation/recovery bookkeeping off this response; see its doc comment
+    // in schemas.ts. `list.get` (admin-only) is the operation that returns the full record.
+    devices: z.array(statusDeviceSchema),
     leases: z.array(leaseRecordSchema),
     capacity: statusCapacitySchema,
     health: daemonHealthSchema,

--- a/src/contract/schemas.test.ts
+++ b/src/contract/schemas.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { grantedDeviceSchema, leaseGrantSchema } from "./schemas.js";
+import { grantedDeviceSchema, leaseGrantSchema, statusDeviceSchema } from "./schemas.js";
 
 /**
  * Regression coverage for the defect fixed alongside ADR 0003 §1: a lease grant's device must
@@ -102,5 +102,73 @@ describe("leaseGrantSchema's device projection", () => {
       driverDeviceId: "SIM-1",
       spec: { platform: "android", model: "Pixel 8", osVersion: "34" },
     });
+  });
+});
+
+/**
+ * Regression coverage for S4 of the ADR 0003 adversarial review: `status.get` is `role:
+ * "agent"` (ADR §3), with no ownership check -- it reports on every device in the registry, not
+ * just ones the caller leases. It must not hand `driverData` (an opaque, driver-defined blob)
+ * or reclamation/recovery bookkeeping to every agent for every device. `statusDeviceSchema` is
+ * what `src/contract/operations.ts`'s `status.get` output declares in place of
+ * `deviceRecordSchema`, and what `DaemonDispatcher#dispatch`'s `#parseOutput` runs each device
+ * through before it reaches any transport.
+ */
+describe("statusDeviceSchema's device projection", () => {
+  /** A device shaped like a full core `DeviceRecord` mid-quarantine, exactly the kind of
+   * payload `DaemonDispatcher#statusGet`'s decoration would carry into `#parseOutput`. */
+  function fullCoreShapedDevice(): Record<string, unknown> {
+    return {
+      id: "device-1",
+      driverDeviceId: "SIM-1",
+      spec: { platform: "ios", model: "iPhone 17 Pro", osVersion: "26.5" },
+      state: "quarantined",
+      driverData: { udid: "SIM-1", secretDriverInternals: true },
+      createdAt: 0,
+      lastLeaseEndedAt: 10,
+      foreignStateDetectedAt: 20,
+      foreignProvenanceDetectedAt: 30,
+      recoveringSince: 40,
+      recoveryAttempts: 2,
+      quarantinedAt: 50,
+      quarantineAttempts: 3,
+      quarantineNextRetryAt: 60,
+      address: "127.0.0.1:1234",
+      featureProfile: "reduced",
+      transitionAgeMs: 70,
+    };
+  }
+
+  it("strips driverData, driverDeviceId, and reclamation/recovery bookkeeping, keeping only what a human status line needs", () => {
+    const device = statusDeviceSchema.parse(fullCoreShapedDevice());
+
+    for (const field of [
+      "driverData",
+      "driverDeviceId",
+      "createdAt",
+      "lastLeaseEndedAt",
+      "recoveringSince",
+      "recoveryAttempts",
+      "quarantinedAt",
+      "address",
+      "featureProfile",
+    ] as const) {
+      expect(device).not.toHaveProperty(field);
+    }
+
+    expect(device).toEqual({
+      id: "device-1",
+      spec: { platform: "ios", model: "iPhone 17 Pro", osVersion: "26.5" },
+      state: "quarantined",
+      foreignStateDetectedAt: 20,
+      foreignProvenanceDetectedAt: 30,
+      quarantineAttempts: 3,
+      quarantineNextRetryAt: 60,
+      transitionAgeMs: 70,
+    });
+  });
+
+  it("rejects a device object that is missing the fields status.get must keep", () => {
+    expect(() => statusDeviceSchema.parse({ id: "device-1" })).toThrow();
   });
 });

--- a/src/contract/schemas.ts
+++ b/src/contract/schemas.ts
@@ -65,6 +65,50 @@ export const deviceRecordSchema = z.object({
 });
 
 /**
+ * The device shape `status.get` returns (ADR §3: `status.get` is `role: "agent"`, with no
+ * ownership check -- it reports on every device in the registry, not just ones the caller
+ * leases). Deliberately narrower than `deviceRecordSchema`, for the same reason
+ * `grantedDeviceSchema` is narrower than it: an agent is not an operator inspecting the
+ * registry, and `deviceRecordSchema`'s `driverData` is an opaque, driver-defined blob whose
+ * contents this contract cannot bound -- handing it to every agent for every device
+ * (including devices other principals hold) is exactly the leak this schema exists to close.
+ *
+ * What stays, and why: `status.get` is what `simlock status` renders for a human (ADR §11,
+ * "Human-readable status ... formatting stays"), and that rendering legitimately surfaces
+ * device health, not just identity --
+ *
+ * - `id`, `spec`: which device this is.
+ * - `state`: the human-status line's primary content (`Device <id>: <state>`).
+ * - `foreignStateDetectedAt`, `foreignProvenanceDetectedAt`: surfaced as "foreign state/
+ *   provenance change" markers -- an agent legitimately wants to know a device it might be
+ *   about to request was tampered with outside simlock.
+ * - `quarantineAttempts`, `quarantineNextRetryAt`: surfaced as purge-retry progress for a
+ *   quarantined device, so a caller waiting on capacity can see why a slot isn't freeing up.
+ * - `transitionAgeMs`: the mid-transition decoration, surfaced as "mid-transition <ms>".
+ *
+ * What stays off, and why: `driverDeviceId` (the driver address of a device the caller does
+ * not hold is not actionable -- a non-owning agent cannot drive it, and a holder already gets
+ * it on their grant), `driverData` (opaque driver-private blob, unbounded contents),
+ * `createdAt`/`lastLeaseEndedAt` (internal bookkeeping timestamps the human formatter never
+ * reads), `recoveringSince`/`recoveryAttempts` (crash-recovery bookkeeping -- `safety.md` rule
+ * 2 scopes that privilege narrowly, and broadcasting its progress to every agent is not part of
+ * that scope), `quarantinedAt` (superseded by `quarantineAttempts`/`quarantineNextRetryAt` for
+ * what a caller needs), and `address`/`featureProfile` (only meaningful to whoever is driving
+ * the device, i.e. the lease holder, who gets them on the grant).
+ */
+export const statusDeviceSchema = z.object({
+  id: z.string(),
+  spec: deviceSpecSchema,
+  state: deviceStateSchema,
+  foreignStateDetectedAt: z.number().optional(),
+  foreignProvenanceDetectedAt: z.number().optional(),
+  quarantineAttempts: z.number().optional(),
+  quarantineNextRetryAt: z.number().optional(),
+  /** Decoration added by `status.get`; absent for a device not mid-transition. */
+  transitionAgeMs: z.number().optional(),
+});
+
+/**
  * The device a `lease.request`/`lease.renew` grant carries -- deliberately narrower than
  * `deviceRecordSchema` (ADR 0003 §1: "the daemon maps [core records] onto contract types in
  * exactly one place"). A grant is agent-facing, not an admin inspection of the registry, so it
@@ -77,9 +121,10 @@ export const deviceRecordSchema = z.object({
  * Everything else on `DeviceRecord` -- `driverData` (opaque driver-private blob), `state`,
  * `createdAt`, every `quarantine*`/`foreign*`/`recovering*` field, and the `status`/`list`
  * decoration's `transitionAgeMs` -- is internal reclamation/health bookkeeping a grant recipient
- * has no business seeing, and stays off this shape. `list.get`/`status.get` (admin-only) still
- * return the full `deviceRecordSchema` -- an operator inspecting the registry legitimately wants
- * the whole record.
+ * has no business seeing, and stays off this shape. `list.get` (admin-only) still returns the
+ * full `deviceRecordSchema` -- an operator inspecting the registry legitimately wants the whole
+ * record. `status.get` (agent-role, ADR §3) is narrower still -- see `statusDeviceSchema` below,
+ * which is what it actually returns.
  */
 export const grantedDeviceSchema = z.object({
   id: z.string(),

--- a/src/daemon/admin-secret.test.ts
+++ b/src/daemon/admin-secret.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+
+import { MemoryFilesystem, CryptoTokenSecrets, type Filesystem } from "../ports/index.js";
+import { AdminSecretManager } from "./admin-secret.js";
+
+/**
+ * Regression coverage for review finding S1: `AdminSecretManager` (ADR 0003 §5's per-start
+ * admin secret) had zero test coverage of its own -- everything that exercises the daemon's
+ * credential handshake in `server.test.ts` goes through a stubbed `resolveRole`, so none of it
+ * ever calls `persist()` or `verify()` for real.
+ */
+describe("AdminSecretManager", () => {
+  function secrets(): CryptoTokenSecrets {
+    return new CryptoTokenSecrets();
+  }
+
+  it("persist() writes the plaintext secret, newline-terminated, with mode 0600", async () => {
+    const filesystem = new MemoryFilesystem();
+    const manager = new AdminSecretManager({
+      filesystem,
+      path: "/admin.token",
+      secrets: secrets(),
+    });
+
+    await manager.persist();
+
+    const contents = await filesystem.readFile("/admin.token");
+    expect(contents.endsWith("\n")).toBe(true);
+    expect(contents.trim().length).toBeGreaterThan(0);
+    const stat = await filesystem.stat("/admin.token");
+    expect(stat.mode).toBe(0o600);
+  });
+
+  // ADR §5: "owner-only permissions set at creation" -- not a later `chmod`. `Filesystem` (see
+  // `ports/filesystem.ts`) has no `chmod` method at all, only `writeFileAtomic(path, contents,
+  // {mode})`, so the interface itself rules out a two-step "write, then chmod" implementation --
+  // this asserts `persist()` actually uses that option rather than, say, calling
+  // `writeFileAtomic` without `mode` and relying on the process umask to happen to land on
+  // 0600. Spying on the raw `Filesystem` call (rather than reading the mode back through
+  // `MemoryFilesystem#stat`, which the test above already does) proves the *call site* passes
+  // the option, not just that `MemoryFilesystem` happens to record whatever mode was implied.
+  it("passes mode 0600 to writeFileAtomic itself, at the single call persist() makes", async () => {
+    const calls: Array<{ readonly path: string; readonly mode: number | undefined }> = [];
+    const filesystem: Filesystem = {
+      readFile: () => Promise.reject(new Error("unused by this test")),
+      writeFileAtomic: async (path, _contents, options) => {
+        calls.push({ path, mode: options?.mode });
+      },
+      mkdirp: () => Promise.reject(new Error("unused by this test")),
+      rm: () => Promise.reject(new Error("unused by this test")),
+      stat: () => Promise.reject(new Error("unused by this test")),
+      readdir: () => Promise.reject(new Error("unused by this test")),
+      exists: () => Promise.reject(new Error("unused by this test")),
+      diskFree: () => Promise.reject(new Error("unused by this test")),
+    };
+    const manager = new AdminSecretManager({
+      filesystem,
+      path: "/admin.token",
+      secrets: secrets(),
+    });
+
+    await manager.persist();
+
+    expect(calls).toEqual([{ path: "/admin.token", mode: 0o600 }]);
+  });
+
+  it("remove() deletes admin.token", async () => {
+    const filesystem = new MemoryFilesystem();
+    const manager = new AdminSecretManager({
+      filesystem,
+      path: "/admin.token",
+      secrets: secrets(),
+    });
+    await manager.persist();
+
+    await manager.remove();
+
+    await expect(filesystem.readFile("/admin.token")).rejects.toThrow();
+  });
+
+  it("verify() rejects a wrong candidate and accepts the real secret", async () => {
+    const filesystem = new MemoryFilesystem();
+    const manager = new AdminSecretManager({
+      filesystem,
+      path: "/admin.token",
+      secrets: secrets(),
+    });
+    await manager.persist();
+    const realSecret = (await filesystem.readFile("/admin.token")).trim();
+
+    expect(manager.verify(realSecret)).toBe(true);
+    expect(manager.verify("definitely-not-it")).toBe(false);
+    expect(manager.verify("")).toBe(false);
+  });
+
+  // ADR §5: "`verify()` never touches the filesystem or reconstructs the secret; it only ever
+  // compares hashes" -- and `session.ts`'s doc on the real credential handshake depends on this:
+  // "`hello` verifies against memory, so a credential can be checked before the file lands and
+  // before convergence." A `Filesystem` whose every method throws proves `verify()` truly never
+  // calls any of them, for a correct candidate, a wrong one, and before `persist()` has ever
+  // run.
+  it("verify() never touches the filesystem, even before persist() has ever run", () => {
+    const throwingFilesystem: Filesystem = {
+      readFile: () => {
+        throw new Error("verify() must not touch the filesystem");
+      },
+      writeFileAtomic: () => {
+        throw new Error("verify() must not touch the filesystem");
+      },
+      mkdirp: () => {
+        throw new Error("verify() must not touch the filesystem");
+      },
+      rm: () => {
+        throw new Error("verify() must not touch the filesystem");
+      },
+      stat: () => {
+        throw new Error("verify() must not touch the filesystem");
+      },
+      readdir: () => {
+        throw new Error("verify() must not touch the filesystem");
+      },
+      exists: () => {
+        throw new Error("verify() must not touch the filesystem");
+      },
+      diskFree: () => {
+        throw new Error("verify() must not touch the filesystem");
+      },
+    };
+    const realSecrets = secrets();
+    // Constructing `AdminSecretManager` calls `secrets.generateSecret()`/`secrets.hash(...)`
+    // once (see its constructor) -- capture the plaintext it generated to verify against, the
+    // only way to get a real candidate without ever calling `persist()`.
+    let generated = "";
+    const spySecrets: CryptoTokenSecrets = {
+      ...realSecrets,
+      generateSecret: () => {
+        generated = realSecrets.generateSecret();
+        return generated;
+      },
+      hash: (value) => realSecrets.hash(value),
+    };
+    const manager = new AdminSecretManager({
+      filesystem: throwingFilesystem,
+      path: "/admin.token",
+      secrets: spySecrets,
+    });
+
+    // None of these touch `throwingFilesystem` -- if they did, the test would already have
+    // thrown before reaching these assertions.
+    expect(manager.verify(generated)).toBe(true);
+    expect(manager.verify("wrong")).toBe(false);
+  });
+
+  it("does not touch the filesystem at construction time either -- only persist()/remove() do", () => {
+    const throwingFilesystem: Filesystem = {
+      readFile: () => {
+        throw new Error("must not touch the filesystem");
+      },
+      writeFileAtomic: () => {
+        throw new Error("must not touch the filesystem");
+      },
+      mkdirp: () => {
+        throw new Error("must not touch the filesystem");
+      },
+      rm: () => {
+        throw new Error("must not touch the filesystem");
+      },
+      stat: () => {
+        throw new Error("must not touch the filesystem");
+      },
+      readdir: () => {
+        throw new Error("must not touch the filesystem");
+      },
+      exists: () => {
+        throw new Error("must not touch the filesystem");
+      },
+      diskFree: () => {
+        throw new Error("must not touch the filesystem");
+      },
+    };
+
+    // Constructing an `AdminSecretManager` -- e.g. a daemon that loses the start race and never
+    // calls `persist()` at all (ADR §5, `admin-secret.ts`'s class doc) -- must not touch the
+    // real file. Nothing here throws.
+    expect(
+      () =>
+        new AdminSecretManager({
+          filesystem: throwingFilesystem,
+          path: "/admin.token",
+          secrets: secrets(),
+        }),
+    ).not.toThrow();
+  });
+});

--- a/src/daemon/dispatcher.test.ts
+++ b/src/daemon/dispatcher.test.ts
@@ -6,9 +6,11 @@ import {
   Doctor,
   FakeDriver,
   LeaseEngine,
+  Nuke,
   Registry,
   type Config,
 } from "../core/index.js";
+import type { CatalogReader } from "../core/lease-ports.js";
 import {
   CryptoTokenSecrets,
   FakeClock,
@@ -35,6 +37,15 @@ async function buildDispatcher(
   overrides: {
     readonly downloadsPolicy?: Config["downloads"]["policy"];
     readonly awaitReady?: () => Promise<void>;
+    /** Overrides the `catalog` dependency -- used only to force `#parseOutput`'s failure path
+     * (see "Dispatcher: #parseOutput") with a fake that returns a payload violating the
+     * contract's output schema, something no real `CatalogReader` implementation would do. */
+    readonly catalog?: CatalogReader;
+    /** ADR §3: `nuke.run` is admin-only and destructive (`safety.md` rules 1/5). `false` by
+     * default -- matching `DispatcherOptions.nuke`'s own undefined default, so most tests don't
+     * pay for wiring one -- since a real `Nuke` needs this function's own `engine`/`registry`,
+     * it is built here (rather than passed in) when a test opts in. */
+    readonly includeNuke?: boolean;
   } = {},
 ) {
   const clock = new FakeClock(1_000);
@@ -90,13 +101,14 @@ async function buildDispatcher(
   const dispatcher = new Dispatcher({
     awaitReady: overrides.awaitReady ?? (() => Promise.resolve()),
     capacity: engine,
-    catalog: engine,
+    catalog: overrides.catalog ?? engine,
     clock,
     config,
     doctor,
     eventBus,
     health: () => "running",
     leases: engine,
+    ...(overrides.includeNuke === true ? { nuke: new Nuke({ executor: engine, registry }) } : {}),
     queue: engine,
     reaper,
     registry,
@@ -377,6 +389,129 @@ describe("Dispatcher: ownership", () => {
     ).resolves.toMatchObject({ result: "cancelled" });
 
     await expect(queuedRequest).rejects.toThrow();
+  });
+});
+
+// Review finding S9: `Dispatcher#leaseReleaseAll` and `#nukeRun` were exercised by no test
+// anywhere (`nuke.run` appeared in `server.test.ts` only inside a comment) -- both are
+// admin-only and destructive, which is exactly what `docs/agent-rules/safety.md` rules 1
+// ("registry-only destruction") and 5 ("destructive CLI commands confirm or require --yes") are
+// about. `--yes`/confirmation is a CLI-layer concern (not this dispatcher's), but role
+// enforcement and "it actually destroys only what it should" are, and neither had coverage.
+describe("Dispatcher: lease.release-all", () => {
+  it("rejects an agent session with FORBIDDEN, without releasing anything", async () => {
+    const { dispatcher, registry } = await buildDispatcher();
+    await dispatcher.dispatch(
+      "lease.request",
+      { mode: "detached", model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
+      session({ principal: "tok_owner" }),
+    );
+
+    await expect(
+      dispatcher.dispatch("lease.release-all", {}, session({ role: "agent" })),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    // The lease this agent session doesn't even own must still be untouched -- a rejected
+    // `lease.release-all` released nothing, it didn't just fail to report what it released.
+    expect(registry.snapshot.leases).toHaveLength(1);
+  });
+
+  it("admin releases every held lease, regardless of owner, and reports every released id", async () => {
+    const { dispatcher, registry } = await buildDispatcher();
+    const first = await dispatcher.dispatch(
+      "lease.request",
+      { mode: "detached", model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
+      session({ principal: "tok_owner_1" }),
+    );
+    const second = await dispatcher.dispatch(
+      "lease.request",
+      { mode: "detached", model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
+      session({ principal: "tok_owner_2" }),
+    );
+    expect(registry.snapshot.leases).toHaveLength(2);
+
+    const result = await dispatcher.dispatch(
+      "lease.release-all",
+      {},
+      session({ principal: "tok_admin", role: "admin" }),
+    );
+
+    expect(new Set(result.leaseIds)).toEqual(new Set([first.lease.id, second.lease.id]));
+    expect(registry.snapshot.leases).toHaveLength(0);
+  });
+});
+
+describe("Dispatcher: nuke.run", () => {
+  it("rejects an agent session with FORBIDDEN, without deleting anything", async () => {
+    const { dispatcher, registry } = await buildDispatcher({ includeNuke: true });
+    await dispatcher.dispatch(
+      "lease.request",
+      { mode: "detached", model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
+      session({ principal: "tok_owner" }),
+    );
+
+    await expect(
+      dispatcher.dispatch("nuke.run", {}, session({ role: "agent" })),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(registry.snapshot.leases).toHaveLength(1);
+  });
+
+  it("admin can run it, releasing every lease and reporting the deleteDevices flag it ran with", async () => {
+    const { dispatcher, registry } = await buildDispatcher({ includeNuke: true });
+    await dispatcher.dispatch(
+      "lease.request",
+      { mode: "detached", model: "iPhone 17 Pro", osVersion: "26.5", platform: "ios" },
+      session({ principal: "tok_owner" }),
+    );
+    expect(registry.snapshot.leases).toHaveLength(1);
+
+    const result = await dispatcher.dispatch(
+      "nuke.run",
+      { deleteDevices: false },
+      session({ role: "admin" }),
+    );
+
+    expect(result.releasedLeaseIds).toHaveLength(1);
+    expect(registry.snapshot.leases).toHaveLength(0);
+  });
+
+  it("throws NukeUnavailableError when the dispatcher was built with no Nuke wired -- an admin cannot bypass this", async () => {
+    const { dispatcher } = await buildDispatcher();
+    await expect(
+      dispatcher.dispatch("nuke.run", {}, session({ role: "admin" })),
+    ).rejects.toMatchObject({ name: "NukeUnavailableError" });
+  });
+});
+
+describe("Dispatcher: #parseOutput", () => {
+  // ADR §1's central claim -- "the daemon maps its own records onto contract types in exactly
+  // one place ... this is what keeps private types out of the public package surface" -- names
+  // `#parseOutput` as the enforcement mechanism (see `schemas.ts`'s module doc). It had no test
+  // of its own failure path: every other dispatcher test exercises a handler whose real output
+  // already satisfies its schema, so `#parseOutput`'s `safeParse` always took the success
+  // branch. This forces the failure branch with a `catalog: CatalogReader` fake that returns a
+  // payload no real `CatalogReader` implementation would -- one that does not satisfy
+  // `platformCatalogSchema` -- and checks the dispatcher does not leak that malformed payload
+  // out, or the underlying zod issue detail, to the caller.
+  it("fails closed with an opaque Internal error when a handler's output violates its contract schema, instead of leaking the malformed payload", async () => {
+    const badCatalog: CatalogReader = {
+      // `platformCatalogSchema` requires (among other fields) `platform`/`models`/`runtimes` --
+      // this satisfies none of them.
+      listCatalog: async () => [{ notAValidCatalogEntry: true } as never],
+    };
+    const { dispatcher } = await buildDispatcher({ catalog: badCatalog });
+
+    await expect(dispatcher.dispatch("catalog.get", {}, session())).rejects.toThrow(
+      /does not match its contract output schema/,
+    );
+    try {
+      await dispatcher.dispatch("catalog.get", {}, session());
+      expect.unreachable();
+    } catch (error: unknown) {
+      // Fails closed, generically -- not the raw zod issues (which could describe internal
+      // shape) and not the malformed payload itself.
+      expect(error).toBeInstanceOf(Error);
+      expect(String(error)).not.toContain("notAValidCatalogEntry");
+    }
   });
 });
 

--- a/src/daemon/main.test.ts
+++ b/src/daemon/main.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { connect, createServer } from "node:net";
+import { connect, createServer, Server } from "node:net";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { EventBus } from "../bus/index.js";
@@ -220,6 +220,107 @@ describe("startDaemon HTTP gateway startup readiness", () => {
 
     const parkedResponse = await parkedStatusPromise;
     expect(parkedResponse.status).toBe(200);
+  });
+});
+
+describe("startDaemon HTTP gateway stop-during-start race (review finding S5)", () => {
+  // Before this fix, `stopAuxiliary` (this file's `stopAuxiliary` closure passed to
+  // `DaemonServer`) returned immediately whenever the concurrently-started HTTP gateway
+  // (`onSocketClaimed` -> `startHttpGateway()`) hadn't finished its own `listen()` yet --
+  // `stopHttpGateway` isn't assigned until it does. `#stop()` (server.ts) awaits
+  // `stopAuxiliary()` first, so it would go on to release leases, settle, and dispose while the
+  // gateway was still binding, then start accepting HTTP requests -- against a torn-down engine
+  // -- once its own `listen()` finally resolved. The fix makes `stopAuxiliary` await
+  // `gatewayStarted` (settled only once the gateway's own bind attempt finishes, one way or the
+  // other) before doing anything else.
+  //
+  // The window this reproduces (`onSocketClaimed` firing to the gateway's `listen()` actually
+  // resolving) is normally a handful of real milliseconds -- reachable, per the review, via
+  // `simlock daemon stop` during startup, but not something a test can land inside reliably by
+  // just racing real I/O against real I/O. So this test holds the window open deterministically
+  // instead: it patches `net.Server.prototype.listen` (restored in `finally`) to delay only a
+  // TCP bind (the gateway's) by 200ms, leaving the daemon's own Unix-socket `listen()` (a string
+  // first argument, not a port) untouched -- so the socket claims and answers `daemon.stop`
+  // long before the patched gateway bind is even allowed to start.
+  it("never lets the HTTP gateway outlive full teardown when daemon.stop lands while the gateway is still mid-bind", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "simlock-main-http-race-"));
+    temporaryDirectories.push(directory);
+    const clock = new FakeClock(1_000);
+    const sink = new MemoryLogSink();
+    const logger = new JsonLinesLogger({ clock, level: "debug", sink });
+    const filesystem = new MemoryFilesystem();
+    const port = 47_013;
+    const socketPath = join(directory, "daemon.sock");
+
+    const restoreListen = delayTcpListen(200);
+    try {
+      const startPromise = startDaemon({
+        clock,
+        configOverrides: { http: { enabled: true, host: "127.0.0.1", port } },
+        dataDirectory: directory,
+        drivers: [new FakeDriver({ availableOsVersions: ["26.5"], clock, platform: "ios" })],
+        filesystem,
+        logger,
+        socketPath,
+        statePath: join(directory, "state.json"),
+        version: "1.2.3",
+      } as StartDaemonOptions);
+      // `stop()` is idempotent, so it is safe for `afterEach` to also stop whatever this
+      // resolves to (it will, once the delayed gateway bind above finishes settling).
+      void startPromise.then((daemon) => runningDaemons.push(daemon)).catch(() => undefined);
+
+      // Connects and authenticates as admin, then sends `daemon.stop` -- comfortably inside the
+      // 200ms window the patch above holds the gateway's own bind open for. The admin secret is
+      // written (`AdminSecretManager#persist`) before `onSocketClaimed` fires, so it is already
+      // there by the time the socket itself is reachable.
+      const client = await connectRetrying(socketPath);
+      const secret = (await readFileRetrying(filesystem, join(directory, "admin.token"))).trim();
+      await client.request("hello", {
+        clientVersion: "test",
+        credential: secret,
+        protocolVersion: DAEMON_PROTOCOL_VERSION,
+      });
+      const stopReply = await client.request("daemon.stop", {});
+      expect(stopReply.ok).toBe(true);
+      client.socket.end();
+
+      // Lets the delayed gateway bind actually fire and settle (one way or the other) before
+      // this test reads the log for it.
+      await new Promise((resolve) => setTimeout(resolve, 400));
+
+      const stoppingIndex = sink.records.findIndex(
+        (record) => record.message === "Daemon stopping",
+      );
+      expect(stoppingIndex).toBeGreaterThanOrEqual(0);
+      const gatewayStoppedIndex = sink.records.findIndex(
+        (record) => record.message === "HTTP gateway stopped",
+      );
+      const gatewayListeningIndex = sink.records.findIndex(
+        (record) => record.message === "HTTP gateway listening",
+      );
+      // The gateway actually got to bind (it does here -- the port is free and 200ms is ample
+      // real time for a loopback `listen()`), so this asserts the meaningful case directly
+      // rather than treating it as merely possible: it bound, and it was stopped, and both
+      // happened strictly before "Daemon stopping" (logged only once `stopAuxiliary` resolves --
+      // see `server.ts#stop`). Before the fix, `stoppingIndex` would be *smaller* than both of
+      // these -- `stopAuxiliary` returned immediately, so "Daemon stopping" logged right away,
+      // well before the (patch-delayed) gateway bind even started.
+      expect(gatewayListeningIndex).toBeGreaterThanOrEqual(0);
+      expect(gatewayListeningIndex).toBeLessThan(stoppingIndex);
+      expect(gatewayStoppedIndex).toBeGreaterThanOrEqual(0);
+      expect(gatewayStoppedIndex).toBeLessThan(stoppingIndex);
+
+      // And the port must never be reachable once the daemon has finished stopping -- the
+      // gateway did not outlive teardown just because it bound after `stop()` was requested.
+      await expect(
+        fetch(`http://127.0.0.1:${port}/v1/status`, {
+          headers: { authorization: "Bearer irrelevant" },
+          signal: AbortSignal.timeout(200),
+        }),
+      ).rejects.toThrow();
+    } finally {
+      restoreListen();
+    }
   });
 });
 
@@ -690,6 +791,52 @@ async function connectRetrying(socketPath: string, timeoutMs = 2_000): Promise<M
     } catch (error: unknown) {
       if (Date.now() >= deadline) throw error;
       await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+  }
+}
+
+/** Delays every TCP `listen()` call (a numeric or options-object port, as HTTP servers use) by
+ * `delayMs`, real time, via `setTimeout` -- but passes a Unix-socket `listen(path, callback)`
+ * call (a string first argument) straight through unpatched. Used only by the S5 race test
+ * above to hold the HTTP gateway's own bind open deterministically without touching `src/http`
+ * -- `@hono/node-server`'s `serve()` ultimately calls `http.Server#listen`, which is `net.Server`'s
+ * own method (Node's `http` module does not override it), so patching it here reaches the
+ * gateway's real bind call. Returns a restorer; always call it, even on failure. */
+function delayTcpListen(delayMs: number): () => void {
+  const original = Server.prototype.listen;
+  type ListenFn = (...callArgs: unknown[]) => Server;
+  Server.prototype.listen = function patchedListen(this: Server, ...args: unknown[]) {
+    const isTcp =
+      typeof args[0] === "number" ||
+      (typeof args[0] === "object" && args[0] !== null && !("path" in (args[0] as object)));
+    if (!isTcp) {
+      return (original as ListenFn).apply(this, args);
+    }
+    setTimeout(() => {
+      (original as ListenFn).apply(this, args);
+    }, delayMs);
+    return this;
+  } as typeof Server.prototype.listen;
+  return () => {
+    Server.prototype.listen = original;
+  };
+}
+
+/** Polls a `MemoryFilesystem` path with no backoff -- used to read `admin.token` the moment
+ * `AdminSecretManager#persist` lands it, without adding artificial delay to a test that is
+ * deliberately racing that write's timing against something else (see the S5 race test). */
+async function readFileRetrying(
+  filesystem: MemoryFilesystem,
+  path: string,
+  timeoutMs = 2_000,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      return await filesystem.readFile(path);
+    } catch (error: unknown) {
+      if (Date.now() >= deadline) throw error;
+      await new Promise((resolve) => setTimeout(resolve, 0));
     }
   }
 }

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -175,19 +175,20 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
   });
   // Reassigned once the HTTP gateway actually starts, but must exist as a stable closure now:
   // `stopAuxiliary` is fixed at `DaemonServer` construction time, before the gateway itself
-  // exists. `httpStopRequested` closes the narrow race `onSocketClaimed`'s doc calls out: if
-  // `stop()` runs (e.g. convergence failed) *while* the gateway is still mid-`start()` below,
-  // `stopHttpGateway` isn't assigned yet for `stopAuxiliary` to call -- this flag lets the
-  // gateway's own startup continuation notice and stop itself the moment it finishes, instead
-  // of leaking a listening HTTP server past a daemon that has already torn everything else down.
+  // exists.
   let stopHttpGateway: (() => Promise<void>) | undefined;
-  let httpStopRequested = false;
   // Settles once the HTTP gateway either finishes starting or fails to -- resolved/rejected from
   // inside `onSocketClaimed`'s handler below. `startDaemon()` awaits this alongside
   // `daemon.start()` itself (see the bottom of this function) so a bind failure (occupied port,
   // invalid host) makes `startDaemon()` reject and the entrypoint report a non-zero exit code,
-  // the way it did before the gateway moved to firing concurrently with convergence. When HTTP
-  // is disabled there is nothing to wait for, so this resolves immediately.
+  // the way it did before the gateway moved to firing concurrently with convergence. `stopAuxiliary`
+  // below *also* awaits this -- that is what closes review finding S5: without it, `stopAuxiliary`
+  // could return having stopped nothing (because `stopHttpGateway` isn't assigned yet, the
+  // gateway still being mid-`start()`), and `#stop()` would go on to release leases, settle, and
+  // dispose while the gateway finishes binding and starts accepting requests against a daemon
+  // already being torn down -- see `server.ts`'s `stopAuxiliary` doc: it "must be shut off before
+  // held-lease release and lease/queue teardown begin". When HTTP is disabled there is nothing to
+  // wait for, so this resolves immediately.
   let resolveGatewayStarted: (() => void) | undefined;
   let rejectGatewayStarted: ((error: unknown) => void) | undefined;
   const gatewayStarted: Promise<void> = config.http.enabled
@@ -239,9 +240,17 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
     },
     settle: async () => leaseEngine.settle(),
     dispose: () => leaseEngine.dispose(),
-    stopAuxiliary: () => {
-      httpStopRequested = true;
-      return stopHttpGateway?.() ?? Promise.resolve();
+    // Review finding S5: waits for the concurrently-started gateway to either finish binding
+    // (so `stopHttpGateway` is assigned and can actually be called) or fail to bind (nothing to
+    // stop) *before* returning -- `#stop()` awaits this call before releasing leases, settling,
+    // and disposing (see `server.ts`), so by the time any of that runs, the gateway is
+    // guaranteed to be either stopped or never listening in the first place. `gatewayStarted`'s
+    // rejection (a bind failure) is not this function's problem to surface -- the
+    // `Promise.allSettled` at the bottom of this function, or the standalone `daemon.stop()`
+    // call after it, already handle that -- so it is swallowed here.
+    stopAuxiliary: async () => {
+      await gatewayStarted.catch(() => undefined);
+      await stopHttpGateway?.();
     },
     // ADR 0003 §2: "an HTTP request during startup now waits like a socket request instead of
     // being refused". Firing the gateway's own `start()` from here (not after `daemon.start()`
@@ -289,10 +298,10 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
       await gateway.stop();
       app.dispose();
     };
-    // Closes the race `stopAuxiliary`'s doc above and `onSocketClaimed`'s own doc on
-    // `DaemonServerOptions` call out: `stop()` may already have run (and found
-    // `stopHttpGateway` still unassigned) by the time this async function finally gets here.
-    if (httpStopRequested) await stopHttpGateway();
+    // No self-stop check here: `stopAuxiliary` above is the single place that decides whether
+    // to stop the gateway, and it does so by awaiting `gatewayStarted` (settled once this
+    // function's caller -- `onSocketClaimed`'s handler below -- resolves or rejects) before
+    // calling `stopHttpGateway`. Stopping here too would double-stop it.
   }
 
   // Awaited together, not `daemon.start()` alone: `gatewayStarted` is the promise

--- a/src/daemon/server.test.ts
+++ b/src/daemon/server.test.ts
@@ -17,6 +17,7 @@ import {
 import { PROTOCOL_VERSION_RANGE } from "../contract/index.js";
 import { AndroidLicenseNotAcceptedError } from "../drivers/android/index.js";
 import {
+  CryptoTokenSecrets,
   FakeClock,
   FakeSystemStats,
   JsonLinesLogger,
@@ -30,6 +31,7 @@ import { DAEMON_PROTOCOL_VERSION } from "../daemon-protocol/index.js";
 import { DaemonEndpointHost } from "./connection-host.js";
 import { AdminAuthenticationFailedError, type SessionRoleResolver } from "./session.js";
 import { DaemonServer } from "./server.js";
+import { AdminSecretManager } from "./admin-secret.js";
 
 const gibibyte = 1024 ** 3;
 
@@ -409,6 +411,64 @@ describe("DaemonServer", () => {
     await hello(client);
     await client.close();
     expect(first.daemon.socketPath).toBe(socketPath);
+  });
+
+  // Review finding S1: `AdminSecretManager`'s own doc (`admin-secret.ts`) asserts "a daemon
+  // that loses the start race never calls `persist()` at all ... so the file an
+  // already-running daemon wrote is never touched by the loser" -- untested anywhere before
+  // this. Mirrors the "recovers a stale socket file" test above (two harnesses racing for the
+  // same socket path), but gives each its own real `AdminSecretManager` over its own
+  // `MemoryFilesystem` so this can assert on the filesystem directly, rather than trusting a
+  // stub. In production both instances would target the *same* real `admin.token` path (see
+  // `main.ts`); separate filesystems here isolate what each instance actually did, without that
+  // shared path letting a wrongly-invoked `remove()` on the loser silently clean up after a
+  // wrongly-invoked `persist()` and mask the very bug this test exists to catch.
+  it("never touches admin.token on the daemon instance that loses the start race", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "simlock-stale-admin-"));
+    temporaryDirectories.push(directory);
+    const socketPath = join(directory, "daemon.sock");
+    await new NodeFilesystem().writeFileAtomic(socketPath, "stale");
+
+    const secrets = new CryptoTokenSecrets();
+    const winnerFilesystem = new MemoryFilesystem();
+    // Not bound to a name: `createHarness` already registers its daemon in `runningDaemons`
+    // for `afterEach` to stop, and this test only needs the winner alive on `socketPath` (so
+    // the loser's own `start()` below actually loses) plus its filesystem.
+    await createHarness({
+      adminSecret: new AdminSecretManager({
+        filesystem: winnerFilesystem,
+        path: "/admin.token",
+        secrets,
+      }),
+      socketPath,
+    });
+    // The winner (the only one whose `start()` actually reached `host.start()`'s success path)
+    // did persist its secret.
+    await expect(winnerFilesystem.readFile("/admin.token")).resolves.toContain("\n");
+
+    const loserFilesystem = new MemoryFilesystem();
+    const second = await createHarness({
+      adminSecret: new AdminSecretManager({
+        filesystem: loserFilesystem,
+        path: "/admin.token",
+        secrets,
+      }),
+      socketPath,
+      start: false,
+    });
+    await expect(second.daemon.start()).rejects.toMatchObject({
+      name: "DaemonAlreadyRunningError",
+    });
+    // The claim under test: the loser's own filesystem was never written to, because its
+    // `start()` threw before reaching `adminSecret.persist()`. `startDaemon()` (`main.ts`)
+    // never calls `stop()` on a `daemon.start()` rejection like this one either, so this
+    // asserts the state exactly as production leaves it, before any test-hygiene cleanup below.
+    await expect(loserFilesystem.readFile("/admin.token")).rejects.toThrow();
+
+    await second.daemon.stop("failed-start");
+    const client = await createClient(socketPath);
+    await hello(client);
+    await client.close();
   });
 
   it("gracefully stops by releasing held leases and persisting the final registry", async () => {
@@ -1845,6 +1905,11 @@ async function createHarness(
     readonly settle?: () => Promise<void>;
     readonly stateFilesystem?: MemoryFilesystem;
     readonly stopAuxiliary?: () => Promise<void>;
+    /** ADR 0003 §5's per-start admin secret (`AdminSecretManager`). Undefined by default, same
+     * as `DaemonServer`'s own default -- most of this suite doesn't exercise the credential
+     * handshake at all. A test that needs to observe `persist()`/`remove()` calls (or their
+     * absence -- see the "loses the start race" test) injects a spy here. */
+    readonly adminSecret?: AdminSecretManager;
     /** ADR 0003 §5's seam (see `session.ts`): defaults every session in this harness to
      * "admin" -- this suite predates roles and exercises every operation freely, the same
      * access a pre-ADR-0003 connection always had. Tests that specifically exercise role
@@ -1903,6 +1968,7 @@ async function createHarness(
     registry,
   });
   const daemon = new DaemonServer({
+    ...(options.adminSecret === undefined ? {} : { adminSecret: options.adminSecret }),
     capacity: engine,
     catalog: engine,
     clock,

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -36,7 +36,7 @@ import {
 } from "../contract/index.js";
 import type { ConnectionHost } from "./connection-host.js";
 import type { TokenStore } from "../http/token-store.js";
-import { Dispatcher, type DispatchSession } from "./dispatcher.js";
+import { Dispatcher, DispatchError, type DispatchSession } from "./dispatcher.js";
 import { resolveAgentRole, type SessionRoleResolver } from "./session.js";
 import type { AdminSecretManager } from "./admin-secret.js";
 import { OwnerRoutedFactBus, type OwnerRoutedFacts } from "./owner-routed-facts.js";
@@ -246,6 +246,18 @@ export class DaemonServer {
     input: unknown,
     session: DispatchSession,
   ): Promise<z.infer<(typeof OPERATIONS)[Op]["output"]>> {
+    // Mirrors the socket path's `#stopping` -> `DAEMON_STOPPING` gate in `#dispatchLine` (just
+    // above the `#stopping` check there), so every transport that calls this method -- not only
+    // the socket -- shares it. Without this, a caller that reaches the dispatcher directly (the
+    // HTTP gateway; review finding S5) could have a request accepted *during* `#stop()`'s
+    // window (after `stopAuxiliary()` has been awaited, but the auxiliary frontend's own
+    // in-flight request already parked past this check) run against an engine `#stop()` is
+    // concurrently tearing down or has already disposed. `daemon.stop` itself never reaches
+    // this method (`DaemonServer#dispatchLine` handles it directly, ahead of this gate, per
+    // ADR §6) so the frozen-exception behaviour is unaffected.
+    if (this.#stopping) {
+      return Promise.reject(new DispatchError("DAEMON_STOPPING", "Daemon is stopping"));
+    }
     return this.#dispatcher.dispatch(operation, input, session);
   }
 

--- a/src/daemon/session.test.ts
+++ b/src/daemon/session.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  AdminAuthenticationFailedError,
+  createCredentialRoleResolver,
+  resolveAgentRole,
+  type AdminCredentialVerifier,
+} from "./session.js";
+
+/**
+ * Regression coverage for review finding S1: `createCredentialRoleResolver` (ADR 0003 §5) was
+ * untested -- every role/ownership test in `server.test.ts` injects a *stubbed* `resolveRole`,
+ * so the real credential-checking logic (the resolver `main.ts` actually wires up against
+ * `TokenStore#verify` and `AdminSecretManager#verify`) had zero coverage. These tests exercise
+ * `createCredentialRoleResolver` directly against a scripted `AdminCredentialVerifier`, the
+ * narrow interface it depends on -- no real token store or admin secret needed.
+ */
+describe("createCredentialRoleResolver", () => {
+  function verifier(overrides: Partial<AdminCredentialVerifier> = {}): AdminCredentialVerifier {
+    return {
+      verifyOperatorToken: vi.fn().mockResolvedValue(false),
+      verifyAdminSecret: vi.fn().mockReturnValue(false),
+      ...overrides,
+    };
+  }
+
+  it("resolves agent, unconditionally, when hello carries no credential", async () => {
+    const verify = verifier({
+      // Neither should even be consulted with no credential to check -- see the "never calls
+      // either verifier" test below for the stronger assertion.
+      verifyOperatorToken: vi.fn().mockResolvedValue(true),
+      verifyAdminSecret: vi.fn().mockReturnValue(true),
+    });
+    const resolver = createCredentialRoleResolver(verify);
+
+    await expect(resolver.resolve({})).resolves.toBe("agent");
+    await expect(resolver.resolve({ principal: "someone" })).resolves.toBe("agent");
+  });
+
+  it("never calls either verifier when hello carries no credential", async () => {
+    const verifyOperatorToken = vi.fn().mockResolvedValue(false);
+    const verifyAdminSecret = vi.fn().mockReturnValue(false);
+    const resolver = createCredentialRoleResolver({ verifyOperatorToken, verifyAdminSecret });
+
+    await resolver.resolve({ principal: "someone" });
+
+    expect(verifyOperatorToken).not.toHaveBeenCalled();
+    expect(verifyAdminSecret).not.toHaveBeenCalled();
+  });
+
+  // ADR §5: "Two credentials are accepted, checked in this order: 1. An operator token ...
+  // 2. The per-start admin secret." Provable order, not just provable outcome: give both
+  // verifiers a way to record *when* they were called, and assert the operator check happened
+  // first.
+  it("checks the operator token store before the per-start admin secret", async () => {
+    const calls: string[] = [];
+    const resolver = createCredentialRoleResolver({
+      verifyOperatorToken: async (secret) => {
+        calls.push(`operator:${secret}`);
+        return false;
+      },
+      verifyAdminSecret: (secret) => {
+        calls.push(`admin-secret:${secret}`);
+        return true;
+      },
+    });
+
+    await expect(resolver.resolve({ credential: "slk_whatever" })).resolves.toBe("admin");
+
+    expect(calls).toEqual(["operator:slk_whatever", "admin-secret:slk_whatever"]);
+  });
+
+  it("resolves admin when only the operator token store accepts the credential", async () => {
+    const verifyAdminSecret = vi.fn().mockReturnValue(false);
+    const resolver = createCredentialRoleResolver({
+      verifyOperatorToken: async (secret) => secret === "slk_operator",
+      verifyAdminSecret,
+    });
+
+    await expect(resolver.resolve({ credential: "slk_operator" })).resolves.toBe("admin");
+    // Short-circuits: the admin-secret check never runs once the operator token store already
+    // accepted the credential.
+    expect(verifyAdminSecret).not.toHaveBeenCalled();
+  });
+
+  it("resolves admin when only the per-start admin secret accepts the credential", async () => {
+    const resolver = createCredentialRoleResolver({
+      verifyOperatorToken: async () => false,
+      verifyAdminSecret: (secret) => secret === "the-admin-secret",
+    });
+
+    await expect(resolver.resolve({ credential: "the-admin-secret" })).resolves.toBe("admin");
+  });
+
+  // The specific guarantee ADR §5/`session.ts`'s doc calls out: a bearer token that verifies
+  // but carries the "agent" role must never resolve to "admin" here -- `AdminCredentialVerifier`
+  // is deliberately typed so `verifyOperatorToken` can only ever answer "operator or not", never
+  // hand back a role, so this is really asserting the interface shape is honored by a verifier
+  // that mirrors what `TokenStore#verify` actually does (a token exists but isn't `operator`).
+  it("never resolves admin for a credential that verifies as a non-operator (agent-role) token", async () => {
+    const resolver = createCredentialRoleResolver({
+      // Mirrors `main.ts`'s real wiring: `(await tokens.verify(secret))?.role === "operator"` --
+      // a token that exists in the store but whose role isn't "operator" (an agent-role bearer
+      // token) answers false here, exactly like a credential with no matching token at all.
+      verifyOperatorToken: async () => false,
+      verifyAdminSecret: () => false,
+    });
+
+    await expect(resolver.resolve({ credential: "slk_agent_token" })).rejects.toThrow(
+      AdminAuthenticationFailedError,
+    );
+  });
+
+  it("throws AdminAuthenticationFailedError for a credential neither verifier accepts", async () => {
+    const resolver = createCredentialRoleResolver(verifier());
+
+    await expect(resolver.resolve({ credential: "not-a-real-secret" })).rejects.toThrow(
+      AdminAuthenticationFailedError,
+    );
+  });
+
+  it("never echoes the rejected credential in the thrown error's message", async () => {
+    const resolver = createCredentialRoleResolver(verifier());
+
+    await expect(resolver.resolve({ credential: "slk_super_secret_value" })).rejects.toThrow(
+      AdminAuthenticationFailedError,
+    );
+    try {
+      await resolver.resolve({ credential: "slk_super_secret_value" });
+      expect.unreachable("resolve should have thrown");
+    } catch (error: unknown) {
+      expect(String(error)).not.toContain("slk_super_secret_value");
+    }
+  });
+});
+
+describe("resolveAgentRole", () => {
+  it("resolves agent unconditionally, regardless of what hello sends", () => {
+    expect(resolveAgentRole.resolve({})).toBe("agent");
+    expect(resolveAgentRole.resolve({ credential: "anything", principal: "someone" })).toBe(
+      "agent",
+    );
+  });
+});


### PR DESCRIPTION
**Stacked on #104.** Two defects and two coverage holes from the adversarial review, plus a root-cause fix.

## `status.get` handed `driverData` to any agent, under a comment saying it could not

`status.get` is **agent**-role (ADR §3) but returned the full `deviceRecordSchema` — `driverData: z.unknown()`, which passes anything a driver puts there through verbatim, plus every `quarantine*`/`foreign*`/`recovering*` field. The schema's own comment asserted *"`list.get`/`status.get` (admin-only)"*, which is false. The earlier grant-projection fix closed this on `lease.request` while leaving a wider hole on an agent-reachable operation.

A new `statusDeviceSchema` keeps what `simlock status` actually renders — `id`, `spec`, `state`, the foreign-tamper markers, purge-retry progress, `transitionAgeMs` — and drops `driverData`, `driverDeviceId`, internal timestamps, and crash-recovery bookkeeping. The selection is deliberately conservative because `status.get` has **no ownership check**: it reports on every device, including ones other principals hold. `list.get` is admin-only and keeps the full record. The false comment is corrected and a regression test added.

## HTTP could provision a device on a disposed engine

In the stop-during-start window, `stopAuxiliary` returned having stopped nothing — breaking its own documented invariant — while `#stop()` went on to release leases, settle and dispose with the gateway possibly already listening. There was no compensating gate: the public `dispatch()` lacked the socket path's `#stopping` check. A request accepted in that window parked on readiness, resumed after convergence, and called `LeaseEngine.request` on a disposed engine — **booting a device with no owner and no daemon to reclaim it**, a `safety.md` concern rather than a lifecycle nit.

`stopAuxiliary` now awaits the gateway's start before stopping it, and `dispatch()` shares the `#stopping` → `DAEMON_STOPPING` gate. The regression test holds the race window open deterministically and was confirmed to fail against the pre-fix code and pass after, repeatedly, in both directions.

## Root cause: `start()` armed live machinery after a completed stop

Two separate fixes in this stack had already worked around this from the outside. `start()` did not re-check `#stopping` after convergence resolved, so it subscribed to a disposed bus, scheduled a heartbeat on a dead daemon, and emitted `daemon.started` *after* `daemon.stopping` — a fact untrue when emitted, which events rule 3 forbids. It now bails out. The outer guards stay correct and become redundant rather than wrong. Verified by stashing the fix and watching the new test fail.

## The authorization boundary had zero tests

`createCredentialRoleResolver` and the whole of `AdminSecretManager` were untested — every role test injected a **stubbed** resolver, so ADR §5's most important guarantees were unproven. Now covered: the check order (operator token, then per-start secret); that an `agent`-role token never resolves to `admin`; that the file is created `0600` **at creation** (asserted both by `stat()` and by spying the raw write call), not by a later `chmod`; that `verify()` never touches the filesystem (proved against an all-throwing stub); that the error never echoes the credential; and that a daemon losing the start race never writes the file.

Also added: dispatcher tests for `lease.release-all` and `nuke.run` — both admin-only and destructive, and previously invoked by **no test at all**, which sat against safety rules 1 and 5 — including agent-role rejection asserting nothing was released or deleted. Plus a `#parseOutput` failure-path test, the mechanism the whole "private types stay private" claim rests on.