### PR TITLE
feat(cli,mcp)!: clients renew their own leases (ADR 0004, PR A)

### DIFF
--- a/e2e/heartbeat-ttl.test.ts
+++ b/e2e/heartbeat-ttl.test.ts
@@ -44,7 +44,7 @@ describe("sliding TTL and heartbeat", () => {
     );
   });
 
-  it("slides every heartbeat-capable held lease (MCP and CLI) past the backstop while a detached lease expires at it", async () => {
+  it("slides every held lease (MCP and CLI) past the backstop while a detached lease expires at it", async () => {
     const env = await withDaemon({
       // detachedTtlMs is pinned to the same value as heldTtlBackstopMs purely so the
       // detached lease's own (unrelated) TTL knob expires it on the timeline this
@@ -98,9 +98,10 @@ describe("sliding TTL and heartbeat", () => {
       ]);
       const detachedGrant = detachedResult.json as { lease: { id: string } };
 
-      // Both held leases -- MCP and CLI -- declare the heartbeat capability and
-      // slide their deadline on every ping; the detached lease holds no connection
-      // at all, never heartbeats, and expires exactly at its grant-time TTL.
+      // Both held holders -- MCP and CLI -- renew on their own timer at a third of the
+      // TTL (ADR 0004 §2), sliding their deadline well past the backstop; the detached
+      // lease has no holder process at all, renews never, and expires exactly at its
+      // grant-time TTL.
       await waitFor(
         async () => {
           const rows = await leaseRows(env);

--- a/e2e/heartbeat-ttl.test.ts
+++ b/e2e/heartbeat-ttl.test.ts
@@ -7,7 +7,6 @@ interface LeaseRow {
   readonly id: string;
   readonly requesterId: string;
   readonly ttlDeadline: number;
-  readonly lastHeartbeatAt?: number;
 }
 
 async function leaseRows(env: Awaited<ReturnType<typeof withDaemon>>): Promise<LeaseRow[]> {
@@ -16,7 +15,7 @@ async function leaseRows(env: Awaited<ReturnType<typeof withDaemon>>): Promise<L
   return result.json as LeaseRow[];
 }
 
-describe("sliding TTL and heartbeat", () => {
+describe("sliding TTL and renewal", () => {
   it("refuses to start with a heartbeat interval that isn't at most backstop / 4, naming the key", async () => {
     const env = await withDaemon({
       mode: "auto",
@@ -48,8 +47,8 @@ describe("sliding TTL and heartbeat", () => {
     const env = await withDaemon({
       // detachedTtlMs is pinned to the same value as heldTtlBackstopMs purely so the
       // detached lease's own (unrelated) TTL knob expires it on the timeline this
-      // test already waits on -- detached mode never heartbeats regardless of TTL,
-      // it just isn't naturally this short by default.
+      // test already waits on -- a detached lease has no holder renewing it regardless
+      // of TTL, it just isn't naturally this short by default.
       //
       // heartbeatIntervalMs is no longer what keeps the held leases alive (their holders
       // renew on their own timer, ADR 0004 §2); it stays here because the config validator
@@ -112,7 +111,7 @@ describe("sliding TTL and heartbeat", () => {
           const detachedRow = rows.find((row) => row.id === detachedGrant.lease.id);
           return detachedRow === undefined;
         },
-        { timeout: 15_000, label: "detached (non-heartbeating) lease expires at its TTL" },
+        { timeout: 15_000, label: "detached (unrenewed) lease expires at its TTL" },
       );
 
       const rowsAfterExpiry = await leaseRows(env);
@@ -127,9 +126,7 @@ describe("sliding TTL and heartbeat", () => {
         "CLI held lease should have survived past the detached lease's expiry",
       ).toBeDefined();
       expect(mcpRow?.ttlDeadline).toBeGreaterThan(mcpLease.lease.ttlDeadline);
-      expect(mcpRow?.lastHeartbeatAt).toBeGreaterThan(0);
       expect(cliRow?.ttlDeadline).toBeGreaterThan(cliGrant.lease.ttlDeadline);
-      expect(cliRow?.lastHeartbeatAt).toBeGreaterThan(0);
 
       const statusResult = await mcp.client.callTool({ name: "lease_status", arguments: {} });
       const statusExpiry = (statusResult.structuredContent as { ttlDeadline: number }).ttlDeadline;
@@ -142,7 +139,7 @@ describe("sliding TTL and heartbeat", () => {
             entry.event === "lease.renewed" &&
             (entry.payload as { leaseId?: string }).leaseId === mcpLease.lease.id,
         ).length,
-        "expected repeated lease.renewed events for the heartbeating MCP lease",
+        "expected repeated lease.renewed events for the renewing MCP lease",
       ).toBeGreaterThan(1);
       expect(
         recorded.filter(
@@ -150,7 +147,7 @@ describe("sliding TTL and heartbeat", () => {
             entry.event === "lease.renewed" &&
             (entry.payload as { leaseId?: string }).leaseId === cliGrant.lease.id,
         ).length,
-        "expected repeated lease.renewed events for the heartbeating CLI lease",
+        "expected repeated lease.renewed events for the renewing CLI lease",
       ).toBeGreaterThan(1);
       expect(recorded).toContainEqual(
         expect.objectContaining({

--- a/e2e/heartbeat-ttl.test.ts
+++ b/e2e/heartbeat-ttl.test.ts
@@ -50,6 +50,10 @@ describe("sliding TTL and heartbeat", () => {
       // detached lease's own (unrelated) TTL knob expires it on the timeline this
       // test already waits on -- detached mode never heartbeats regardless of TTL,
       // it just isn't naturally this short by default.
+      //
+      // heartbeatIntervalMs is no longer what keeps the held leases alive (their holders
+      // renew on their own timer, ADR 0004 §2); it stays here because the config validator
+      // still requires it to be at most heldTtlBackstopMs / 4, and 4_000ms is short.
       configOverrides: {
         lease: { detachedTtlMs: 4_000, heldTtlBackstopMs: 4_000, heartbeatIntervalMs: 800 },
       },

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -1409,18 +1409,120 @@ describe("CLI: held-mode renew and release (ADR 0004 §2)", () => {
 
   it("declares no heartbeat capability at hello, in either mode (ADR 0004 §4)", async () => {
     const output = outputCapture();
+    const signals = new EventEmitter();
     const declared: Array<boolean | undefined> = [];
     const environment = output.environmentWith({
+      clock: new FakeClock(0),
       connectAdmin: async (_resolveCredential, options) => {
         declared.push(options?.heartbeat);
         return fakeClient();
       },
+      signals: signals as unknown as CliEnvironment["signals"],
     });
     await runCli(
       ["lease", "--platform", "ios", "--device", "iPhone 17 Pro", "--detach"],
       environment,
     );
-    expect(declared).toEqual([false]);
+
+    // Held mode is the case ADR 0004 §4 is actually about: it is the mode the daemon's push
+    // keys off, and the one that used to declare the capability.
+    const heldRun = runCli(
+      ["lease", "--platform", "ios", "--device", "iPhone 17 Pro"],
+      environment,
+    );
+    await settle();
+    signals.emit("SIGINT");
+    expect(await heldRun).toBe(0);
+
+    expect(declared).toEqual([false, false]);
+  });
+
+  it("reports a failed renewal on stderr and keeps holding the lease", async () => {
+    const clock = new FakeClock(0);
+    const output = outputCapture();
+    const signals = new EventEmitter();
+    let released: string | undefined;
+    const client = fakeClient({
+      renewLease: () =>
+        Promise.reject(new SimlockError("INTERNAL", "domain", "could not persist the lease", {})),
+      releaseLease: (input) => {
+        released = input.leaseId;
+        return Promise.resolve({ leaseId: input.leaseId });
+      },
+    });
+    const runPromise = runCli(
+      ["lease", "--platform", "ios", "--device", "iPhone 17 Pro"],
+      output.environmentWith({
+        clock,
+        connectAdmin: async () => client,
+        signals: signals as unknown as CliEnvironment["signals"],
+      }),
+    );
+    await settle();
+    clock.advance(20_000);
+    await settle();
+
+    const errorLines = output.stderr
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>)
+      .filter((line) => line.error !== undefined);
+    expect(errorLines).toContainEqual({
+      error: { code: "INTERNAL", message: "could not persist the lease" },
+    });
+
+    // A failed renewal is not an exit condition: the holder still holds, and still releases.
+    signals.emit("SIGINT");
+    expect(await runPromise).toBe(0);
+    expect(released).toBe("lse_1");
+  });
+
+  it("still releases the lease when printing the grant throws (--export-env with a bad key)", async () => {
+    const clock = new FakeClock(0);
+    const output = outputCapture();
+    let released: string | undefined;
+    const client = fakeClient({
+      requestLease: () =>
+        Promise.resolve({
+          device: {
+            id: "dev_1",
+            driverDeviceId: "dev_1",
+            spec: { platform: "ios", model: "x", osVersion: "26.5" },
+          },
+          // A driver-supplied key that is not a shell identifier fails the command rather than
+          // being silently dropped -- and that throw must not cost the device.
+          environment: { "NOT A KEY": "value" },
+          lease: {
+            id: "lse_1",
+            deviceId: "dev_1",
+            requesterId: "test-requester",
+            ownerId: "test-requester",
+            mode: "held" as const,
+            grantedAt: 0,
+            ttlDeadline: 60_000,
+          },
+          timing: {
+            estimatedProvisionMs: 0,
+            estimatedBootMs: 0,
+            estimatedReclaimMs: 0,
+            estimatedReadyMs: 0,
+          },
+        }),
+      releaseLease: (input) => {
+        released = input.leaseId;
+        return Promise.resolve({ leaseId: input.leaseId });
+      },
+    });
+    const exitCode = await runCli(
+      ["lease", "--platform", "ios", "--device", "iPhone 17 Pro", "--export-env"],
+      output.environmentWith({ clock, connectAdmin: async () => client }),
+    );
+
+    expect(exitCode).toBe(1);
+    expect(released, "an exit through a throw is still an exit, and still owes a release").toBe(
+      "lse_1",
+    );
+    expect(clock.pendingTimerCount).toBe(0);
   });
 
   it("arms no renew timer for --detach: it prints and exits, exactly as before", async () => {

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -42,6 +42,7 @@ import type {
   TokenListOutput,
 } from "../simlock-client/client.js";
 import { connectSimlockAdmin } from "../admin/index.js";
+import { RELEASE_TIMEOUT_MS } from "../lease-policy/index.js";
 import {
   buildCliEnvironment,
   errorExitCode,
@@ -1437,7 +1438,7 @@ describe("CLI: held-mode renew and release (ADR 0004 §2)", () => {
     expect(declared).toEqual([false, false]);
   });
 
-  it.each(["SIGHUP", "SIGINT", "SIGTERM"] as const)(
+  it.each(["SIGINT", "SIGTERM"] as const)(
     "releases explicitly on %s (ADR 0004 §2's catchable signals)",
     async (signal) => {
       const output = outputCapture();
@@ -1503,6 +1504,65 @@ describe("CLI: held-mode renew and release (ADR 0004 §2)", () => {
     signals.emit("SIGINT");
     expect(await runPromise).toBe(0);
     expect(released).toBe("lse_1");
+  });
+
+  it("exits 14 without a farewell release when a renewal is answered UNKNOWN_LEASE", async () => {
+    const clock = new FakeClock(0);
+    const output = outputCapture();
+    let released = false;
+    let renewals = 0;
+    const client = fakeClient({
+      renewLease: () => {
+        renewals += 1;
+        return Promise.reject(
+          new SimlockError("UNKNOWN_LEASE", "domain", "no such lease", { leaseId: "lse_1" }),
+        );
+      },
+      releaseLease: () => {
+        released = true;
+        return Promise.resolve({ leaseId: "lse_1" });
+      },
+    });
+    const runPromise = runCli(
+      ["lease", "--platform", "ios", "--device", "iPhone 17 Pro"],
+      output.environmentWith({ clock, connectAdmin: async () => client }),
+    );
+    await settle();
+    clock.advance(20_000);
+
+    // The daemon's answer is final: this ends the same way the lease-lost push does, rather
+    // than repeating the rejection until the deadline and then sitting alive.
+    expect(await runPromise).toBe(14);
+    expect(released, "asking again would only raise UNKNOWN_LEASE").toBe(false);
+    expect(renewals).toBe(1);
+    expect(clock.pendingTimerCount).toBe(0);
+    expect(JSON.parse(output.stderr.trim().split("\n").at(-1) ?? "{}")).toEqual({
+      error: { code: "UNKNOWN_LEASE", message: "no such lease" },
+    });
+  });
+
+  it("gives up on a farewell release the daemon never answers, instead of hanging", async () => {
+    const clock = new FakeClock(0);
+    const output = outputCapture();
+    const signals = new EventEmitter();
+    const client = fakeClient({ releaseLease: () => new Promise(() => {}) });
+    const runPromise = runCli(
+      ["lease", "--platform", "ios", "--device", "iPhone 17 Pro"],
+      output.environmentWith({
+        clock,
+        connectAdmin: async () => client,
+        signals: signals as unknown as CliEnvironment["signals"],
+      }),
+    );
+    await settle();
+    signals.emit("SIGINT");
+    await settle();
+
+    clock.advance(RELEASE_TIMEOUT_MS);
+
+    expect(await runPromise).toBe(0);
+    expect(output.stderr).toContain("Timed out releasing lease lse_1");
+    expect(clock.pendingTimerCount).toBe(0);
   });
 
   it("still releases the lease when printing the grant throws (--export-env with a bad key)", async () => {

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -1335,6 +1335,160 @@ describe("CLI: lease pushes and exit codes (own logic, not the dispatcher's)", (
   });
 });
 
+/**
+ * ADR 0004 §2: held mode is a client policy -- this process renews on a timer at a third of the
+ * remaining TTL and releases explicitly, rather than ponging a daemon push and relying on the
+ * socket closing. The wire is untouched in this slice (`mode: "held"` still goes out); what is
+ * asserted here is the CLI's own behaviour while it holds.
+ */
+describe("CLI: held-mode renew and release (ADR 0004 §2)", () => {
+  /** Lets `runLease` get past `requestLease` and arm its timer before the clock is advanced. */
+  const settle = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+  it("renews at a third of the TTL the daemon returned, re-deriving the cadence from each renewal", async () => {
+    const clock = new FakeClock(0);
+    const output = outputCapture();
+    const signals = new EventEmitter();
+    const renewals: Array<{ leaseId: string; at: number }> = [];
+    let released: string | undefined;
+    const client = fakeClient({
+      renewLease: (input) => {
+        renewals.push({ at: clock.now(), leaseId: input.leaseId });
+        // Half the grant's TTL comes back, so the next renewal must be half as far out too.
+        return Promise.resolve({
+          deviceId: "dev_1",
+          grantedAt: 0,
+          id: input.leaseId,
+          mode: "held",
+          ownerId: "test-requester",
+          requesterId: "test-requester",
+          ttlDeadline: clock.now() + 30_000,
+        });
+      },
+      releaseLease: (input) => {
+        released = input.leaseId;
+        return Promise.resolve({ leaseId: input.leaseId });
+      },
+    });
+    const runPromise = runCli(
+      ["lease", "--platform", "ios", "--device", "iPhone 17 Pro"],
+      output.environmentWith({
+        clock,
+        connectAdmin: async () => client,
+        signals: signals as unknown as CliEnvironment["signals"],
+      }),
+    );
+    await settle();
+
+    // The grant's deadline is 60_000, so the first renewal is due at 20_000 -- and not before.
+    clock.advance(19_999);
+    await settle();
+    expect(renewals).toEqual([]);
+    clock.advance(1);
+    await settle();
+    expect(renewals).toEqual([{ at: 20_000, leaseId: "lse_1" }]);
+
+    // 30_000ms of TTL came back at 20_000, so the next renewal is at 30_000, not at 40_000.
+    clock.advance(10_000);
+    await settle();
+    expect(renewals).toEqual([
+      { at: 20_000, leaseId: "lse_1" },
+      { at: 30_000, leaseId: "lse_1" },
+    ]);
+
+    signals.emit("SIGINT");
+    expect(await runPromise).toBe(0);
+    // The release is the CLI's own call, not a side effect of the socket closing.
+    expect(released).toBe("lse_1");
+    // And the timer is gone with it: no renewal can race the release, and nothing keeps the
+    // process alive after the command returns.
+    expect(clock.pendingTimerCount).toBe(0);
+    clock.advance(600_000);
+    expect(renewals).toHaveLength(2);
+  });
+
+  it("declares no heartbeat capability at hello, in either mode (ADR 0004 §4)", async () => {
+    const output = outputCapture();
+    const declared: Array<boolean | undefined> = [];
+    const environment = output.environmentWith({
+      connectAdmin: async (_resolveCredential, options) => {
+        declared.push(options?.heartbeat);
+        return fakeClient();
+      },
+    });
+    await runCli(
+      ["lease", "--platform", "ios", "--device", "iPhone 17 Pro", "--detach"],
+      environment,
+    );
+    expect(declared).toEqual([false]);
+  });
+
+  it("arms no renew timer for --detach: it prints and exits, exactly as before", async () => {
+    const clock = new FakeClock(0);
+    const output = outputCapture();
+    let renewed = 0;
+    const client = fakeClient({
+      renewLease: () => {
+        renewed += 1;
+        return Promise.reject(new Error("--detach must not renew"));
+      },
+    });
+    const exitCode = await runCli(
+      ["lease", "--platform", "ios", "--device", "iPhone 17 Pro", "--detach"],
+      output.environmentWith({ clock, connectAdmin: async () => client }),
+    );
+
+    expect(exitCode).toBe(0);
+    expect(clock.pendingTimerCount).toBe(0);
+    clock.advance(600_000);
+    expect(renewed).toBe(0);
+  });
+
+  it("stops renewing when the lease is lost, and still does not re-release it", async () => {
+    const clock = new FakeClock(0);
+    const output = outputCapture();
+    let leaseLostListener:
+      | ((push: { leaseId: string; deviceId: string; reason: string }) => void)
+      | undefined;
+    let renewed = 0;
+    let released = false;
+    const client = fakeClient({
+      onLeaseLost: (listener) => {
+        leaseLostListener = listener;
+        return () => {};
+      },
+      renewLease: (input) => {
+        renewed += 1;
+        return Promise.resolve({
+          deviceId: "dev_1",
+          grantedAt: 0,
+          id: input.leaseId,
+          mode: "held",
+          ownerId: "test-requester",
+          requesterId: "test-requester",
+          ttlDeadline: clock.now() + 60_000,
+        });
+      },
+      releaseLease: () => {
+        released = true;
+        return Promise.resolve({ leaseId: "lse_1" });
+      },
+    });
+    const runPromise = runCli(
+      ["lease", "--platform", "ios", "--device", "iPhone 17 Pro"],
+      output.environmentWith({ clock, connectAdmin: async () => client }),
+    );
+    await settle();
+    leaseLostListener?.({ deviceId: "dev_1", leaseId: "lse_1", reason: "ttl-backstop" });
+
+    expect(await runPromise).toBe(14);
+    expect(released).toBe(false);
+    expect(clock.pendingTimerCount).toBe(0);
+    clock.advance(600_000);
+    expect(renewed).toBe(0);
+  });
+});
+
 describe("CLI: mcp command (ADR 0003 §11 -- lazy module load)", () => {
   it("does not load the MCP stdio module unless the mcp command runs", async () => {
     const output = outputCapture();
@@ -1684,6 +1838,8 @@ function outputCapture(ports?: CliEnvironmentPorts): OutputCapture {
       const stdoutOut = { write: (value: string) => (capture.stdout += value) };
       if (ports === undefined) {
         return {
+          // Overridable through `environmentWith({ clock })` -- see the renew-cadence suite.
+          clock: new FakeClock(0),
           configPath: "/simlock/config.json",
           requesterId: "test-requester",
           now: () => 0,

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -1554,6 +1554,81 @@ describe("CLI: held-mode renew and release (ADR 0004 §2)", () => {
     });
   });
 
+  it("exits 14 when renewal gives up, rather than holding a lease it cannot keep", async () => {
+    const clock = new FakeClock(0);
+    const output = outputCapture();
+    let released = false;
+    const client = fakeClient({
+      // Never terminal, never successful: the ladder retries until the lease's own deadline
+      // passes, and then there is nothing left to hold.
+      renewLease: () =>
+        Promise.reject(new SimlockError("INTERNAL", "domain", "could not persist", {})),
+      releaseLease: () => {
+        released = true;
+        return Promise.resolve({ leaseId: "lse_1" });
+      },
+    });
+    const runPromise = runCli(
+      ["lease", "--platform", "ios", "--device", "iPhone 17 Pro"],
+      output.environmentWith({ clock, connectAdmin: async () => client }),
+    );
+    await settle();
+    clock.advance(20_000); // first attempt, fails, retries
+    await settle();
+    clock.advance(60_000); // the retry lands past the lease's 60_000 deadline
+
+    expect(await runPromise).toBe(14);
+    expect(released, "a lease that expired is not this process's to release").toBe(false);
+    const lines = output.stderr
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(lines).toContainEqual({
+      push: "lease-lost",
+      deviceId: "dev_1",
+      leaseId: "lse_1",
+      reason: "renew-failed",
+    });
+  });
+
+  it("writes one lease-lost line when a rejected renewal and the daemon's push both arrive", async () => {
+    const clock = new FakeClock(0);
+    const output = outputCapture();
+    let leaseLostListener:
+      | ((push: { leaseId: string; deviceId: string; reason: string }) => void)
+      | undefined;
+    const client = fakeClient({
+      onLeaseLost: (listener) => {
+        leaseLostListener = listener;
+        return () => {};
+      },
+      renewLease: () =>
+        Promise.reject(
+          new SimlockError("UNKNOWN_LEASE", "domain", "no such lease", { leaseId: "lse_1" }),
+        ),
+    });
+    const runPromise = runCli(
+      ["lease", "--platform", "ios", "--device", "iPhone 17 Pro"],
+      output.environmentWith({ clock, connectAdmin: async () => client }),
+    );
+    await settle();
+    clock.advance(20_000);
+    await settle();
+    // The daemon's own push for the same lease follows the renewal's answer. One ending, one
+    // line: a script tailing stderr must not read this as two devices lost.
+    leaseLostListener?.({ deviceId: "dev_1", leaseId: "lse_1", reason: "expired" });
+
+    expect(await runPromise).toBe(14);
+    const leaseLostLines = output.stderr
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>)
+      .filter((line) => line.push === "lease-lost");
+    expect(leaseLostLines).toEqual([
+      { push: "lease-lost", deviceId: "dev_1", leaseId: "lse_1", reason: "renew-rejected" },
+    ]);
+  });
+
   it("gives up on a farewell release the daemon never answers, instead of hanging", async () => {
     const clock = new FakeClock(0);
     const output = outputCapture();

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -1536,7 +1536,20 @@ describe("CLI: held-mode renew and release (ADR 0004 §2)", () => {
     expect(released, "asking again would only raise UNKNOWN_LEASE").toBe(false);
     expect(renewals).toBe(1);
     expect(clock.pendingTimerCount).toBe(0);
-    expect(JSON.parse(output.stderr.trim().split("\n").at(-1) ?? "{}")).toEqual({
+
+    // The same stderr line the push path writes, so a script tailing for `push: "lease-lost"`
+    // sees this way of losing a lease too, with the error line after it as the detail.
+    const lines = output.stderr
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(lines).toContainEqual({
+      push: "lease-lost",
+      deviceId: "dev_1",
+      leaseId: "lse_1",
+      reason: "renew-rejected",
+    });
+    expect(lines.at(-1)).toEqual({
       error: { code: "UNKNOWN_LEASE", message: "no such lease" },
     });
   });

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -1437,6 +1437,34 @@ describe("CLI: held-mode renew and release (ADR 0004 §2)", () => {
     expect(declared).toEqual([false, false]);
   });
 
+  it.each(["SIGHUP", "SIGINT", "SIGTERM"] as const)(
+    "releases explicitly on %s (ADR 0004 §2's catchable signals)",
+    async (signal) => {
+      const output = outputCapture();
+      const signals = new EventEmitter();
+      let released: string | undefined;
+      const client = fakeClient({
+        releaseLease: (input) => {
+          released = input.leaseId;
+          return Promise.resolve({ leaseId: input.leaseId });
+        },
+      });
+      const runPromise = runCli(
+        ["lease", "--platform", "ios", "--device", "iPhone 17 Pro"],
+        output.environmentWith({
+          clock: new FakeClock(0),
+          connectAdmin: async () => client,
+          signals: signals as unknown as CliEnvironment["signals"],
+        }),
+      );
+      await settle();
+      signals.emit(signal);
+
+      expect(await runPromise).toBe(0);
+      expect(released).toBe("lse_1");
+    },
+  );
+
   it("reports a failed renewal on stderr and keeps holding the lease", async () => {
     const clock = new FakeClock(0);
     const output = outputCapture();
@@ -1944,7 +1972,6 @@ function outputCapture(ports?: CliEnvironmentPorts): OutputCapture {
           clock: new FakeClock(0),
           configPath: "/simlock/config.json",
           requesterId: "test-requester",
-          now: () => 0,
           connectAdmin: async () => fakeClient(),
           connectExistingAdmin: async () => fakeClient(),
           readAdminTokenFile: async () => undefined,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -733,16 +733,29 @@ async function runLease(
   const leaseLostSignal = new Promise<void>((resolve) => {
     notifyLeaseLost = resolve;
   });
-  /** The lease ended without this process asking: stop waiting, skip the release it can no
-   * longer perform, and exit with the lost-lease code. */
-  const markLeaseLost = (): void => {
+  /**
+   * The lease ended without this process asking, from either of the two places that can find
+   * out -- the daemon's push, or a renewal it rejects. Both write the one `lease-lost` line a
+   * script tails for (whichever gets there first; the flag is what makes that structural
+   * rather than a matter of ordering), stop the wait, skip the release this process can no
+   * longer perform, and leave `runLease` returning the lost-lease code.
+   */
+  let wroteLeaseLost = false;
+  const markLeaseLost = (notice: {
+    readonly deviceId: string;
+    readonly leaseId: string;
+    readonly reason: string;
+  }): void => {
+    if (!wroteLeaseLost) {
+      wroteLeaseLost = true;
+      environment.stderr.write(`${JSON.stringify({ push: "lease-lost", ...notice })}\n`);
+    }
     leaseLost = true;
     notifyLeaseLost?.();
   };
   const offLeaseLost = client.onLeaseLost((push) => {
     if (push.leaseId !== ourLeaseId) return;
-    environment.stderr.write(`${JSON.stringify({ push: "lease-lost", ...push })}\n`);
-    markLeaseLost();
+    markLeaseLost(push);
   });
   const offUnhealthy = client.onDeviceUnhealthy((push) => {
     environment.stderr.write(`${JSON.stringify({ push: "device-unhealthy", ...push })}\n`);
@@ -833,16 +846,12 @@ async function runLease(
       // watching for `push: "lease-lost"` sees this way of losing a lease too. The error line
       // follows it as the detail of why.
       onLeaseGone: (error) => {
-        environment.stderr.write(
-          `${JSON.stringify({
-            push: "lease-lost",
-            deviceId: grant.lease.deviceId,
-            leaseId: grant.lease.id,
-            reason: "renew-rejected",
-          })}\n`,
-        );
+        markLeaseLost({
+          deviceId: grant.lease.deviceId,
+          leaseId: grant.lease.id,
+          reason: "renew-rejected",
+        });
         writeError(environment, error);
-        markLeaseLost();
       },
     });
     await Promise.race([termination.settled, leaseLostSignal]);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -35,7 +35,7 @@ import {
 } from "../admin/index.js";
 import type { Role } from "../contract/index.js";
 import type { PassthroughCommand } from "../client/index.js";
-import { startLeaseRenewal } from "../lease-policy/index.js";
+import { startLeaseRenewal, type LeaseRenewal } from "../lease-policy/index.js";
 import { spawnPassthrough } from "./passthrough.js";
 import { ERROR_TABLE } from "../contract/index.js";
 
@@ -742,6 +742,32 @@ async function runLease(
   const offRecovered = client.onDeviceRecovered((push) => {
     environment.stderr.write(`${JSON.stringify({ push: "device-recovered", ...push })}\n`);
   });
+  /**
+   * ADR 0004 §2/§3: the release a held holder owes when it stops holding -- an exit, parent
+   * death, a catchable signal, or a throw on the way to any of them. It runs from the `finally`
+   * below so no exit path can skip it (a broken `--export-env` key or an EPIPE on a closed pipe
+   * both throw between the grant and the wait), and it is the call that will still be here when
+   * the daemon stops releasing on connection close in PR B.
+   *
+   * Set only for held mode, and cleared as it runs, so it happens exactly once and never for
+   * `--detach` (whose lease deliberately outlives this process) or for a lease the daemon has
+   * already ended (`leaseLost` -- asking again would only raise UNKNOWN_LEASE).
+   */
+  let heldLeaseId: string | undefined;
+  const releaseHeldLease = async (): Promise<void> => {
+    if (heldLeaseId === undefined || leaseLost) return;
+    const leaseId = heldLeaseId;
+    heldLeaseId = undefined;
+    try {
+      await client.releaseLease({ leaseId });
+    } catch (error: unknown) {
+      // Non-fatal: the process still exits 0 after a signal, but the release
+      // failure is still diagnostic output, so it stays a structured stderr
+      // line rather than reverting to prose.
+      writeError(environment, error);
+    }
+  };
+  let renewal: LeaseRenewal | undefined;
   try {
     const grant = await client.requestLease(
       {
@@ -762,6 +788,8 @@ async function runLease(
       },
     );
     ourLeaseId = grant.lease.id;
+    // Owed from here on, whatever happens next -- see `releaseHeldLease`.
+    if (!detached && termination !== undefined) heldLeaseId = grant.lease.id;
     // ADR §5: "simlock lease output includes the resolved role" -- the one field this CLI
     // adds on top of the contract's `LeaseGrant` shape, everything else passed through as-is.
     const result = { ...grant, role: client.role };
@@ -774,42 +802,25 @@ async function runLease(
     // TTL -- computed from the deadline the daemon just returned, not from a config value this
     // process does not have. `--detach` returned above: it stays exactly as it was, printing
     // and exiting with no timer at all.
-    const renewal = startLeaseRenewal({
+    renewal = startLeaseRenewal({
       clock: environment.clock,
       leaseId: grant.lease.id,
       ttlDeadline: grant.lease.ttlDeadline,
       renew: (leaseId) => client.renewLease({ leaseId }),
-      // A renewal that fails has ended this holder's claim (see `startLeaseRenewal`); it is
-      // diagnostic output, on the same structured stderr channel as a failed release, and it
-      // does not by itself end the process -- the lease-lost push or the daemon's own expiry
-      // is what decides that.
+      // A failed attempt is retried until the lease's deadline (see `startLeaseRenewal`), so
+      // this is diagnostic output on the same structured stderr channel as a failed release,
+      // not an exit condition: the lease-lost push or the daemon's own expiry is what decides
+      // when this process stops holding.
       onError: (error) => writeError(environment, error),
     });
-    try {
-      await Promise.race([termination.settled, leaseLostSignal]);
-    } finally {
-      // Before the release below, and before any early return: a renew must never race the
-      // release of the lease it is renewing.
-      renewal.stop();
-    }
-    if (leaseLost) {
-      // The daemon already released it; asking again would only raise UNKNOWN_LEASE.
-      return LEASE_LOST_EXIT_CODE;
-    }
-    try {
-      // ADR 0004 §2/§3: the release a held holder owes on exit, parent death, or a catchable
-      // signal is this call -- not the socket closing in the `finally` below. The daemon still
-      // releases on close today (PR B removes that), so this is the path that will still be
-      // here when nothing else is.
-      await client.releaseLease({ leaseId: grant.lease.id });
-    } catch (error: unknown) {
-      // Non-fatal: the process still exits 0 after a signal, but the release
-      // failure is still diagnostic output, so it stays a structured stderr
-      // line rather than reverting to prose.
-      writeError(environment, error);
-    }
-    return 0;
+    await Promise.race([termination.settled, leaseLostSignal]);
+    // The daemon already released a lost lease; `releaseHeldLease` skips it for that reason.
+    return leaseLost ? LEASE_LOST_EXIT_CODE : 0;
   } finally {
+    // Stopped before the release, always: a renew must never race the release of the lease it
+    // is renewing, and no timer may outlive this command.
+    renewal?.stop();
+    await releaseHeldLease();
     termination?.dispose();
     offLeaseLost();
     offUnhealthy();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -35,6 +35,7 @@ import {
 } from "../admin/index.js";
 import type { Role } from "../contract/index.js";
 import type { PassthroughCommand } from "../client/index.js";
+import { startLeaseRenewal } from "../lease-policy/index.js";
 import { spawnPassthrough } from "./passthrough.js";
 import { ERROR_TABLE } from "../contract/index.js";
 
@@ -108,6 +109,11 @@ type McpStdioRunner = () => Promise<void>;
  * one connection helper instead of two.
  */
 export interface CliEnvironment {
+  /**
+   * The `Clock` port (architecture rule 9). Held mode's renew timer runs on it, so a test can
+   * drive the cadence by hand instead of waiting out a real TTL.
+   */
+  readonly clock: Clock;
   readonly configPath: string;
   /** ADR §4's requester default and this connection's fixed principal -- see §9's
    * "SIMLOCK_AGENT_ID and --agent-id still set the requester id ... they are not the
@@ -387,6 +393,7 @@ export function buildCliEnvironment(
   };
 
   return {
+    clock,
     configPath,
     requesterId,
     now: () => clock.now(),
@@ -706,7 +713,11 @@ async function runLease(
     ? undefined
     : waitForTermination(environment.signals, environment.parentWatch, watchedPid);
 
-  const client = await connectDaemonClient(environment, token, { heartbeat: !detached });
+  // ADR 0004 §2/§4: held mode is a client policy now -- this process renews on its own timer
+  // (below) instead of ponging the daemon's push, so neither mode declares the heartbeat
+  // capability any more. The daemon still has the push, and still slides a lease for any
+  // connection that asks for it; this one no longer asks.
+  const client = await connectDaemonClient(environment, token, { heartbeat: false });
   // Set once the daemon says this connection's lease ended without us asking. ADR 0003 §8:
   // lease-scoped pushes go to every live connection sharing the lease's owner, in either mode
   // -- filtered below against this connection's own granted lease id, the same way the
@@ -759,12 +770,37 @@ async function runLease(
     if (values["export-env"] === true) writeExportEnv(environment, result);
     else writeResult(environment, result);
     if (detached || termination === undefined) return 0;
-    await Promise.race([termination.settled, leaseLostSignal]);
+    // ADR 0004 §2: what a held holder does while alive is renew on a timer at a third of the
+    // TTL -- computed from the deadline the daemon just returned, not from a config value this
+    // process does not have. `--detach` returned above: it stays exactly as it was, printing
+    // and exiting with no timer at all.
+    const renewal = startLeaseRenewal({
+      clock: environment.clock,
+      leaseId: grant.lease.id,
+      ttlDeadline: grant.lease.ttlDeadline,
+      renew: (leaseId) => client.renewLease({ leaseId }),
+      // A renewal that fails has ended this holder's claim (see `startLeaseRenewal`); it is
+      // diagnostic output, on the same structured stderr channel as a failed release, and it
+      // does not by itself end the process -- the lease-lost push or the daemon's own expiry
+      // is what decides that.
+      onError: (error) => writeError(environment, error),
+    });
+    try {
+      await Promise.race([termination.settled, leaseLostSignal]);
+    } finally {
+      // Before the release below, and before any early return: a renew must never race the
+      // release of the lease it is renewing.
+      renewal.stop();
+    }
     if (leaseLost) {
       // The daemon already released it; asking again would only raise UNKNOWN_LEASE.
       return LEASE_LOST_EXIT_CODE;
     }
     try {
+      // ADR 0004 §2/§3: the release a held holder owes on exit, parent death, or a catchable
+      // signal is this call -- not the socket closing in the `finally` below. The daemon still
+      // releases on close today (PR B removes that), so this is the path that will still be
+      // here when nothing else is.
       await client.releaseLease({ leaseId: grant.lease.id });
     } catch (error: unknown) {
       // Non-fatal: the process still exits 0 after a signal, but the release

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -95,18 +95,9 @@ interface Output {
   write(value: string): unknown;
 }
 
-/**
- * ADR 0004 §2's "a catchable signal", enumerated: the two a holder is asked to stop with, plus
- * `SIGHUP` -- what a closing terminal sends, and the likeliest way a backgrounded holder dies
- * short of `SIGKILL`. All three take the same path: stop renewing, release, exit.
- */
-const TERMINATION_SIGNALS = ["SIGHUP", "SIGINT", "SIGTERM"] as const;
-
-type TerminationSignal = (typeof TERMINATION_SIGNALS)[number];
-
 interface Signals {
-  on(signal: TerminationSignal, listener: () => void): unknown;
-  off(signal: TerminationSignal, listener: () => void): unknown;
+  on(signal: "SIGINT" | "SIGTERM", listener: () => void): unknown;
+  off(signal: "SIGINT" | "SIGTERM", listener: () => void): unknown;
 }
 
 type McpStdioRunner = () => Promise<void>;
@@ -742,11 +733,16 @@ async function runLease(
   const leaseLostSignal = new Promise<void>((resolve) => {
     notifyLeaseLost = resolve;
   });
+  /** The lease ended without this process asking: stop waiting, skip the release it can no
+   * longer perform, and exit with the lost-lease code. */
+  const markLeaseLost = (): void => {
+    leaseLost = true;
+    notifyLeaseLost?.();
+  };
   const offLeaseLost = client.onLeaseLost((push) => {
     if (push.leaseId !== ourLeaseId) return;
     environment.stderr.write(`${JSON.stringify({ push: "lease-lost", ...push })}\n`);
-    leaseLost = true;
-    notifyLeaseLost?.();
+    markLeaseLost();
   });
   const offUnhealthy = client.onDeviceUnhealthy((push) => {
     environment.stderr.write(`${JSON.stringify({ push: "device-unhealthy", ...push })}\n`);
@@ -826,11 +822,17 @@ async function runLease(
       leaseId: grant.lease.id,
       ttlDeadline: grant.lease.ttlDeadline,
       renew: (leaseId) => client.renewLease({ leaseId }),
-      // A failed attempt is retried until the lease's deadline (see `startLeaseRenewal`), so
-      // this is diagnostic output on the same structured stderr channel as a failed release,
-      // not an exit condition: the lease-lost push or the daemon's own expiry is what decides
-      // when this process stops holding.
+      // A retryable attempt failed (see `startLeaseRenewal`): diagnostic output on the same
+      // structured stderr channel as a failed release, and not an exit condition -- the lease
+      // is still this process's until something says otherwise.
       onError: (error) => writeError(environment, error),
+      // Something did say otherwise: the daemon answered that this lease is gone or not ours.
+      // Same ending as the `lease-lost` push -- exit 14, and no farewell release for a lease
+      // that would only answer UNKNOWN_LEASE again.
+      onLeaseGone: (error) => {
+        writeError(environment, error);
+        markLeaseLost();
+      },
     });
     await Promise.race([termination.settled, leaseLostSignal]);
     // The daemon already released a lost lease; `releaseHeldLease` skips it for that reason.
@@ -1574,10 +1576,12 @@ function waitForTermination(
       resolve();
     };
     detach = () => {
-      for (const signal of TERMINATION_SIGNALS) signals.off(signal, finish);
+      signals.off("SIGINT", finish);
+      signals.off("SIGTERM", finish);
       watchHandle?.stop();
     };
-    for (const signal of TERMINATION_SIGNALS) signals.on(signal, finish);
+    signals.on("SIGINT", finish);
+    signals.on("SIGTERM", finish);
     watchHandle =
       parentWatch !== undefined && parentPid !== undefined && parentPid > 0
         ? parentWatch.watch(parentPid, finish)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -35,7 +35,12 @@ import {
 } from "../admin/index.js";
 import type { Role } from "../contract/index.js";
 import type { PassthroughCommand } from "../client/index.js";
-import { startLeaseRenewal, type LeaseRenewal } from "../lease-policy/index.js";
+import {
+  awaitWithin,
+  RELEASE_TIMEOUT_MS,
+  startLeaseRenewal,
+  type LeaseRenewal,
+} from "../lease-policy/index.js";
 import { spawnPassthrough } from "./passthrough.js";
 import { ERROR_TABLE } from "../contract/index.js";
 
@@ -90,9 +95,18 @@ interface Output {
   write(value: string): unknown;
 }
 
+/**
+ * ADR 0004 §2's "a catchable signal", enumerated: the two a holder is asked to stop with, plus
+ * `SIGHUP` -- what a closing terminal sends, and the likeliest way a backgrounded holder dies
+ * short of `SIGKILL`. All three take the same path: stop renewing, release, exit.
+ */
+const TERMINATION_SIGNALS = ["SIGHUP", "SIGINT", "SIGTERM"] as const;
+
+type TerminationSignal = (typeof TERMINATION_SIGNALS)[number];
+
 interface Signals {
-  on(signal: "SIGINT" | "SIGTERM", listener: () => void): unknown;
-  off(signal: "SIGINT" | "SIGTERM", listener: () => void): unknown;
+  on(signal: TerminationSignal, listener: () => void): unknown;
+  off(signal: TerminationSignal, listener: () => void): unknown;
 }
 
 type McpStdioRunner = () => Promise<void>;
@@ -119,7 +133,6 @@ export interface CliEnvironment {
    * "SIMLOCK_AGENT_ID and --agent-id still set the requester id ... they are not the
    * principal": `--agent-id` overrides `lease.request`'s `requesterId` field, never this. */
   readonly requesterId: string;
-  readonly now?: () => number;
   /**
    * Connects (auto-launching the daemon if it is not already running) and completes `hello`
    * with whatever `resolveCredential` resolves to.
@@ -396,7 +409,6 @@ export function buildCliEnvironment(
     clock,
     configPath,
     requesterId,
-    now: () => clock.now(),
     connectAdmin: (resolveCredential, options) =>
       connect(autoLaunchIpc, resolveCredential, options),
     connectExistingAdmin: (resolveCredential, options) => connect(ipc, resolveCredential, options),
@@ -759,7 +771,14 @@ async function runLease(
     const leaseId = heldLeaseId;
     heldLeaseId = undefined;
     try {
-      await client.releaseLease({ leaseId });
+      // Bounded like MCP's farewell release: a daemon that accepts the frame and never answers
+      // must not leave `simlock lease` hanging after a Ctrl-C.
+      await awaitWithin(
+        environment.clock,
+        RELEASE_TIMEOUT_MS,
+        client.releaseLease({ leaseId }),
+        `Timed out releasing lease ${leaseId}`,
+      );
     } catch (error: unknown) {
       // Non-fatal: the process still exits 0 after a signal, but the release
       // failure is still diagnostic output, so it stays a structured stderr
@@ -1099,7 +1118,7 @@ async function runEvents(
   try {
     const sinceTs =
       typeof values.since === "string"
-        ? (environment.now ?? Date.now)() - parseDuration(values.since)
+        ? environment.clock.now() - parseDuration(values.since)
         : undefined;
     for (const event of await client.replayEvents(sinceTs === undefined ? {} : { sinceTs })) {
       writeResult(environment, event);
@@ -1555,12 +1574,10 @@ function waitForTermination(
       resolve();
     };
     detach = () => {
-      signals.off("SIGINT", finish);
-      signals.off("SIGTERM", finish);
+      for (const signal of TERMINATION_SIGNALS) signals.off(signal, finish);
       watchHandle?.stop();
     };
-    signals.on("SIGINT", finish);
-    signals.on("SIGTERM", finish);
+    for (const signal of TERMINATION_SIGNALS) signals.on(signal, finish);
     watchHandle =
       parentWatch !== undefined && parentPid !== undefined && parentPid > 0
         ? parentWatch.watch(parentPid, finish)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -804,7 +804,7 @@ async function runLease(
     );
     ourLeaseId = grant.lease.id;
     // Owed from here on, whatever happens next -- see `releaseHeldLease`.
-    if (!detached && termination !== undefined) heldLeaseId = grant.lease.id;
+    if (!detached) heldLeaseId = grant.lease.id;
     // ADR §5: "simlock lease output includes the resolved role" -- the one field this CLI
     // adds on top of the contract's `LeaseGrant` shape, everything else passed through as-is.
     const result = { ...grant, role: client.role };
@@ -812,11 +812,12 @@ async function runLease(
     // changes what stdout carries, never how long the lease lives.
     if (values["export-env"] === true) writeExportEnv(environment, result);
     else writeResult(environment, result);
-    if (detached || termination === undefined) return 0;
+    // `--detach` is the only invocation without a termination watch: it prints and exits,
+    // with no timer and no release, exactly as it did before ADR 0004.
+    if (termination === undefined) return 0;
     // ADR 0004 §2: what a held holder does while alive is renew on a timer at a third of the
     // TTL -- computed from the deadline the daemon just returned, not from a config value this
-    // process does not have. `--detach` returned above: it stays exactly as it was, printing
-    // and exiting with no timer at all.
+    // process does not have.
     renewal = startLeaseRenewal({
       clock: environment.clock,
       leaseId: grant.lease.id,
@@ -828,8 +829,18 @@ async function runLease(
       onError: (error) => writeError(environment, error),
       // Something did say otherwise: the daemon answered that this lease is gone or not ours.
       // Same ending as the `lease-lost` push -- exit 14, and no farewell release for a lease
-      // that would only answer UNKNOWN_LEASE again.
+      // that would only answer UNKNOWN_LEASE again -- and the same stderr line, so a script
+      // watching for `push: "lease-lost"` sees this way of losing a lease too. The error line
+      // follows it as the detail of why.
       onLeaseGone: (error) => {
+        environment.stderr.write(
+          `${JSON.stringify({
+            push: "lease-lost",
+            deviceId: grant.lease.deviceId,
+            leaseId: grant.lease.id,
+            reason: "renew-rejected",
+          })}\n`,
+        );
         writeError(environment, error);
         markLeaseLost();
       },

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -840,17 +840,14 @@ async function runLease(
       // structured stderr channel as a failed release, and not an exit condition -- the lease
       // is still this process's until something says otherwise.
       onError: (error) => writeError(environment, error),
-      // Something did say otherwise: the daemon answered that this lease is gone or not ours.
-      // Same ending as the `lease-lost` push -- exit 14, and no farewell release for a lease
-      // that would only answer UNKNOWN_LEASE again -- and the same stderr line, so a script
-      // watching for `push: "lease-lost"` sees this way of losing a lease too. The error line
-      // follows it as the detail of why.
-      onLeaseGone: (error) => {
-        markLeaseLost({
-          deviceId: grant.lease.deviceId,
-          leaseId: grant.lease.id,
-          reason: "renew-rejected",
-        });
+      // Something did say otherwise: renewal ended, either because the daemon answered that
+      // this lease is gone or not ours (`renew-rejected`) or because it could not be kept
+      // alive to its deadline (`renew-failed`). Both are the same ending as the `lease-lost`
+      // push -- the same stderr line, so a script watching for `push: "lease-lost"` sees every
+      // way of losing a lease; exit 14; and no farewell release for a lease this process can
+      // no longer speak for. The error line follows as the detail of why.
+      onLeaseGone: (reason, error) => {
+        markLeaseLost({ deviceId: grant.lease.deviceId, leaseId: grant.lease.id, reason });
         writeError(environment, error);
       },
     });

--- a/src/lease-policy/index.test.ts
+++ b/src/lease-policy/index.test.ts
@@ -24,9 +24,10 @@ describe("startLeaseRenewal", () => {
       renew: (leaseId) => {
         renewedAt.push(clock.now());
         seenLeaseIds.push(leaseId);
-        // The daemon's answer -- deliberately a *different* TTL than the grant's, so a
-        // cadence computed from anything but this deadline shows up as a wrong timestamp.
-        return Promise.resolve({ ttlDeadline: clock.now() + 6_000 });
+        // The daemon's answer -- deliberately a shorter TTL than the grant's, and a
+        // deadline the grant's own (10_000) could never produce, so a cadence derived from
+        // anything but this value shows up as a wrong timestamp below.
+        return Promise.resolve({ ttlDeadline: clock.now() + 3_000 });
       },
       ttlDeadline: 1_000 + 9_000,
     });
@@ -40,14 +41,15 @@ describe("startLeaseRenewal", () => {
     expect(renewedAt).toEqual([4_000]);
     expect(seenLeaseIds).toEqual(["lse_1"]);
 
-    // 6_000ms of TTL came back, so the next renewal is 2_000ms out -- not the 3_000ms the
-    // grant's own TTL would imply, and not 3_000ms after the previous *scheduled* time either.
-    clock.advance(1_999);
+    // 3_000ms of TTL came back at 4_000, so the next renewal is 1_000ms out -- not the
+    // 2_000ms the grant's own deadline would still imply, and not 3_000ms after the previous
+    // scheduled time either.
+    clock.advance(999);
     await flushMicrotasks();
     expect(renewedAt).toEqual([4_000]);
     clock.advance(1);
     await flushMicrotasks();
-    expect(renewedAt).toEqual([4_000, 6_000]);
+    expect(renewedAt).toEqual([4_000, 5_000]);
 
     renewal.stop();
   });
@@ -140,32 +142,85 @@ describe("startLeaseRenewal", () => {
     expect(clock.pendingTimerCount).toBe(1);
   });
 
-  it("gives up once the lease's own deadline has passed", async () => {
+  it("retries on a shrinking ladder, then gives up once the lease's own deadline has passed", async () => {
     const clock = new FakeClock(0);
-    const errors: unknown[] = [];
-    let calls = 0;
+    const errors: Error[] = [];
+    const attemptsAt: number[] = [];
     startLeaseRenewal({
       clock,
       leaseId: "lse_1",
-      onError: (error) => errors.push(error),
+      onError: (error) => errors.push(error as Error),
       renew: () => {
-        calls += 1;
-        return Promise.reject(new Error("DAEMON_CONNECTION_LOST"));
+        attemptsAt.push(clock.now());
+        return Promise.reject(new Error("INTERNAL"));
       },
       ttlDeadline: 3_000,
     });
 
-    // Retries keep shrinking with what is left of the TTL; once the deadline is behind us
-    // there is nothing left to save, and the timer is gone for good.
+    // Every retry is a third of what is *left* of the TTL, so the ladder shrinks towards the
+    // deadline instead of marching past it at a fixed interval.
+    clock.advance(1_000);
+    await flushMicrotasks();
+    expect(attemptsAt).toEqual([1_000]);
+    clock.advance(666);
+    await flushMicrotasks();
+    expect(attemptsAt).toEqual([1_000, 1_666]);
+    clock.advance(444);
+    await flushMicrotasks();
+    expect(attemptsAt).toEqual([1_000, 1_666, 2_110]);
+    expect(errors.map((error) => error.message)).toEqual(["INTERNAL", "INTERNAL", "INTERNAL"]);
+
+    // Once the deadline is behind us there is nothing left to save: renewal ends, with its own
+    // final report, distinct from the attempt failure that preceded it.
     clock.advance(60_000);
     await flushMicrotasks();
     expect(clock.pendingTimerCount).toBe(0);
-    const attemptsBefore = calls;
-    expect(errors).toHaveLength(attemptsBefore);
+    expect(errors.at(-1)?.message).toContain("Gave up renewing lease lse_1");
 
+    const attempts = attemptsAt.length;
     clock.advance(600_000);
     await flushMicrotasks();
-    expect(calls).toBe(attemptsBefore);
+    expect(attemptsAt).toHaveLength(attempts);
+  });
+
+  it("keeps a deadline an abandoned renewal turns out to have moved", async () => {
+    const clock = new FakeClock(0);
+    const attemptsAt: number[] = [];
+    let answerFirst!: (renewed: { ttlDeadline: number }) => void;
+    startLeaseRenewal({
+      clock,
+      leaseId: "lse_1",
+      renew: () => {
+        attemptsAt.push(clock.now());
+        if (attemptsAt.length > 1) return Promise.reject(new Error("INTERNAL"));
+        return new Promise<{ ttlDeadline: number }>((resolve) => {
+          answerFirst = resolve;
+        });
+      },
+      ttlDeadline: 3_000,
+    });
+
+    clock.advance(1_000);
+    await flushMicrotasks();
+    expect(attemptsAt).toEqual([1_000]);
+
+    // The attempt is abandoned at its bound (a third of the 2_000ms left), and only then does
+    // the daemon answer it. The request still reached the daemon, so that deadline is real.
+    clock.advance(666);
+    await flushMicrotasks();
+    answerFirst({ ttlDeadline: 30_000 });
+    await flushMicrotasks();
+
+    clock.advance(444);
+    await flushMicrotasks();
+    expect(attemptsAt).toEqual([1_000, 2_110]);
+
+    // Working towards 30_000 now, not the stale 3_000: a retry lands long after the deadline
+    // this renewal would otherwise have given up at, because the lease has not expired.
+    clock.advance(9_296);
+    await flushMicrotasks();
+    expect(attemptsAt).toEqual([1_000, 2_110, 11_406]);
+    expect(clock.pendingTimerCount).toBe(1);
   });
 
   it("abandons a renewal the daemon never answers, and retries it", async () => {

--- a/src/lease-policy/index.test.ts
+++ b/src/lease-policy/index.test.ts
@@ -368,6 +368,56 @@ describe("startLeaseRenewal", () => {
     expect(errors.at(-1)?.message).toContain("Gave up renewing lease lse_1");
   });
 
+  it("applies two late answers newest-first, not largest-first", async () => {
+    const clock = new FakeClock(0);
+    const attemptsAt: number[] = [];
+    const answers: Array<(renewed: { ttlDeadline: number }) => void> = [];
+    startLeaseRenewal({
+      clock,
+      leaseId: "lse_1",
+      renew: () => {
+        attemptsAt.push(clock.now());
+        // The first two attempts are accepted and left unanswered until the end of the test;
+        // everything after fails, so the schedule is driven purely by `deadline`.
+        if (attemptsAt.length <= 2)
+          return new Promise<{ ttlDeadline: number }>((resolve) => {
+            answers.push(resolve);
+          });
+        return Promise.reject(new Error("INTERNAL"));
+      },
+      ttlDeadline: 9_000,
+    });
+
+    clock.advance(3_000); // attempt 1 starts, bound 2_000
+    await flushMicrotasks();
+    clock.advance(2_000); // abandoned at 5_000; next attempt at 6_333
+    await flushMicrotasks();
+    clock.advance(1_333); // attempt 2 starts, bound 889
+    await flushMicrotasks();
+    clock.advance(889); // abandoned at 7_222; next attempt at 7_814
+    await flushMicrotasks();
+    expect(attemptsAt).toEqual([3_000, 6_333]);
+
+    // Both abandoned requests did reach the daemon, and answer out of order. Attempt 2 is the
+    // newer request, so its 12_000 is the truth; attempt 1's 900_000 is stale, and being the
+    // larger number does not make it newer -- adopting it would leave this holder renewing
+    // long after the lease was gone.
+    answers[1]?.({ ttlDeadline: 12_000 });
+    await flushMicrotasks();
+    answers[0]?.({ ttlDeadline: 900_000 });
+    await flushMicrotasks();
+
+    clock.advance(592); // attempt 3 at 7_814, which fails and reschedules off the deadline
+    await flushMicrotasks();
+    expect(attemptsAt).toEqual([3_000, 6_333, 7_814]);
+
+    // A third of what is left of 12_000 at 7_814 is 1_395ms -- so the next attempt lands at
+    // 9_209. Against the stale 900_000 it would not have come for another five minutes.
+    clock.advance(1_395);
+    await flushMicrotasks();
+    expect(attemptsAt).toEqual([3_000, 6_333, 7_814, 9_209]);
+  });
+
   it("never reports a failure that arrives after stop()", async () => {
     const clock = new FakeClock(0);
     let rejectRenew!: (error: Error) => void;

--- a/src/lease-policy/index.test.ts
+++ b/src/lease-policy/index.test.ts
@@ -1,0 +1,186 @@
+/**
+ * The renew cadence ADR 0004 §2 specifies, exercised on a hand-advanced `FakeClock`: a third of
+ * the *remaining* TTL, recomputed from the deadline the daemon returned every time, and nothing
+ * at all after `stop()`.
+ */
+import { describe, expect, it } from "vitest";
+
+import { FakeClock } from "../ports/index.js";
+import { startLeaseRenewal } from "./index.js";
+
+/** Lets the awaited `renew` call settle; the fake clock never moves on its own. */
+async function flushMicrotasks(times = 10): Promise<void> {
+  for (let index = 0; index < times; index += 1) await Promise.resolve();
+}
+
+describe("startLeaseRenewal", () => {
+  it("renews at a third of the remaining TTL and reschedules off each renewal's own deadline", async () => {
+    const clock = new FakeClock(1_000);
+    const renewedAt: number[] = [];
+    const seenLeaseIds: string[] = [];
+    const renewal = startLeaseRenewal({
+      clock,
+      leaseId: "lse_1",
+      renew: (leaseId) => {
+        renewedAt.push(clock.now());
+        seenLeaseIds.push(leaseId);
+        // The daemon's answer -- deliberately a *different* TTL than the grant's, so a
+        // cadence computed from anything but this deadline shows up as a wrong timestamp.
+        return Promise.resolve({ ttlDeadline: clock.now() + 6_000 });
+      },
+      ttlDeadline: 1_000 + 9_000,
+    });
+
+    clock.advance(2_999);
+    await flushMicrotasks();
+    expect(renewedAt, "must not renew before a third of the TTL has passed").toEqual([]);
+
+    clock.advance(1);
+    await flushMicrotasks();
+    expect(renewedAt).toEqual([4_000]);
+    expect(seenLeaseIds).toEqual(["lse_1"]);
+
+    // 6_000ms of TTL came back, so the next renewal is 2_000ms out -- not the 3_000ms the
+    // grant's own TTL would imply, and not 3_000ms after the previous *scheduled* time either.
+    clock.advance(1_999);
+    await flushMicrotasks();
+    expect(renewedAt).toEqual([4_000]);
+    clock.advance(1);
+    await flushMicrotasks();
+    expect(renewedAt).toEqual([4_000, 6_000]);
+
+    renewal.stop();
+  });
+
+  it("stops cleanly: the pending timer is cancelled and no renewal follows", async () => {
+    const clock = new FakeClock(0);
+    let calls = 0;
+    const renewal = startLeaseRenewal({
+      clock,
+      leaseId: "lse_1",
+      renew: () => {
+        calls += 1;
+        return Promise.resolve({ ttlDeadline: clock.now() + 3_000 });
+      },
+      ttlDeadline: 3_000,
+    });
+    expect(clock.pendingTimerCount).toBe(1);
+
+    renewal.stop();
+
+    expect(clock.pendingTimerCount, "a stopped renewal leaves no timer behind").toBe(0);
+    clock.advance(60_000);
+    await flushMicrotasks();
+    expect(calls).toBe(0);
+  });
+
+  it("does not reschedule when a renewal that was already in flight comes back after stop()", async () => {
+    const clock = new FakeClock(0);
+    let resolveRenew!: (renewed: { ttlDeadline: number }) => void;
+    let calls = 0;
+    const renewal = startLeaseRenewal({
+      clock,
+      leaseId: "lse_1",
+      renew: () => {
+        calls += 1;
+        return new Promise<{ ttlDeadline: number }>((resolve) => {
+          resolveRenew = resolve;
+        });
+      },
+      ttlDeadline: 3_000,
+    });
+
+    clock.advance(1_000);
+    await flushMicrotasks();
+    expect(calls).toBe(1);
+
+    renewal.stop();
+    resolveRenew({ ttlDeadline: 60_000 });
+    await flushMicrotasks();
+
+    expect(clock.pendingTimerCount, "a late renewal must not re-arm a stopped timer").toBe(0);
+    clock.advance(60_000);
+    await flushMicrotasks();
+    expect(calls).toBe(1);
+  });
+
+  it("ends renewal on the first failure, reporting it exactly once", async () => {
+    const clock = new FakeClock(0);
+    const failure = new Error("UNKNOWN_LEASE");
+    const errors: unknown[] = [];
+    let calls = 0;
+    startLeaseRenewal({
+      clock,
+      leaseId: "lse_1",
+      onError: (error) => errors.push(error),
+      renew: () => {
+        calls += 1;
+        return Promise.reject(failure);
+      },
+      ttlDeadline: 3_000,
+    });
+
+    clock.advance(1_000);
+    await flushMicrotasks();
+    expect(errors).toEqual([failure]);
+    expect(clock.pendingTimerCount).toBe(0);
+
+    clock.advance(60_000);
+    await flushMicrotasks();
+    expect(calls, "a failed renewal is not retried on a timer").toBe(1);
+    expect(errors).toHaveLength(1);
+  });
+
+  it("never reports a failure that arrives after stop()", async () => {
+    const clock = new FakeClock(0);
+    let rejectRenew!: (error: Error) => void;
+    const errors: unknown[] = [];
+    const renewal = startLeaseRenewal({
+      clock,
+      leaseId: "lse_1",
+      onError: (error) => errors.push(error),
+      renew: () =>
+        new Promise<{ ttlDeadline: number }>((_resolve, reject) => {
+          rejectRenew = reject;
+        }),
+      ttlDeadline: 3_000,
+    });
+
+    clock.advance(1_000);
+    await flushMicrotasks();
+    renewal.stop();
+    rejectRenew(new Error("connection lost"));
+    await flushMicrotasks();
+
+    expect(errors).toEqual([]);
+  });
+
+  it("still renews a deadline that is already in the past, without becoming a hot loop", async () => {
+    const clock = new FakeClock(1_000);
+    const renewedAt: number[] = [];
+    const renewal = startLeaseRenewal({
+      clock,
+      leaseId: "lse_1",
+      renew: () => {
+        renewedAt.push(clock.now());
+        // A daemon that keeps answering with an expired deadline: without the floor this
+        // would renew once per tick forever.
+        return Promise.resolve({ ttlDeadline: clock.now() });
+      },
+      ttlDeadline: 500,
+    });
+
+    clock.advance(249);
+    await flushMicrotasks();
+    expect(renewedAt).toEqual([]);
+    clock.advance(1);
+    await flushMicrotasks();
+    expect(renewedAt).toEqual([1_250]);
+
+    clock.advance(250);
+    await flushMicrotasks();
+    expect(renewedAt).toEqual([1_250, 1_500]);
+
+    renewal.stop();
+  });
+});

--- a/src/lease-policy/index.test.ts
+++ b/src/lease-policy/index.test.ts
@@ -104,9 +104,44 @@ describe("startLeaseRenewal", () => {
     expect(calls).toBe(1);
   });
 
-  it("ends renewal on the first failure, reporting it exactly once", async () => {
+  it("retries a failed renewal while the lease can still be saved, and reports every attempt", async () => {
     const clock = new FakeClock(0);
-    const failure = new Error("UNKNOWN_LEASE");
+    const failure = new Error("INTERNAL");
+    const errors: unknown[] = [];
+    const attemptsAt: number[] = [];
+    let failuresLeft = 1;
+    startLeaseRenewal({
+      clock,
+      leaseId: "lse_1",
+      onError: (error) => errors.push(error),
+      renew: () => {
+        attemptsAt.push(clock.now());
+        if (failuresLeft > 0) {
+          failuresLeft -= 1;
+          return Promise.reject(failure);
+        }
+        return Promise.resolve({ ttlDeadline: clock.now() + 3_000 });
+      },
+      ttlDeadline: 3_000,
+    });
+
+    // A daemon that failed to persist one renewal is still willing to serve the next, and the
+    // one-third cadence exists precisely to leave room for the retry.
+    clock.advance(1_000);
+    await flushMicrotasks();
+    expect(attemptsAt).toEqual([1_000]);
+    expect(errors).toEqual([failure]);
+
+    clock.advance(666);
+    await flushMicrotasks();
+    expect(attemptsAt).toEqual([1_000, 1_666]);
+    expect(errors).toHaveLength(1);
+    // The successful retry put the lease back on a full TTL: renewal continues from there.
+    expect(clock.pendingTimerCount).toBe(1);
+  });
+
+  it("gives up once the lease's own deadline has passed", async () => {
+    const clock = new FakeClock(0);
     const errors: unknown[] = [];
     let calls = 0;
     startLeaseRenewal({
@@ -115,20 +150,55 @@ describe("startLeaseRenewal", () => {
       onError: (error) => errors.push(error),
       renew: () => {
         calls += 1;
-        return Promise.reject(failure);
+        return Promise.reject(new Error("DAEMON_CONNECTION_LOST"));
       },
       ttlDeadline: 3_000,
     });
 
-    clock.advance(1_000);
-    await flushMicrotasks();
-    expect(errors).toEqual([failure]);
-    expect(clock.pendingTimerCount).toBe(0);
-
+    // Retries keep shrinking with what is left of the TTL; once the deadline is behind us
+    // there is nothing left to save, and the timer is gone for good.
     clock.advance(60_000);
     await flushMicrotasks();
-    expect(calls, "a failed renewal is not retried on a timer").toBe(1);
+    expect(clock.pendingTimerCount).toBe(0);
+    const attemptsBefore = calls;
+    expect(errors).toHaveLength(attemptsBefore);
+
+    clock.advance(600_000);
+    await flushMicrotasks();
+    expect(calls).toBe(attemptsBefore);
+  });
+
+  it("abandons a renewal the daemon never answers, and retries it", async () => {
+    const clock = new FakeClock(0);
+    const errors: unknown[] = [];
+    let calls = 0;
+    startLeaseRenewal({
+      clock,
+      leaseId: "lse_1",
+      onError: (error) => errors.push(error),
+      renew: () => {
+        calls += 1;
+        // Accepted and never answered: the wire has no request timeout of its own.
+        return new Promise<{ ttlDeadline: number }>(() => {});
+      },
+      ttlDeadline: 9_000,
+    });
+
+    clock.advance(3_000);
+    await flushMicrotasks();
+    expect(calls).toBe(1);
+    expect(errors).toEqual([]);
+
+    // The attempt is bounded by the interval it was scheduled on (2_000ms of the 6_000ms
+    // left), so it does not swallow the rest of the TTL in silence.
+    clock.advance(2_000);
+    await flushMicrotasks();
     expect(errors).toHaveLength(1);
+    expect(calls).toBe(1);
+
+    clock.advance(1_333);
+    await flushMicrotasks();
+    expect(calls).toBe(2);
   });
 
   it("never reports a failure that arrives after stop()", async () => {
@@ -155,18 +225,21 @@ describe("startLeaseRenewal", () => {
     expect(errors).toEqual([]);
   });
 
-  it("still renews a deadline that is already in the past, without becoming a hot loop", async () => {
+  it("tries a deadline that is already in the past once, then stops instead of hot-looping", async () => {
     const clock = new FakeClock(1_000);
     const renewedAt: number[] = [];
-    const renewal = startLeaseRenewal({
+    const errors: unknown[] = [];
+    startLeaseRenewal({
       clock,
       leaseId: "lse_1",
+      onError: (error) => errors.push(error),
       renew: () => {
         renewedAt.push(clock.now());
-        // A daemon that keeps answering with an expired deadline: without the floor this
-        // would renew once per tick forever.
+        // A daemon answering with a deadline that is not in the future -- reachable with
+        // `lease.heldTtlBackstopMs: 0`, which the config validator allows.
         return Promise.resolve({ ttlDeadline: clock.now() });
       },
+      // Already expired at the grant: the floor keeps even this from being an instant loop.
       ttlDeadline: 500,
     });
 
@@ -177,10 +250,11 @@ describe("startLeaseRenewal", () => {
     await flushMicrotasks();
     expect(renewedAt).toEqual([1_250]);
 
-    clock.advance(250);
+    // Nothing to renew towards: renewal ends rather than spinning at the floor forever.
+    expect(clock.pendingTimerCount).toBe(0);
+    expect(errors).toHaveLength(1);
+    clock.advance(600_000);
     await flushMicrotasks();
-    expect(renewedAt).toEqual([1_250, 1_500]);
-
-    renewal.stop();
+    expect(renewedAt).toEqual([1_250]);
   });
 });

--- a/src/lease-policy/index.test.ts
+++ b/src/lease-policy/index.test.ts
@@ -5,12 +5,20 @@
  */
 import { describe, expect, it } from "vitest";
 
+import { SimlockError } from "../contract/index.js";
 import { FakeClock } from "../ports/index.js";
-import { startLeaseRenewal } from "./index.js";
+import { awaitWithin, RELEASE_TIMEOUT_MS, startLeaseRenewal } from "./index.js";
 
 /** Lets the awaited `renew` call settle; the fake clock never moves on its own. */
 async function flushMicrotasks(times = 10): Promise<void> {
   for (let index = 0; index < times; index += 1) await Promise.resolve();
+}
+
+/** The daemon's two "this lease is not yours to renew" answers, with their real detail shapes. */
+function leaseGoneError(code: "UNKNOWN_LEASE" | "FORBIDDEN"): SimlockError {
+  return code === "UNKNOWN_LEASE"
+    ? new SimlockError("UNKNOWN_LEASE", "domain", "no such lease", { leaseId: "lse_1" })
+    : new SimlockError("FORBIDDEN", "protocol", "not your lease", {});
 }
 
 describe("startLeaseRenewal", () => {
@@ -104,6 +112,68 @@ describe("startLeaseRenewal", () => {
     clock.advance(60_000);
     await flushMicrotasks();
     expect(calls).toBe(1);
+  });
+
+  it.each(["UNKNOWN_LEASE", "FORBIDDEN"] as const)(
+    "treats %s as the end of the lease, not a failed attempt",
+    async (code) => {
+      const clock = new FakeClock(0);
+      const gone: unknown[] = [];
+      const errors: unknown[] = [];
+      let calls = 0;
+      startLeaseRenewal({
+        clock,
+        leaseId: "lse_1",
+        onError: (error) => errors.push(error),
+        onLeaseGone: (error) => gone.push(error),
+        renew: () => {
+          calls += 1;
+          return Promise.reject(leaseGoneError(code));
+        },
+        ttlDeadline: 30_000,
+      });
+
+      clock.advance(10_000);
+      await flushMicrotasks();
+
+      expect(gone).toHaveLength(1);
+      expect(gone[0]).toMatchObject({ code });
+      expect(errors, "a lease that is over is not a retryable failure").toEqual([]);
+      expect(clock.pendingTimerCount).toBe(0);
+
+      clock.advance(600_000);
+      await flushMicrotasks();
+      expect(calls, "and it is never retried").toBe(1);
+    },
+  );
+
+  it("reports and retries a renew that throws synchronously", async () => {
+    const clock = new FakeClock(0);
+    const errors: unknown[] = [];
+    const attemptsAt: number[] = [];
+    startLeaseRenewal({
+      clock,
+      leaseId: "lse_1",
+      onError: (error) => errors.push(error),
+      renew: () => {
+        attemptsAt.push(clock.now());
+        // A client that validates its input before it ever reaches the wire throws here
+        // rather than rejecting; that must not escape into the unawaited tick.
+        if (attemptsAt.length === 1) throw new Error("BAD_REQUEST");
+        return Promise.resolve({ ttlDeadline: clock.now() + 3_000 });
+      },
+      ttlDeadline: 3_000,
+    });
+
+    clock.advance(1_000);
+    await flushMicrotasks();
+    expect(attemptsAt).toEqual([1_000]);
+    expect((errors[0] as Error).message).toBe("BAD_REQUEST");
+
+    clock.advance(666);
+    await flushMicrotasks();
+    expect(attemptsAt).toEqual([1_000, 1_666]);
+    expect(clock.pendingTimerCount).toBe(1);
   });
 
   it("retries a failed renewal while the lease can still be saved, and reports every attempt", async () => {
@@ -244,8 +314,8 @@ describe("startLeaseRenewal", () => {
     expect(calls).toBe(1);
     expect(errors).toEqual([]);
 
-    // The attempt is bounded by the interval it was scheduled on (2_000ms of the 6_000ms
-    // left), so it does not swallow the rest of the TTL in silence.
+    // The attempt is bounded by a third of what is left of the TTL when it starts (2_000ms of
+    // the 6_000ms remaining at 3_000), so it does not swallow the rest of the TTL in silence.
     clock.advance(2_000);
     await flushMicrotasks();
     expect(errors).toHaveLength(1);
@@ -311,5 +381,54 @@ describe("startLeaseRenewal", () => {
     clock.advance(600_000);
     await flushMicrotasks();
     expect(renewedAt).toEqual([1_250]);
+  });
+});
+
+/**
+ * The bound both frontends put on their farewell `lease.release`: an unresponsive daemon may
+ * cost a holder the wait, never its exit.
+ */
+describe("awaitWithin", () => {
+  it("resolves with the work and leaves no timer behind", async () => {
+    const clock = new FakeClock(0);
+
+    await expect(
+      awaitWithin(clock, RELEASE_TIMEOUT_MS, Promise.resolve({ leaseId: "lse_1" }), "too slow"),
+    ).resolves.toEqual({ leaseId: "lse_1" });
+    // A live timer here would keep a real process alive for the whole bound after the work
+    // it was guarding had already finished.
+    expect(clock.pendingTimerCount).toBe(0);
+  });
+
+  it("rejects with the given message once the bound passes, and cleans up after itself", async () => {
+    const clock = new FakeClock(0);
+    const bounded = awaitWithin(
+      clock,
+      RELEASE_TIMEOUT_MS,
+      new Promise<void>(() => {}),
+      "Timed out releasing lease lse_1",
+    );
+    await flushMicrotasks();
+    expect(clock.pendingTimerCount).toBe(1);
+
+    clock.advance(RELEASE_TIMEOUT_MS - 1);
+    await flushMicrotasks();
+    expect(clock.pendingTimerCount).toBe(1);
+
+    clock.advance(1);
+    await expect(bounded).rejects.toThrow("Timed out releasing lease lse_1");
+    expect(clock.pendingTimerCount).toBe(0);
+  });
+
+  it("propagates the work's own rejection rather than waiting out the bound", async () => {
+    const clock = new FakeClock(0);
+    const failure = new SimlockError("UNKNOWN_LEASE", "domain", "no such lease", {
+      leaseId: "lse_1",
+    });
+
+    await expect(
+      awaitWithin(clock, RELEASE_TIMEOUT_MS, Promise.reject(failure), "too slow"),
+    ).rejects.toBe(failure);
+    expect(clock.pendingTimerCount).toBe(0);
   });
 });

--- a/src/lease-policy/index.test.ts
+++ b/src/lease-policy/index.test.ts
@@ -326,6 +326,48 @@ describe("startLeaseRenewal", () => {
     expect(calls).toBe(2);
   });
 
+  it("ignores an abandoned renewal's answer once a newer one has come back", async () => {
+    const clock = new FakeClock(0);
+    const errors: Error[] = [];
+    let answerFirst!: (renewed: { ttlDeadline: number }) => void;
+    let attempts = 0;
+    startLeaseRenewal({
+      clock,
+      leaseId: "lse_1",
+      onError: (error) => errors.push(error as Error),
+      renew: () => {
+        attempts += 1;
+        if (attempts === 1)
+          return new Promise<{ ttlDeadline: number }>((resolve) => {
+            answerFirst = resolve;
+          });
+        // The second attempt is the daemon's newest word: 3_000ms from now.
+        if (attempts === 2) return Promise.resolve({ ttlDeadline: clock.now() + 3_000 });
+        return Promise.reject(new Error("INTERNAL"));
+      },
+      ttlDeadline: 3_000,
+    });
+
+    clock.advance(1_000); // attempt 1, abandoned at its bound below
+    await flushMicrotasks();
+    clock.advance(666);
+    await flushMicrotasks();
+    clock.advance(444); // attempt 2 at 2_110, answering 5_110
+    await flushMicrotasks();
+    expect(attempts).toBe(2);
+
+    // Attempt 1 finally answers, with a far longer deadline -- but it is older than attempt 2,
+    // whose answer is the daemon's current word. Adopting it would have this holder renewing
+    // towards a deadline the daemon never promised.
+    answerFirst({ ttlDeadline: 999_999 });
+    await flushMicrotasks();
+
+    clock.advance(60_000);
+    await flushMicrotasks();
+    expect(clock.pendingTimerCount, "renewal works towards 5_110, so it gives up past it").toBe(0);
+    expect(errors.at(-1)?.message).toContain("Gave up renewing lease lse_1");
+  });
+
   it("never reports a failure that arrives after stop()", async () => {
     const clock = new FakeClock(0);
     let rejectRenew!: (error: Error) => void;

--- a/src/lease-policy/index.test.ts
+++ b/src/lease-policy/index.test.ts
@@ -118,14 +118,14 @@ describe("startLeaseRenewal", () => {
     "treats %s as the end of the lease, not a failed attempt",
     async (code) => {
       const clock = new FakeClock(0);
-      const gone: unknown[] = [];
+      const gone: Array<{ reason: string; error: unknown }> = [];
       const errors: unknown[] = [];
       let calls = 0;
       startLeaseRenewal({
         clock,
         leaseId: "lse_1",
         onError: (error) => errors.push(error),
-        onLeaseGone: (error) => gone.push(error),
+        onLeaseGone: (reason, error) => gone.push({ error, reason }),
         renew: () => {
           calls += 1;
           return Promise.reject(leaseGoneError(code));
@@ -137,7 +137,10 @@ describe("startLeaseRenewal", () => {
       await flushMicrotasks();
 
       expect(gone).toHaveLength(1);
-      expect(gone[0]).toMatchObject({ code });
+      expect(gone[0]?.reason, "the daemon's answer, not a failure to reach it").toBe(
+        "renew-rejected",
+      );
+      expect(gone[0]?.error).toMatchObject({ code });
       expect(errors, "a lease that is over is not a retryable failure").toEqual([]);
       expect(clock.pendingTimerCount).toBe(0);
 
@@ -215,11 +218,13 @@ describe("startLeaseRenewal", () => {
   it("retries on a shrinking ladder, then gives up once the lease's own deadline has passed", async () => {
     const clock = new FakeClock(0);
     const errors: Error[] = [];
+    const gone: Array<{ reason: string; error: Error }> = [];
     const attemptsAt: number[] = [];
     startLeaseRenewal({
       clock,
       leaseId: "lse_1",
       onError: (error) => errors.push(error as Error),
+      onLeaseGone: (reason, error) => gone.push({ error: error as Error, reason }),
       renew: () => {
         attemptsAt.push(clock.now());
         return Promise.reject(new Error("INTERNAL"));
@@ -240,12 +245,15 @@ describe("startLeaseRenewal", () => {
     expect(attemptsAt).toEqual([1_000, 1_666, 2_110]);
     expect(errors.map((error) => error.message)).toEqual(["INTERNAL", "INTERNAL", "INTERNAL"]);
 
-    // Once the deadline is behind us there is nothing left to save: renewal ends, with its own
-    // final report, distinct from the attempt failure that preceded it.
+    // Once the deadline is behind us there is nothing left to save. That is the end of the
+    // lease, not one more failed attempt, so it is reported as such -- a holder that only
+    // watched `onError` would sit alive holding nothing.
     clock.advance(60_000);
     await flushMicrotasks();
     expect(clock.pendingTimerCount).toBe(0);
-    expect(errors.at(-1)?.message).toContain("Gave up renewing lease lse_1");
+    expect(gone).toHaveLength(1);
+    expect(gone[0]?.reason).toBe("renew-failed");
+    expect(gone[0]?.error.message).toContain("Gave up renewing lease lse_1");
 
     const attempts = attemptsAt.length;
     clock.advance(600_000);
@@ -329,12 +337,14 @@ describe("startLeaseRenewal", () => {
   it("ignores an abandoned renewal's answer once a newer one has come back", async () => {
     const clock = new FakeClock(0);
     const errors: Error[] = [];
+    const gone: Array<{ reason: string }> = [];
     let answerFirst!: (renewed: { ttlDeadline: number }) => void;
     let attempts = 0;
     startLeaseRenewal({
       clock,
       leaseId: "lse_1",
       onError: (error) => errors.push(error as Error),
+      onLeaseGone: (reason) => gone.push({ reason }),
       renew: () => {
         attempts += 1;
         if (attempts === 1)
@@ -365,7 +375,7 @@ describe("startLeaseRenewal", () => {
     clock.advance(60_000);
     await flushMicrotasks();
     expect(clock.pendingTimerCount, "renewal works towards 5_110, so it gives up past it").toBe(0);
-    expect(errors.at(-1)?.message).toContain("Gave up renewing lease lse_1");
+    expect(gone.at(-1)?.reason).toBe("renew-failed");
   });
 
   it("applies two late answers newest-first, not largest-first", async () => {
@@ -418,6 +428,57 @@ describe("startLeaseRenewal", () => {
     expect(attemptsAt).toEqual([3_000, 6_333, 7_814, 9_209]);
   });
 
+  it("does not send a renewal that stop() beat to the wire", async () => {
+    const clock = new FakeClock(0);
+    let calls = 0;
+    const renewal = startLeaseRenewal({
+      clock,
+      leaseId: "lse_1",
+      renew: () => {
+        calls += 1;
+        return Promise.resolve({ ttlDeadline: clock.now() + 3_000 });
+      },
+      ttlDeadline: 3_000,
+    });
+
+    // The timer has fired -- the tick is running -- but `stop()` lands before the request
+    // leaves. "No further `renew` call" has to mean this too, or a released lease gets one
+    // last renewal after its release.
+    clock.advance(1_000);
+    renewal.stop();
+    await flushMicrotasks();
+
+    expect(calls).toBe(0);
+    expect(clock.pendingTimerCount).toBe(0);
+  });
+
+  it("clamps the delay to what a timer can express, for a deadline months away", async () => {
+    const clock = new FakeClock(0);
+    const renewedAt: number[] = [];
+    const ninetyDays = 90 * 24 * 60 * 60 * 1_000;
+    const renewal = startLeaseRenewal({
+      clock,
+      leaseId: "lse_1",
+      renew: () => {
+        renewedAt.push(clock.now());
+        return Promise.resolve({ ttlDeadline: clock.now() + ninetyDays });
+      },
+      ttlDeadline: ninetyDays,
+    });
+
+    // A third of 90 days is past what `setTimeout` can hold, and a truncated delay would fire
+    // in a millisecond -- the hot loop the floor exists to prevent, from the other end.
+    clock.advance(2_147_483_646);
+    await flushMicrotasks();
+    expect(renewedAt).toEqual([]);
+
+    clock.advance(1);
+    await flushMicrotasks();
+    expect(renewedAt).toEqual([2_147_483_647]);
+
+    renewal.stop();
+  });
+
   it("never reports a failure that arrives after stop()", async () => {
     const clock = new FakeClock(0);
     let rejectRenew!: (error: Error) => void;
@@ -445,11 +506,11 @@ describe("startLeaseRenewal", () => {
   it("tries a deadline that is already in the past once, then stops instead of hot-looping", async () => {
     const clock = new FakeClock(1_000);
     const renewedAt: number[] = [];
-    const errors: unknown[] = [];
+    const gone: Array<{ reason: string }> = [];
     startLeaseRenewal({
       clock,
       leaseId: "lse_1",
-      onError: (error) => errors.push(error),
+      onLeaseGone: (reason) => gone.push({ reason }),
       renew: () => {
         renewedAt.push(clock.now());
         // A daemon answering with a deadline that is not in the future -- reachable with
@@ -467,9 +528,10 @@ describe("startLeaseRenewal", () => {
     await flushMicrotasks();
     expect(renewedAt).toEqual([1_250]);
 
-    // Nothing to renew towards: renewal ends rather than spinning at the floor forever.
+    // Nothing to renew towards: renewal ends -- and says so, rather than spinning at the floor
+    // forever or leaving the holder to infer it.
     expect(clock.pendingTimerCount).toBe(0);
-    expect(errors).toHaveLength(1);
+    expect(gone).toEqual([{ reason: "renew-failed" }]);
     clock.advance(600_000);
     await flushMicrotasks();
     expect(renewedAt).toEqual([1_250]);

--- a/src/lease-policy/index.ts
+++ b/src/lease-policy/index.ts
@@ -24,11 +24,46 @@ const RENEW_DIVISOR = 3;
 
 /**
  * Floor on the scheduled delay. Only reachable when the daemon returns a deadline that is
- * already very close (or in the past) -- a misconfigured `lease.heldTtlBackstopMs`, a clock
+ * already very close (or in the past) -- a daemon configured with a zero-length TTL, a clock
  * that jumped, or a renewal that raced its own expiry. Without it, a non-positive remaining
  * TTL would turn the timer into an unbounded renew-per-tick loop against the daemon.
  */
 const MINIMUM_RENEW_DELAY_MS = 250;
+
+/**
+ * How long a holder waits for its farewell `lease.release` before giving up and closing the
+ * connection anyway. The daemon is a local process answering a local socket, so this is not a
+ * latency budget -- it is the bound that keeps an unresponsive daemon from hanging the exit of
+ * a CLI holder or an MCP server. Exceeding it costs nothing but the wait: the lease then ends
+ * the way every unreleased lease ends, at its deadline.
+ */
+export const RELEASE_TIMEOUT_MS = 5_000;
+
+/**
+ * Resolves with `work`, or rejects once `timeoutMs` has passed on `clock`. The timer is always
+ * cancelled, so it never holds a process open by itself, and a rejection from an abandoned
+ * `work` is swallowed rather than surfacing as an unhandled rejection.
+ */
+export async function awaitWithin<T>(
+  clock: Clock,
+  timeoutMs: number,
+  work: Promise<T>,
+  timeoutMessage: string,
+): Promise<T> {
+  work.catch(() => undefined);
+  let timer: TimerHandle | undefined;
+  const expiry = new Promise<never>((_resolve, reject) => {
+    timer = clock.setTimer(timeoutMs, () => {
+      timer = undefined;
+      reject(new Error(timeoutMessage));
+    });
+  });
+  try {
+    return await Promise.race([work, expiry]);
+  } finally {
+    if (timer !== undefined) clock.cancel(timer);
+  }
+}
 
 /** The subset of a `LeaseRecord` renewal needs back: the daemon's new deadline. */
 export interface RenewedLease {
@@ -100,20 +135,42 @@ export function startLeaseRenewal(options: LeaseRenewalOptions): LeaseRenewal {
     timer = undefined;
   };
 
+  /** Isolated: a holder that cannot report a failure must still keep holding. */
+  const report = (error: unknown): void => {
+    if (onError === undefined) return;
+    try {
+      onError(error);
+    } catch {
+      // A `stderr` that throws (a closed pipe, say) must not take the release path down with
+      // it -- see the `void tick()` below, which nothing awaits.
+    }
+  };
+
   const schedule = (): void => {
     if (stopped) return;
     timer = clock.setTimer(renewDelayMs(deadline - clock.now()), () => {
       timer = undefined;
-      void tick();
+      // Nothing awaits this: an unhandled rejection here would take the whole process down,
+      // and with it the release the holder still owes.
+      void tick().catch(() => undefined);
     });
   };
 
   /** One renewal attempt, bounded by the interval it was scheduled on. */
   const attemptRenew = async (): Promise<Attempt> => {
     const request = renew(leaseId);
-    // Attached unconditionally: an abandoned request still settles later, and a rejection
-    // nobody awaits would surface as an unhandled rejection.
-    request.catch(() => undefined);
+    // An abandoned request still reaches the daemon: if it succeeds after this attempt has
+    // been given up on, its deadline is real and worth keeping -- discarding it would let the
+    // give-up test below fire against a deadline the daemon has already moved. (It also keeps
+    // a late rejection from surfacing as an unhandled rejection.)
+    request.then(
+      (renewed) => {
+        // `Math.max`, not a plain assignment: this answer belongs to a request older than
+        // whatever has happened since, so it may only ever push the deadline forward.
+        if (!stopped) deadline = Math.max(deadline, renewed.ttlDeadline);
+      },
+      () => undefined,
+    );
     return Promise.race<Attempt>([
       request.then(
         (renewed) => ({ ok: true, renewed }),
@@ -138,11 +195,14 @@ export function startLeaseRenewal(options: LeaseRenewalOptions): LeaseRenewal {
     if (stopped) return;
 
     if (!attempt.ok) {
-      onError?.(attempt.error);
+      report(attempt.error);
       // Out of runway: the lease is gone (or about to be), and another attempt would only
-      // produce another error.
+      // produce another error. Reported separately from the attempt that failed, because
+      // "this one did not work" and "this lease will not be renewed again" are different
+      // things for a holder to read.
       if (clock.now() >= deadline) {
         stopped = true;
+        report(new Error(`Gave up renewing lease ${leaseId}: its deadline has passed`));
         return;
       }
       schedule();
@@ -153,9 +213,11 @@ export function startLeaseRenewal(options: LeaseRenewalOptions): LeaseRenewal {
       // A deadline that is not in the future cannot be renewed towards -- scheduling off it
       // would be a hot loop against a lease that is already over.
       stopped = true;
-      onError?.(new Error(`Lease ${leaseId} was renewed to a deadline that has already passed`));
+      report(new Error(`Lease ${leaseId} was renewed to a deadline that has already passed`));
       return;
     }
+    // The daemon's answer is authoritative, in both directions: it may hand back a shorter
+    // deadline than the one that was asked for, and the cadence follows it.
     deadline = attempt.renewed.ttlDeadline;
     schedule();
   };

--- a/src/lease-policy/index.ts
+++ b/src/lease-policy/index.ts
@@ -26,8 +26,7 @@ const RENEW_DIVISOR = 3;
  * Floor on the scheduled delay. Only reachable when the daemon returns a deadline that is
  * already very close (or in the past) -- a misconfigured `lease.heldTtlBackstopMs`, a clock
  * that jumped, or a renewal that raced its own expiry. Without it, a non-positive remaining
- * TTL would turn the timer into an unbounded renew-per-tick loop against the daemon. The
- * renewal still happens; it is only kept from becoming a hot loop.
+ * TTL would turn the timer into an unbounded renew-per-tick loop against the daemon.
  */
 const MINIMUM_RENEW_DELAY_MS = 250;
 
@@ -44,17 +43,18 @@ export interface LeaseRenewalOptions {
   /** Calls `lease.renew` for this lease -- `client.renewLease({ leaseId })`, in practice. */
   readonly renew: (leaseId: string) => Promise<RenewedLease>;
   /**
-   * Reports the failure that stopped renewal (see `LeaseRenewal#stop` for why renewal ends
-   * there). Never called after `stop()`.
+   * Reports every failed attempt, and the failure that finally ends renewal. Never called
+   * after `stop()`.
    */
   readonly onError?: (error: unknown) => void;
 }
 
 export interface LeaseRenewal {
   /**
-   * Cancels the pending timer and guarantees no further `renew` call, `onError` call, or
-   * reschedule -- including from a renewal that is already in flight. Idempotent, and the one
-   * thing a holder must do before releasing, so a renew cannot race its own release.
+   * Cancels whatever timer is armed -- the wait between renewals, or the bound on an attempt
+   * already in flight -- and guarantees no further `renew` call, `onError` call, or reschedule.
+   * Idempotent, and the one thing a holder must do before releasing, so a renew cannot race its
+   * own release.
    */
   stop(): void;
 }
@@ -64,50 +64,108 @@ function renewDelayMs(remainingMs: number): number {
   return Math.max(MINIMUM_RENEW_DELAY_MS, Math.floor(remainingMs / RENEW_DIVISOR));
 }
 
+type Attempt =
+  | { readonly ok: true; readonly renewed: RenewedLease }
+  | { readonly ok: false; readonly error: unknown };
+
 /**
  * Starts renewing `leaseId` at a third of the remaining TTL, rescheduling off each renewal's
  * own returned deadline, until `stop()`.
  *
- * A failed renewal ends renewal rather than retrying: the typed client never reconnects (ADR
- * 0003 §10), so a rejection is either a dead connection -- on which no later call would
- * succeed either -- or the daemon saying this lease is no longer renewable (it expired, or
- * was force-released). Both end this holder's claim; retrying would only turn one honest
- * error into a stream of them. The caller learns through `onError` and through the
- * `lease-lost` push that accompanies the second case.
+ * Renewing at a third of the TTL exists to leave room for two more tries before the deadline,
+ * so a failed attempt is retried on the same cadence rather than ending the lease: the daemon
+ * may have failed to persist one renewal (`INTERNAL`) and still be perfectly willing to serve
+ * the next. Renewal ends only when the lease can no longer be saved -- its last known deadline
+ * has passed, or the daemon answered with one that is not in the future. A holder whose
+ * connection died, or whose lease was force-released, stops sooner than that through its
+ * `lease-lost` handler (ADR 0003 §10), which is the signal that actually means "this lease is
+ * over"; the retries in between are cheap and bounded by the deadline.
+ *
+ * Each attempt is bounded by the same interval it was scheduled on, so a daemon that accepts
+ * `lease.renew` and never answers costs one interval rather than the whole lease: the wire has
+ * no request timeout of its own, and an abandoned request cannot slide the deadline anywhere
+ * but forward.
  */
 export function startLeaseRenewal(options: LeaseRenewalOptions): LeaseRenewal {
   const { clock, leaseId, onError, renew } = options;
+  /** The last deadline the daemon actually gave us -- the only input to the cadence. */
+  let deadline = options.ttlDeadline;
+  /** Whichever timer is armed right now: the wait between renewals, or an attempt's bound. */
   let timer: TimerHandle | undefined;
   let stopped = false;
 
-  const schedule = (ttlDeadline: number): void => {
+  const cancelTimer = (): void => {
+    if (timer === undefined) return;
+    clock.cancel(timer);
+    timer = undefined;
+  };
+
+  const schedule = (): void => {
     if (stopped) return;
-    timer = clock.setTimer(renewDelayMs(ttlDeadline - clock.now()), () => {
+    timer = clock.setTimer(renewDelayMs(deadline - clock.now()), () => {
       timer = undefined;
       void tick();
     });
   };
 
-  const tick = async (): Promise<void> => {
-    if (stopped) return;
-    try {
-      const renewed = await renew(leaseId);
-      schedule(renewed.ttlDeadline);
-    } catch (error: unknown) {
-      if (stopped) return;
-      stopped = true;
-      onError?.(error);
-    }
+  /** One renewal attempt, bounded by the interval it was scheduled on. */
+  const attemptRenew = async (): Promise<Attempt> => {
+    const request = renew(leaseId);
+    // Attached unconditionally: an abandoned request still settles later, and a rejection
+    // nobody awaits would surface as an unhandled rejection.
+    request.catch(() => undefined);
+    return Promise.race<Attempt>([
+      request.then(
+        (renewed) => ({ ok: true, renewed }),
+        (error: unknown) => ({ error, ok: false }),
+      ),
+      new Promise<Attempt>((resolve) => {
+        timer = clock.setTimer(renewDelayMs(deadline - clock.now()), () => {
+          timer = undefined;
+          resolve({
+            error: new Error(`Timed out renewing lease ${leaseId}`),
+            ok: false,
+          });
+        });
+      }),
+    ]);
   };
 
-  schedule(options.ttlDeadline);
+  const tick = async (): Promise<void> => {
+    if (stopped) return;
+    const attempt = await attemptRenew();
+    cancelTimer();
+    if (stopped) return;
+
+    if (!attempt.ok) {
+      onError?.(attempt.error);
+      // Out of runway: the lease is gone (or about to be), and another attempt would only
+      // produce another error.
+      if (clock.now() >= deadline) {
+        stopped = true;
+        return;
+      }
+      schedule();
+      return;
+    }
+
+    if (attempt.renewed.ttlDeadline <= clock.now()) {
+      // A deadline that is not in the future cannot be renewed towards -- scheduling off it
+      // would be a hot loop against a lease that is already over.
+      stopped = true;
+      onError?.(new Error(`Lease ${leaseId} was renewed to a deadline that has already passed`));
+      return;
+    }
+    deadline = attempt.renewed.ttlDeadline;
+    schedule();
+  };
+
+  schedule();
 
   return {
     stop: (): void => {
       stopped = true;
-      if (timer === undefined) return;
-      clock.cancel(timer);
-      timer = undefined;
+      cancelTimer();
     },
   };
 }

--- a/src/lease-policy/index.ts
+++ b/src/lease-policy/index.ts
@@ -1,0 +1,113 @@
+/**
+ * Client-side lease renewal: the timer half of ADR 0004 §2 ("'Held' is a client policy, not a
+ * daemon mode ... what it does while alive is renew on a timer (one third of the TTL) and
+ * release on exit, parent death, or a catchable signal").
+ *
+ * It lives in its own module, outside both frontends and outside `simlock/client`, for two
+ * reasons:
+ *
+ * - the CLI's held mode and the MCP session follow the *same* policy, and a second copy of a
+ *   liveness loop is exactly the duplication ADR 0004 exists to remove;
+ * - the typed client deliberately owns no renew loop (ADR 0003 §10, `docs/CLIENT.md`): renew
+ *   and reconnect policy is a frontend concern, so this is a helper frontends *choose*, never
+ *   something `connectSimlock` starts on their behalf. Nothing here is exported from
+ *   `simlock/client` or `simlock/admin`.
+ *
+ * The cadence is computed only from the deadline the daemon returned with the grant (and with
+ * every renewal since), never from a TTL config value: a client does not have the daemon's
+ * config, and the daemon is free to hand back a shorter deadline than the one asked for.
+ */
+import type { Clock, TimerHandle } from "../ports/index.js";
+
+/** ADR 0004 §2's "one third of the TTL". */
+const RENEW_DIVISOR = 3;
+
+/**
+ * Floor on the scheduled delay. Only reachable when the daemon returns a deadline that is
+ * already very close (or in the past) -- a misconfigured `lease.heldTtlBackstopMs`, a clock
+ * that jumped, or a renewal that raced its own expiry. Without it, a non-positive remaining
+ * TTL would turn the timer into an unbounded renew-per-tick loop against the daemon. The
+ * renewal still happens; it is only kept from becoming a hot loop.
+ */
+const MINIMUM_RENEW_DELAY_MS = 250;
+
+/** The subset of a `LeaseRecord` renewal needs back: the daemon's new deadline. */
+export interface RenewedLease {
+  readonly ttlDeadline: number;
+}
+
+export interface LeaseRenewalOptions {
+  readonly clock: Clock;
+  readonly leaseId: string;
+  /** The deadline the grant (or a previous renewal) returned, in `clock.now()`'s epoch. */
+  readonly ttlDeadline: number;
+  /** Calls `lease.renew` for this lease -- `client.renewLease({ leaseId })`, in practice. */
+  readonly renew: (leaseId: string) => Promise<RenewedLease>;
+  /**
+   * Reports the failure that stopped renewal (see `LeaseRenewal#stop` for why renewal ends
+   * there). Never called after `stop()`.
+   */
+  readonly onError?: (error: unknown) => void;
+}
+
+export interface LeaseRenewal {
+  /**
+   * Cancels the pending timer and guarantees no further `renew` call, `onError` call, or
+   * reschedule -- including from a renewal that is already in flight. Idempotent, and the one
+   * thing a holder must do before releasing, so a renew cannot race its own release.
+   */
+  stop(): void;
+}
+
+/** The delay before the next renewal, given how much of the TTL is left. */
+function renewDelayMs(remainingMs: number): number {
+  return Math.max(MINIMUM_RENEW_DELAY_MS, Math.floor(remainingMs / RENEW_DIVISOR));
+}
+
+/**
+ * Starts renewing `leaseId` at a third of the remaining TTL, rescheduling off each renewal's
+ * own returned deadline, until `stop()`.
+ *
+ * A failed renewal ends renewal rather than retrying: the typed client never reconnects (ADR
+ * 0003 §10), so a rejection is either a dead connection -- on which no later call would
+ * succeed either -- or the daemon saying this lease is no longer renewable (it expired, or
+ * was force-released). Both end this holder's claim; retrying would only turn one honest
+ * error into a stream of them. The caller learns through `onError` and through the
+ * `lease-lost` push that accompanies the second case.
+ */
+export function startLeaseRenewal(options: LeaseRenewalOptions): LeaseRenewal {
+  const { clock, leaseId, onError, renew } = options;
+  let timer: TimerHandle | undefined;
+  let stopped = false;
+
+  const schedule = (ttlDeadline: number): void => {
+    if (stopped) return;
+    timer = clock.setTimer(renewDelayMs(ttlDeadline - clock.now()), () => {
+      timer = undefined;
+      void tick();
+    });
+  };
+
+  const tick = async (): Promise<void> => {
+    if (stopped) return;
+    try {
+      const renewed = await renew(leaseId);
+      schedule(renewed.ttlDeadline);
+    } catch (error: unknown) {
+      if (stopped) return;
+      stopped = true;
+      onError?.(error);
+    }
+  };
+
+  schedule(options.ttlDeadline);
+
+  return {
+    stop: (): void => {
+      stopped = true;
+      if (timer === undefined) return;
+      clock.cancel(timer);
+      timer = undefined;
+    },
+  };
+}

--- a/src/lease-policy/index.ts
+++ b/src/lease-policy/index.ts
@@ -17,6 +17,7 @@
  * every renewal since), never from a TTL config value: a client does not have the daemon's
  * config, and the daemon is free to hand back a shorter deadline than the one asked for.
  */
+import { isSimlockError } from "../contract/index.js";
 import type { Clock, TimerHandle } from "../ports/index.js";
 
 /** ADR 0004 §2's "one third of the TTL". */
@@ -78,10 +79,19 @@ export interface LeaseRenewalOptions {
   /** Calls `lease.renew` for this lease -- `client.renewLease({ leaseId })`, in practice. */
   readonly renew: (leaseId: string) => Promise<RenewedLease>;
   /**
-   * Reports every failed attempt, and the failure that finally ends renewal. Never called
-   * after `stop()`.
+   * Reports every failed attempt that is worth retrying, and the failure that finally ends
+   * renewal. Never called after `stop()`, and never for the terminal answers `onLeaseGone`
+   * covers.
    */
   readonly onError?: (error: unknown) => void;
+  /**
+   * The lease is over: the daemon answered that it does not exist (`UNKNOWN_LEASE`) or is not
+   * this principal's (`FORBIDDEN`). Renewal has already stopped by the time this runs, and
+   * retrying would only repeat the same answer -- so a holder should treat this exactly like
+   * the `lease-lost` push (ADR 0003 §8) it may or may not also receive: stop holding, and do
+   * not try to release what is no longer there. Called at most once.
+   */
+  readonly onLeaseGone?: (error: unknown) => void;
 }
 
 export interface LeaseRenewal {
@@ -104,6 +114,17 @@ type Attempt =
   | { readonly ok: false; readonly error: unknown };
 
 /**
+ * A rejection that answers "this lease is not yours to renew" rather than "that attempt did
+ * not work". Both codes are the daemon's final word: `UNKNOWN_LEASE` means the record is gone
+ * (expired, released, force-released), `FORBIDDEN` that it belongs to another principal
+ * (`ownsLease` in `src/contract/operations.ts`). Retrying either just prints the same answer
+ * until the deadline.
+ */
+function isLeaseGone(error: unknown): boolean {
+  return isSimlockError(error) && (error.code === "UNKNOWN_LEASE" || error.code === "FORBIDDEN");
+}
+
+/**
  * Starts renewing `leaseId` at a third of the remaining TTL, rescheduling off each renewal's
  * own returned deadline, until `stop()`.
  *
@@ -116,13 +137,16 @@ type Attempt =
  * `lease-lost` handler (ADR 0003 §10), which is the signal that actually means "this lease is
  * over"; the retries in between are cheap and bounded by the deadline.
  *
- * Each attempt is bounded by the same interval it was scheduled on, so a daemon that accepts
- * `lease.renew` and never answers costs one interval rather than the whole lease: the wire has
- * no request timeout of its own, and an abandoned request cannot slide the deadline anywhere
- * but forward.
+ * Each attempt is bounded by a third of what is left of the TTL when it starts, so a daemon
+ * that accepts `lease.renew` and never answers costs one interval rather than the whole lease:
+ * the wire has no request timeout of its own, and an abandoned request cannot slide the
+ * deadline anywhere but forward.
+ *
+ * A daemon answering `UNKNOWN_LEASE` or `FORBIDDEN` is not a failed attempt at all -- the lease
+ * is over, or was never this holder's -- so renewal stops at once and `onLeaseGone` says so.
  */
 export function startLeaseRenewal(options: LeaseRenewalOptions): LeaseRenewal {
-  const { clock, leaseId, onError, renew } = options;
+  const { clock, leaseId, onError, onLeaseGone, renew } = options;
   /** The last deadline the daemon actually gave us -- the only input to the cadence. */
   let deadline = options.ttlDeadline;
   /** Whichever timer is armed right now: the wait between renewals, or an attempt's bound. */
@@ -136,15 +160,16 @@ export function startLeaseRenewal(options: LeaseRenewalOptions): LeaseRenewal {
   };
 
   /** Isolated: a holder that cannot report a failure must still keep holding. */
-  const report = (error: unknown): void => {
-    if (onError === undefined) return;
+  const notify = (listener: ((error: unknown) => void) | undefined, error: unknown): void => {
+    if (listener === undefined) return;
     try {
-      onError(error);
+      listener(error);
     } catch {
       // A `stderr` that throws (a closed pipe, say) must not take the release path down with
       // it -- see the `void tick()` below, which nothing awaits.
     }
   };
+  const report = (error: unknown): void => notify(onError, error);
 
   const schedule = (): void => {
     if (stopped) return;
@@ -156,9 +181,12 @@ export function startLeaseRenewal(options: LeaseRenewalOptions): LeaseRenewal {
     });
   };
 
-  /** One renewal attempt, bounded by the interval it was scheduled on. */
+  /** One renewal attempt, bounded by a third of what is left of the TTL when it starts. */
   const attemptRenew = async (): Promise<Attempt> => {
-    const request = renew(leaseId);
+    // `Promise.resolve().then` rather than a bare call: a `renew` that throws *synchronously*
+    // (a client that rejects a malformed input before it ever reaches the wire) is a failed
+    // attempt like any other, not something that should escape into the unawaited `tick()`.
+    const request = Promise.resolve().then(() => renew(leaseId));
     // An abandoned request still reaches the daemon: if it succeeds after this attempt has
     // been given up on, its deadline is real and worth keeping -- discarding it would let the
     // give-up test below fire against a deadline the daemon has already moved. (It also keeps
@@ -195,6 +223,13 @@ export function startLeaseRenewal(options: LeaseRenewalOptions): LeaseRenewal {
     if (stopped) return;
 
     if (!attempt.ok) {
+      if (isLeaseGone(attempt.error)) {
+        // Terminal, not transient: this lease is over, and the holder needs to hear that once
+        // rather than read the same rejection on every retry until the deadline.
+        stopped = true;
+        notify(onLeaseGone, attempt.error);
+        return;
+      }
       report(attempt.error);
       // Out of runway: the lease is gone (or about to be), and another attempt would only
       // produce another error. Reported separately from the attempt that failed, because

--- a/src/lease-policy/index.ts
+++ b/src/lease-policy/index.ts
@@ -89,6 +89,18 @@ export interface RenewedLease {
   readonly ttlDeadline: number;
 }
 
+/**
+ * Why renewal ended for good. Both mean "this holder no longer has a lease", and both are told
+ * to `onLeaseGone`; they differ in what a reader should conclude:
+ *
+ * - `renew-rejected`: the daemon answered `UNKNOWN_LEASE`/`FORBIDDEN` -- the lease is gone, or
+ *   was never this principal's. Nothing was lost by this client.
+ * - `renew-failed`: renewal never got an answer it could use before the lease's own deadline
+ *   passed (or the daemon answered with a deadline already behind us). The lease may still be
+ *   alive on the daemon for a moment, but nothing here can keep it, and it will expire.
+ */
+export type LeaseGoneReason = "renew-rejected" | "renew-failed";
+
 export interface LeaseRenewalOptions {
   readonly clock: Clock;
   readonly leaseId: string;
@@ -103,13 +115,14 @@ export interface LeaseRenewalOptions {
    */
   readonly onError?: (error: unknown) => void;
   /**
-   * The lease is over: the daemon answered that it does not exist (`UNKNOWN_LEASE`) or is not
-   * this principal's (`FORBIDDEN`). Renewal has already stopped by the time this runs, and
-   * retrying would only repeat the same answer -- so a holder should treat this exactly like
-   * the `lease-lost` push (ADR 0003 §8) it may or may not also receive: stop holding, and do
-   * not try to release what is no longer there. Called at most once.
+   * The lease is over, for either of the reasons `LeaseGoneReason` names. Renewal has already
+   * stopped by the time this runs, and nothing it could do would bring the lease back -- so a
+   * holder should treat this exactly like the `lease-lost` push (ADR 0003 §8) it may or may
+   * not also receive: stop holding, and do not try to release what is no longer there. Called
+   * at most once, and it is the *only* end-of-lease signal this module raises: `onError`
+   * reports attempts that failed while the lease was still savable.
    */
-  readonly onLeaseGone?: (error: unknown) => void;
+  readonly onLeaseGone?: (reason: LeaseGoneReason, error: unknown) => void;
 }
 
 export interface LeaseRenewal {
@@ -183,16 +196,25 @@ export function startLeaseRenewal(options: LeaseRenewalOptions): LeaseRenewal {
   };
 
   /** Isolated: a holder that cannot report a failure must still keep holding. */
-  const notify = (listener: ((error: unknown) => void) | undefined, error: unknown): void => {
-    if (listener === undefined) return;
+  const report = (error: unknown): void => {
+    if (onError === undefined) return;
     try {
-      listener(error);
+      onError(error);
     } catch {
       // A `stderr` that throws (a closed pipe, say) must not take the release path down with
       // it -- see the `void tick()` below, which nothing awaits.
     }
   };
-  const report = (error: unknown): void => notify(onError, error);
+  /** Ends renewal and says why, once. Isolated for the same reason `report` is. */
+  const giveUp = (reason: LeaseGoneReason, error: unknown): void => {
+    stopped = true;
+    if (onLeaseGone === undefined) return;
+    try {
+      onLeaseGone(reason, error);
+    } catch {
+      // A holder that cannot handle the news still has to stop renewing, which it now has.
+    }
+  };
 
   const schedule = (): void => {
     if (stopped) return;
@@ -211,7 +233,14 @@ export function startLeaseRenewal(options: LeaseRenewalOptions): LeaseRenewal {
     // `Promise.resolve().then` rather than a bare call: a `renew` that throws *synchronously*
     // (a client that rejects a malformed input before it ever reaches the wire) is a failed
     // attempt like any other, not something that should escape into the unawaited `tick()`.
-    const request = Promise.resolve().then(() => renew(leaseId));
+    // The `stopped` check inside it is what makes `stop()`'s "no further `renew` call"
+    // guarantee true even for a stop that lands in the microtask between the timer firing and
+    // the request going out.
+    const request = Promise.resolve().then(() =>
+      stopped
+        ? Promise.reject(new Error(`Renewal of lease ${leaseId} was stopped before it was sent`))
+        : renew(leaseId),
+    );
     // An abandoned request still reaches the daemon: if it succeeds after this attempt has
     // been given up on, its deadline is real and worth keeping -- discarding it would let the
     // give-up test below fire against a deadline the daemon has already moved. (It also keeps
@@ -256,18 +285,19 @@ export function startLeaseRenewal(options: LeaseRenewalOptions): LeaseRenewal {
       if (isLeaseGone(attempt.error)) {
         // Terminal, not transient: this lease is over, and the holder needs to hear that once
         // rather than read the same rejection on every retry until the deadline.
-        stopped = true;
-        notify(onLeaseGone, attempt.error);
+        giveUp("renew-rejected", attempt.error);
         return;
       }
       report(attempt.error);
-      // Out of runway: the lease is gone (or about to be), and another attempt would only
-      // produce another error. Reported separately from the attempt that failed, because
-      // "this one did not work" and "this lease will not be renewed again" are different
-      // things for a holder to read.
+      // Out of runway: the deadline has passed, so another attempt would only produce another
+      // error against a lease that is expiring. That is the end of this lease as far as any
+      // holder is concerned -- reported as such, not as one more failed attempt, so a frontend
+      // stops holding instead of sitting alive with no timer.
       if (clock.now() >= deadline) {
-        stopped = true;
-        report(new Error(`Gave up renewing lease ${leaseId}: its deadline has passed`));
+        giveUp(
+          "renew-failed",
+          new Error(`Gave up renewing lease ${leaseId}: its deadline has passed`),
+        );
         return;
       }
       schedule();
@@ -282,9 +312,11 @@ export function startLeaseRenewal(options: LeaseRenewalOptions): LeaseRenewal {
     }
     if (attempt.renewed.ttlDeadline <= clock.now()) {
       // A deadline that is not in the future cannot be renewed towards -- scheduling off it
-      // would be a hot loop against a lease that is already over.
-      stopped = true;
-      report(new Error(`Lease ${leaseId} was renewed to a deadline that has already passed`));
+      // would be a hot loop against a lease that is already over, so this is an ending too.
+      giveUp(
+        "renew-failed",
+        new Error(`Lease ${leaseId} was renewed to a deadline that has already passed`),
+      );
       return;
     }
     // The cadence follows the newest answer in both directions: the daemon may hand back a

--- a/src/lease-policy/index.ts
+++ b/src/lease-policy/index.ts
@@ -16,6 +16,17 @@
  * The cadence is computed only from the deadline the daemon returned with the grant (and with
  * every renewal since), never from a TTL config value: a client does not have the daemon's
  * config, and the daemon is free to hand back a shorter deadline than the one asked for.
+ *
+ * Two things follow from deriving the interval as `ttlDeadline - clock.now()`:
+ *
+ * - it assumes the daemon and this client read the same wall clock. True on the unix socket,
+ *   where they are processes on one machine, and the reason `ttlDeadline` is usable as-is
+ *   today. It is not true across a network hop, where a client's clock may sit minutes from
+ *   the daemon's and this arithmetic would renew far too early or far too late.
+ * - the fix for that is ADR 0004's own: once a lease record carries `ttlMs` (PR B), the
+ *   cadence becomes `ttlMs / 3` -- a duration, which needs no shared epoch -- and the deadline
+ *   is left as what it really is, a bound to stop renewing at rather than a clock to schedule
+ *   from. This module is where that change lands; nothing above it has to move.
  */
 import { isSimlockError } from "../contract/index.js";
 import type { Clock, TimerHandle } from "../ports/index.js";
@@ -152,6 +163,10 @@ export function startLeaseRenewal(options: LeaseRenewalOptions): LeaseRenewal {
   /** Whichever timer is armed right now: the wait between renewals, or an attempt's bound. */
   let timer: TimerHandle | undefined;
   let stopped = false;
+  /** Attempts are numbered so a late answer can tell whether anything newer has been answered
+   * since (attempts never overlap: one is in flight at a time, by construction). */
+  let attempts = 0;
+  let newestAnswered = 0;
 
   const cancelTimer = (): void => {
     if (timer === undefined) return;
@@ -183,6 +198,8 @@ export function startLeaseRenewal(options: LeaseRenewalOptions): LeaseRenewal {
 
   /** One renewal attempt, bounded by a third of what is left of the TTL when it starts. */
   const attemptRenew = async (): Promise<Attempt> => {
+    attempts += 1;
+    const attemptId = attempts;
     // `Promise.resolve().then` rather than a bare call: a `renew` that throws *synchronously*
     // (a client that rejects a malformed input before it ever reaches the wire) is a failed
     // attempt like any other, not something that should escape into the unawaited `tick()`.
@@ -193,9 +210,11 @@ export function startLeaseRenewal(options: LeaseRenewalOptions): LeaseRenewal {
     // a late rejection from surfacing as an unhandled rejection.)
     request.then(
       (renewed) => {
-        // `Math.max`, not a plain assignment: this answer belongs to a request older than
-        // whatever has happened since, so it may only ever push the deadline forward.
-        if (!stopped) deadline = Math.max(deadline, renewed.ttlDeadline);
+        // Only while no *newer* attempt has been answered, and then only forward: this answer
+        // is older than anything that has happened since, so it may raise a deadline nobody
+        // has since improved on, and never overwrite a fresher one.
+        if (stopped || attemptId <= newestAnswered) return;
+        deadline = Math.max(deadline, renewed.ttlDeadline);
       },
       () => undefined,
     );
@@ -244,6 +263,9 @@ export function startLeaseRenewal(options: LeaseRenewalOptions): LeaseRenewal {
       return;
     }
 
+    // This attempt is now the newest answer there is, so no request older than it may move the
+    // deadline again (see `attemptRenew`).
+    newestAnswered = attempts;
     if (attempt.renewed.ttlDeadline <= clock.now()) {
       // A deadline that is not in the future cannot be renewed towards -- scheduling off it
       // would be a hot loop against a lease that is already over.
@@ -251,8 +273,9 @@ export function startLeaseRenewal(options: LeaseRenewalOptions): LeaseRenewal {
       report(new Error(`Lease ${leaseId} was renewed to a deadline that has already passed`));
       return;
     }
-    // The daemon's answer is authoritative, in both directions: it may hand back a shorter
-    // deadline than the one that was asked for, and the cadence follows it.
+    // The daemon's answer is authoritative, in both directions: it may hand back a *shorter*
+    // deadline than the one that was asked for -- a lowered `lease.heldTtlBackstopMs`, a
+    // `ttlMs` it clamped -- and the cadence follows it rather than an older, longer belief.
     deadline = attempt.renewed.ttlDeadline;
     schedule();
   };

--- a/src/lease-policy/index.ts
+++ b/src/lease-policy/index.ts
@@ -43,6 +43,13 @@ const RENEW_DIVISOR = 3;
 const MINIMUM_RENEW_DELAY_MS = 250;
 
 /**
+ * Ceiling on the scheduled delay: the largest delay a Node timer can express (~24.9 days).
+ * Anything above it silently truncates to 1ms, which would turn a very distant deadline into
+ * exactly the hot loop the floor above exists to prevent. Renewing early costs one round trip.
+ */
+const MAXIMUM_RENEW_DELAY_MS = 2_147_483_647;
+
+/**
  * How long a holder waits for its farewell `lease.release` before giving up and closing the
  * connection anyway. The daemon is a local process answering a local socket, so this is not a
  * latency budget -- it is the bound that keeps an unresponsive daemon from hanging the exit of
@@ -117,12 +124,13 @@ export interface LeaseRenewal {
 
 /** The delay before the next renewal, given how much of the TTL is left. */
 function renewDelayMs(remainingMs: number): number {
-  return Math.max(MINIMUM_RENEW_DELAY_MS, Math.floor(remainingMs / RENEW_DIVISOR));
+  const delay = Math.max(MINIMUM_RENEW_DELAY_MS, Math.floor(remainingMs / RENEW_DIVISOR));
+  return Math.min(MAXIMUM_RENEW_DELAY_MS, delay);
 }
 
 type Attempt =
-  | { readonly ok: true; readonly renewed: RenewedLease }
-  | { readonly ok: false; readonly error: unknown };
+  | { readonly attemptId: number; readonly ok: true; readonly renewed: RenewedLease }
+  | { readonly attemptId: number; readonly ok: false; readonly error: unknown };
 
 /**
  * A rejection that answers "this lease is not yours to renew" rather than "that attempt did
@@ -163,8 +171,8 @@ export function startLeaseRenewal(options: LeaseRenewalOptions): LeaseRenewal {
   /** Whichever timer is armed right now: the wait between renewals, or an attempt's bound. */
   let timer: TimerHandle | undefined;
   let stopped = false;
-  /** Attempts are numbered so a late answer can tell whether anything newer has been answered
-   * since (attempts never overlap: one is in flight at a time, by construction). */
+  /** Every attempt is numbered, and every *answer* is applied by that number: two abandoned
+   * attempts can answer in either order, and only the newer one's deadline is the truth. */
   let attempts = 0;
   let newestAnswered = 0;
 
@@ -210,23 +218,26 @@ export function startLeaseRenewal(options: LeaseRenewalOptions): LeaseRenewal {
     // a late rejection from surfacing as an unhandled rejection.)
     request.then(
       (renewed) => {
-        // Only while no *newer* attempt has been answered, and then only forward: this answer
-        // is older than anything that has happened since, so it may raise a deadline nobody
-        // has since improved on, and never overwrite a fresher one.
+        // Newest answer wins, by attempt number rather than by arrival order or by which
+        // deadline is larger: an older attempt's answer is not "better" for being further
+        // out, it is out of date, and taking it would leave this holder renewing towards a
+        // deadline the daemon has already replaced.
         if (stopped || attemptId <= newestAnswered) return;
-        deadline = Math.max(deadline, renewed.ttlDeadline);
+        newestAnswered = attemptId;
+        deadline = renewed.ttlDeadline;
       },
       () => undefined,
     );
     return Promise.race<Attempt>([
       request.then(
-        (renewed) => ({ ok: true, renewed }),
-        (error: unknown) => ({ error, ok: false }),
+        (renewed) => ({ attemptId, ok: true, renewed }),
+        (error: unknown) => ({ attemptId, error, ok: false }),
       ),
       new Promise<Attempt>((resolve) => {
         timer = clock.setTimer(renewDelayMs(deadline - clock.now()), () => {
           timer = undefined;
           resolve({
+            attemptId,
             error: new Error(`Timed out renewing lease ${leaseId}`),
             ok: false,
           });
@@ -263,9 +274,12 @@ export function startLeaseRenewal(options: LeaseRenewalOptions): LeaseRenewal {
       return;
     }
 
-    // This attempt is now the newest answer there is, so no request older than it may move the
-    // deadline again (see `attemptRenew`).
-    newestAnswered = attempts;
+    // Applied by this attempt's own number, exactly as a late answer is (`attemptRenew` above
+    // has usually already done it for this very answer; both paths agree).
+    if (attempt.attemptId > newestAnswered) {
+      newestAnswered = attempt.attemptId;
+      deadline = attempt.renewed.ttlDeadline;
+    }
     if (attempt.renewed.ttlDeadline <= clock.now()) {
       // A deadline that is not in the future cannot be renewed towards -- scheduling off it
       // would be a hot loop against a lease that is already over.
@@ -273,10 +287,9 @@ export function startLeaseRenewal(options: LeaseRenewalOptions): LeaseRenewal {
       report(new Error(`Lease ${leaseId} was renewed to a deadline that has already passed`));
       return;
     }
-    // The daemon's answer is authoritative, in both directions: it may hand back a *shorter*
-    // deadline than the one that was asked for -- a lowered `lease.heldTtlBackstopMs`, a
-    // `ttlMs` it clamped -- and the cadence follows it rather than an older, longer belief.
-    deadline = attempt.renewed.ttlDeadline;
+    // The cadence follows the newest answer in both directions: the daemon may hand back a
+    // *shorter* deadline than the one asked for -- a lowered `lease.heldTtlBackstopMs`, a
+    // `ttlMs` it clamped -- and a longer, older belief does not override it.
     schedule();
   };
 

--- a/src/mcp/connect.ts
+++ b/src/mcp/connect.ts
@@ -65,7 +65,9 @@ export async function connectWithAutoLaunch(
 function attempt(options: ConnectWithAutoLaunchOptions): Promise<SimlockClient> {
   return connectSimlock({
     endpoint: options.socketPath,
-    heartbeat: options.heartbeat ?? true,
+    // ADR 0004 §2/§4: the session renews its own lease on a timer, so it declares no heartbeat
+    // capability unless a caller explicitly asks for one.
+    heartbeat: options.heartbeat ?? false,
     ipc: options.ipc,
     principal: options.principal,
   });

--- a/src/mcp/connect.ts
+++ b/src/mcp/connect.ts
@@ -18,6 +18,8 @@ import { IpcError, type Clock, type DaemonLauncher, type IpcConnector } from "..
 
 export interface ConnectWithAutoLaunchOptions {
   readonly clock: Clock;
+  /** Dead as of ADR 0004 §4 -- nothing passes `true` any more, and the capability itself goes
+   * away with the daemon's push in PR B, which removes this option with it. */
   readonly heartbeat?: boolean;
   readonly ipc: IpcConnector;
   readonly launcher: DaemonLauncher;

--- a/src/mcp/main.ts
+++ b/src/mcp/main.ts
@@ -10,6 +10,7 @@ import {
   resolveDaemonSocketPath,
   resolveSimlockHome,
   SystemClock,
+  type Clock,
 } from "../ports/index.js";
 import { connectWithAutoLaunch } from "./connect.js";
 import { McpSession } from "./session.js";
@@ -33,6 +34,8 @@ export interface McpTransport {
 }
 
 export interface McpStdioEnvironment {
+  /** The `Clock` the session's renew timer runs on; a real one unless a test injects otherwise. */
+  readonly clock?: Clock;
   readonly connect?: () => Promise<SimlockClient>;
   readonly createServer?: (session: McpSession) => McpServer;
   readonly createTransport?: () => McpTransport;
@@ -67,6 +70,7 @@ export async function startMcpStdio(
   const requesterId = environment.requesterId ?? env.SIMLOCK_AGENT_ID ?? `mcp:${process.pid}`;
   const defaults = defaultEnvironment(requesterId);
   const session = new McpSession({
+    clock: environment.clock ?? new SystemClock(),
     connect: environment.connect ?? defaults.connect,
   });
   const server = (environment.createServer ?? createMcpServer)(session);
@@ -149,10 +153,11 @@ function defaultEnvironment(
     connect: () =>
       connectWithAutoLaunch({
         clock,
-        // MCP's holder process dies with its agent (stdin EOF -> session.close()), so a
-        // sliding TTL is safe here. CLI held mode declares the same capability now that
-        // it self-terminates on parent death too — see docs/known-pitfalls.md.
-        heartbeat: true,
+        // ADR 0004 §2/§4: the session keeps its lease alive with its own `lease.renew` timer
+        // and releases explicitly when the agent goes away (stdin EOF -> session.close()), so
+        // it no longer declares the daemon-initiated heartbeat. CLI held mode dropped the same
+        // capability in the same change.
+        heartbeat: false,
         ipc,
         launcher: new NodeDaemonLauncher({
           args: [join(dirname(fileURLToPath(import.meta.url)), "../daemon/main.js")],

--- a/src/mcp/main.ts
+++ b/src/mcp/main.ts
@@ -68,9 +68,12 @@ export async function startMcpStdio(
 ): Promise<McpStdioRunner> {
   const env = environment.env ?? process.env;
   const requesterId = environment.requesterId ?? env.SIMLOCK_AGENT_ID ?? `mcp:${process.pid}`;
-  const defaults = defaultEnvironment(requesterId);
+  // One `Clock` for the whole frontend: the session's renew timer and the auto-launch retry
+  // loop must not be able to disagree about what time it is (architecture rule 9).
+  const clock = environment.clock ?? new SystemClock();
+  const defaults = defaultEnvironment(requesterId, clock);
   const session = new McpSession({
-    clock: environment.clock ?? new SystemClock(),
+    clock,
     connect: environment.connect ?? defaults.connect,
   });
   const server = (environment.createServer ?? createMcpServer)(session);
@@ -144,9 +147,9 @@ export async function startMcpStdio(
 
 function defaultEnvironment(
   requesterId: string,
+  clock: Clock,
 ): Required<Pick<McpStdioEnvironment, "connect" | "createTransport">> {
   const dataDirectory = resolveSimlockHome();
-  const clock = new SystemClock();
   const ipc = new NodeIpcTransport();
   const logPath = join(dataDirectory, "daemon.log");
   return {

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -9,6 +9,7 @@ import {
 import { describe, expect, it } from "vitest";
 
 import { SimlockError } from "../client/index.js";
+import { FakeClock } from "../ports/index.js";
 import { FakeSimlockClient, sampleGrant } from "./test-support.js";
 import { McpSession } from "./session.js";
 import { createMcpServer } from "./server.js";
@@ -292,7 +293,7 @@ describe("MCP server (smoke)", () => {
 });
 
 async function connectedServer(client: FakeSimlockClient) {
-  const session = new McpSession({ connect: async () => client });
+  const session = new McpSession({ clock: new FakeClock(), connect: async () => client });
   const server = createMcpServer(session);
   const mcpClient = new Client({ name: "mcp-test-client", version: "1.0.0" });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();

--- a/src/mcp/session.test.ts
+++ b/src/mcp/session.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from "vitest";
 
 import { SimlockError } from "../client/index.js";
+import { FakeClock } from "../ports/index.js";
 import { FakeSimlockClient, sampleGrant } from "./test-support.js";
 import { McpSession, toMcpErrorResult } from "./session.js";
+
+/** Lets an awaited renewal settle; the fake clock never moves on its own. */
+async function flushMicrotasks(times = 10): Promise<void> {
+  for (let index = 0; index < times; index += 1) await Promise.resolve();
+}
 
 describe("McpSession", () => {
   it("requests a held lease with the tool input as-is, and returns the grant unchanged", async () => {
@@ -15,7 +21,7 @@ describe("McpSession", () => {
       seenOptions = options;
       return Promise.resolve(grant);
     };
-    const session = new McpSession({ connect: async () => client });
+    const session = new McpSession({ clock: new FakeClock(), connect: async () => client });
 
     const signal = new AbortController().signal;
     const onProgress = () => undefined;
@@ -34,7 +40,7 @@ describe("McpSession", () => {
     const client = new FakeSimlockClient();
     client.releaseLeaseImpl = () =>
       Promise.reject(new SimlockError("FORBIDDEN", "protocol", "not your lease", {}));
-    const session = new McpSession({ connect: async () => client });
+    const session = new McpSession({ clock: new FakeClock(), connect: async () => client });
 
     await expect(session.release({ leaseId: "someone-elses-lease" })).rejects.toMatchObject({
       code: "FORBIDDEN",
@@ -47,7 +53,7 @@ describe("McpSession", () => {
   it("adds released: true to a successful release without otherwise reshaping the result", async () => {
     const client = new FakeSimlockClient();
     client.releaseLeaseImpl = (input) => Promise.resolve({ leaseId: input.leaseId });
-    const session = new McpSession({ connect: async () => client });
+    const session = new McpSession({ clock: new FakeClock(), connect: async () => client });
 
     await expect(session.release({ leaseId: "lease-1" })).resolves.toEqual({
       leaseId: "lease-1",
@@ -58,7 +64,7 @@ describe("McpSession", () => {
   it("forwards list_devices straight to getCatalog", async () => {
     const client = new FakeSimlockClient();
     client.getCatalogImpl = () => Promise.resolve({ platforms: [] });
-    const session = new McpSession({ connect: async () => client });
+    const session = new McpSession({ clock: new FakeClock(), connect: async () => client });
 
     await session.listDevices({ platform: "ios" });
     expect(client.calls).toEqual([{ input: { platform: "ios" }, method: "getCatalog" }]);
@@ -88,7 +94,7 @@ describe("McpSession", () => {
             },
       );
     };
-    const session = new McpSession({ connect: async () => client });
+    const session = new McpSession({ clock: new FakeClock(), connect: async () => client });
 
     await expect(session.status()).resolves.toEqual({ held: false });
     await session.lease({ model: "iPhone 17 Pro", platform: "ios" });
@@ -125,7 +131,7 @@ describe("McpSession", () => {
           },
         ],
       });
-    const session = new McpSession({ connect: async () => client });
+    const session = new McpSession({ clock: new FakeClock(), connect: async () => client });
 
     await expect(session.status()).resolves.toEqual({ held: false });
   });
@@ -147,7 +153,7 @@ describe("McpSession", () => {
           },
         ],
       });
-    const session = new McpSession({ connect: async () => client });
+    const session = new McpSession({ clock: new FakeClock(), connect: async () => client });
 
     await session.lease({ model: "iPhone 17 Pro", platform: "ios" });
     await expect(session.status()).resolves.toMatchObject({ held: true, id: "lease-1" });
@@ -166,7 +172,7 @@ describe("McpSession", () => {
       clients.push(client);
       return client;
     };
-    const session = new McpSession({ connect });
+    const session = new McpSession({ clock: new FakeClock(), connect });
 
     await session.listDevices({});
     await session.listDevices({});
@@ -193,7 +199,7 @@ describe("McpSession", () => {
       order.push("release");
       return Promise.resolve({ leaseId: input.leaseId });
     };
-    const session = new McpSession({ connect: async () => client });
+    const session = new McpSession({ clock: new FakeClock(), connect: async () => client });
 
     const leaseCall = session.lease({ model: "iPhone 17 Pro", platform: "ios" });
     const releaseCall = session.release({ leaseId: "lease-1" });
@@ -210,7 +216,7 @@ describe("McpSession", () => {
     const pendingClient = new Promise<FakeSimlockClient>((resolve) => {
       resolveConnect = resolve;
     });
-    const session = new McpSession({ connect: () => pendingClient });
+    const session = new McpSession({ clock: new FakeClock(), connect: () => pendingClient });
 
     const listDevicesCall = session.listDevices({});
     await Promise.resolve(); // let the queued mutation reach #clientForUse() and start connecting
@@ -229,7 +235,7 @@ describe("McpSession", () => {
 
   it("rejects every tool call with SESSION_CLOSED, without contacting the client, once closed", async () => {
     const client = new FakeSimlockClient();
-    const session = new McpSession({ connect: async () => client });
+    const session = new McpSession({ clock: new FakeClock(), connect: async () => client });
     await session.close();
 
     await expect(session.lease({ model: "x", platform: "ios" })).rejects.toMatchObject({
@@ -243,10 +249,115 @@ describe("McpSession", () => {
     expect(client.calls).toEqual([]);
   });
 
+  /**
+   * ADR 0004 §2: the session's lease lives on its own `lease.renew` timer, at a third of the
+   * remaining TTL, and is released explicitly when the session ends -- not left to the socket.
+   */
+  it("renews its lease at a third of the TTL, re-deriving the cadence from each renewal", async () => {
+    const clock = new FakeClock(0);
+    const client = new FakeSimlockClient();
+    client.requestLeaseImpl = () => Promise.resolve(sampleGrant({ leaseId: "lease-1" }));
+    const renewals: Array<{ leaseId: string; at: number }> = [];
+    client.renewLeaseImpl = (input) => {
+      renewals.push({ at: clock.now(), leaseId: input.leaseId });
+      return Promise.resolve({
+        deviceId: "device-1",
+        grantedAt: 0,
+        id: input.leaseId,
+        mode: "held" as const,
+        ownerId: "mcp-test",
+        requesterId: "mcp-test",
+        ttlDeadline: clock.now() + 3_000,
+      });
+    };
+    const session = new McpSession({ clock, connect: async () => client });
+
+    // `sampleGrant`'s deadline is 12_345, so the first renewal is due at 4_115.
+    await session.lease({ model: "iPhone 17 Pro", platform: "ios" });
+    clock.advance(4_114);
+    await flushMicrotasks();
+    expect(renewals).toEqual([]);
+    clock.advance(1);
+    await flushMicrotasks();
+    expect(renewals).toEqual([{ at: 4_115, leaseId: "lease-1" }]);
+
+    // 3_000ms came back, so the next one is 1_000ms later -- off the renewal's own deadline.
+    clock.advance(1_000);
+    await flushMicrotasks();
+    expect(renewals).toHaveLength(2);
+    expect(renewals[1]).toEqual({ at: 5_115, leaseId: "lease-1" });
+
+    await session.close();
+  });
+
+  it("releases the session's lease explicitly on close, before closing the connection", async () => {
+    const clock = new FakeClock(0);
+    const client = new FakeSimlockClient();
+    client.requestLeaseImpl = () => Promise.resolve(sampleGrant({ leaseId: "lease-1" }));
+    client.releaseLeaseImpl = (input) => Promise.resolve({ leaseId: input.leaseId });
+    const session = new McpSession({ clock, connect: async () => client });
+    await session.lease({ model: "iPhone 17 Pro", platform: "ios" });
+
+    await session.close();
+
+    expect(client.calls.map((call) => call.method)).toEqual(["requestLease", "releaseLease"]);
+    expect(client.calls.at(-1)?.input).toEqual({ leaseId: "lease-1" });
+    expect(client.closeCalls).toBe(1);
+    expect(clock.pendingTimerCount, "the renew timer must not outlive the session").toBe(0);
+  });
+
+  it("closes cleanly even when the farewell release fails", async () => {
+    const clock = new FakeClock(0);
+    const client = new FakeSimlockClient();
+    client.requestLeaseImpl = () => Promise.resolve(sampleGrant({ leaseId: "lease-1" }));
+    client.releaseLeaseImpl = () =>
+      Promise.reject(new SimlockError("UNKNOWN_LEASE", "domain", "gone", { leaseId: "lease-1" }));
+    const session = new McpSession({ clock, connect: async () => client });
+    await session.lease({ model: "iPhone 17 Pro", platform: "ios" });
+
+    await expect(session.close()).resolves.toBeUndefined();
+    expect(client.closeCalls).toBe(1);
+  });
+
+  it("does not release on close when the lease was already released by a tool call", async () => {
+    const clock = new FakeClock(0);
+    const client = new FakeSimlockClient();
+    client.requestLeaseImpl = () => Promise.resolve(sampleGrant({ leaseId: "lease-1" }));
+    client.releaseLeaseImpl = (input) => Promise.resolve({ leaseId: input.leaseId });
+    const session = new McpSession({ clock, connect: async () => client });
+    await session.lease({ model: "iPhone 17 Pro", platform: "ios" });
+
+    await session.release({ leaseId: "lease-1" });
+    // The timer goes with the lease, so nothing can renew what was just given up.
+    expect(clock.pendingTimerCount).toBe(0);
+
+    await session.close();
+    expect(client.calls.filter((call) => call.method === "releaseLease")).toHaveLength(1);
+  });
+
+  it("stops renewing a lease that ended elsewhere", async () => {
+    const clock = new FakeClock(0);
+    const client = new FakeSimlockClient();
+    client.requestLeaseImpl = () => Promise.resolve(sampleGrant({ leaseId: "lease-1" }));
+    const session = new McpSession({ clock, connect: async () => client });
+    await session.lease({ model: "iPhone 17 Pro", platform: "ios" });
+
+    client.emitLeaseLost({ deviceId: "device-1", leaseId: "lease-1", reason: "expired" });
+
+    expect(clock.pendingTimerCount).toBe(0);
+    clock.advance(600_000);
+    await flushMicrotasks();
+    expect(client.calls.filter((call) => call.method === "renewLease")).toEqual([]);
+
+    await session.close();
+    // Nothing to release either: the daemon already ended it.
+    expect(client.calls.filter((call) => call.method === "releaseLease")).toEqual([]);
+  });
+
   it("relays the client's lease-lost, device-unhealthy, and device-recovered pushes to session listeners", async () => {
     const client = new FakeSimlockClient();
     client.getCatalogImpl = () => Promise.resolve({ platforms: [] });
-    const session = new McpSession({ connect: async () => client });
+    const session = new McpSession({ clock: new FakeClock(), connect: async () => client });
     await session.listDevices({}); // forces the client to connect and wire up push relays
 
     const leaseLost: unknown[] = [];

--- a/src/mcp/session.test.ts
+++ b/src/mcp/session.test.ts
@@ -335,28 +335,87 @@ describe("McpSession", () => {
     expect(client.calls.filter((call) => call.method === "releaseLease")).toHaveLength(1);
   });
 
-  it("does not send a second release for a lease whose release is already in flight", async () => {
+  it("still releases on close when a tool call's own release is in flight and dies with the wire", async () => {
     const clock = new FakeClock(0);
     const client = new FakeSimlockClient();
     client.requestLeaseImpl = () => Promise.resolve(sampleGrant({ leaseId: "lease-1" }));
-    let answerRelease!: (result: { leaseId: string }) => void;
+    const pending: Array<{
+      resolve: (result: { leaseId: string }) => void;
+      reject: (error: Error) => void;
+      settled: boolean;
+    }> = [];
     client.releaseLeaseImpl = () =>
-      new Promise<{ leaseId: string }>((resolve) => {
-        answerRelease = resolve;
+      new Promise<{ leaseId: string }>((resolve, reject) => {
+        const entry = {
+          reject: (error: Error) => {
+            entry.settled = true;
+            reject(error);
+          },
+          resolve: (result: { leaseId: string }) => {
+            entry.settled = true;
+            resolve(result);
+          },
+          settled: false,
+        };
+        pending.push(entry);
       });
+    // What the real wire does when the connection closes: every request still waiting for an
+    // answer rejects (ADR 0003 §10).
+    client.onConnectionLost(() => {
+      for (const entry of pending) {
+        if (!entry.settled)
+          entry.reject(new SimlockError("DAEMON_CONNECTION_LOST", "transport", "gone", {}));
+      }
+    });
     const session = new McpSession({ clock, connect: async () => client });
     await session.lease({ model: "iPhone 17 Pro", platform: "ios" });
 
     // `close()` deliberately does not queue behind the tool-call serializer, so it can land
-    // while a `release_simulator` call is still waiting on the daemon.
+    // while a `release_simulator` call is still waiting on the daemon. Skipping the farewell
+    // release because that one exists would mean *no* release at all: the wire kills it a
+    // moment later.
     const releasing = session.release({ leaseId: "lease-1" });
     await flushMicrotasks();
     const closing = session.close();
-    answerRelease({ leaseId: "lease-1" });
-    await expect(releasing).resolves.toMatchObject({ leaseId: "lease-1", released: true });
+    await flushMicrotasks();
+    expect(client.calls.filter((call) => call.method === "releaseLease")).toHaveLength(2);
+
+    pending[1]?.resolve({ leaseId: "lease-1" }); // the daemon answers the farewell release
+    await closing;
+    await expect(releasing).rejects.toMatchObject({ code: "DAEMON_CONNECTION_LOST" });
+
+    // Exactly one release actually completed -- and the lease really is released.
+    expect(pending.filter((entry) => entry.settled)).toHaveLength(2);
+    expect(pending[0]?.settled).toBe(true); // rejected with the wire
+    expect(client.closeCalls).toBe(1);
+  });
+
+  it("releases a grant that lands after the session closed, and arms no timer for it", async () => {
+    const clock = new FakeClock(0);
+    const client = new FakeSimlockClient();
+    let answerGrant!: (grant: ReturnType<typeof sampleGrant>) => void;
+    client.requestLeaseImpl = () =>
+      new Promise((resolve) => {
+        answerGrant = resolve;
+      });
+    client.releaseLeaseImpl = (input) => Promise.resolve({ leaseId: input.leaseId });
+    const session = new McpSession({ clock, connect: async () => client });
+
+    const leasing = session.lease({ model: "iPhone 17 Pro", platform: "ios" });
+    await flushMicrotasks();
+    const closing = session.close();
     await closing;
 
-    expect(client.calls.filter((call) => call.method === "releaseLease")).toHaveLength(1);
+    // The daemon finished provisioning after the session ended: the device goes straight back
+    // rather than being renewed by a session that no longer exists.
+    answerGrant(sampleGrant({ leaseId: "lease-1" }));
+    await expect(leasing).rejects.toMatchObject({ code: "SESSION_CLOSED" });
+
+    expect(client.calls.filter((call) => call.method === "releaseLease")).toEqual([
+      { input: { leaseId: "lease-1" }, method: "releaseLease" },
+    ]);
+    expect(client.calls.filter((call) => call.method === "renewLease")).toEqual([]);
+    expect(clock.pendingTimerCount, "a closed session must leave no timer behind").toBe(0);
   });
 
   it("keeps renewing when a release fails, because the session still holds the device", async () => {
@@ -419,6 +478,32 @@ describe("McpSession", () => {
     await session.close();
     expect(client.calls.filter((call) => call.method === "releaseLease")).toEqual([]);
     expect(client.calls.filter((call) => call.method === "renewLease")).toHaveLength(1);
+  });
+
+  it("announces one ending once, even when the renewal and the daemon both report it", async () => {
+    const clock = new FakeClock(0);
+    const client = new FakeSimlockClient();
+    client.requestLeaseImpl = () => Promise.resolve(sampleGrant({ leaseId: "lease-1" }));
+    client.renewLeaseImpl = () =>
+      Promise.reject(
+        new SimlockError("UNKNOWN_LEASE", "domain", "no such lease", { leaseId: "lease-1" }),
+      );
+    const session = new McpSession({ clock, connect: async () => client });
+    const notices: unknown[] = [];
+    session.onLeaseLost((notice) => notices.push(notice));
+    await session.lease({ model: "iPhone 17 Pro", platform: "ios" });
+
+    clock.advance(4_115);
+    await flushMicrotasks();
+    // The daemon's own push for the same lease arrives a moment later; an agent must not read
+    // that as a second device lost.
+    client.emitLeaseLost({ deviceId: "device-1", leaseId: "lease-1", reason: "expired" });
+
+    expect(notices).toEqual([
+      { deviceId: "device-1", leaseId: "lease-1", reason: "renew-rejected" },
+    ]);
+
+    await session.close();
   });
 
   it("stops renewing a lease that ended elsewhere", async () => {

--- a/src/mcp/session.test.ts
+++ b/src/mcp/session.test.ts
@@ -394,6 +394,33 @@ describe("McpSession", () => {
     await session.close();
   });
 
+  it("reports a lease the daemon says is gone as lease-lost, and releases nothing on close", async () => {
+    const clock = new FakeClock(0);
+    const client = new FakeSimlockClient();
+    client.requestLeaseImpl = () => Promise.resolve(sampleGrant({ leaseId: "lease-1" }));
+    client.renewLeaseImpl = () =>
+      Promise.reject(
+        new SimlockError("UNKNOWN_LEASE", "domain", "no such lease", { leaseId: "lease-1" }),
+      );
+    const session = new McpSession({ clock, connect: async () => client });
+    const notices: unknown[] = [];
+    session.onLeaseLost((notice) => notices.push(notice));
+    await session.lease({ model: "iPhone 17 Pro", platform: "ios" });
+
+    // A lease that expired while this session was idle may never produce a push -- the
+    // renewal's own answer is what tells the agent.
+    clock.advance(4_115);
+    await flushMicrotasks();
+    expect(notices).toEqual([
+      { deviceId: "device-1", leaseId: "lease-1", reason: "renew-rejected" },
+    ]);
+    expect(clock.pendingTimerCount).toBe(0);
+
+    await session.close();
+    expect(client.calls.filter((call) => call.method === "releaseLease")).toEqual([]);
+    expect(client.calls.filter((call) => call.method === "renewLease")).toHaveLength(1);
+  });
+
   it("stops renewing a lease that ended elsewhere", async () => {
     const clock = new FakeClock(0);
     const client = new FakeSimlockClient();

--- a/src/mcp/session.test.ts
+++ b/src/mcp/session.test.ts
@@ -335,6 +335,41 @@ describe("McpSession", () => {
     expect(client.calls.filter((call) => call.method === "releaseLease")).toHaveLength(1);
   });
 
+  it("keeps renewing when a release fails, because the session still holds the device", async () => {
+    const clock = new FakeClock(0);
+    const client = new FakeSimlockClient();
+    client.requestLeaseImpl = () => Promise.resolve(sampleGrant({ leaseId: "lease-1" }));
+    client.releaseLeaseImpl = () =>
+      Promise.reject(new SimlockError("INTERNAL", "domain", "could not release", {}));
+    let renewals = 0;
+    client.renewLeaseImpl = (input) => {
+      renewals += 1;
+      return Promise.resolve({
+        deviceId: "device-1",
+        grantedAt: 0,
+        id: input.leaseId,
+        mode: "held" as const,
+        ownerId: "mcp-test",
+        requesterId: "mcp-test",
+        ttlDeadline: clock.now() + 12_000,
+      });
+    };
+    const session = new McpSession({ clock, connect: async () => client });
+    await session.lease({ model: "iPhone 17 Pro", platform: "ios" });
+
+    await expect(session.release({ leaseId: "lease-1" })).rejects.toMatchObject({
+      code: "INTERNAL",
+    });
+
+    // The daemon still has the lease, so the timer that keeps it must still be running --
+    // otherwise the device is reclaimed at the deadline under a session that was told its
+    // release failed.
+    clock.advance(4_115);
+    await flushMicrotasks();
+    expect(renewals).toBe(1);
+    await session.close();
+  });
+
   it("stops renewing a lease that ended elsewhere", async () => {
     const clock = new FakeClock(0);
     const client = new FakeSimlockClient();

--- a/src/mcp/session.test.ts
+++ b/src/mcp/session.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { SimlockError } from "../client/index.js";
+import { RELEASE_TIMEOUT_MS } from "../lease-policy/index.js";
 import { FakeClock } from "../ports/index.js";
 import { FakeSimlockClient, sampleGrant } from "./test-support.js";
 import { McpSession, toMcpErrorResult } from "./session.js";
@@ -335,6 +336,50 @@ describe("McpSession", () => {
     expect(client.calls.filter((call) => call.method === "releaseLease")).toHaveLength(1);
   });
 
+  it("renews and releases every lease it obtained, not only the latest", async () => {
+    const clock = new FakeClock(0);
+    const client = new FakeSimlockClient();
+    let granted = 0;
+    client.requestLeaseImpl = () => {
+      granted += 1;
+      return Promise.resolve(sampleGrant({ leaseId: `lease-${granted}` }));
+    };
+    const renewed: string[] = [];
+    client.renewLeaseImpl = (input) => {
+      renewed.push(input.leaseId);
+      return Promise.resolve({
+        deviceId: "device-1",
+        grantedAt: 0,
+        id: input.leaseId,
+        mode: "held" as const,
+        ownerId: "mcp-test",
+        requesterId: "mcp-test",
+        ttlDeadline: clock.now() + 12_345,
+      });
+    };
+    client.releaseLeaseImpl = (input) => Promise.resolve({ leaseId: input.leaseId });
+    const session = new McpSession({ clock, connect: async () => client });
+
+    // Nothing here limits a session to one lease -- the daemon's one-lease-per-requester rule
+    // is the authority (ADR 0003 §11). Whatever it grants, this session has to keep alive and
+    // hand back; the second grant must not silently strand the first.
+    await session.lease({ model: "iPhone 17 Pro", platform: "ios" });
+    await session.lease({ model: "iPhone 17 Pro", platform: "ios" });
+
+    clock.advance(4_115);
+    await flushMicrotasks();
+    expect(renewed.slice().sort()).toEqual(["lease-1", "lease-2"]);
+
+    await session.close();
+    expect(
+      client.calls
+        .filter((call) => call.method === "releaseLease")
+        .map((call) => (call.input as { leaseId: string }).leaseId)
+        .sort(),
+    ).toEqual(["lease-1", "lease-2"]);
+    expect(clock.pendingTimerCount).toBe(0);
+  });
+
   it("still releases on close when a tool call's own release is in flight and dies with the wire", async () => {
     const clock = new FakeClock(0);
     const client = new FakeSimlockClient();
@@ -370,13 +415,17 @@ describe("McpSession", () => {
     const session = new McpSession({ clock, connect: async () => client });
     await session.lease({ model: "iPhone 17 Pro", platform: "ios" });
 
-    // `close()` deliberately does not queue behind the tool-call serializer, so it can land
-    // while a `release_simulator` call is still waiting on the daemon. Skipping the farewell
-    // release because that one exists would mean *no* release at all: the wire kills it a
-    // moment later.
+    // `close()` deliberately does not queue behind the tool-call serializer: it waits for the
+    // call in flight, but only so long. Here the daemon never answers that release, so the
+    // wait times out -- and skipping the farewell release because a tool call "has one on the
+    // way" would mean *no* release at all, since the wire kills that one a moment later.
     const releasing = session.release({ leaseId: "lease-1" });
     await flushMicrotasks();
     const closing = session.close();
+    await flushMicrotasks();
+    expect(client.calls.filter((call) => call.method === "releaseLease")).toHaveLength(1);
+
+    clock.advance(RELEASE_TIMEOUT_MS);
     await flushMicrotasks();
     expect(client.calls.filter((call) => call.method === "releaseLease")).toHaveLength(2);
 
@@ -384,10 +433,11 @@ describe("McpSession", () => {
     await closing;
     await expect(releasing).rejects.toMatchObject({ code: "DAEMON_CONNECTION_LOST" });
 
-    // Exactly one release actually completed -- and the lease really is released.
-    expect(pending.filter((entry) => entry.settled)).toHaveLength(2);
-    expect(pending[0]?.settled).toBe(true); // rejected with the wire
+    // Exactly one release completed -- the farewell one -- and the lease really is released.
+    expect(pending[1]?.settled, "the farewell release was answered").toBe(true);
+    expect(pending[0]?.settled, "the tool call's release died with the wire").toBe(true);
     expect(client.closeCalls).toBe(1);
+    expect(clock.pendingTimerCount, "no bound outlives the close").toBe(0);
   });
 
   it("releases a grant that lands after the session closed, and arms no timer for it", async () => {
@@ -404,12 +454,15 @@ describe("McpSession", () => {
     const leasing = session.lease({ model: "iPhone 17 Pro", platform: "ios" });
     await flushMicrotasks();
     const closing = session.close();
-    await closing;
+    await flushMicrotasks();
 
-    // The daemon finished provisioning after the session ended: the device goes straight back
-    // rather than being renewed by a session that no longer exists.
+    // The daemon finishes provisioning just after the session ended. `close()` is still
+    // waiting on that call (bounded), so the wire is alive: the device goes straight back
+    // rather than being renewed by a session that no longer exists -- or stranded until its
+    // deadline because the connection was already gone.
     answerGrant(sampleGrant({ leaseId: "lease-1" }));
     await expect(leasing).rejects.toMatchObject({ code: "SESSION_CLOSED" });
+    await closing;
 
     expect(client.calls.filter((call) => call.method === "releaseLease")).toEqual([
       { input: { leaseId: "lease-1" }, method: "releaseLease" },

--- a/src/mcp/session.test.ts
+++ b/src/mcp/session.test.ts
@@ -380,64 +380,69 @@ describe("McpSession", () => {
     expect(clock.pendingTimerCount).toBe(0);
   });
 
-  it("still releases on close when a tool call's own release is in flight and dies with the wire", async () => {
+  it("still sends its own release when a tool call's release is already in flight", async () => {
     const clock = new FakeClock(0);
     const client = new FakeSimlockClient();
     client.requestLeaseImpl = () => Promise.resolve(sampleGrant({ leaseId: "lease-1" }));
-    const pending: Array<{
-      resolve: (result: { leaseId: string }) => void;
-      reject: (error: Error) => void;
-      settled: boolean;
-    }> = [];
+    const pending: Array<(result: { leaseId: string }) => void> = [];
     client.releaseLeaseImpl = () =>
-      new Promise<{ leaseId: string }>((resolve, reject) => {
-        const entry = {
-          reject: (error: Error) => {
-            entry.settled = true;
-            reject(error);
-          },
-          resolve: (result: { leaseId: string }) => {
-            entry.settled = true;
-            resolve(result);
-          },
-          settled: false,
-        };
-        pending.push(entry);
+      new Promise<{ leaseId: string }>((resolve) => {
+        pending.push(resolve);
       });
-    // What the real wire does when the connection closes: every request still waiting for an
-    // answer rejects (ADR 0003 §10).
-    client.onConnectionLost(() => {
-      for (const entry of pending) {
-        if (!entry.settled)
-          entry.reject(new SimlockError("DAEMON_CONNECTION_LOST", "transport", "gone", {}));
-      }
-    });
     const session = new McpSession({ clock, connect: async () => client });
     await session.lease({ model: "iPhone 17 Pro", platform: "ios" });
 
-    // `close()` deliberately does not queue behind the tool-call serializer: it waits for the
-    // call in flight, but only so long. Here the daemon never answers that release, so the
-    // wait times out -- and skipping the farewell release because a tool call "has one on the
-    // way" would mean *no* release at all, since the wire kills that one a moment later.
+    // `close()` does not queue behind the tool-call serializer, so it can land while a
+    // `release_simulator` call is still waiting on the daemon. It waits for that call, then
+    // sends its own release anyway: deferring to the in-flight one would mean no release at
+    // all if the wire died first, and a duplicate only costs an `UNKNOWN_LEASE` it swallows.
     const releasing = session.release({ leaseId: "lease-1" });
     await flushMicrotasks();
     const closing = session.close();
     await flushMicrotasks();
     expect(client.calls.filter((call) => call.method === "releaseLease")).toHaveLength(1);
 
-    clock.advance(RELEASE_TIMEOUT_MS);
+    pending[0]?.({ leaseId: "lease-1" }); // the tool call's own release is answered
+    await expect(releasing).resolves.toMatchObject({ leaseId: "lease-1", released: true });
     await flushMicrotasks();
     expect(client.calls.filter((call) => call.method === "releaseLease")).toHaveLength(2);
 
-    pending[1]?.resolve({ leaseId: "lease-1" }); // the daemon answers the farewell release
+    pending[1]?.({ leaseId: "lease-1" });
     await closing;
-    await expect(releasing).rejects.toMatchObject({ code: "DAEMON_CONNECTION_LOST" });
-
-    // Exactly one release completed -- the farewell one -- and the lease really is released.
-    expect(pending[1]?.settled, "the farewell release was answered").toBe(true);
-    expect(pending[0]?.settled, "the tool call's release died with the wire").toBe(true);
     expect(client.closeCalls).toBe(1);
     expect(clock.pendingTimerCount, "no bound outlives the close").toBe(0);
+  });
+
+  it("spends one shutdown budget in total, not one per step", async () => {
+    const clock = new FakeClock(0);
+    const client = new FakeSimlockClient();
+    client.requestLeaseImpl = () => Promise.resolve(sampleGrant({ leaseId: "lease-1" }));
+    // A daemon that answers nothing: neither the tool call in flight nor the release that
+    // would follow it ever comes back.
+    client.listLeasesImpl = () => new Promise(() => {});
+    client.releaseLeaseImpl = () => new Promise(() => {});
+    const session = new McpSession({ clock, connect: async () => client });
+    await session.lease({ model: "iPhone 17 Pro", platform: "ios" });
+    void session.status().catch(() => undefined); // in flight, never answered
+    await flushMicrotasks();
+
+    let closed = false;
+    const closing = session.close().then(() => {
+      closed = true;
+    });
+    await flushMicrotasks();
+
+    // A budget per step -- one for the in-flight call, then one more for the lease -- would
+    // leave `simlock mcp` sitting here for a multiple of this after stdin EOF.
+    clock.advance(RELEASE_TIMEOUT_MS - 1);
+    await flushMicrotasks();
+    expect(closed).toBe(false);
+
+    clock.advance(1);
+    await closing;
+    expect(closed).toBe(true);
+    expect(client.closeCalls, "the wire closes when the budget is spent").toBe(1);
+    expect(clock.pendingTimerCount).toBe(0);
   });
 
   it("releases a grant that lands after the session closed, and arms no timer for it", async () => {
@@ -533,6 +538,34 @@ describe("McpSession", () => {
     expect(client.calls.filter((call) => call.method === "renewLease")).toHaveLength(1);
   });
 
+  it("reports a lease it could not keep alive as lost, and releases nothing for it on close", async () => {
+    const clock = new FakeClock(0);
+    const client = new FakeSimlockClient();
+    client.requestLeaseImpl = () => Promise.resolve(sampleGrant({ leaseId: "lease-1" }));
+    // Never terminal, never successful: the ladder retries until `sampleGrant`'s own 12_345
+    // deadline passes and renewal gives up.
+    client.renewLeaseImpl = () =>
+      Promise.reject(new SimlockError("INTERNAL", "domain", "could not persist", {}));
+    const session = new McpSession({ clock, connect: async () => client });
+    const notices: unknown[] = [];
+    session.onLeaseLost((notice) => notices.push(notice));
+    await session.lease({ model: "iPhone 17 Pro", platform: "ios" });
+
+    clock.advance(4_115);
+    await flushMicrotasks();
+    clock.advance(20_000); // the retry lands past the deadline
+    await flushMicrotasks();
+
+    expect(notices).toEqual([{ deviceId: "device-1", leaseId: "lease-1", reason: "renew-failed" }]);
+    expect(clock.pendingTimerCount).toBe(0);
+
+    await session.close();
+    expect(
+      client.calls.filter((call) => call.method === "releaseLease"),
+      "a lease that expired is not the session's to release",
+    ).toEqual([]);
+  });
+
   it("announces one ending once, even when the renewal and the daemon both report it", async () => {
     const clock = new FakeClock(0);
     const client = new FakeSimlockClient();
@@ -612,6 +645,32 @@ describe("toMcpErrorResult", () => {
     expect(toMcpErrorResult(new Error("/private/secret-stack-path"))).toEqual({
       code: "INTERNAL",
       message: "Simlock could not complete the request",
+    });
+  });
+});
+
+/**
+ * The double itself: MCP's tests are only worth what it is faithful to, and the one thing it
+ * has to get right is that a closed connection is dead (ADR 0003 §10) -- a fake that kept
+ * answering would let a test pass on a wire the real session had already closed.
+ */
+describe("FakeSimlockClient", () => {
+  it("rejects every call once closed, the way the wire does", async () => {
+    const client = new FakeSimlockClient();
+    client.releaseLeaseImpl = (input) => Promise.resolve({ leaseId: input.leaseId });
+    client.getCatalogImpl = () => Promise.resolve({ platforms: [] });
+
+    await expect(client.releaseLease({ leaseId: "lease-1" })).resolves.toEqual({
+      leaseId: "lease-1",
+    });
+
+    await client.close();
+
+    await expect(client.releaseLease({ leaseId: "lease-1" })).rejects.toMatchObject({
+      code: "DAEMON_CONNECTION_LOST",
+    });
+    await expect(client.getCatalog({})).rejects.toMatchObject({
+      code: "DAEMON_CONNECTION_LOST",
     });
   });
 });

--- a/src/mcp/session.test.ts
+++ b/src/mcp/session.test.ts
@@ -335,6 +335,30 @@ describe("McpSession", () => {
     expect(client.calls.filter((call) => call.method === "releaseLease")).toHaveLength(1);
   });
 
+  it("does not send a second release for a lease whose release is already in flight", async () => {
+    const clock = new FakeClock(0);
+    const client = new FakeSimlockClient();
+    client.requestLeaseImpl = () => Promise.resolve(sampleGrant({ leaseId: "lease-1" }));
+    let answerRelease!: (result: { leaseId: string }) => void;
+    client.releaseLeaseImpl = () =>
+      new Promise<{ leaseId: string }>((resolve) => {
+        answerRelease = resolve;
+      });
+    const session = new McpSession({ clock, connect: async () => client });
+    await session.lease({ model: "iPhone 17 Pro", platform: "ios" });
+
+    // `close()` deliberately does not queue behind the tool-call serializer, so it can land
+    // while a `release_simulator` call is still waiting on the daemon.
+    const releasing = session.release({ leaseId: "lease-1" });
+    await flushMicrotasks();
+    const closing = session.close();
+    answerRelease({ leaseId: "lease-1" });
+    await expect(releasing).resolves.toMatchObject({ leaseId: "lease-1", released: true });
+    await closing;
+
+    expect(client.calls.filter((call) => call.method === "releaseLease")).toHaveLength(1);
+  });
+
   it("keeps renewing when a release fails, because the session still holds the device", async () => {
     const clock = new FakeClock(0);
     const client = new FakeSimlockClient();

--- a/src/mcp/session.ts
+++ b/src/mcp/session.ts
@@ -161,11 +161,17 @@ export class McpSession {
     return this.#mutate(async () => {
       this.#throwIfClosed();
       const client = await this.#clientForUse();
-      // Stopped before the call, not after it: a renew that overtook its own release would
-      // resurrect the lease the caller just gave up.
-      if (input.leaseId === this.#heldLeaseId) this.#stopRenewal();
       const result = await client.releaseLease(input);
-      if (result.leaseId === this.#heldLeaseId) this.#heldLeaseId = undefined;
+      // Stopped only once the daemon has actually let the lease go. A release that fails
+      // (anything but a dead connection) leaves the session still holding the device, and a
+      // session that has stopped renewing a lease it still holds loses that device at the
+      // deadline. A renew that overtakes a *successful* release cannot resurrect anything:
+      // `Registry#beginRelease` drops the record, so `lease.renew` can only answer
+      // UNKNOWN_LEASE.
+      if (result.leaseId === this.#heldLeaseId) {
+        this.#stopRenewal();
+        this.#heldLeaseId = undefined;
+      }
       return { ...result, released: true };
     });
   }

--- a/src/mcp/session.ts
+++ b/src/mcp/session.ts
@@ -23,6 +23,13 @@ import type {
   ReleaseSimulatorOutput,
 } from "./contracts.js";
 
+/**
+ * How many ended leases `#announceLeaseLost` remembers, to keep one ending from reaching a
+ * listener twice. Generous: a session holds one lease at a time in practice, so this is only
+ * ever reached by a session that has churned through many.
+ */
+const ANNOUNCED_LOST_LIMIT = 64;
+
 export interface McpSessionOptions {
   /**
    * The `Clock` port (architecture rule 9): the session's renew timer and `close()`'s release
@@ -101,9 +108,9 @@ export function toMcpErrorResult(error: unknown): McpErrorResult {
  * a cache of lease *state* (§11's point): it is only the id of the lease this session's own
  * `lease()` last obtained, kept so `status()` can tell that lease apart from any other lease
  * `lease.list` happens to return under the same owner principal -- see `status()`'s doc
- * comment for why that distinction is load-bearing. Alongside it sits `#renewal`, the timer
- * that keeps that lease alive (ADR 0004 §2); the two are started, stopped, and cleared
- * together.
+ * comment for why that distinction is load-bearing. Alongside it sits `#renewals`, one timer
+ * per lease this session obtained (ADR 0004 §2): a lease enters it when `lease()` returns and
+ * leaves it the moment the session stops holding that lease, by release, by loss, or by close.
  */
 export class McpSession {
   readonly #clock: Clock;
@@ -268,9 +275,12 @@ export class McpSession {
 
   /**
    * `close()`'s tail: let the last tool call finish on a live wire, hand every lease back, then
-   * close. The wait is bounded because an in-flight `lease.request` can take minutes and an
-   * ending session cannot wait that long; past the bound the connection closes, the daemon
-   * rejects what was still pending, and any lease that slipped through ends at its deadline.
+   * close -- all inside **one** `RELEASE_TIMEOUT_MS` budget for the whole tail, not one per
+   * step. A session ending against an unresponsive daemon must cost a bounded wait, and "one
+   * timeout for the in-flight call plus one per lease" would let a dead daemon hold an MCP
+   * server open for a multiple of it. Whatever has not finished when the budget runs out is
+   * abandoned; the connection closes in the `finally`, the daemon rejects what was pending,
+   * and any lease that did not make it ends at its own deadline.
    */
   async #endSession(
     client: SimlockClient,
@@ -281,14 +291,22 @@ export class McpSession {
       await awaitWithin(
         this.#clock,
         RELEASE_TIMEOUT_MS,
-        inFlight,
-        "Timed out waiting for the last tool call to finish",
+        (async () => {
+          // `#mutations` never rejects (see `#mutate`), but a caller-supplied queue might.
+          await inFlight.catch(() => undefined);
+          for (const leaseId of heldLeaseIds) {
+            // One lease the daemon refuses (already expired, force-released) must not cost the
+            // rest of them their release.
+            await client.releaseLease({ leaseId }).catch(() => undefined);
+          }
+        })(),
+        "Timed out ending the session",
       );
     } catch {
       // Bounded by design -- see above.
+    } finally {
+      await this.#closeClient(client);
     }
-    for (const leaseId of heldLeaseIds) await this.#releaseQuietly(client, leaseId);
-    await this.#closeClient(client);
   }
 
   /**
@@ -297,6 +315,10 @@ export class McpSession {
    * answer never arrived), the connection may be dead, or the daemon may not answer at all --
    * none of which should hold up an ending session, and all of which end the same way in the
    * daemon regardless, at the lease's deadline.
+   *
+   * Used by the grant-after-close path in `lease()`, which runs *inside* `#endSession`'s own
+   * budget: this bound is the fallback for a caller that is not already bounded, and the outer
+   * one wins whenever it is shorter.
    */
   async #releaseQuietly(client: SimlockClient, leaseId: string): Promise<void> {
     try {
@@ -326,15 +348,12 @@ export class McpSession {
     const renewal = startLeaseRenewal({
       clock: this.#clock,
       leaseId: lease.id,
-      onLeaseGone: () => {
-        // The daemon says this lease is gone or not ours: the same ending as the push, which
+      onLeaseGone: (reason) => {
+        // Renewal is over -- the daemon says the lease is gone or not ours, or it could not be
+        // kept alive to its deadline. Either way this is the same ending as the push, which
         // may never arrive (a lease that expired while this connection was away has nothing
-        // left to push about).
-        this.#reportLeaseLost({
-          deviceId: lease.deviceId,
-          leaseId: lease.id,
-          reason: "renew-rejected",
-        });
+        // left to push about), and the session must stop counting the lease as its own.
+        this.#reportLeaseLost({ deviceId: lease.deviceId, leaseId: lease.id, reason });
       },
       renew: (id) => client.renewLease({ leaseId: id }),
       ttlDeadline: lease.ttlDeadline,
@@ -363,6 +382,13 @@ export class McpSession {
   #announceLeaseLost(notice: LeaseLostNotice): void {
     if (this.#announcedLost.has(notice.leaseId)) return;
     this.#announcedLost.add(notice.leaseId);
+    // Capped: a long-lived session that loses many leases must not accumulate their ids
+    // forever. A `Set` keeps insertion order, so this drops the oldest -- whose duplicate
+    // push, if it were ever coming, arrived long ago.
+    if (this.#announcedLost.size > ANNOUNCED_LOST_LIMIT) {
+      const oldest = this.#announcedLost.values().next().value;
+      if (oldest !== undefined) this.#announcedLost.delete(oldest);
+    }
     for (const listener of this.#leaseLostListeners) listener(notice);
   }
 

--- a/src/mcp/session.ts
+++ b/src/mcp/session.ts
@@ -2,6 +2,7 @@ import {
   isSimlockError,
   SimlockError,
   type LeaseProgress,
+  type LeaseRecord,
   type LeaseRequestInput,
   type SimlockClient,
 } from "../client/index.js";
@@ -151,7 +152,7 @@ export class McpSession {
         ...(signal === undefined ? {} : { signal }),
       });
       this.#heldLeaseId = grant.lease.id;
-      this.#startRenewal(client, grant.lease.id, grant.lease.ttlDeadline);
+      this.#startRenewal(client, grant.lease);
       return grant;
     });
   }
@@ -159,13 +160,14 @@ export class McpSession {
   release(input: ReleaseSimulatorInput): Promise<ReleaseSimulatorOutput> {
     return this.#mutate(async () => {
       this.#throwIfClosed();
-      const client = await this.#clientForUse();
-      // `close()` does not queue behind `#mutations` (see its doc comment), so it can read
-      // `#heldLeaseId` while this release is still in flight. This is how it knows the lease
-      // already has a release on the way and must not get a second one.
+      // Marked before `#clientForUse()`, not after: that call can reconnect, which takes as
+      // long as a daemon launch, and `close()` does not queue behind `#mutations` (see its doc
+      // comment). This is how it knows the lease already has a release on the way -- from the
+      // moment this call commits to sending one -- and must not get a second one.
       this.#releaseInFlight = input.leaseId;
       let result;
       try {
+        const client = await this.#clientForUse();
         result = await client.releaseLease(input);
       } finally {
         this.#releaseInFlight = undefined;
@@ -286,17 +288,41 @@ export class McpSession {
    * quietly reconnecting behind the tool surface -- reconnect stays a decision the next tool
    * call makes (`#clientForUse`).
    */
-  #startRenewal(client: SimlockClient, leaseId: string, ttlDeadline: number): void {
+  #startRenewal(client: SimlockClient, lease: LeaseRecord): void {
     this.#stopRenewal();
     // No `onError`: this frontend owns stdout (it is the protocol) and has no side channel a
-    // failed renewal could be written to. Every failure that matters to the agent surfaces as
-    // the `lease-lost` notice that follows it, or as the next tool call's own error.
+    // retryable failure could be written to. What the agent has to know is that the lease is
+    // over, and that arrives as the `lease-lost` notice `onLeaseGone` raises below (or as the
+    // daemon's own push, whichever comes first) rather than as a stream of attempt failures.
     this.#renewal = startLeaseRenewal({
       clock: this.#clock,
-      leaseId,
+      leaseId: lease.id,
+      onLeaseGone: () => {
+        // The daemon says this lease is gone or not ours: the same ending as the push, which
+        // may never arrive (a lease that expired while this connection was away has nothing
+        // left to push about).
+        this.#reportLeaseLost({
+          deviceId: lease.deviceId,
+          leaseId: lease.id,
+          reason: "renew-rejected",
+        });
+      },
       renew: (id) => client.renewLease({ leaseId: id }),
-      ttlDeadline,
+      ttlDeadline: lease.ttlDeadline,
     });
+  }
+
+  /**
+   * This session's own lease has ended, as told by a renewal rather than by a push: drop the
+   * timer, forget the id, and deliver the same notice a push would have. (The push relay in
+   * `#wireClient` stays separate because it forwards every lease-lost push to listeners,
+   * including ones for leases this session never held; this only ever fires for its own.)
+   */
+  #reportLeaseLost(notice: LeaseLostNotice): void {
+    if (notice.leaseId !== this.#heldLeaseId) return;
+    this.#stopRenewal();
+    this.#heldLeaseId = undefined;
+    for (const listener of this.#leaseLostListeners) listener(notice);
   }
 
   #stopRenewal(): void {

--- a/src/mcp/session.ts
+++ b/src/mcp/session.ts
@@ -5,8 +5,13 @@ import {
   type LeaseRequestInput,
   type SimlockClient,
 } from "../client/index.js";
-import { startLeaseRenewal, type LeaseRenewal } from "../lease-policy/index.js";
-import type { Clock, TimerHandle } from "../ports/index.js";
+import {
+  awaitWithin,
+  RELEASE_TIMEOUT_MS,
+  startLeaseRenewal,
+  type LeaseRenewal,
+} from "../lease-policy/index.js";
+import type { Clock } from "../ports/index.js";
 import type {
   LeaseSimulatorInput,
   LeaseSimulatorOutput,
@@ -16,15 +21,6 @@ import type {
   ReleaseSimulatorInput,
   ReleaseSimulatorOutput,
 } from "./contracts.js";
-
-/**
- * How long `close()` waits for its farewell `lease.release` before closing the connection
- * anyway. The daemon is a local process answering a local socket, so this is not a latency
- * budget -- it is the bound that keeps an unresponsive daemon from holding an MCP server's
- * shutdown open forever. Exceeding it costs nothing but the wait: the lease then ends the way
- * every unreleased lease ends, at its deadline.
- */
-const RELEASE_ON_CLOSE_TIMEOUT_MS = 5_000;
 
 export interface McpSessionOptions {
   /**
@@ -132,6 +128,9 @@ export class McpSession {
    * holds a lease it obtained itself.
    */
   #renewal: LeaseRenewal | undefined;
+  /** The lease a `release()` call has in flight right now, so `close()` never sends a second
+   * release for the same lease (it does not queue behind `#mutations`). */
+  #releaseInFlight: string | undefined;
 
   constructor(options: McpSessionOptions) {
     this.#clock = options.clock;
@@ -161,7 +160,16 @@ export class McpSession {
     return this.#mutate(async () => {
       this.#throwIfClosed();
       const client = await this.#clientForUse();
-      const result = await client.releaseLease(input);
+      // `close()` does not queue behind `#mutations` (see its doc comment), so it can read
+      // `#heldLeaseId` while this release is still in flight. This is how it knows the lease
+      // already has a release on the way and must not get a second one.
+      this.#releaseInFlight = input.leaseId;
+      let result;
+      try {
+        result = await client.releaseLease(input);
+      } finally {
+        this.#releaseInFlight = undefined;
+      }
       // Stopped only once the daemon has actually let the lease go. A release that fails
       // (anything but a dead connection) leaves the session still holding the device, and a
       // session that has stopped renewing a lease it still holds loses that device at the
@@ -241,7 +249,8 @@ export class McpSession {
     this.#stopRenewal();
     this.#unwireClient();
     const client = this.#client;
-    const heldLeaseId = this.#heldLeaseId;
+    // A lease whose release is already in flight is not released again.
+    const heldLeaseId = this.#heldLeaseId === this.#releaseInFlight ? undefined : this.#heldLeaseId;
     this.#heldLeaseId = undefined;
     this.#client = undefined;
     if (this.#connecting !== undefined) {
@@ -256,7 +265,12 @@ export class McpSession {
   async #endSession(client: SimlockClient, heldLeaseId: string | undefined): Promise<void> {
     if (heldLeaseId !== undefined) {
       try {
-        await this.#withReleaseTimeout(client.releaseLease({ leaseId: heldLeaseId }));
+        await awaitWithin(
+          this.#clock,
+          RELEASE_TIMEOUT_MS,
+          client.releaseLease({ leaseId: heldLeaseId }),
+          `Timed out releasing lease ${heldLeaseId}`,
+        );
       } catch {
         // Best-effort by design: the lease may already be gone (expired, force-released), the
         // connection may be dead, or the daemon may not answer. Shutdown continues either way,
@@ -264,23 +278,6 @@ export class McpSession {
       }
     }
     await this.#closeClient(client);
-  }
-
-  /** Rejects once `RELEASE_ON_CLOSE_TIMEOUT_MS` passes, so a dead-but-open socket cannot pin an
-   * MCP server open. The timer is always cancelled, so it never holds the process open itself. */
-  async #withReleaseTimeout(release: Promise<unknown>): Promise<void> {
-    let timer: TimerHandle | undefined;
-    const expiry = new Promise<never>((_resolve, reject) => {
-      timer = this.#clock.setTimer(RELEASE_ON_CLOSE_TIMEOUT_MS, () => {
-        timer = undefined;
-        reject(new McpSessionError("RELEASE_TIMEOUT", "Timed out releasing the session's lease"));
-      });
-    });
-    try {
-      await Promise.race([release, expiry]);
-    } finally {
-      if (timer !== undefined) this.#clock.cancel(timer);
-    }
   }
 
   /**

--- a/src/mcp/session.ts
+++ b/src/mcp/session.ts
@@ -129,9 +129,9 @@ export class McpSession {
    * holds a lease it obtained itself.
    */
   #renewal: LeaseRenewal | undefined;
-  /** The lease a `release()` call has in flight right now, so `close()` never sends a second
-   * release for the same lease (it does not queue behind `#mutations`). */
-  #releaseInFlight: string | undefined;
+  /** Lease ids already announced as lost, so one ending never reaches a listener twice -- see
+   * `#announceLeaseLost`. */
+  readonly #announcedLost = new Set<string>();
 
   constructor(options: McpSessionOptions) {
     this.#clock = options.clock;
@@ -151,6 +151,15 @@ export class McpSession {
         ...(onProgress === undefined ? {} : { onProgress }),
         ...(signal === undefined ? {} : { signal }),
       });
+      if (this.#closed) {
+        // The session ended while the daemon was provisioning. `close()` does not queue behind
+        // `#mutations`, so it has already stopped renewing and closed the connection: arming a
+        // timer now would leave a closed session renewing on a dead client until the backstop,
+        // and `simlock mcp` (which never calls `process.exit`) alive with it. Hand the device
+        // straight back instead, and fail the call that can no longer be honoured.
+        await this.#releaseQuietly(client, grant.lease.id);
+        this.#throwIfClosed();
+      }
       this.#heldLeaseId = grant.lease.id;
       this.#startRenewal(client, grant.lease);
       return grant;
@@ -160,18 +169,8 @@ export class McpSession {
   release(input: ReleaseSimulatorInput): Promise<ReleaseSimulatorOutput> {
     return this.#mutate(async () => {
       this.#throwIfClosed();
-      // Marked before `#clientForUse()`, not after: that call can reconnect, which takes as
-      // long as a daemon launch, and `close()` does not queue behind `#mutations` (see its doc
-      // comment). This is how it knows the lease already has a release on the way -- from the
-      // moment this call commits to sending one -- and must not get a second one.
-      this.#releaseInFlight = input.leaseId;
-      let result;
-      try {
-        const client = await this.#clientForUse();
-        result = await client.releaseLease(input);
-      } finally {
-        this.#releaseInFlight = undefined;
-      }
+      const client = await this.#clientForUse();
+      const result = await client.releaseLease(input);
       // Stopped only once the daemon has actually let the lease go. A release that fails
       // (anything but a dead connection) leaves the session still holding the device, and a
       // session that has stopped renewing a lease it still holds loses that device at the
@@ -239,11 +238,12 @@ export class McpSession {
    * its own call now rather than a side effect of the socket going away -- the daemon still
    * releases on close today, and will not once PR B lands.
    *
-   * One race is deliberately left: a `lease()` still in flight here can set `#heldLeaseId`
-   * after this method read it, and that lease is not released explicitly. It is not reachable
-   * from the MCP frontend (`close()` runs on shutdown, after the transport is gone) and
-   * blocking shutdown on an in-flight provisioning request -- minutes, potentially -- would be
-   * a worse trade than the daemon's own expiry handling it.
+   * It does not queue behind `#mutations`: blocking shutdown on an in-flight provisioning
+   * request -- minutes, potentially -- would be a worse trade than ending now. A `lease()` that
+   * lands after this point releases its own grant instead (see `lease()`), and a `release()`
+   * still in flight is *not* a reason to skip the farewell one: the wire rejects every pending
+   * request when the connection closes below, so skipping would mean no release at all. A
+   * duplicate costs one `UNKNOWN_LEASE` this method already swallows.
    */
   close(): Promise<void> {
     if (this.#closePromise !== undefined) return this.#closePromise;
@@ -251,8 +251,7 @@ export class McpSession {
     this.#stopRenewal();
     this.#unwireClient();
     const client = this.#client;
-    // A lease whose release is already in flight is not released again.
-    const heldLeaseId = this.#heldLeaseId === this.#releaseInFlight ? undefined : this.#heldLeaseId;
+    const heldLeaseId = this.#heldLeaseId;
     this.#heldLeaseId = undefined;
     this.#client = undefined;
     if (this.#connecting !== undefined) {
@@ -265,21 +264,28 @@ export class McpSession {
 
   /** `close()`'s tail: the farewell release (best-effort, bounded), then the connection. */
   async #endSession(client: SimlockClient, heldLeaseId: string | undefined): Promise<void> {
-    if (heldLeaseId !== undefined) {
-      try {
-        await awaitWithin(
-          this.#clock,
-          RELEASE_TIMEOUT_MS,
-          client.releaseLease({ leaseId: heldLeaseId }),
-          `Timed out releasing lease ${heldLeaseId}`,
-        );
-      } catch {
-        // Best-effort by design: the lease may already be gone (expired, force-released), the
-        // connection may be dead, or the daemon may not answer. Shutdown continues either way,
-        // and an unreleased lease still ends at its deadline.
-      }
-    }
+    if (heldLeaseId !== undefined) await this.#releaseQuietly(client, heldLeaseId);
     await this.#closeClient(client);
+  }
+
+  /**
+   * A release nobody is waiting on an answer to: bounded, and silent whatever happens. The
+   * lease may already be gone (expired, force-released, or released by a tool call whose own
+   * answer never arrived), the connection may be dead, or the daemon may not answer at all --
+   * none of which should hold up an ending session, and all of which end the same way in the
+   * daemon regardless, at the lease's deadline.
+   */
+  async #releaseQuietly(client: SimlockClient, leaseId: string): Promise<void> {
+    try {
+      await awaitWithin(
+        this.#clock,
+        RELEASE_TIMEOUT_MS,
+        client.releaseLease({ leaseId }),
+        `Timed out releasing lease ${leaseId}`,
+      );
+    } catch {
+      // Best-effort by design -- see above.
+    }
   }
 
   /**
@@ -322,6 +328,17 @@ export class McpSession {
     if (notice.leaseId !== this.#heldLeaseId) return;
     this.#stopRenewal();
     this.#heldLeaseId = undefined;
+    this.#announceLeaseLost(notice);
+  }
+
+  /**
+   * Tells the listeners a lease ended, once per lease. A lease that a renewal found gone is
+   * very often also pushed as `lease-lost` a moment later (or the other way round) -- two
+   * accounts of one ending, which would read to an agent as two devices lost.
+   */
+  #announceLeaseLost(notice: LeaseLostNotice): void {
+    if (this.#announcedLost.has(notice.leaseId)) return;
+    this.#announcedLost.add(notice.leaseId);
     for (const listener of this.#leaseLostListeners) listener(notice);
   }
 
@@ -383,7 +400,7 @@ export class McpSession {
           this.#stopRenewal();
           this.#heldLeaseId = undefined;
         }
-        for (const listener of this.#leaseLostListeners) listener(push);
+        this.#announceLeaseLost(push);
       }),
       client.onDeviceUnhealthy((push) => {
         for (const listener of this.#deviceHealthListeners) {

--- a/src/mcp/session.ts
+++ b/src/mcp/session.ts
@@ -124,11 +124,13 @@ export class McpSession {
    * cannot answer `lease_status` correctly. */
   #heldLeaseId: string | undefined;
   /**
-   * ADR 0004 §2: the session's half of "held is a client policy" -- the timer that renews
-   * `#heldLeaseId` at a third of its remaining TTL. Non-`undefined` exactly while this session
-   * holds a lease it obtained itself.
+   * ADR 0004 §2: the session's half of "held is a client policy" -- one renew timer per lease
+   * this session obtained, keyed by lease id. Keyed rather than single because nothing here
+   * limits a session to one lease: the daemon's one-lease-per-requester rule is the authority
+   * (ADR 0003 §11), and if it starts allowing two, both have to be kept alive and both have to
+   * be handed back on close. An entry lives exactly as long as this session holds that lease.
    */
-  #renewal: LeaseRenewal | undefined;
+  readonly #renewals = new Map<string, LeaseRenewal>();
   /** Lease ids already announced as lost, so one ending never reaches a listener twice -- see
    * `#announceLeaseLost`. */
   readonly #announcedLost = new Set<string>();
@@ -153,10 +155,10 @@ export class McpSession {
       });
       if (this.#closed) {
         // The session ended while the daemon was provisioning. `close()` does not queue behind
-        // `#mutations`, so it has already stopped renewing and closed the connection: arming a
-        // timer now would leave a closed session renewing on a dead client until the backstop,
-        // and `simlock mcp` (which never calls `process.exit`) alive with it. Hand the device
-        // straight back instead, and fail the call that can no longer be honoured.
+        // `#mutations`, so it has already stopped renewing: arming a timer now would leave a
+        // closed session renewing on a client nobody owns any more, and `simlock mcp` (which
+        // never calls `process.exit`) alive with it. Hand the device straight back instead --
+        // `close()` waits, bounded, for exactly this -- and fail the call it cannot honour.
         await this.#releaseQuietly(client, grant.lease.id);
         this.#throwIfClosed();
       }
@@ -177,10 +179,7 @@ export class McpSession {
       // deadline. A renew that overtakes a *successful* release cannot resurrect anything:
       // `Registry#beginRelease` drops the record, so `lease.renew` can only answer
       // UNKNOWN_LEASE.
-      if (result.leaseId === this.#heldLeaseId) {
-        this.#stopRenewal();
-        this.#heldLeaseId = undefined;
-      }
+      this.#forgetLease(result.leaseId);
       return { ...result, released: true };
     });
   }
@@ -248,23 +247,47 @@ export class McpSession {
   close(): Promise<void> {
     if (this.#closePromise !== undefined) return this.#closePromise;
     this.#closed = true;
-    this.#stopRenewal();
+    // Whatever a tool call has in flight right now. `#endSession` waits on it (bounded) before
+    // touching the connection, so a `lease()` that lands in that window still has a live wire
+    // to hand its device back on.
+    const inFlight = this.#mutations;
     this.#unwireClient();
     const client = this.#client;
-    const heldLeaseId = this.#heldLeaseId;
+    const heldLeaseIds = [...this.#renewals.keys()];
+    this.#stopAllRenewals();
     this.#heldLeaseId = undefined;
+    this.#announcedLost.clear();
     this.#client = undefined;
     if (this.#connecting !== undefined) {
       void this.#connecting.then((next) => this.#closeClient(next)).catch(noop);
     }
     this.#closePromise =
-      client === undefined ? Promise.resolve() : this.#endSession(client, heldLeaseId);
+      client === undefined ? Promise.resolve() : this.#endSession(client, heldLeaseIds, inFlight);
     return this.#closePromise;
   }
 
-  /** `close()`'s tail: the farewell release (best-effort, bounded), then the connection. */
-  async #endSession(client: SimlockClient, heldLeaseId: string | undefined): Promise<void> {
-    if (heldLeaseId !== undefined) await this.#releaseQuietly(client, heldLeaseId);
+  /**
+   * `close()`'s tail: let the last tool call finish on a live wire, hand every lease back, then
+   * close. The wait is bounded because an in-flight `lease.request` can take minutes and an
+   * ending session cannot wait that long; past the bound the connection closes, the daemon
+   * rejects what was still pending, and any lease that slipped through ends at its deadline.
+   */
+  async #endSession(
+    client: SimlockClient,
+    heldLeaseIds: readonly string[],
+    inFlight: Promise<void>,
+  ): Promise<void> {
+    try {
+      await awaitWithin(
+        this.#clock,
+        RELEASE_TIMEOUT_MS,
+        inFlight,
+        "Timed out waiting for the last tool call to finish",
+      );
+    } catch {
+      // Bounded by design -- see above.
+    }
+    for (const leaseId of heldLeaseIds) await this.#releaseQuietly(client, leaseId);
     await this.#closeClient(client);
   }
 
@@ -295,12 +318,12 @@ export class McpSession {
    * call makes (`#clientForUse`).
    */
   #startRenewal(client: SimlockClient, lease: LeaseRecord): void {
-    this.#stopRenewal();
+    this.#stopRenewal(lease.id);
     // No `onError`: this frontend owns stdout (it is the protocol) and has no side channel a
     // retryable failure could be written to. What the agent has to know is that the lease is
     // over, and that arrives as the `lease-lost` notice `onLeaseGone` raises below (or as the
     // daemon's own push, whichever comes first) rather than as a stream of attempt failures.
-    this.#renewal = startLeaseRenewal({
+    const renewal = startLeaseRenewal({
       clock: this.#clock,
       leaseId: lease.id,
       onLeaseGone: () => {
@@ -316,6 +339,7 @@ export class McpSession {
       renew: (id) => client.renewLease({ leaseId: id }),
       ttlDeadline: lease.ttlDeadline,
     });
+    this.#renewals.set(lease.id, renewal);
   }
 
   /**
@@ -325,9 +349,9 @@ export class McpSession {
    * including ones for leases this session never held; this only ever fires for its own.)
    */
   #reportLeaseLost(notice: LeaseLostNotice): void {
-    if (notice.leaseId !== this.#heldLeaseId) return;
-    this.#stopRenewal();
-    this.#heldLeaseId = undefined;
+    if (!this.#renewals.has(notice.leaseId)) return;
+    this.#stopRenewal(notice.leaseId);
+    if (this.#heldLeaseId === notice.leaseId) this.#heldLeaseId = undefined;
     this.#announceLeaseLost(notice);
   }
 
@@ -342,9 +366,26 @@ export class McpSession {
     for (const listener of this.#leaseLostListeners) listener(notice);
   }
 
-  #stopRenewal(): void {
-    this.#renewal?.stop();
-    this.#renewal = undefined;
+  /** Stops and forgets one lease's renew timer. */
+  #stopRenewal(leaseId: string): void {
+    this.#renewals.get(leaseId)?.stop();
+    this.#renewals.delete(leaseId);
+  }
+
+  #stopAllRenewals(): void {
+    for (const renewal of this.#renewals.values()) renewal.stop();
+    this.#renewals.clear();
+  }
+
+  /**
+   * This session no longer holds `leaseId`: stop renewing it, drop it from `status()`'s answer
+   * if it was the latest, and let its lost-notice bookkeeping go (nothing can announce a lease
+   * that is no longer ours).
+   */
+  #forgetLease(leaseId: string): void {
+    this.#stopRenewal(leaseId);
+    this.#announcedLost.delete(leaseId);
+    if (this.#heldLeaseId === leaseId) this.#heldLeaseId = undefined;
   }
 
   /**
@@ -394,12 +435,10 @@ export class McpSession {
   #wireClient(client: SimlockClient): void {
     this.#clientUnsubscribers = [
       client.onLeaseLost((push) => {
-        if (push.leaseId === this.#heldLeaseId) {
-          // Nothing left to renew: the lease ended elsewhere (expiry, a force-release, or this
-          // connection dying -- the client synthesizes the push for that last one).
-          this.#stopRenewal();
-          this.#heldLeaseId = undefined;
-        }
+        // Nothing left to renew for that lease: it ended elsewhere (expiry, a force-release,
+        // or this connection dying -- the client synthesizes the push for that last one).
+        this.#stopRenewal(push.leaseId);
+        if (this.#heldLeaseId === push.leaseId) this.#heldLeaseId = undefined;
         this.#announceLeaseLost(push);
       }),
       client.onDeviceUnhealthy((push) => {

--- a/src/mcp/session.ts
+++ b/src/mcp/session.ts
@@ -5,6 +5,8 @@ import {
   type LeaseRequestInput,
   type SimlockClient,
 } from "../client/index.js";
+import { startLeaseRenewal, type LeaseRenewal } from "../lease-policy/index.js";
+import type { Clock, TimerHandle } from "../ports/index.js";
 import type {
   LeaseSimulatorInput,
   LeaseSimulatorOutput,
@@ -15,7 +17,21 @@ import type {
   ReleaseSimulatorOutput,
 } from "./contracts.js";
 
+/**
+ * How long `close()` waits for its farewell `lease.release` before closing the connection
+ * anyway. The daemon is a local process answering a local socket, so this is not a latency
+ * budget -- it is the bound that keeps an unresponsive daemon from holding an MCP server's
+ * shutdown open forever. Exceeding it costs nothing but the wait: the lease then ends the way
+ * every unreleased lease ends, at its deadline.
+ */
+const RELEASE_ON_CLOSE_TIMEOUT_MS = 5_000;
+
 export interface McpSessionOptions {
+  /**
+   * The `Clock` port (architecture rule 9): the session's renew timer and `close()`'s release
+   * bound both run on it, so tests drive them by hand.
+   */
+  readonly clock: Clock;
   /**
    * Opens one connection and completes the `hello` handshake, fixing this session's principal
    * for the connection's lifetime (ADR §4). Called again -- building a brand new client, never
@@ -84,13 +100,16 @@ export function toMcpErrorResult(error: unknown): McpErrorResult {
  * session does not own surfaces the daemon's own `FORBIDDEN` rather than a client-side guard
  * pre-empting it (ADR §11).
  *
- * `#heldLeaseId` is the one piece of state this class keeps between calls, and it is not a
- * cache of lease *state* (§11's point): it is only the id of the lease this session's own
+ * `#heldLeaseId` is the one piece of lease *data* this class keeps between calls, and it is not
+ * a cache of lease *state* (§11's point): it is only the id of the lease this session's own
  * `lease()` last obtained, kept so `status()` can tell that lease apart from any other lease
  * `lease.list` happens to return under the same owner principal -- see `status()`'s doc
- * comment for why that distinction is load-bearing.
+ * comment for why that distinction is load-bearing. Alongside it sits `#renewal`, the timer
+ * that keeps that lease alive (ADR 0004 §2); the two are started, stopped, and cleared
+ * together.
  */
 export class McpSession {
+  readonly #clock: Clock;
   readonly #connect: () => Promise<SimlockClient>;
   #client: SimlockClient | undefined;
   #connecting: Promise<SimlockClient> | undefined;
@@ -107,8 +126,15 @@ export class McpSession {
    * none is outstanding. See the class doc comment and `status()` for why `lease.list` alone
    * cannot answer `lease_status` correctly. */
   #heldLeaseId: string | undefined;
+  /**
+   * ADR 0004 §2: the session's half of "held is a client policy" -- the timer that renews
+   * `#heldLeaseId` at a third of its remaining TTL. Non-`undefined` exactly while this session
+   * holds a lease it obtained itself.
+   */
+  #renewal: LeaseRenewal | undefined;
 
   constructor(options: McpSessionOptions) {
+    this.#clock = options.clock;
     this.#connect = options.connect;
   }
 
@@ -126,6 +152,7 @@ export class McpSession {
         ...(signal === undefined ? {} : { signal }),
       });
       this.#heldLeaseId = grant.lease.id;
+      this.#startRenewal(client, grant.lease.id, grant.lease.ttlDeadline);
       return grant;
     });
   }
@@ -134,6 +161,9 @@ export class McpSession {
     return this.#mutate(async () => {
       this.#throwIfClosed();
       const client = await this.#clientForUse();
+      // Stopped before the call, not after it: a renew that overtook its own release would
+      // resurrect the lease the caller just gave up.
+      if (input.leaseId === this.#heldLeaseId) this.#stopRenewal();
       const result = await client.releaseLease(input);
       if (result.leaseId === this.#heldLeaseId) this.#heldLeaseId = undefined;
       return { ...result, released: true };
@@ -187,17 +217,88 @@ export class McpSession {
     return () => this.#deviceHealthListeners.delete(listener);
   }
 
+  /**
+   * Ends the session: stops renewing, releases this session's lease explicitly, then closes the
+   * connection. ADR 0004 §3 ("connection close means nothing to a lease") is why the release is
+   * its own call now rather than a side effect of the socket going away -- the daemon still
+   * releases on close today, and will not once PR B lands.
+   *
+   * One race is deliberately left: a `lease()` still in flight here can set `#heldLeaseId`
+   * after this method read it, and that lease is not released explicitly. It is not reachable
+   * from the MCP frontend (`close()` runs on shutdown, after the transport is gone) and
+   * blocking shutdown on an in-flight provisioning request -- minutes, potentially -- would be
+   * a worse trade than the daemon's own expiry handling it.
+   */
   close(): Promise<void> {
     if (this.#closePromise !== undefined) return this.#closePromise;
     this.#closed = true;
+    this.#stopRenewal();
     this.#unwireClient();
     const client = this.#client;
+    const heldLeaseId = this.#heldLeaseId;
+    this.#heldLeaseId = undefined;
     this.#client = undefined;
     if (this.#connecting !== undefined) {
       void this.#connecting.then((next) => this.#closeClient(next)).catch(noop);
     }
-    this.#closePromise = client === undefined ? Promise.resolve() : this.#closeClient(client);
+    this.#closePromise =
+      client === undefined ? Promise.resolve() : this.#endSession(client, heldLeaseId);
     return this.#closePromise;
+  }
+
+  /** `close()`'s tail: the farewell release (best-effort, bounded), then the connection. */
+  async #endSession(client: SimlockClient, heldLeaseId: string | undefined): Promise<void> {
+    if (heldLeaseId !== undefined) {
+      try {
+        await this.#withReleaseTimeout(client.releaseLease({ leaseId: heldLeaseId }));
+      } catch {
+        // Best-effort by design: the lease may already be gone (expired, force-released), the
+        // connection may be dead, or the daemon may not answer. Shutdown continues either way,
+        // and an unreleased lease still ends at its deadline.
+      }
+    }
+    await this.#closeClient(client);
+  }
+
+  /** Rejects once `RELEASE_ON_CLOSE_TIMEOUT_MS` passes, so a dead-but-open socket cannot pin an
+   * MCP server open. The timer is always cancelled, so it never holds the process open itself. */
+  async #withReleaseTimeout(release: Promise<unknown>): Promise<void> {
+    let timer: TimerHandle | undefined;
+    const expiry = new Promise<never>((_resolve, reject) => {
+      timer = this.#clock.setTimer(RELEASE_ON_CLOSE_TIMEOUT_MS, () => {
+        timer = undefined;
+        reject(new McpSessionError("RELEASE_TIMEOUT", "Timed out releasing the session's lease"));
+      });
+    });
+    try {
+      await Promise.race([release, expiry]);
+    } finally {
+      if (timer !== undefined) this.#clock.cancel(timer);
+    }
+  }
+
+  /**
+   * Starts (or restarts) the renew timer for the lease this session just obtained. The client
+   * is captured deliberately: if that connection dies, the renewal fails and stops rather than
+   * quietly reconnecting behind the tool surface -- reconnect stays a decision the next tool
+   * call makes (`#clientForUse`).
+   */
+  #startRenewal(client: SimlockClient, leaseId: string, ttlDeadline: number): void {
+    this.#stopRenewal();
+    // No `onError`: this frontend owns stdout (it is the protocol) and has no side channel a
+    // failed renewal could be written to. Every failure that matters to the agent surfaces as
+    // the `lease-lost` notice that follows it, or as the next tool call's own error.
+    this.#renewal = startLeaseRenewal({
+      clock: this.#clock,
+      leaseId,
+      renew: (id) => client.renewLease({ leaseId: id }),
+      ttlDeadline,
+    });
+  }
+
+  #stopRenewal(): void {
+    this.#renewal?.stop();
+    this.#renewal = undefined;
   }
 
   /**
@@ -247,7 +348,12 @@ export class McpSession {
   #wireClient(client: SimlockClient): void {
     this.#clientUnsubscribers = [
       client.onLeaseLost((push) => {
-        if (push.leaseId === this.#heldLeaseId) this.#heldLeaseId = undefined;
+        if (push.leaseId === this.#heldLeaseId) {
+          // Nothing left to renew: the lease ended elsewhere (expiry, a force-release, or this
+          // connection dying -- the client synthesizes the push for that last one).
+          this.#stopRenewal();
+          this.#heldLeaseId = undefined;
+        }
         for (const listener of this.#leaseLostListeners) listener(push);
       }),
       client.onDeviceUnhealthy((push) => {

--- a/src/mcp/test-support.ts
+++ b/src/mcp/test-support.ts
@@ -101,7 +101,6 @@ export class FakeSimlockClient implements SimlockClient {
     return this.cancelLeaseImpl(input);
   }
 
-  // fallow-ignore-next-line unused-class-member -- part of the SimlockClient interface this fake implements; MCP itself never calls lease.renew.
   renewLease(input: LeaseRenewInput): Promise<LeaseRecord> {
     this.calls.push({ input, method: "renewLease" });
     return this.renewLeaseImpl(input);

--- a/src/mcp/test-support.ts
+++ b/src/mcp/test-support.ts
@@ -50,6 +50,10 @@ export class FakeSimlockClient implements SimlockClient {
   readonly daemonVersion: string;
   closeCalls = 0;
   readonly calls: Array<{ readonly method: string; readonly input: unknown }> = [];
+  /** Set by `close()`. Every operation after it rejects, the way `SimlockWire` does once the
+   * connection is gone (ADR 0003 §10) -- a fake that stayed usable would let a test pass on a
+   * dead wire. */
+  #dead = false;
 
   getCatalogImpl: (input: CatalogGetInput) => Promise<CatalogGetOutput> = notStubbed("getCatalog");
   getStatusImpl: () => Promise<StatusGetOutput> = notStubbed("getStatus");
@@ -81,57 +85,57 @@ export class FakeSimlockClient implements SimlockClient {
 
   getCatalog(input: CatalogGetInput = {}): Promise<CatalogGetOutput> {
     this.calls.push({ input, method: "getCatalog" });
-    return this.getCatalogImpl(input);
+    return this.#dead ? this.#deadConnection() : this.getCatalogImpl(input);
   }
 
   // fallow-ignore-next-line unused-class-member -- part of the SimlockClient interface this fake implements; MCP itself never calls status.get.
   getStatus(): Promise<StatusGetOutput> {
     this.calls.push({ input: undefined, method: "getStatus" });
-    return this.getStatusImpl();
+    return this.#dead ? this.#deadConnection() : this.getStatusImpl();
   }
 
   requestLease(input: LeaseRequestInput, options: RequestLeaseOptions = {}): Promise<LeaseGrant> {
     this.calls.push({ input, method: "requestLease" });
-    return this.requestLeaseImpl(input, options);
+    return this.#dead ? this.#deadConnection() : this.requestLeaseImpl(input, options);
   }
 
   // fallow-ignore-next-line unused-class-member -- part of the SimlockClient interface this fake implements; MCP itself never calls lease.cancel.
   cancelLease(input: LeaseCancelInput = {}): Promise<LeaseCancelOutput> {
     this.calls.push({ input, method: "cancelLease" });
-    return this.cancelLeaseImpl(input);
+    return this.#dead ? this.#deadConnection() : this.cancelLeaseImpl(input);
   }
 
   renewLease(input: LeaseRenewInput): Promise<LeaseRecord> {
     this.calls.push({ input, method: "renewLease" });
-    return this.renewLeaseImpl(input);
+    return this.#dead ? this.#deadConnection() : this.renewLeaseImpl(input);
   }
 
   releaseLease(input: LeaseReleaseInput): Promise<LeaseReleaseOutput> {
     this.calls.push({ input, method: "releaseLease" });
-    return this.releaseLeaseImpl(input);
+    return this.#dead ? this.#deadConnection() : this.releaseLeaseImpl(input);
   }
 
   listLeases(): Promise<LeaseListOutput> {
     this.calls.push({ input: undefined, method: "listLeases" });
-    return this.listLeasesImpl();
+    return this.#dead ? this.#deadConnection() : this.listLeasesImpl();
   }
 
   // fallow-ignore-next-line unused-class-member -- part of the SimlockClient interface this fake implements; MCP itself never calls lease.heartbeat (the client handles it internally).
   heartbeat(): Promise<LeaseHeartbeatOutput> {
     this.calls.push({ input: undefined, method: "heartbeat" });
-    return this.heartbeatImpl();
+    return this.#dead ? this.#deadConnection() : this.heartbeatImpl();
   }
 
   // fallow-ignore-next-line unused-class-member -- part of the SimlockClient interface this fake implements; MCP itself never calls doctor.run.
   runDoctor(input: DoctorRunInput = {}): Promise<DoctorReport> {
     this.calls.push({ input, method: "runDoctor" });
-    return this.runDoctorImpl(input);
+    return this.#dead ? this.#deadConnection() : this.runDoctorImpl(input);
   }
 
   // fallow-ignore-next-line unused-class-member -- part of the SimlockClient interface this fake implements; MCP itself never resolves a passthrough.
   resolvePassthrough(input: DriverPassthroughInput): Promise<PassthroughCommand> {
     this.calls.push({ input, method: "resolvePassthrough" });
-    return this.resolvePassthroughImpl(input);
+    return this.#dead ? this.#deadConnection() : this.resolvePassthroughImpl(input);
   }
 
   onLeaseLost(listener: (push: LeaseLostPush) => void): () => void {
@@ -180,8 +184,16 @@ export class FakeSimlockClient implements SimlockClient {
 
   async close(): Promise<void> {
     this.closeCalls += 1;
+    this.#dead = true;
     this.emitConnectionLost(
       new SimlockError("DAEMON_CONNECTION_LOST", "transport", "Client closed the connection", {}),
+    );
+  }
+
+  /** The rejection every operation gets once this connection is closed. */
+  #deadConnection<T>(): Promise<T> {
+    return Promise.reject(
+      new SimlockError("DAEMON_CONNECTION_LOST", "transport", "Connection is closed", {}),
     );
   }
 }

--- a/src/simlock-client/client.test.ts
+++ b/src/simlock-client/client.test.ts
@@ -105,6 +105,38 @@ describe("connectSimlock: handshake", () => {
     expect(connection.sent).toHaveLength(1);
   });
 
+  it("declares no heartbeat capability by default, and starts no renew timer of its own (ADR 0004 §2/§4)", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection });
+    await flushMicrotasks();
+    const hello = connection.lastSentOf("hello")!;
+    // The daemon-initiated heartbeat is what ADR 0004 §4 removes; a client that does not
+    // declare it is never pushed one, and keeps its leases alive with `lease.renew` instead.
+    expect((hello.payload as { capabilities?: { heartbeat?: boolean } }).capabilities).toEqual({
+      heartbeat: false,
+    });
+    completeHello(connection);
+    const client = await connectPromise;
+
+    // Renew policy stays a frontend's (ADR 0003 §10): connecting alone sends nothing further.
+    const sentAfterHello = connection.sent.length;
+    await flushMicrotasks();
+    expect(connection.sent).toHaveLength(sentAfterHello);
+    await client.close();
+  });
+
+  it("still declares the heartbeat capability when a caller explicitly asks for one", async () => {
+    const connection = new ScriptedConnection();
+    const connectPromise = connectSimlock({ connection, heartbeat: true });
+    await flushMicrotasks();
+    const hello = connection.lastSentOf("hello")!;
+    expect((hello.payload as { capabilities?: { heartbeat?: boolean } }).capabilities).toEqual({
+      heartbeat: true,
+    });
+    completeHello(connection);
+    await (await connectPromise).close();
+  });
+
   it("a bad admin credential causes zero requests after hello, and closes the connection", async () => {
     const connection = new ScriptedConnection();
     const connectPromise = connectSimlockAdmin({ connection, credential: "wrong" });

--- a/src/simlock-client/client.ts
+++ b/src/simlock-client/client.ts
@@ -132,8 +132,15 @@ export interface ConnectOptions {
    * option (programmatic client)". Only meaningful via `connectSimlockAdmin` -- the base
    * `connectSimlock` does not accept one, by design (ADR §10: "the split is by import path"). */
   readonly credential?: string;
-  /** Declares heartbeat support at `hello`; defaults to `true` so held leases keep sliding
-   * without the caller doing anything. */
+  /**
+   * Declares heartbeat support at `hello`. Defaults to `false`: ADR 0004 §1/§2 makes a
+   * client-initiated `lease.renew` the only thing that keeps a lease alive, and §4 removes the
+   * daemon-initiated heartbeat outright, so a frontend that wants its lease to survive renews
+   * on its own timer (`src/lease-policy`) rather than declaring a capability. The flag is still
+   * accepted -- the daemon still speaks the push until PR B deletes it -- but nothing in this
+   * repository asks for it any more. This client starts no timer of its own either way: renew
+   * and reconnect policy is the frontend's (ADR 0003 §10, `docs/CLIENT.md`).
+   */
   readonly heartbeat?: boolean;
 }
 
@@ -211,7 +218,7 @@ export async function connectSimlockClient(
     hello = await wire.hello({
       ...(options.principal === undefined ? {} : { principal: options.principal }),
       ...(options.credential === undefined ? {} : { credential: options.credential }),
-      capabilities: { heartbeat: options.heartbeat ?? true },
+      capabilities: { heartbeat: options.heartbeat ?? false },
     });
   } catch (error: unknown) {
     // ADR §6: a `PROTOCOL_VERSION_UNSUPPORTED` `hello` rejection is the one handshake failure


### PR DESCRIPTION
> **BREAKING CHANGE:** `simlock/client` and `simlock/admin` default the `heartbeat` connect option to `false`, and a held lease is now kept alive only by its holder's own `lease.renew` — the daemon no longer slides it for you (ADR 0004 §1/§2/§4). A programmatic consumer that held a lease over a live connection must renew it (the CLI and MCP do; `src/lease-policy` is the pattern) or pass `heartbeat: true` while PR B is pending. `client.heartbeat()` answers `BAD_REQUEST` by default, since the daemon rejects the call on a connection that declared no capability. #122 carries the changelog entry; PR B removes the capability altogether.

First of three slices of [ADR 0004](docs/adr/0004-ttl-first-leases-on-every-transport.md). The client side starts behaving the way the ADR describes; **the daemon, the contract, the core, and the HTTP gateway are untouched**, and `mode: "held"` still goes over the wire. Behaviour is otherwise unchanged from a user's point of view: a held lease still ends promptly when its holder exits, and still ends on the daemon's backstop if the holder is `SIGKILL`ed.

`Part of #114`

## What changed, and which part of the ADR it implements

**§2 — "'Held' is a client policy, not a daemon mode."** New module `src/lease-policy`, the renew timer both frontends share: it fires at one third of the remaining TTL, computed from the deadline the daemon returned with the grant and with every renewal since — never from a config value the client does not have. A failed attempt is retried on the same shrinking ladder while the lease can still be saved; each attempt is bounded by a third of what is left of the TTL when it starts, because the wire has no request timeout and a daemon that accepts `lease.renew` and never answers would otherwise cost the whole lease in silence. Every attempt is numbered and every answer applied by that number — two abandoned attempts can answer in either order, and the newer one's deadline is the truth, shorter or longer.

Renewal ends for exactly two reasons, and says which: `renew-rejected` (the daemon answered `UNKNOWN_LEASE`/`FORBIDDEN` — the lease is gone or was never ours) and `renew-failed` (the deadline passed with no usable answer, or the daemon answered with one already behind us). Both reach the frontend through `onLeaseGone`; `onError` is only for attempts that failed while the lease was still savable. A holder never ends up alive with no timer and no lease.

**§2 — `simlock lease` (held mode)** runs that timer through the `Clock` port and releases explicitly on exit, parent death, `SIGINT`, or `SIGTERM`. The release moved into the command's `finally`, so no exit path can skip it — including a throw between the grant and the wait, such as a `--export-env` key that is not a shell identifier — and it is bounded, so an unresponsive daemon costs the wait rather than the exit. Losing the lease writes exactly one `{"push":"lease-lost",…}` stderr line however it is found out — the daemon's push, or renewal ending with its reason — and exits 14 without a farewell release.

**§2 — the MCP session** does the same for every lease it holds: one renew timer per lease id, each stopped when that lease stops being the session's (a successful release, a `lease-lost` push, renewal ending, or `close()`), and every held lease released on close. Nothing here limits a session to one lease — the daemon's one-lease-per-requester rule is the authority (ADR 0003 §11) — so a second grant can no longer strand the first, which the daemon's heartbeat used to keep alive. `close()` runs its whole tail (wait for the tool call in flight, release every lease, close the wire) inside **one** `RELEASE_TIMEOUT_MS` budget, so a grant landing just after shutdown is still handed back on a live wire while a dead daemon can only ever cost that one budget. Lease-lost notices are deduplicated by lease id.

**§4 — the daemon-initiated heartbeat goes away.** Neither frontend declares the `heartbeat` capability at `hello`, and the client default flips — see the breaking-change note at the top. The client itself still starts no renew loop: renew and reconnect policy stays a frontend concern (ADR 0003 §10, `docs/CLIENT.md`), which is why `src/lease-policy` is a helper frontends choose rather than something `connectSimlock` does for them.

**§3 — connection close means nothing to a lease** is *not* implemented here: the daemon still releases on close, which is what keeps a `SIGKILL`ed holder's device coming back immediately today.

`--detach` is byte-identical: it prints, exits, and arms no timer.

## Deliberately left for PR B

- `lease.heartbeat`, the `heartbeat` hello capability, and the daemon's held set / release-on-close.
- `mode` on `lease.request` (still sent as `"held"`), and the `lease.heldTtlBackstopMs` / `lease.heartbeatIntervalMs` / `lease.detachedTtlMs` config keys. `src/mcp/connect.ts`'s `heartbeat` option is left in place, labelled, so B does not get a conflict on the file it is editing.
- The cadence's one assumption: `ttlDeadline - clock.now()` presumes daemon and client share a clock epoch — true on the unix socket, not across a network hop. ADR 0004's stored `ttlMs` (PR B) turns the interval into `ttlMs / 3`, a duration that needs no shared epoch, with the deadline left as the bound it really is. The module doc says so at the one place that changes.
- `e2e/heartbeat-ttl.test.ts`'s filename still names the heartbeat, and its `heartbeatIntervalMs: 800` override has to stay for now — the config validator still requires `heartbeatIntervalMs <= heldTtlBackstopMs / 4`, and that suite pins the backstop to 4s.
- `SIGHUP`. ADR §2 says "a catchable signal", and one review round argued for adding it here; it was tried and reverted, because catching it changes behaviour a user can see (`nohup simlock lease … &` would start dying on hangup) and MCP traps no signals at all, so the parity it claimed was not real. It belongs with PR B, where explicit release actually becomes load-bearing.

## Docs

No doc changes here, and no ADR status change: **PR C (#122)** owns exactly those lines, and the stack merges in one go, so editing them here would only hand C a rebase conflict.

Intended merge order: **#121** (the ADR branch, which this PR is based on) → **#122** (docs rewritten, ADR 0004 marked *Accepted — not yet implemented*, which `AGENTS.md` explicitly allows ahead of the code) → **#124** (this PR) → **#125** (PR B), then a one-line follow-up flips ADR 0004 to *Accepted*. That is what keeps `main` from contradicting itself: the accepted record describes the end state before any slice of code lands, and the docs and the code become true together at the end of the stack. It is also why the `heartbeat` default flip ships here rather than waiting: PR B deletes the option one PR later and PR C documents the end state, and the stack merges in order, so no consumer ever sees the intermediate state in a release.

The passages #122 rewrites, so they are not lost: `docs/ARCHITECTURE.md` (~line 420, the `lease.heartbeat` push and held-lease liveness), `docs/CLI.md:251-256` (a held lease's `lease renew --ttl` now *does* stick), `docs/known-pitfalls.md:32` ("CLI held mode now declares the `heartbeat` capability"), `docs/EVENTS.md:17,19` (`lease.renewed` / `lease.expired` described in terms of the push), `docs/CONFIGURATION.md:19` (`lease.heartbeatIntervalMs`, now inert), and `docs/CLIENT.md` (no lease-liveness section at all, and now the `heartbeat` default flip to document).

## Adversarial review

Seven isolated rounds, each by a reviewer given only the ADR, the agent rules, the issue, and the diff.

**Round 1 — MERGE AFTER FIXES.** A single transient renew failure ended liveness for good (**fixed**: retry until the deadline); a failed MCP `release()` left a lease nothing renewed (**fixed**); the CLI's release was not on every exit path (**fixed**: moved into `finally`); the 250ms floor bounded a hot loop at 4 req/s rather than ending it (**fixed**); no watchdog on the renew request (**fixed**); the capability test only covered `--detach` (**fixed**); missing failure-path tests (**fixed**); a false comment (**fixed**). Docs/ADR status **declined** (see above); the `heartbeat` default flip **kept**.

**Round 2 — MERGE AFTER FIXES.** An abandoned renewal's answer was discarded, so the give-up check could fire against a stale deadline (**fixed**); a throwing `onError` could reject the timer's unawaited tick and kill the process past the release (**fixed**); the CLI's farewell release was unbounded while MCP's was bounded (**fixed**: one shared helper); `close()` could double-release (guarded, then reworked in round 4); the cadence test did not discriminate the returned deadline (**fixed**); the give-up test exercised one attempt, not the ladder (**fixed**); `CliEnvironment` carried both `clock` and a `Date.now`-falling-back `now` (**fixed**).

**Round 3 — MERGE AFTER FIXES**, run with test execution. `UNKNOWN_LEASE` on renew treated as transient (**fixed**: `onLeaseGone`); no tests for `awaitWithin` (**fixed**); `#releaseInFlight` set after a call that can reconnect (**fixed**, then removed); SIGHUP dropped (**done**); a synchronously throwing `renew` ended renewal silently (**fixed**); comment and e2e-wording nits (**fixed**).

**Round 4 — MERGE AFTER FIXES**, two blocking findings in `close()`. A `lease()` racing `close()` armed a timer on a closed session (**fixed**: the grant is released and the call fails `SESSION_CLOSED`); the release-in-flight guard turned two releases into zero (**fixed**: the guard is gone). Plus notice dedupe, the `lease-lost` line on the renew-rejected path, dead conditions collapsed, the clock-epoch note, and the breaking-change marker — all **done**.

**Round 5 — MERGE AFTER FIXES.** Two late answers merged by taking the larger deadline (**fixed**: every attempt numbered, newest answer wins); a second `lease()` overwrote the session's single renewal (**fixed**: renewals keyed by lease id, all renewed, all released); `close()` ran straight into the wire close so a late grant had no live connection (**fixed**: it waits for the tool call in flight, and `FakeSimlockClient` now rejects calls after `close()` the way the wire does). Plus the timer-delay ceiling, `#announcedLost` pruning, the structural `lease-lost` flag, and one `Clock` for the MCP frontend.

**Round 6 — MERGE AFTER FIXES.**

1. *BLOCKING: the shutdown was bounded per step — one budget for the in-flight wait, then another per lease — so `simlock mcp` could sit 10-15s after stdin EOF against a dead daemon.* **Fixed**: `#endSession` puts the whole tail (wait, then every release) inside a single `awaitWithin(RELEASE_TIMEOUT_MS)` and closes the wire in a `finally`, so the connection stays open until the last release settles or the budget is spent. Covered by a test asserting the total is exactly one budget, and by the existing late-grant test, which still gets its release completed inside it.
2. *BLOCKING: the ladder's give-up and the already-passed-deadline case reported through `onError` and stopped, so nobody learned the lease was gone — the CLI sat alive and exited 0 on Ctrl-C, MCP leaked the renewal entry and released a dead lease on close.* **Fixed**: both go through `onLeaseGone` with reason `renew-failed` (against `renew-rejected` for the daemon's own refusal). The CLI writes its `lease-lost` line with that reason and exits 14; the MCP session raises the matching notice, drops the renewal, and releases nothing for it. Tested per frontend.
3. *The `simlock/client` default flip stays.* **Declined** as directed, with the reasoning in the Docs paragraph above.
4-5. *Docs and ADR status.* **Declined** as before — #122's, merge order above.
6. *`stop()` must prevent the `renew` call itself.* **Fixed**: the deferred call checks `stopped` and abandons instead of calling. Test asserts zero `renew` calls for a stop landing in that microtask.
7. *Folded into 1.* Covered.
8. *Mutation-found test holes.* All three added: a rejected renewal plus the daemon's push for the same lease yields exactly one `push: "lease-lost"` line and exit 14; a `FakeSimlockClient` call after `close()` rejects `DAEMON_CONNECTION_LOST`; a ~90-day deadline schedules a delay clamped to `MAXIMUM_RENEW_DELAY_MS`.
9. *Nits.* `#announcedLost` is capped (oldest id dropped past 64); `mcp/connect.ts`'s dead option and the CLI `finally` ordering left as they are.

**Final review — MERGE**, with no blocking findings. Its remaining non-blocking items are carried by **#125** (PR B), which has rebased onto this branch and owns `src/mcp/session.ts` and `src/lease-policy/index.ts` from here: a self-initiated `release()` racing the renew timer into a false `lease-lost` notice; `giveUp` not honouring a re-entrant `stop()`; tests for the never-launch property, the `#announcedLost` cap, and the fake's dead guard on every method; the abandoned shutdown loop; and the nested `#releaseQuietly` timer.

Also noted by the reviewers, not defects: `lastHeartbeatAt` in `simlock status` / `list --leases` now reflects a renewal every `heldTtlBackstopMs / 3` instead of a ping every `heartbeatIntervalMs`.

## Validation

`pnpm check` — typecheck, e2e typecheck, lint, format check, 1366 unit tests, and the fake-driver e2e suite (15 files, 47 tests; `slow-*` excluded, they need a Mac). Run twice at the end of every review round; green both times, most recently on `c81c644`.

The e2e suites this touches most — `held-lease-liveness`, `heartbeat-ttl`, `parent-watch`, `mcp-session` — pass unchanged; `heartbeat-ttl`'s "both held leases slide past the backstop" assertions now hold because the clients renew, not because the daemon pings. The only e2e edits are comments, a test title, and one dropped assertion (`lastHeartbeatAt > 0`, which held for any lease at any time).

Several of the new tests were mutation-checked against the code they cover (the close-race guard, the newest-answer guard, both late-answer orderings): each fails when its guard is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsDU7hQcEDhK6kpH8M2YUz