### PR TITLE
fix(daemon): reject instead of hanging when the socket claim loses the race

### DIFF
--- a/src/daemon/main.test.ts
+++ b/src/daemon/main.test.ts
@@ -324,6 +324,58 @@ describe("startDaemon HTTP gateway stop-during-start race (review finding S5)", 
   });
 });
 
+describe("startDaemon socket race with HTTP enabled", () => {
+  // Review finding V1: `gatewayStarted` is settled only from inside `onSocketClaimed`'s
+  // handler, and `start()` fires that callback only after the socket claim succeeds. A daemon
+  // that loses the start race therefore rejected without the callback ever running, so nothing
+  // settled `gatewayStarted` and `Promise.allSettled` waited on it forever -- `startDaemon()`
+  // hung instead of reporting the lost race, with no rejection and no non-zero exit code.
+  // Reachable by racing `simlock daemon start`, or by the CLI's own auto-launch.
+  it("rejects rather than hanging when the socket is already claimed", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "simlock-main-socket-race-"));
+    temporaryDirectories.push(directory);
+    const filesystem = new MemoryFilesystem();
+    const statePath = join(directory, "state.json");
+    const options = (port: number): StartDaemonOptions =>
+      ({
+        clock: new FakeClock(1_000),
+        configOverrides: { http: { enabled: true, host: "127.0.0.1", port } },
+        dataDirectory: directory,
+        drivers: [
+          new FakeDriver({
+            availableOsVersions: ["26.5"],
+            clock: new FakeClock(1_000),
+            platform: "ios",
+          }),
+        ],
+        filesystem,
+        logger: new JsonLinesLogger({
+          clock: new FakeClock(1_000),
+          level: "debug",
+          sink: new MemoryLogSink(),
+        }),
+        statePath,
+        version: "1.2.3",
+      }) as StartDaemonOptions;
+
+    const first = await startDaemon(options(47_013));
+    try {
+      // A distinct port, so the only thing that can fail is the socket claim itself.
+      const second = startDaemon(options(47_014));
+      const outcome = await Promise.race([
+        second.then(
+          () => "resolved" as const,
+          () => "rejected" as const,
+        ),
+        new Promise<"hung">((resolve) => setTimeout(() => resolve("hung"), 3_000)),
+      ]);
+      expect(outcome).toBe("rejected");
+    } finally {
+      await first.stop("test-cleanup").catch(() => undefined);
+    }
+  });
+});
+
 describe("startDaemon HTTP gateway bind failure", () => {
   // Review finding B6: before this fix, an HTTP bind failure (occupied port) logged and
   // stopped the daemon from inside `onSocketClaimed`'s handler without `startDaemon()` itself

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -191,6 +191,9 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
   // wait for, so this resolves immediately.
   let resolveGatewayStarted: (() => void) | undefined;
   let rejectGatewayStarted: ((error: unknown) => void) | undefined;
+  /** Whether `onSocketClaimed` ever fired, i.e. whether anything will ever settle
+   * `gatewayStarted`. See the `finally` on `daemon.start()` below. */
+  let socketClaimed = false;
   const gatewayStarted: Promise<void> = config.http.enabled
     ? new Promise<void>((resolve, reject) => {
         resolveGatewayStarted = resolve;
@@ -263,6 +266,7 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
     ...(config.http.enabled
       ? {
           onSocketClaimed: () => {
+            socketClaimed = true;
             void startHttpGateway().then(
               () => resolveGatewayStarted?.(),
               (error: unknown) => {
@@ -309,7 +313,17 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
   // finishes starting or fails to. Both are already running concurrently by the time this line
   // is reached (the gateway since `onSocketClaimed` fired partway through `daemon.start()`), so
   // this changes nothing about when either finishes -- only what `startDaemon()` itself reports.
-  const [daemonResult, gatewayResult] = await Promise.allSettled([daemon.start(), gatewayStarted]);
+  // `gatewayStarted` is settled only from inside `onSocketClaimed`'s handler, and `start()`
+  // fires that callback only once the socket claim (and the admin-secret write) has succeeded.
+  // A daemon that loses the start race therefore rejects without the callback ever running, so
+  // nothing would settle `gatewayStarted` and the join below would hang forever rather than
+  // reporting the failure. Release it here on that path -- resolving an already-settled promise
+  // is a no-op, so this cannot pre-empt a real bind result, and the `socketClaimed` guard keeps
+  // it from resolving early while a claimed daemon's gateway is still binding.
+  const daemonStarted = daemon.start().finally(() => {
+    if (!socketClaimed) resolveGatewayStarted?.();
+  });
+  const [daemonResult, gatewayResult] = await Promise.allSettled([daemonStarted, gatewayStarted]);
   if (gatewayResult.status === "rejected" && daemonResult.status === "fulfilled") {
     // The daemon itself came all the way up -- convergence succeeded, `daemon.started` was
     // already emitted -- but its HTTP gateway never bound. Tear the whole thing down now,


### PR DESCRIPTION
**Stacked on #107.** A regression this stack introduced, caught by a verification pass over the earlier fixes.

`gatewayStarted` is settled only from inside `onSocketClaimed`'s handler, and `DaemonServer.start()` fires that callback only once the socket claim **and** the admin-secret write have succeeded. So a daemon that loses the start race rejects with `DaemonAlreadyRunningError` without the callback ever running — nothing settles `gatewayStarted`, and the `Promise.allSettled` join added by the bind-failure fix waits on it **forever**.

`startDaemon()` therefore hung: no rejection, no "Daemon failed to start", no non-zero exit code. Both `main` and the pre-fix stack awaited `daemon.start()` alone and rejected immediately, so this is a regression introduced by that fix, not a pre-existing gap. It is reachable by racing `simlock daemon start`, and by the CLI's own auto-launch — a common path, not an exotic one, whenever HTTP is enabled.

The fix releases `gatewayStarted` on the `daemon.start()` failure path. A `socketClaimed` guard keeps it from resolving early while a *claimed* daemon's gateway is still binding, so a genuine bind failure is still reported — the behaviour the previous PR added stays intact.

The regression test races two `startDaemon()` calls on one data directory with distinct HTTP ports, so the only thing that can fail is the socket claim, and asserts the second **rejects** rather than hanging. Verified by stashing the fix: without it the test reports `hung` instead of `rejected`.