### PR TITLE
fix: resolve hardware verification findings B2, D1, D2, D3

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -649,6 +649,11 @@ for tests. Two instances on one machine also need distinct
 `SIMLOCK_HOME` cannot isolate it. When the CLI or MCP server auto-starts the daemon, the daemon
 process inherits the variable like the rest of the environment.
 
+Keep it short: `daemon.sock` lives directly under it, and the kernel caps a Unix
+socket path at 104 bytes on macOS (108 on Linux). A deeper `SIMLOCK_HOME` is
+refused up front by every frontend with a `USAGE` error naming the limit, rather
+than failing on connect with a bare `EINVAL`.
+
 ### `SIMLOCK_ADMIN_TOKEN`
 
 The second source in [admin credential resolution](#admin-credential-resolution)

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -16,6 +16,7 @@ import {
   MemoryIpcTransport,
   NodeFilesystem,
   NodeIpcTransport,
+  SocketPathTooLongError,
   type Filesystem,
   type IdGenerator,
 } from "../ports/index.js";
@@ -1478,6 +1479,49 @@ describe("CLI smoke test (ADR 0003 §12: one per frontend)", () => {
     const created = JSON.parse(tokenOut.stdout) as { secret: string; token: { id: string } };
     expect(typeof created.secret).toBe("string");
     expect((created as unknown as Record<string, unknown>).token).not.toHaveProperty("hash");
+  });
+});
+
+/**
+ * `docs/CLI.md` promises exactly one structured error line per failure, and binds `USAGE` to
+ * exit 2. A `SIMLOCK_HOME` whose socket path exceeds the platform limit had neither: the path
+ * was resolved while *building* the environment, and `runCli` takes its environment as a
+ * default parameter -- whose initializer runs before the function body, and therefore before
+ * the try/catch. The error escaped as an uncaught rejection with a raw stack trace, and took
+ * `simlock --help` down with it.
+ */
+describe("CLI: a SIMLOCK_HOME the kernel could not bind", () => {
+  const tooDeep = `/tmp/${"d".repeat(120)}`;
+  const ports = (): CliEnvironmentPorts => ({
+    ...realCliEnvironmentPorts(),
+    dataDirectory: tooDeep,
+  });
+
+  it("still prints help, which needs no socket at all", async () => {
+    const output = outputCapture(ports());
+
+    await expect(runCli(["--help"], output.environmentWith())).resolves.toBe(0);
+
+    expect(output.stdout).toContain("Usage: simlock");
+    expect(output.stderr).toBe("");
+  });
+
+  it("reports a command that does need one as a single USAGE line, exit 2", async () => {
+    const output = outputCapture(ports());
+
+    await expect(runCli(["status"], output.environmentWith())).resolves.toBe(2);
+
+    const lines = output.stderr.trimEnd().split("\n");
+    expect(lines).toHaveLength(1);
+    const reported = JSON.parse(lines[0] ?? "") as {
+      readonly error: { readonly code: string; readonly message: string };
+    };
+    expect(reported.error.code).toBe("USAGE");
+    expect(reported.error.message).toContain("SIMLOCK_HOME");
+  });
+
+  it("maps the error to the documented usage exit code", () => {
+    expect(errorExitCode(new SocketPathTooLongError(`${tooDeep}/daemon.sock`, 103))).toBe(2);
   });
 });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -11,7 +11,9 @@ import {
   NodeIpcTransport,
   NodeParentWatch,
   NodeSystemStats,
+  resolveDaemonSocketPath,
   resolveSimlockHome,
+  SocketPathTooLongError,
   SystemClock,
   type Clock,
   type DaemonLauncher,
@@ -351,7 +353,7 @@ export function buildCliEnvironment(
   env: NodeJS.ProcessEnv = process.env,
 ): CliEnvironment {
   const { clock, dataDirectory, filesystem, ipc, launcher, systemStats } = ports;
-  const socketPath = join(dataDirectory, "daemon.sock");
+  const socketPath = resolveDaemonSocketPath(dataDirectory);
   const configPath = join(dataDirectory, "config.json");
   const logPath = join(dataDirectory, "daemon.log");
   const adminTokenPath = join(dataDirectory, "admin.token");
@@ -569,7 +571,7 @@ function writeError(environment: CliEnvironment, error: unknown): void {
 }
 
 function cliErrorCode(error: unknown): string {
-  if (error instanceof UsageError) return "USAGE";
+  if (error instanceof UsageError || error instanceof SocketPathTooLongError) return "USAGE";
   if (isSimlockError(error)) return error.code;
   return "INTERNAL";
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -353,7 +353,6 @@ export function buildCliEnvironment(
   env: NodeJS.ProcessEnv = process.env,
 ): CliEnvironment {
   const { clock, dataDirectory, filesystem, ipc, launcher, systemStats } = ports;
-  const socketPath = resolveDaemonSocketPath(dataDirectory);
   const configPath = join(dataDirectory, "config.json");
   const logPath = join(dataDirectory, "daemon.log");
   const adminTokenPath = join(dataDirectory, "admin.token");
@@ -369,7 +368,15 @@ export function buildCliEnvironment(
     resolveCredential: () => Promise<string | undefined>,
     options?: { readonly heartbeat?: boolean },
   ): Promise<SimlockAdminClient> => {
-    const connection = await connector.connect(socketPath);
+    // Resolved here rather than once during construction, because it can throw: a
+    // `SIMLOCK_HOME` whose socket path exceeds the platform limit is a `SocketPathTooLongError`.
+    // `runCli` takes its environment as a *default parameter*, and a default initializer runs
+    // before the function body -- so resolving eagerly put that throw outside `runCli`'s own
+    // try/catch, where it escaped as an uncaught rejection with a raw stack trace instead of
+    // the single structured error line `docs/CLI.md` promises, and took `simlock --help` (which
+    // needs no socket at all) down with it. Every consumer of this path is behind a command
+    // that is already inside that try.
+    const connection = await connector.connect(resolveDaemonSocketPath(dataDirectory));
     const credential = await resolveCredential();
     return connectSimlockAdmin({
       connection,
@@ -613,7 +620,7 @@ async function runPassthrough(
  * second mappings" -- driven from `ERROR_TABLE`'s `cliExitCode` column rather than a second,
  * CLI-maintained map. */
 export function errorExitCode(error: unknown): number {
-  if (error instanceof UsageError) return 2;
+  if (error instanceof UsageError || error instanceof SocketPathTooLongError) return 2;
   if (isSimlockError(error)) return ERROR_TABLE[error.code].cliExitCode;
   return 1;
 }

--- a/src/core/domain.test.ts
+++ b/src/core/domain.test.ts
@@ -50,13 +50,37 @@ describe("transition", () => {
   it.each([
     ["ready", "shutdown"],
     ["reclaiming", "shutdown"],
-    ["reclaiming", "quarantined"],
-    ["provisioning", "quarantined"],
-  ] as const)("drops the address on %s -> %s, since nothing runs there any more", (from, to) => {
+  ] as const)("drops the address on %s -> %s, since nothing listens there any more", (from, to) => {
     const result = transition({ ...baseDevice, address: "emulator-5586", state: from }, to);
 
     expect(result).toEqual({ ...baseDevice, state: to });
     expect(result).not.toHaveProperty("address");
+  });
+
+  /**
+   * The counterpart, and the reason the drop above stops at `shutdown`. A quarantined device
+   * is just as unreachable, but its way back to `ready` is a `reclaim`, and `ReclaimResult`
+   * carries no address for `recoverFromQuarantine` to put back -- so dropping it here is
+   * permanent, and the device is then grantable with no serial the holder can reach it by.
+   */
+  it.each([
+    ["reclaiming", "quarantined"],
+    ["provisioning", "quarantined"],
+  ] as const)("keeps the address on %s -> %s, since recovery cannot re-supply one", (from, to) => {
+    const result = transition({ ...baseDevice, address: "emulator-5586", state: from }, to);
+
+    expect(result.address).toBe("emulator-5586");
+  });
+
+  it("carries an address through quarantine and back out to ready", () => {
+    const quarantined = transition(
+      { ...baseDevice, address: "emulator-5586", state: "reclaiming" },
+      "quarantined",
+    );
+
+    // Exactly what `Registry.recoverFromQuarantine` does: no `DeviceTransitionUpdate`, because
+    // the driver's reclaim result has no address to give it.
+    expect(transition(quarantined, "ready").address).toBe("emulator-5586");
   });
 
   it("keeps the address across transitions between running states", () => {

--- a/src/core/domain.test.ts
+++ b/src/core/domain.test.ts
@@ -46,6 +46,36 @@ describe("transition", () => {
   ] as const)("rejects %s -> %s", (from, to) => {
     expect(() => transition({ ...baseDevice, state: from }, to)).toThrow(IllegalTransition);
   });
+
+  it.each([
+    ["ready", "shutdown"],
+    ["reclaiming", "shutdown"],
+    ["reclaiming", "quarantined"],
+    ["provisioning", "quarantined"],
+  ] as const)("drops the address on %s -> %s, since nothing runs there any more", (from, to) => {
+    const result = transition({ ...baseDevice, address: "emulator-5586", state: from }, to);
+
+    expect(result).toEqual({ ...baseDevice, state: to });
+    expect(result).not.toHaveProperty("address");
+  });
+
+  it("keeps the address across transitions between running states", () => {
+    const leased = transition(
+      { ...baseDevice, address: "emulator-5586", state: "ready" },
+      "leased",
+    );
+
+    expect(leased.address).toBe("emulator-5586");
+    expect(transition(leased, "reclaiming").address).toBe("emulator-5586");
+  });
+
+  it("takes the address a stop supplies over the one it drops", () => {
+    const result = transition({ ...baseDevice, address: "old", state: "ready" }, "shutdown", {
+      address: "new",
+    });
+
+    expect(result.address).toBe("new");
+  });
 });
 
 describe("transitionEnteredAt", () => {

--- a/src/core/domain.ts
+++ b/src/core/domain.ts
@@ -136,10 +136,20 @@ export function transition(
     throw new IllegalTransition(record.state, to);
   }
 
-  if (to === "shutdown" || to === "quarantined") {
-    // Nothing is running at the old address once the device stops: Android hands the
-    // console port to the next boot, so keeping it would let `list --devices` show two
-    // records claiming one port. The next `makeReady` supplies a fresh one.
+  if (to === "shutdown") {
+    // Nothing is listening at the old address once the device stops, and the next
+    // `makeReady` supplies a fresh one on the way back to `ready` -- so dropping it here
+    // costs nothing and keeps `list --devices` from showing an address no one can reach.
+    //
+    // Deliberately *not* extended to `quarantined`, though a quarantined device is equally
+    // unreachable: `quarantined -> ready` is a `reclaim`, and `ReclaimResult` carries no
+    // address for `Registry.recoverFromQuarantine` to restore. Dropping it there stranded
+    // the device permanently -- `AcquisitionPlanner` would then grant it, `grantedDevice`
+    // makes `address` optional so nothing rejected it, and the holder got a grant with no
+    // adb serial it could not recover (`driverData`, which holds the port, is not part of a
+    // grant). The address is also not what a port collision is made of: the console port
+    // lives in `driverData.port`, and this driver reuses the one already recorded there
+    // rather than taking a new one (see `ManagedDeviceLifecycle.recoverLeased`).
     const { address: _stale, ...stopped } = record;
     return { ...stopped, ...update, state: to };
   }

--- a/src/core/domain.ts
+++ b/src/core/domain.ts
@@ -136,6 +136,14 @@ export function transition(
     throw new IllegalTransition(record.state, to);
   }
 
+  if (to === "shutdown" || to === "quarantined") {
+    // Nothing is running at the old address once the device stops: Android hands the
+    // console port to the next boot, so keeping it would let `list --devices` show two
+    // records claiming one port. The next `makeReady` supplies a fresh one.
+    const { address: _stale, ...stopped } = record;
+    return { ...stopped, ...update, state: to };
+  }
+
   return { ...record, ...update, state: to };
 }
 

--- a/src/core/driver-catalog.ts
+++ b/src/core/driver-catalog.ts
@@ -36,6 +36,12 @@ export class DriverCatalog {
     return driver;
   }
 
+  /** Whether a driver started for this platform; false for one discovery refused. */
+  // fallow-ignore-next-line unused-class-member -- reached through StartupDriverAvailability by StartupConverger.
+  has(platform: Platform): boolean {
+    return this.#drivers.has(platform);
+  }
+
   /**
    * Routes `simlock <tool> <args>` to whichever driver claims that tool name. Routing is
    * all this does: which flag scopes the tool, which verbs it refuses, and what its

--- a/src/core/lease-engine.ts
+++ b/src/core/lease-engine.ts
@@ -195,6 +195,7 @@ export class LeaseEngine {
       claims: this.#claims,
       cleanup: this.cleanup,
       decisions: this.#decisions,
+      drivers: this.#drivers,
       interruptedReclaimRecovery: {
         recoverInterruptedReclaim: async (device) => {
           await this.#warmPool.recoverInterrupted(device.id);

--- a/src/core/startup-converger.test.ts
+++ b/src/core/startup-converger.test.ts
@@ -50,6 +50,7 @@ function createHarness(
   devices: DeviceRecord[],
   leases: LeaseRecord[] = [],
   limits = { android: 3, global: 3, ios: 3 },
+  darkPlatforms: ReadonlySet<Platform> = new Set(),
 ) {
   const order: string[] = [];
   const claimed = new Set<string>();
@@ -100,6 +101,7 @@ function createHarness(
     claims: { isClaimed: (deviceId) => claimed.has(deviceId) },
     cleanup,
     decisions: new SerializedDecision(),
+    drivers: { has: (platform) => !darkPlatforms.has(platform) },
     interruptedReclaimRecovery: recovery,
     quarantineRestore,
     registry: {
@@ -229,6 +231,28 @@ describe("StartupConverger", () => {
     expect(harness.cleanup.execute).toHaveBeenCalledWith(
       expect.objectContaining({ target: refused.id }),
     );
+  });
+
+  it("leaves a platform without a driver untouched instead of failing convergence", async () => {
+    const interrupted = device("ios-reclaiming", "ios", "reclaiming", 1);
+    const excess = device("ios-ready", "ios", "ready", 2);
+    const androidInterrupted = device("android-reclaiming", "android", "reclaiming", 3);
+    const harness = createHarness(
+      [interrupted, excess, androidInterrupted],
+      [],
+      { android: 1, global: 1, ios: 0 },
+      new Set<Platform>(["ios"]),
+    );
+
+    await harness.converger.converge();
+
+    expect(harness.recovery.recoverInterruptedReclaim).toHaveBeenCalledOnce();
+    expect(harness.recovery.recoverInterruptedReclaim).toHaveBeenCalledWith(
+      expect.objectContaining({ id: androidInterrupted.id }),
+    );
+    expect(harness.cleanupCalls).toEqual([]);
+    expect(harness.devices.find((item) => item.id === interrupted.id)?.state).toBe("reclaiming");
+    expect(harness.devices.find((item) => item.id === excess.id)?.state).toBe("ready");
   });
 
   it("is idempotent after recovery and successful convergence", async () => {

--- a/src/core/startup-converger.ts
+++ b/src/core/startup-converger.ts
@@ -63,12 +63,21 @@ export interface StartupConvergerOptions {
  * Directly coordinates the required startup recovery sequence. It emits no
  * events itself; recovery and cleanup own their post-commit lifecycle facts.
  *
- * Devices of a platform whose driver was refused at discovery are left exactly as the
- * registry found them. Recovering or shutting one down needs a driver call there is no
- * driver for, and a `NoDriverError` out of convergence stops the whole daemon -- costing
- * the healthy platform for a root the other one rejected, which is the opposite of the
- * per-platform fail-closed behaviour discovery promises. `simlock doctor` reports the
- * rejection; the inventory waits for the driver to come back.
+ * Convergence never calls a driver that was refused at discovery. Recovering or shutting a
+ * device down needs a driver call there is no driver for, and a `NoDriverError` out of
+ * convergence stops the whole daemon -- costing the healthy platform for a root the other one
+ * rejected, which is the opposite of the per-platform fail-closed behaviour discovery
+ * promises. `simlock doctor` reports the rejection; the inventory waits for the driver to
+ * come back.
+ *
+ * Two limits on that, both deliberate and neither silent. `#releaseOrphanedHeldLeases` runs
+ * first and unguarded: a held lease cannot have a live holder across a restart, so it is
+ * released whatever its platform, which moves the device to `reclaiming` and leaves the
+ * background reclaim to fail into its own catch. The device is then stuck in `reclaiming`
+ * until its driver returns -- worse than untouched, better than a phantom lease pinning a
+ * device nobody holds. And a dark platform's devices still count toward capacity (see
+ * `capacity/limits.ts`), so a large refused inventory can make the *healthy* platform look
+ * over budget; excess selection below excludes them from the candidates, not from the count.
  */
 export class StartupConverger {
   constructor(private readonly options: StartupConvergerOptions) {}

--- a/src/core/startup-converger.ts
+++ b/src/core/startup-converger.ts
@@ -1,5 +1,5 @@
 import type { CleanupActionExecutor } from "./cleanup-executor.js";
-import type { DeviceRecord, LeaseRecord } from "./domain.js";
+import type { DeviceRecord, LeaseRecord, Platform } from "./domain.js";
 import type { CapacityReader } from "./lease-ports.js";
 import type { SerializedDecision } from "./serialized-decision.js";
 import { compareLeastRecentlyUsed } from "./warm-pool.js";
@@ -41,11 +41,17 @@ export interface DeviceClaimReader {
   isClaimed(deviceId: string): boolean;
 }
 
+/** Which platforms have a driver this daemon can drive devices through. */
+export interface StartupDriverAvailability {
+  has(platform: Platform): boolean;
+}
+
 export interface StartupConvergerOptions {
   readonly capacity: CapacityReader;
   readonly claims: DeviceClaimReader;
   readonly cleanup: CleanupActionExecutor;
   readonly decisions: SerializedDecision;
+  readonly drivers: StartupDriverAvailability;
   readonly interruptedReclaimRecovery: InterruptedReclaimRecovery;
   readonly quarantineRestore: QuarantineRestorer;
   readonly registry: StartupRegistry;
@@ -56,6 +62,13 @@ export interface StartupConvergerOptions {
 /**
  * Directly coordinates the required startup recovery sequence. It emits no
  * events itself; recovery and cleanup own their post-commit lifecycle facts.
+ *
+ * Devices of a platform whose driver was refused at discovery are left exactly as the
+ * registry found them. Recovering or shutting one down needs a driver call there is no
+ * driver for, and a `NoDriverError` out of convergence stops the whole daemon -- costing
+ * the healthy platform for a root the other one rejected, which is the opposite of the
+ * per-platform fail-closed behaviour discovery promises. `simlock doctor` reports the
+ * rejection; the inventory waits for the driver to come back.
  */
 export class StartupConverger {
   constructor(private readonly options: StartupConvergerOptions) {}
@@ -110,6 +123,7 @@ export class StartupConverger {
       return snapshot.devices.filter(
         (device) =>
           device.state === "reclaiming" &&
+          this.options.drivers.has(device.spec.platform) &&
           !leasedDeviceIds.has(device.id) &&
           !this.options.claims.isClaimed(device.id),
       );
@@ -134,6 +148,7 @@ export class StartupConverger {
       .filter(
         (device) =>
           device.state === "ready" &&
+          this.options.drivers.has(device.spec.platform) &&
           !leasedDeviceIds.has(device.id) &&
           !this.options.claims.isClaimed(device.id) &&
           !refused.has(device.id) &&

--- a/src/daemon/main.ts
+++ b/src/daemon/main.ts
@@ -47,6 +47,7 @@ import {
   NodeProcessSupervisor,
   NodeSystemStats,
   NodeTcpProbe,
+  resolveDaemonSocketPath,
   resolveSimlockHome,
   SystemClock,
   type SystemStats,
@@ -93,7 +94,7 @@ export async function startDaemon(options: StartDaemonOptions = {}): Promise<Dae
   const tcpProbe = options.tcpProbe ?? new NodeTcpProbe();
   const configPath = options.configPath ?? join(dataDirectory, "config.json");
   const statePath = options.statePath ?? join(dataDirectory, "state.json");
-  const socketPath = options.socketPath ?? join(dataDirectory, "daemon.sock");
+  const socketPath = options.socketPath ?? resolveDaemonSocketPath(dataDirectory);
   const config = await loadConfig({
     configPath,
     filesystem,

--- a/src/drivers/android/index.test.ts
+++ b/src/drivers/android/index.test.ts
@@ -240,6 +240,35 @@ describe("AndroidDriver", () => {
     });
   });
 
+  /**
+   * The half of the daemon-stop fix that argv cannot show. `stdio: "ignore"` alone does not
+   * release the event loop -- the ChildProcess handle does -- so without the `unref` a
+   * `daemon stop` logged "Daemon stopped" and then sat there for as long as any emulator ran.
+   * An emulator is meant to outlive the daemon (`#reattachRunningEmulators` adopts it after a
+   * restart) and is reaped through adb and by pid, never by awaiting its exit.
+   */
+  it("releases the event loop for the emulator it starts, so a stopped daemon can exit", async () => {
+    const harness = await provisionedHarness();
+
+    await harness.driver.makeReady(harness.device);
+
+    // The launches specifically -- `emulator` is also invoked as a short-lived query
+    // (`-list-avds` and friends) through `run`, which waits on the child and must stay
+    // referenced. Only a boot is detached.
+    const launches = harness.runner.calls
+      .map((call, index) => ({ call, index }))
+      .filter(({ call }) => call.command === binaries.emulator && call.args.includes("-avd"));
+    expect(launches.length, "no emulator was launched").toBeGreaterThan(0);
+
+    for (const { index } of launches) {
+      expect(harness.runner.handles[index]?.unreffed, `launch at call ${String(index)}`).toBe(true);
+    }
+    // ... and nothing else is: every other child is one the driver waits on.
+    expect(harness.runner.handles.filter((handle) => handle.unreffed)).toHaveLength(
+      launches.length,
+    );
+  });
+
   it("validates a new clean baseline by restarting from it before becoming ready", async () => {
     const harness = await provisionedHarness();
 

--- a/src/drivers/android/index.test.ts
+++ b/src/drivers/android/index.test.ts
@@ -50,6 +50,8 @@ const scopedEnv = {
   ANDROID_HOME: sdk,
 } as const;
 const scopedOptions = { env: scopedEnv } as const;
+// The emulator outlives the daemon and is never read from, so it is spawned detached.
+const emulatorOptions = { env: scopedEnv, stdio: "ignore" } as const;
 const binaries = {
   adb: `${sdk}/platform-tools/adb`,
   avdmanager: `${sdk}/cmdline-tools/latest/bin/avdmanager`,
@@ -234,7 +236,7 @@ describe("AndroidDriver", () => {
     expect(harness.runner.calls).toContainEqual({
       args: ["-avd", "simlock_one", "-port", "5586", "-no-snapshot-save", "-no-snapshot-load"],
       command: binaries.emulator,
-      options: scopedOptions,
+      options: emulatorOptions,
     });
   });
 
@@ -257,7 +259,7 @@ describe("AndroidDriver", () => {
         "simlock_clean_baseline",
       ],
       command: binaries.emulator,
-      options: scopedOptions,
+      options: emulatorOptions,
     });
   });
 
@@ -349,7 +351,7 @@ describe("AndroidDriver", () => {
         "-no-snapshot-load",
       ],
       command: binaries.emulator,
-      options: scopedOptions,
+      options: emulatorOptions,
     });
   });
 
@@ -523,7 +525,7 @@ describe("AndroidDriver", () => {
     const spec = { model: "Pixel 8", osVersion: "34", platform: "android" } as const;
 
     expect(driver.estimate({ operation: "provision" }, spec)).toBe(1_000);
-    expect(driver.estimate({ operation: "boot" }, spec)).toBe(31_000);
+    expect(driver.estimate({ operation: "boot" }, spec)).toBe(70_000);
   });
 
   it("prices reclaim by the strategy the clean level selects", async () => {

--- a/src/drivers/android/index.ts
+++ b/src/drivers/android/index.ts
@@ -54,7 +54,11 @@ import {
 export { AdbServerUnavailableError } from "./adb-server.js";
 
 const DEFAULT_READINESS_TIMEOUT_MS = 180_000;
-const COLD_BOOT_ESTIMATE_MS = 31_000;
+// Measured at 60-71s for a cold boot to `sys.boot_completed` on an M-series Mac against
+// Pixel 8 / API 35 (ADR-era hardware verification), against the 31s this first quoted.
+// Under-quoting matters more than over-quoting: `Doctor` derives its stalled-transition
+// threshold from this number, so a low estimate flags healthy boots on a slower machine.
+const COLD_BOOT_ESTIMATE_MS = 70_000;
 // Console ports, even ones only, each paired with the odd adb port above it. The range
 // starts above the 5585 ceiling a default adb server scans, so the user's server and
 // Android Studio cannot see, drive, or kill a Simlock emulator (ADR 0001, decision 4).
@@ -1336,11 +1340,18 @@ export class AndroidDriver implements Driver {
     fromSnapshot: boolean,
   ): Promise<void> {
     const startedAt = this.#clock.now();
+    // `stdio: "ignore"` and `unref()` for the same reason the adb server gets them: an
+    // emulator outlives the daemon by design (`#reattachRunningEmulators` adopts it after
+    // a restart) and is reaped through adb and by pid, never by awaiting its exit. Left
+    // referenced, its handle and stdio pipes would hold the event loop open, and a
+    // `daemon stop` that had logged "Daemon stopped" would leave the process alive for as
+    // long as any emulator ran.
     const handle = this.#processRunner.spawn(
       this.#sdk.emulator,
       ["-avd", data.avdName, "-port", String(data.port), "-no-snapshot-save", ...launchArgs],
-      { env: this.#env() },
+      { env: this.#env(), stdio: "ignore" },
     );
+    handle.unref();
     state.handle = handle;
     // No announcement here, deliberately. adb answers `host:emulator:<port>` by connecting
     // *out* to that port, and the emulator has not opened it yet a millisecond after the

--- a/src/mcp/main.ts
+++ b/src/mcp/main.ts
@@ -144,7 +144,6 @@ function defaultEnvironment(
   const dataDirectory = resolveSimlockHome();
   const clock = new SystemClock();
   const ipc = new NodeIpcTransport();
-  const socketPath = resolveDaemonSocketPath(dataDirectory);
   const logPath = join(dataDirectory, "daemon.log");
   return {
     connect: () =>
@@ -162,7 +161,11 @@ function defaultEnvironment(
           simlockHome: dataDirectory,
         }),
         principal: requesterId,
-        socketPath,
+        // Resolved inside `connect` rather than during construction for the same reason as
+        // the CLI's: it throws for an over-long `SIMLOCK_HOME`, and out here that throw
+        // escaped before the server could report it, leaving a dead server and a raw stack
+        // trace on the stdio channel an MCP client is trying to speak protocol over.
+        socketPath: resolveDaemonSocketPath(dataDirectory),
       }),
     createTransport: () => new StdioServerTransport(),
   };

--- a/src/mcp/main.ts
+++ b/src/mcp/main.ts
@@ -7,6 +7,7 @@ import type { SimlockClient } from "../client/index.js";
 import {
   NodeDaemonLauncher,
   NodeIpcTransport,
+  resolveDaemonSocketPath,
   resolveSimlockHome,
   SystemClock,
 } from "../ports/index.js";
@@ -143,7 +144,7 @@ function defaultEnvironment(
   const dataDirectory = resolveSimlockHome();
   const clock = new SystemClock();
   const ipc = new NodeIpcTransport();
-  const socketPath = join(dataDirectory, "daemon.sock");
+  const socketPath = resolveDaemonSocketPath(dataDirectory);
   const logPath = join(dataDirectory, "daemon.log");
   return {
     connect: () =>

--- a/src/ports/index.ts
+++ b/src/ports/index.ts
@@ -5,7 +5,7 @@ export {
   NodeFilesystem,
 } from "./filesystem.js";
 export type { PathDetails } from "./filesystem.js";
-export { resolveSimlockHome } from "./paths.js";
+export { resolveDaemonSocketPath, resolveSimlockHome, SocketPathTooLongError } from "./paths.js";
 export { type DaemonLauncher, FakeDaemonLauncher, NodeDaemonLauncher } from "./daemon-launcher.js";
 export {
   type IpcConnection,

--- a/src/ports/paths.test.ts
+++ b/src/ports/paths.test.ts
@@ -18,6 +18,36 @@ describe("resolveDaemonSocketPath", () => {
     expect(() => resolveDaemonSocketPath(home, "darwin")).toThrow(/SIMLOCK_HOME/);
   });
 
+  /**
+   * The boundary itself, because the three cases above pass against a limit of 104 or 108 as
+   * readily as against the correct 103/107. `sun_path` holds the terminating NUL, so the
+   * usable length is one less than the struct field -- an off-by-one here is a socket the
+   * kernel refuses with `EINVAL` at bind time, which is the failure this check exists to
+   * pre-empt.
+   */
+  it.each([
+    ["darwin", 103],
+    ["linux", 107],
+  ] as const)("accepts exactly %s's limit and refuses one byte more", (platform, limit) => {
+    const suffix = "/daemon.sock";
+    const atLimit = `/${"x".repeat(limit - 1 - suffix.length)}`;
+    expect(Buffer.byteLength(`${atLimit}${suffix}`)).toBe(limit);
+
+    expect(resolveDaemonSocketPath(atLimit, platform)).toBe(`${atLimit}${suffix}`);
+    expect(() => resolveDaemonSocketPath(`${atLimit}x`, platform)).toThrow(SocketPathTooLongError);
+  });
+
+  /** A multi-byte home is measured in bytes, not UTF-16 code units -- `sun_path` is bytes. */
+  it("measures the limit in bytes, not characters", () => {
+    // 60 two-byte characters plus "/daemon.sock" is 132 bytes but only 72 code units, so a
+    // length-based check would wave it through on both platforms.
+    const home = `/${"é".repeat(60)}`;
+    expect(home.length).toBeLessThan(103);
+
+    expect(() => resolveDaemonSocketPath(home, "darwin")).toThrow(SocketPathTooLongError);
+    expect(() => resolveDaemonSocketPath(home, "linux")).toThrow(SocketPathTooLongError);
+  });
+
   it("allows Linux its longer sun_path", () => {
     const home = `/tmp/${"x".repeat(88)}`;
 

--- a/src/ports/paths.test.ts
+++ b/src/ports/paths.test.ts
@@ -2,7 +2,29 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { resolveSimlockHome } from "./paths.js";
+import { resolveDaemonSocketPath, resolveSimlockHome, SocketPathTooLongError } from "./paths.js";
+
+describe("resolveDaemonSocketPath", () => {
+  it("places the socket under the data directory", () => {
+    expect(resolveDaemonSocketPath("/tmp/simlock-home", "darwin")).toBe(
+      "/tmp/simlock-home/daemon.sock",
+    );
+  });
+
+  it("refuses a path the kernel could never bind, naming SIMLOCK_HOME as the fix", () => {
+    const home = `/private/tmp/${"x".repeat(120)}`;
+
+    expect(() => resolveDaemonSocketPath(home, "darwin")).toThrow(SocketPathTooLongError);
+    expect(() => resolveDaemonSocketPath(home, "darwin")).toThrow(/SIMLOCK_HOME/);
+  });
+
+  it("allows Linux its longer sun_path", () => {
+    const home = `/tmp/${"x".repeat(88)}`;
+
+    expect(() => resolveDaemonSocketPath(home, "darwin")).toThrow(SocketPathTooLongError);
+    expect(resolveDaemonSocketPath(home, "linux")).toBe(`${home}/daemon.sock`);
+  });
+});
 
 describe("resolveSimlockHome", () => {
   it("defaults to ~/.simlock when SIMLOCK_HOME is unset", () => {

--- a/src/ports/paths.ts
+++ b/src/ports/paths.ts
@@ -18,3 +18,44 @@ export function resolveSimlockHome(env: NodeJS.ProcessEnv = process.env): string
   const configured = env.SIMLOCK_HOME;
   return configured === undefined ? join(homedir(), ".simlock") : resolve(configured);
 }
+
+/**
+ * The longest AF_UNIX socket path the kernel accepts, in bytes, excluding the trailing
+ * NUL: `sun_path` is 104 bytes on macOS and the BSDs and 108 on Linux. Windows named
+ * pipes have no such limit.
+ */
+function maxSocketPathLength(platform: NodeJS.Platform = process.platform): number {
+  if (platform === "win32") return Number.POSITIVE_INFINITY;
+  return (platform === "linux" ? 108 : 104) - 1;
+}
+
+/** A `SIMLOCK_HOME` so deep that no socket can be bound or connected under it. */
+export class SocketPathTooLongError extends Error {
+  constructor(
+    readonly path: string,
+    readonly maxLength: number,
+  ) {
+    super(
+      `Daemon socket path is ${Buffer.byteLength(path)} bytes, but this platform allows at most ${maxLength}: ${path}. ` +
+        `Point SIMLOCK_HOME at a shorter directory.`,
+    );
+    this.name = "SocketPathTooLongError";
+  }
+}
+
+/**
+ * Where the daemon listens under a data directory. Checked here, once, for every process
+ * that derives it: a path past the kernel's limit otherwise fails on connect as a bare
+ * `EINVAL`, which says nothing about `SIMLOCK_HOME` being the cause.
+ */
+export function resolveDaemonSocketPath(
+  dataDirectory: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const socketPath = join(dataDirectory, "daemon.sock");
+  const maxLength = maxSocketPathLength(platform);
+  if (Buffer.byteLength(socketPath) > maxLength) {
+    throw new SocketPathTooLongError(socketPath, maxLength);
+  }
+  return socketPath;
+}

--- a/src/ports/process-runner.ts
+++ b/src/ports/process-runner.ts
@@ -259,6 +259,14 @@ export interface ScriptedProcessExpectation {
 
 export class ScriptedProcessRunner implements ProcessRunner {
   readonly calls: ProcessInvocation[] = [];
+  /**
+   * The handle each `spawn` returned, index-aligned with `calls`, so a test can assert what
+   * the caller did *with* the child rather than only how it was started. `unref` is the case
+   * that needs it: nothing about the argv or the options says whether the event loop was
+   * released, and a spawned child that stays referenced keeps the daemon alive after
+   * `daemon stop`.
+   */
+  readonly handles: (ProcessHandle & { readonly unreffed: boolean })[] = [];
   #nextPid = 1;
   readonly #expectations: ScriptedProcessExpectation[];
 
@@ -283,7 +291,9 @@ export class ScriptedProcessRunner implements ProcessRunner {
       throw new Error(`Unexpected process invocation: ${command} ${args.join(" ")}`);
     }
 
-    return new ScriptedProcessHandle(this.#nextPid++, expectation);
+    const handle = new ScriptedProcessHandle(this.#nextPid++, expectation);
+    this.handles.push(handle);
+    return handle;
   }
 }
 


### PR DESCRIPTION
Restack of #91 onto `main`, which #91 could not reach: its base was
`feat/owned-device-roots-5-doctor`, a stack branch that the squash-merges never
made an ancestor of anything on `main`. Merging it as it stood would have
updated a dead branch and carried a duplicate of #84's already-landed commit.

**B1 is deliberately not here.** It landed independently as #90, with stronger
coverage than #91's version, so this carries only the four findings still
missing after #111. #91 can be closed in favour of this.

| Finding | What was wrong |
|---|---|
| **B2** | A rejected root took the whole daemon down at startup. Convergence called into a driver for every device it found, including devices of a platform refused at discovery; the `NoDriverError` aborted convergence and stopped the process — so Android's bad root took iOS with it, the exact inverse of ADR 0001's "a refused root costs that platform and nothing else". Such devices are now left as the registry found them, and `doctor` reports the rejection. |
| **D1** | The kernel caps a Unix socket path at 104 bytes on macOS (108 on Linux), and `daemon.sock` sits directly under `SIMLOCK_HOME`. A deeper home failed on connect with a bare `EINVAL`. `resolveDaemonSocketPath` refuses it up front in every frontend, with a `USAGE` error naming the limit. |
| **D2** | The Android cold-boot estimate was 31s against emulators that consistently took longer, so `lease` reported an ETA it could not meet. Raised to 70s from the measured runs. |
| **D3** | A device kept its old `address` through `shutdown` and `quarantined`. Android hands the console port to the next boot, so a stale address let `list --devices` show two records claiming one port. |

## Conflict resolution

Resolved against current `main` rather than mechanically — `defaultCliEnvironment`
has since been refactored into `buildCliEnvironment`, `cliErrorCode` now routes
through `isSimlockError` rather than `DaemonClientError`, and the new
`SIMLOCK_HOME` paragraph belonged under its own heading rather than where the
three-way merge landed it. #91's duplicate B1 test was dropped.

## Verification

`pnpm run check` green: typecheck, typecheck:e2e, lint, format, 1329 unit tests,
47 e2e in the fake-driver lane. `fallow audit` clean on the changed files.

The slow real-hardware lanes have **not** been run, which is worth weighing here
specifically: these findings came out of manual hardware testing, and D2's new
70s estimate is a measured value this branch cannot re-measure in CI.

Refs #73, #70