### PR TITLE
fix(http,mcp,docs): one answer per operation across transports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,13 @@ breaking release for every frontend's wire vocabulary; see below.
 - **MCP:** tool names are unchanged, but every tool's input/output schema is
   now derived from the contract instead of hand-declared. Two field changes
   need every caller updated:
-  - `lease_simulator`'s `timeout_seconds` is now `timeoutMs` — **a unit
-    change, not just a rename.** A caller that keeps the old field name
-    under the new key silently waits 1000× too long before timing out; this
-    is the single highest-risk change in this release.
+  - `lease_simulator`'s `timeout_seconds` is now `timeoutMs`. The input
+    schema is `.strict()`, so a caller still sending the old key gets a
+    hard `BAD_REQUEST`, not a silent failure. The real hazard is a caller
+    that renames the field but not its value: `{"timeoutMs": 30}` meaning
+    "30 seconds" is valid input, and times out ~1000× _sooner_ than
+    intended (`QUEUE_TIMEOUT`, exit 10) rather than later — update the
+    field name **and** multiply the value by 1000.
   - The top-level `slim: boolean` on a grant is gone; it is now
     `device.featureProfile` (`"full" | "reduced" | undefined`). A caller
     still checking `result.slim === true` silently never sees a
@@ -40,9 +43,15 @@ breaking release for every frontend's wire vocabulary; see below.
   aliases and the nested `request` wrapper the pre-0.3.0 daemon accepted;
   an old client sending them now gets `BAD_REQUEST` instead of those keys
   silently vanishing.
-- **HTTP:** `GET /v1/leases/:id` (and `renew`/`events`/`DELETE` on the same
-  resource) now returns `404 UNKNOWN_LEASE` instead of `403 FORBIDDEN` for
-  another requester's lease — see `docs/HTTP-API.md#get-v1leasesid`.
+- **HTTP:** `GET /v1/leases/:id` and `GET /v1/leases/:id/events` now return
+  `404 UNKNOWN_LEASE` instead of `403 FORBIDDEN` for another requester's
+  still-live lease — there is no dispatcher operation for a single-lease
+  read to defer to, so both fall back to `lease.list`'s own filter, which
+  does not distinguish "unknown" from "not yours" either. `POST
+/v1/leases/:id/renew` and `DELETE /v1/leases/:id` dispatch
+  `lease.renew`/`lease.release` directly instead and keep answering `403
+FORBIDDEN` for the same case, matching the socket transport exactly — see
+  `docs/HTTP-API.md#get-v1leasesid`.
 - **`token create|list|revoke`** are now daemon operations (admin role) —
   the daemon is the sole owner of `tokens.json`. `config set` and
   `daemon logs` remain file operations.
@@ -64,6 +73,11 @@ breaking release for every frontend's wire vocabulary; see below.
 - **contract:** restrict `lease.cancel` to the calling principal (only
   admin may cancel on another principal's behalf).
 - **daemon:** require the admin role for `daemon.stop`.
+- **http:** `GET /v1/lease-requests/{id}` and friends now answer `404
+UNKNOWN_LEASE_REQUEST`, not `404 UNKNOWN_REQUEST` — the latter collided
+  with the contract's own `UNKNOWN_REQUEST` (a 400 protocol error for an
+  unrecognized operation name), so a client branching on `error.code` alone
+  could not tell "no such request id" from "no such operation".
 
 ### Features
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -787,7 +787,7 @@ download, since no download could make it work.
 Permission comes from `config.downloads.policy`, resolved once, in the
 daemon, before a request ever reaches the acquisition path: `"never"`
 forbids installs outright, even over an explicit `--allow-download` /
-`allow_download`; `"always"` grants it to every explicit lease request
+`allowDownload`; `"always"` grants it to every explicit lease request
 without the caller having to ask; `"on-request"` (the default) defers to
 the request's own flag, which is today's behavior byte-for-byte. Only an
 explicit lease request (`LeaseEngine#request`) can carry download

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -285,13 +285,20 @@ HTTP, and `simlock/client`, not a fourth one. Two changes in here are easy
 to miss and will silently produce wrong behavior if you don't update a
 caller:
 
-- **`lease_simulator`'s `timeout_seconds` is now `timeoutMs` — a unit
-  change, not just a rename.** A caller that keeps sending the old field
-  name under the new one (`{"timeoutMs": 30}` meaning "30 seconds", the old
-  convention) waits 1000× longer than intended before timing out. This is
-  the single highest-risk change in this release — it does not fail loudly,
-  it just waits far too long. Update every caller's timeout field name *and*
-  multiply its value by 1000.
+- **`lease_simulator`'s `timeout_seconds` is now `timeoutMs`.** This is a
+  rename, not a silent unit change: every tool input schema is
+  `.strict()` (`src/contract/operations.ts`), so a caller that keeps
+  sending the old `timeout_seconds` key gets a hard `BAD_REQUEST` — loud,
+  immediate, and impossible to miss. The real, narrower hazard is a caller
+  that migrates the field *name* but not its *value*: sending
+  `{"timeoutMs": 30}` meaning "30 seconds" (the old convention) is valid
+  input, so nothing rejects it — the request just times out in 30
+  milliseconds instead of 30 seconds, roughly 1000× *sooner* than intended,
+  not longer. That surfaces immediately as `QUEUE_TIMEOUT` (CLI exit code
+  10), not as a silent hang, but it can still read as "the daemon is
+  broken" rather than "my timeout value is three orders of magnitude too
+  small" unless you know to check the unit. Update every caller's timeout
+  field name *and* multiply its value by 1000.
 - **The top-level `slim: boolean` on a grant is gone; it's now
   `device.featureProfile`** (`"full" | "reduced" | undefined`, undefined
   meaning "not applicable" — always undefined for Android). A caller

--- a/docs/HTTP-API.md
+++ b/docs/HTTP-API.md
@@ -167,7 +167,7 @@ Role: `agent` (ownership as above). Cancel a pending request.
 → `204` if it was still cancellable (no device work claimed for it yet).
 `409 REQUEST_NOT_CANCELLABLE` once device work is in flight, or the request
 already reached a terminal state — the body names the lease id if it was
-`granted` (release that instead). `404 UNKNOWN_REQUEST` if unknown.
+`granted` (release that instead). `404 UNKNOWN_LEASE_REQUEST` if unknown.
 
 ### The lease object
 
@@ -198,15 +198,25 @@ as a bug.
 
 Role: `agent` (own lease; `operator` any). Re-fetches the lease — a client
 that restarts mid-lease recovers its state instead of leaking the lease.
-`404 UNKNOWN_LEASE` once it has expired or been released, **and now also for
-another requester's own, still-live lease** (bug fix, 0.3.0: this used to be
-`403 FORBIDDEN`, which told an unauthorized caller a lease id was valid).
-Every route under `/v1/leases/{id}` (this one, `renew`, `events`, `DELETE`)
-resolves the lease the same way `lease.list`'s dispatcher handler already
-filters leases — to the session's own set, admin sees all — so an id outside
-that set simply isn't in the list; `404` covers "doesn't exist" and "not
-yours" identically, the same way `lease.list` itself does not distinguish
-them. This is different from the lease-*request* routes below
+`404 UNKNOWN_LEASE` both once it has expired or been released, and for
+another requester's own, still-live lease: this route (and `GET
+/v1/leases/{id}/events` below) has no dispatcher operation to defer to for a
+single-lease read, so it resolves the lease the same way `lease.list`'s
+handler already filters leases — to the session's own set, admin sees all —
+and an id outside that set simply isn't in the list. `404` covers "doesn't
+exist" and "not yours" identically, the same way `lease.list` itself does
+not distinguish them.
+
+`POST /v1/leases/{id}/renew` and `DELETE /v1/leases/{id}` are different:
+both dispatch `lease.renew`/`lease.release` directly, so another requester's
+own, still-live lease answers `403 FORBIDDEN` from those two routes — the
+same answer the socket transport gives, via the same operation's `ownsLease`
+authorize hook. (0.3.0 briefly had all four routes answering `404` here;
+that overcorrected the lease-*request* routes' old `403` and is why renew
+and release were moved off the `lease.list`-filtered lookup — see
+`docs/known-pitfalls.md`.)
+
+This is different again from the lease-*request* routes below
 (`/v1/lease-requests/{id}` and friends), which are still HTTP's own resource
 and still answer `403 FORBIDDEN` for another requester's request — that
 envelope stays HTTP-specific until
@@ -270,8 +280,8 @@ Every failure is the same shape the daemon protocol uses:
 |---|---|
 | 400 | `BAD_REQUEST` (malformed body, bad query param, validation) |
 | 401 | `UNAUTHENTICATED` (missing or unrecognized token) |
-| 403 | `FORBIDDEN` (role doesn't permit the route; or a `/v1/lease-requests/*` route whose request belongs to another requester) |
-| 404 | `UNKNOWN_REQUEST` (unknown request id), `UNKNOWN_LEASE` (unknown lease id, expired/released, **or a `/v1/leases/*` route naming another requester's lease** — see [`GET /v1/leases/{id}`](#get-v1leasesid)) |
+| 403 | `FORBIDDEN` (role doesn't permit the route; a `/v1/lease-requests/*` route whose request belongs to another requester; or `POST /v1/leases/{id}/renew`/`DELETE /v1/leases/{id}` naming another requester's still-live lease) |
+| 404 | `UNKNOWN_LEASE_REQUEST` (unknown request id), `UNKNOWN_LEASE` (unknown lease id, expired/released, **or `GET /v1/leases/{id}`/`GET /v1/leases/{id}/events` naming another requester's lease** — see [`GET /v1/leases/{id}`](#get-v1leasesid)) |
 | 409 | `REQUESTER_ALREADY_LEASED` (body names the existing lease id), `REQUEST_NOT_CANCELLABLE` (body names the lease id if the request had already been granted) |
 | 422 | `UNKNOWN_MODEL`, `RUNTIME_MISSING`, `NO_DRIVER` |
 | 503 | `NO_CAPACITY` (only with `noWait: true`; response carries `Retry-After`) |
@@ -280,7 +290,7 @@ Every failure is the same shape the daemon protocol uses:
 
 - **Daemon restart.** In-flight lease requests are in-memory and do not
   survive, same as the socket protocol's queue today. A client polling a
-  request id from before the restart gets `404 UNKNOWN_REQUEST`; if its
+  request id from before the restart gets `404 UNKNOWN_LEASE_REQUEST`; if its
   grant had actually landed before the crash, the persisted detached lease
   answers a retried `POST` with `409 REQUESTER_ALREADY_LEASED` naming the
   lease id, which the client then `GET`s to recover its state. This is the

--- a/docs/agent-rules/safety.md
+++ b/docs/agent-rules/safety.md
@@ -27,7 +27,7 @@ never enforce them only inside an individual rule or driver.
    over a read-only registry view returning proposed actions. A rule that
    executes side effects directly is a bug regardless of what it does.
 4. **No implicit multi-GB downloads.** Missing runtimes / system images fail
-   the request unless `--allow-download` (or MCP's `allow_download`) was
+   the request unless `--allow-download` (or MCP's `allowDownload`) was
    explicitly passed, or `downloads.policy: "always"` is set in config --
    both count as the required explicit consent, and `downloads.policy:
    "never"` overrides either one back to forbidden. Warm-pool provisioning

--- a/docs/known-pitfalls.md
+++ b/docs/known-pitfalls.md
@@ -218,6 +218,76 @@ HTTP alone tracks. Once that lands, `LeaseRequestTracker` and
 `LeaseNoticeBuffer` should be able to shrink to thin views over core state
 rather than independent bookkeeping.
 
+## HTTP single-lease reads answer 404, not 403, for an unowned lease
+
+`GET /v1/leases/:id` and `GET /v1/leases/:id/events` resolve their lease
+through `findOwnedLease` (`src/http/app.ts`), which calls `lease.list` and
+filters to the id in question. `lease.list`'s own scoping (own leases; admin
+sees all) means an id owned by a different agent simply is not in the list —
+indistinguishable, at that point, from an id that does not exist at all. Both
+answer `UNKNOWN_LEASE`/404.
+
+Over the socket there is no equivalent read: `lease.list` is the only
+operation that can answer "what does this session see", and it does not
+distinguish "unknown" from "not yours" either — it just omits the row. So
+these two routes are not actually diverging from a socket answer; there is no
+`lease.get` operation with an `ownsLease` authorize hook to diverge from.
+
+This is deliberately narrower than the fix applied to the two *mutating*
+single-lease routes, `POST /v1/leases/:id/renew` and `DELETE /v1/leases/:id`,
+which used to go through the same `findOwnedLease` helper and therefore used
+to answer 404 for an unowned lease where the socket's `lease.renew`/
+`lease.release` (via their `ownsLease` authorize hook) answer `FORBIDDEN`/403.
+Those two routes now dispatch directly and let the shared error table answer,
+matching the socket exactly. The two read routes above were left on
+`lease.list`-filtered 404 because there is no dispatcher operation for them to
+match — 404-as-anti-enumeration is the *table's* answer here too, just via
+`lease.list`'s own filter rather than a per-op `authorize` hook.
+
+**If a `lease.get` operation with an `ownsLease` hook is ever added to the
+contract**, these two routes should move onto it and start answering 403 for
+an unowned lease, the same way the mutating routes do today.
+
+## HTTP error codes outside the closed contract union
+
+ADR §7: `SimlockError` has a `code` from the contract's closed union, and "a code the client
+does not know... wraps as `UNKNOWN_DAEMON_ERROR`". Four codes the HTTP gateway answers with
+today (`src/http/errors.ts`) have no row in that union
+(`src/contract/errors.ts`'s `ERROR_TABLE`), so a typed client built against the contract can
+only ever see them as `UNKNOWN_DAEMON_ERROR` with the real code buried in `details`:
+
+| Code | Status | Meaning | Where thrown |
+|---|---|---|---|
+| `UNAUTHENTICATED` | 401 | Missing/invalid bearer token | `errors.ts:37` |
+| `UNKNOWN_LEASE_REQUEST` | 404 | No such lease-*request* resource (`POST /v1/lease-requests`'s HTTP-only envelope, ADR §11, kept until #72) | `errors.ts:59` |
+| `REQUEST_NOT_CANCELLABLE` | 409 | `DELETE /v1/lease-requests/:id` on a request already granted or past cancellable state | `errors.ts:70` |
+| `REQUEST_CANCELLED` | 500 | Defensive-only: `RequestCancelledError` reaching `mapError` should never happen in practice (the tracker consumes it internally) | `errors.ts:123` |
+
+`UNKNOWN_LEASE_REQUEST` used to be minted as `UNKNOWN_REQUEST` — the same code the contract
+already declares, but for a different meaning at a different status: the contract's
+`UNKNOWN_REQUEST` is a *protocol* error ("unknown operation name") at 400, thrown by
+`DispatchError` in `src/daemon/dispatcher.ts` for a request naming an operation the dispatcher
+has no handler for. Reusing it for "no such lease-request id" at 404 meant a client branching
+on `error.code` alone could not distinguish the two (S8, adversarial review). Renamed to
+`UNKNOWN_LEASE_REQUEST` so it no longer collides, but that only fixes the collision — it does
+not add a contract row, so it still wraps as `UNKNOWN_DAEMON_ERROR` for a typed client.
+
+**What the contract needs** (out of scope here — `src/contract/` is owned elsewhere): four new
+rows in `ERROR_TABLE` (`src/contract/errors.ts`), each with a `kind` and the `httpStatus`/
+`cliExitCode` columns this table already has for every other code:
+
+```ts
+UNAUTHENTICATED: Record<string, never>;             // kind: "protocol", httpStatus: 401
+UNKNOWN_LEASE_REQUEST: Record<string, never>;        // kind: "domain",   httpStatus: 404
+REQUEST_NOT_CANCELLABLE: { readonly leaseId?: string }; // kind: "domain", httpStatus: 409
+REQUEST_CANCELLED: Record<string, never>;            // kind: "domain",   httpStatus: 500
+```
+
+Once those exist, `src/http/errors.ts` should stop constructing ad hoc `HttpApiError`s for
+these four and instead go through the same `ERROR_TABLE`-driven path `mapError` already uses
+for every contract-declared code, the same way `UNKNOWN_LEASE`/`FORBIDDEN`/`BAD_REQUEST` do
+today.
+
 ## iOS slim mode: accepted costs and feature loss (#87)
 
 `ios.slim` (opt-in, default off) has the iOS driver disable ~170 launchd

--- a/src/http/app.test.ts
+++ b/src/http/app.test.ts
@@ -6,6 +6,7 @@ import {
   LicenseNotAcceptedError,
   NoCapacityError,
   RequesterAlreadyLeasedError,
+  UnknownLeaseError,
 } from "../core/index.js";
 import { DispatchError, DoctorUnavailableError } from "../daemon/dispatcher.js";
 import { StartupFailedError } from "../daemon/error-code.js";
@@ -607,12 +608,33 @@ describe("lease routes", () => {
   });
 
   it("404s a renew for an unknown lease", async () => {
-    const { app } = buildHarness();
+    const { app, dispatcher } = buildHarness();
+    dispatcher.handlers["lease.renew"] = () => {
+      throw new UnknownLeaseError("lse-missing");
+    };
+
     const response = await app.request("/v1/leases/lse-missing/renew", {
       headers: agentAuth,
       method: "POST",
     });
     expect(response.status).toBe(404);
+    expect(((await response.json()) as { error: { code: string } }).error.code).toBe(
+      "UNKNOWN_LEASE",
+    );
+  });
+
+  it("403s a renew for another requester's still-live lease -- dispatched directly through lease.renew's own ownsLease hook, not lease.list's 404-for-everything filter (S6)", async () => {
+    const { app, dispatcher } = buildHarness();
+    dispatcher.handlers["lease.renew"] = () => {
+      throw new DispatchError("FORBIDDEN", "Not authorized for lease.renew");
+    };
+
+    const response = await app.request("/v1/leases/lse_other/renew", {
+      headers: agentAuth,
+      method: "POST",
+    });
+    expect(response.status).toBe(403);
+    expect(((await response.json()) as { error: { code: string } }).error.code).toBe("FORBIDDEN");
   });
 
   it("streams live lease notices over SSE, ending on lease_lost -- fed by the owner-routed fact bus, not a direct eventBus subscription", async () => {
@@ -675,6 +697,36 @@ describe("lease routes", () => {
       method: "DELETE",
     });
     expect(response.status).toBe(202);
+  });
+
+  it("404s a release for an unknown lease", async () => {
+    const { app, dispatcher } = buildHarness();
+    dispatcher.handlers["lease.release"] = () => {
+      throw new UnknownLeaseError("lse-missing");
+    };
+
+    const response = await app.request("/v1/leases/lse-missing", {
+      headers: agentAuth,
+      method: "DELETE",
+    });
+    expect(response.status).toBe(404);
+    expect(((await response.json()) as { error: { code: string } }).error.code).toBe(
+      "UNKNOWN_LEASE",
+    );
+  });
+
+  it("403s a release of another requester's still-live lease -- dispatched directly through lease.release's own ownsLease hook, not lease.list's 404-for-everything filter (S6)", async () => {
+    const { app, dispatcher } = buildHarness();
+    dispatcher.handlers["lease.release"] = () => {
+      throw new DispatchError("FORBIDDEN", "Not authorized for lease.release");
+    };
+
+    const response = await app.request("/v1/leases/lse_other", {
+      headers: agentAuth,
+      method: "DELETE",
+    });
+    expect(response.status).toBe(403);
+    expect(((await response.json()) as { error: { code: string } }).error.code).toBe("FORBIDDEN");
   });
 });
 

--- a/src/http/app.ts
+++ b/src/http/app.ts
@@ -111,12 +111,12 @@ export function createHttpApp(deps: HttpGatewayDeps): Hono<Env> & HttpAppDisposa
   const notices = new LeaseNoticeBuffer(deps.ownerRoutedFacts);
   // Replaces the tracker's own former direct `eventBus.subscribe("lease.released"/"lease.expired",
   // ...)` -- ADR §8's "consumes the owner-routed facts" applies here too, not just to `notices`.
-  const unsubscribeLeaseBookkeeping = deps.eventBus.subscribe("lease.released", (envelope) =>
-    tracker.forgetLease(envelope.payload.leaseId),
-  );
-  const unsubscribeExpiryBookkeeping = deps.eventBus.subscribe("lease.expired", (envelope) =>
-    tracker.forgetLease(envelope.payload.leaseId),
-  );
+  // `OwnerRoutedFactBus` already folds both events into a `lease-lost` fact carrying the lease
+  // id (`src/daemon/owner-routed-facts.ts`), so this is one subscription to that seam rather
+  // than two direct subscriptions to the raw bus.
+  const unsubscribeLeaseBookkeeping = deps.ownerRoutedFacts.subscribe((fact) => {
+    if (fact.type === "lease-lost") tracker.forgetLease(fact.leaseId);
+  });
 
   const agentAuth = requireAuth(deps.tokens);
 
@@ -279,20 +279,23 @@ export function createHttpApp(deps: HttpGatewayDeps): Hono<Env> & HttpAppDisposa
   app.post("/v1/leases/:id/renew", agentAuth, async (c) => {
     const identity = c.get("identity");
     const session = buildHttpSession(identity);
-    const current = await findOwnedLease(deps, session, c.req.param("id"));
-    const id = current.id;
+    const id = c.req.param("id");
 
     const ttlMs = await parseRenewBody(c);
     if (ttlMs !== undefined && (!Number.isFinite(ttlMs) || ttlMs <= 0)) {
       throw badRequest("ttlMs must be a positive number");
     }
 
+    // Dispatched directly (not via `findOwnedLease`/`lease.list`) so `lease.renew`'s own
+    // `ownsLease` authorize hook answers -- an unowned lease is `FORBIDDEN`/403, matching the
+    // socket transport, rather than the `UNKNOWN_LEASE`/404 a `lease.list` filter would produce
+    // (S6). An unknown id still surfaces as `UNKNOWN_LEASE`/404 from the handler itself.
     const renewed = await deps.dispatch(
       "lease.renew",
       { leaseId: id, ...(ttlMs === undefined ? {} : { ttlMs }) },
       session,
     );
-    tracker.recordLeaseTtl(id, ttlMs ?? modeDefaultTtlMs(current, deps.config));
+    tracker.recordLeaseTtl(id, ttlMs ?? modeDefaultTtlMs(renewed, deps.config));
 
     return c.json({
       expiresAt: new Date(renewed.ttlDeadline).toISOString(),
@@ -318,13 +321,23 @@ export function createHttpApp(deps: HttpGatewayDeps): Hono<Env> & HttpAppDisposa
   app.delete("/v1/leases/:id", agentAuth, async (c) => {
     const identity = c.get("identity");
     const session = buildHttpSession(identity);
-    const lease = await findOwnedLease(deps, session, c.req.param("id"));
+    const id = c.req.param("id");
 
-    await deps.dispatch("lease.release", { leaseId: lease.id }, session);
+    // Best-effort lookup, only to decorate the response with the device id/state --
+    // `lease.release`'s output schema is `{ leaseId }` alone (no `deviceId`), so this is still
+    // needed for the response body. It is *not* the authorization decision: `lease.release`
+    // below is dispatched directly and is the sole source of truth for whether this request is
+    // allowed (S6). Its `ownsLease` hook answers `FORBIDDEN`/403 for someone else's lease and
+    // the handler answers `UNKNOWN_LEASE`/404 for a nonexistent one, matching the socket
+    // transport exactly -- unlike the `lease.list`-filtered `findOwnedLease`, which always
+    // answered 404 for both cases.
+    const deviceId = await findLeaseDeviceId(deps, session, id);
 
-    const device = findDevice(deps, lease.deviceId);
+    await deps.dispatch("lease.release", { leaseId: id }, session);
+
+    const device = deviceId === undefined ? undefined : findDevice(deps, deviceId);
     return c.json(
-      { device: { id: lease.deviceId, state: device?.state ?? "reclaiming" }, released: true },
+      { device: { id: deviceId ?? id, state: device?.state ?? "reclaiming" }, released: true },
       202,
     );
   });
@@ -391,7 +404,6 @@ export function createHttpApp(deps: HttpGatewayDeps): Hono<Env> & HttpAppDisposa
   return Object.assign(app, {
     dispose: () => {
       unsubscribeLeaseBookkeeping();
-      unsubscribeExpiryBookkeeping();
       tracker.dispose();
       notices.dispose();
     },
@@ -408,10 +420,15 @@ function requireOwnRequest(identity: TokenIdentity, requesterId: string): void {
   throw forbidden("Not permitted to access another requester's resource");
 }
 
-/** `lease.list`'s dispatcher handler already filters to the session's own leases (admin sees
- * all) -- reusing it here for a single-lease lookup means an unauthorized id simply isn't in
- * the list, so `unknownLease` covers both "doesn't exist" and "not yours" the same way
- * `lease.list` itself does not distinguish them. */
+/** Read-only single-lease lookup for `GET /v1/leases/:id` and `GET /v1/leases/:id/events`.
+ * There is no `lease.get` operation in the contract -- only `lease.renew`/`lease.release`
+ * carry an `ownsLease` authorize hook to compare against -- so these two routes stay on
+ * `lease.list`'s own filter (own leases; admin sees all): an unauthorized id simply isn't in
+ * the list, and `unknownLease` covers both "doesn't exist" and "not yours" the same way
+ * `lease.list` itself does not distinguish them, at 404. This is a deliberate, narrower
+ * divergence than the one S6 fixed for the mutating routes below -- see
+ * `docs/known-pitfalls.md` ("HTTP single-lease reads answer 404, not 403, for an unowned
+ * lease"). */
 async function findOwnedLease(
   deps: HttpGatewayDeps,
   session: ReturnType<typeof buildHttpSession>,
@@ -421,6 +438,19 @@ async function findOwnedLease(
   const lease = leases.find((candidate) => candidate.id === id);
   if (lease === undefined) throw unknownLease(id);
   return lease;
+}
+
+/** Best-effort `deviceId` lookup for a lease id, scoped to what the session's `lease.list`
+ * would show it (own leases; admin sees all) -- used only to decorate a response after an
+ * authoritative dispatch has already decided whether the request is allowed. Never used to
+ * gate access itself (see the `DELETE /v1/leases/:id` route). */
+async function findLeaseDeviceId(
+  deps: HttpGatewayDeps,
+  session: ReturnType<typeof buildHttpSession>,
+  id: string,
+): Promise<string | undefined> {
+  const { leases } = await deps.dispatch("lease.list", {}, session);
+  return leases.find((candidate) => candidate.id === id)?.deviceId;
 }
 
 function serializeRequest(

--- a/src/http/errors.ts
+++ b/src/http/errors.ts
@@ -12,6 +12,14 @@ export type HttpStatus = 400 | 401 | 403 | 404 | 409 | 422 | 500 | 503;
  * Uniform `{status, code}` pair a route or middleware raises directly (auth, ownership,
  * validation, not-found on gateway-owned resources like lease requests). Thrown core errors
  * are mapped separately by `mapError` -- this class is for facts only the HTTP layer knows.
+ *
+ * `UNAUTHENTICATED`, `UNKNOWN_LEASE_REQUEST`, `REQUEST_NOT_CANCELLABLE`, and
+ * `REQUEST_CANCELLED` (below) are gateway-local codes with no row in the contract's closed
+ * `SimlockErrorCode` union (`src/contract/errors.ts`) -- ADR §7's "a code the client does not
+ * know wraps as `UNKNOWN_DAEMON_ERROR`" applies here: a typed client built against the contract
+ * cannot narrow on any of these four today, only on the raw string inside
+ * `UNKNOWN_DAEMON_ERROR`'s `details`. See `docs/known-pitfalls.md` ("HTTP error codes outside
+ * the closed contract union") for the exact rows this needs.
  */
 export class HttpApiError extends Error {
   constructor(
@@ -37,8 +45,18 @@ export function badRequest(message: string): HttpApiError {
   return new HttpApiError(400, "BAD_REQUEST", message);
 }
 
+/** Gateway-local code for "no such lease-*request* resource" (`POST /v1/lease-requests`, ADR
+ * §11's HTTP-only envelope kept until #72). Deliberately **not** `UNKNOWN_REQUEST` -- that code
+ * is the contract's (`src/contract/errors.ts`), meaning "unknown operation name" at 400
+ * (`DispatchError` in `dispatcher.ts`, thrown for a request naming an operation the dispatcher
+ * has no handler for). Reusing it here for a different resource at a different status (404)
+ * meant a client branching on `error.code` alone could not tell "no such request id" from "no
+ * such operation" -- ADR §7 makes codes contract, not message text (S8). `UNKNOWN_LEASE_REQUEST`
+ * is outside the contract's closed union like `UNAUTHENTICATED`/`REQUEST_NOT_CANCELLABLE`/
+ * `REQUEST_CANCELLED` below; see `docs/known-pitfalls.md` for what a closed-union fix would
+ * need. */
 export function unknownRequest(id: string): HttpApiError {
-  return new HttpApiError(404, "UNKNOWN_REQUEST", `Unknown lease request: ${id}`);
+  return new HttpApiError(404, "UNKNOWN_LEASE_REQUEST", `Unknown lease request: ${id}`);
 }
 
 export function unknownLease(id: string): HttpApiError {

--- a/src/http/tracker.ts
+++ b/src/http/tracker.ts
@@ -344,9 +344,8 @@ export class LeaseRequestTracker {
   }
 
   /** Drops the tracked ttl/request-id bookkeeping for a lease that just ended -- called from the
-   * HTTP app on the same owner-routed fact stream `LeaseNoticeBuffer` consumes, replacing the
-   * direct `eventBus.subscribe("lease.released"/"lease.expired", ...)` this class used to do
-   * itself. */
+   * HTTP app on the same owner-routed fact stream (`OwnerRoutedFacts`, `lease-lost`)
+   * `LeaseNoticeBuffer` consumes, not from a direct `eventBus.subscribe` on this class. */
   forgetLease(leaseId: string): void {
     this.#leaseRequestId.delete(leaseId);
     this.#leaseTtlMs.delete(leaseId);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -100,7 +100,7 @@ export function createMcpServer(session: McpSession): McpServer {
     {
       title: "Lease simulator",
       description:
-        "Lease one simulator or emulator for this MCP session. The lease is held until released or this MCP connection closes; provisioning can block unless no_wait is true. Downloads are disabled by default and require allow_download: true.",
+        "Lease one simulator or emulator for this MCP session. The lease is held until released or this MCP connection closes; provisioning can block unless noWait is true. Downloads are disabled by default and require allowDownload: true.",
       inputSchema: leaseSimulatorInputSchema,
       outputSchema: leaseSimulatorOutputSchema,
     },


### PR DESCRIPTION
**Stacked on #105.** Five findings from the adversarial review.

## Four routes answered 404 where the shared table says 403

Agent A owns `lse_1`; agent B's token calling `POST /v1/leases/lse_1/renew` got **404 `UNKNOWN_LEASE`**, while the same act over the socket ran `lease.renew`'s `ownsLease` hook and answered **403 `FORBIDDEN`**. One operation, two answers depending on transport — the divergence §2 and §7 exist to delete. The gateway was internally inconsistent too, answering 403 for the analogous act on a lease-*request* resource.

`POST /v1/leases/:id/renew` and `DELETE /v1/leases/:id` now dispatch the operation directly and let the hook answer, which also drops an extra `lease.list` round-trip. `GET /v1/leases/:id` and its events route stay on the filtered lookup because there is no `lease.get` operation with an ownership hook to defer to — that divergence is now **recorded explicitly in `known-pitfalls.md`** rather than left implicit.

## The HTTP app subscribed to the raw event bus under a comment saying it did not

The comment claimed the tracker's direct `eventBus.subscribe` had been replaced by owner-routed facts; it had merely been **relocated** from `tracker.ts` into `app.ts`, and `tracker.ts` repeated the false claim. A frontend mutating its own state off raw bus events instead of the daemon-owned fact seam is `architecture.md` rule 5. It now consumes `ownerRoutedFacts`, which already emits both facts. The `/v1/events/stream` relay is a genuine observer and is untouched.

## `UNKNOWN_REQUEST` meant two different things at two statuses

The gateway minted it at 404 for an unknown lease-request resource while the contract declares it a protocol error at 400 for an unknown operation name — so a client branching on `error.code` could not tell them apart, though §7 makes codes the contract. The gateway's code is now `UNKNOWN_LEASE_REQUEST`. It, `UNAUTHENTICATED`, `REQUEST_NOT_CANCELLABLE` and `REQUEST_CANCELLED` remain outside the closed union (a typed client wraps them as `UNKNOWN_DAEMON_ERROR`); the exact `ERROR_TABLE` rows needed are specified in `known-pitfalls.md`.

## MCP's tool description advertised deleted fields

`lease_simulator` still told the model to send `no_wait` and `allow_download`, while the schema is the contract's `.strict()` camelCase one — so a model following the description got a hard rejection, and one whose `no_wait` was rejected might retry without it and **block** instead of failing fast. Fixed, along with two stale `allow_download` mentions in `ARCHITECTURE.md` and `agent-rules/safety.md`.

## The release's headline migration note was wrong in both directions

**This corrects the framing across the docs and CHANGELOG.** `timeout_seconds` → `timeoutMs` is **not** a silent 1000× unit change: verified against `leaseRequestInputSchema`, the input is `.strict()`, so an unmigrated caller gets a hard `BAD_REQUEST`. And `CLI.md` described the symptom backwards — a seconds-valued `timeoutMs` times out ~1000× *sooner*, surfacing as `QUEUE_TIMEOUT` (exit 10), not later and silently. The real hazard is narrower: a caller that migrates the field *name* while keeping a seconds-valued number. Documented as that.

## Note

Removing the ownership pre-check exposed an existing `app.test.ts` case that **hung forever** — the fake dispatcher had no `lease.renew` handler, so a route no longer short-circuited by `lease.list` never got an answer. Fixed, with four new tests covering 404-vs-403 for both renew and release.