### PR TITLE
test(e2e): prove the gateway happy path over the CLI and HTTP (ADR 0005)

### DIFF
--- a/e2e/fake-driver/fake-driver.ts
+++ b/e2e/fake-driver/fake-driver.ts
@@ -118,12 +118,21 @@ const PASSTHROUGH_REFUSALS: Readonly<
  * its own environment rather than from the script file, so a test controls the exit code
  * through the CLI invocation it is already making and this stays synchronous.
  *
- * It also answers two flags of its own -- `--fake-exec-stderr=<text>` and
- * `--fake-exec-exit=<n>` -- because `device.exec` (ADR 0005 §19a) runs this program in the
+ * It also answers three flags of its own -- `--fake-exec-stderr=<text>`, `--fake-exec-exit=<n>`
+ * and `--fake-exec-silent` -- because `device.exec` (ADR 0005 §19a) runs this program in the
  * *daemon's* process, where a per-invocation environment variable cannot reach it: an HTTP
- * caller has only the argument list. They are the minimum needed to observe the two things a
+ * caller has only the argument list. They are the minimum needed to observe the three things a
  * streamed exec must get right and a local passthrough never showed: output on the second
- * stream, and an exit code that is not zero.
+ * stream, an exit code that is not zero, and a process that produces **no output at all**.
+ *
+ * `--fake-exec-silent` and `--fake-exec-sleep=<ms>` exist for that last one, together. What
+ * §19a's `started` push buys a transport is *timing*, not status: `http/app.ts` races the
+ * command settling against `started`, and a command that merely succeeds reaches the same
+ * committed `200` either way -- just not until it exits. Only a command that is both silent and
+ * slow separates them, because only then is there a stretch where the route must already have
+ * answered and has nothing else to answer on. That is what makes "a silent long-running command
+ * gets its `200` and its keepalives immediately" (the route's own words) an assertion rather
+ * than a claim.
  */
 const PASSTHROUGH_PROGRAM =
   "const argv = process.argv.slice(1);" +
@@ -137,6 +146,11 @@ const PASSTHROUGH_PROGRAM =
   // is only observable from the far end if the tool reads it back out. Opt-in, so every other
   // flow's command still exits without waiting on a stdin nobody wrote to.
   "const echoStdin = argv.includes('--fake-exec-echo-stdin');" +
+  "const silent = argv.includes('--fake-exec-silent');" +
+  // Keeps the event loop alive without writing anything, so the process genuinely exists and is
+  // running while the route has to decide what to answer.
+  "const sleepMs = Number(flag('--fake-exec-sleep') ?? 0);" +
+  "if (sleepMs > 0) setTimeout(() => {}, sleepMs);" +
   "const report = (stdin) => process.stdout.write(JSON.stringify({" +
   "argv," +
   "platform: process.env.SIMLOCK_FAKE_PASSTHROUGH_PLATFORM ?? null," +
@@ -151,7 +165,7 @@ const PASSTHROUGH_PROGRAM =
   // the tool's own process, not merely that the daemon returned it in the resolved command --
   // the half of ADR 0001 decision 7 the wrapper exists for: handing back the scoping that
   // containment removed.
-  "} else report(undefined);" +
+  "} else if (!silent) report(undefined);" +
   // `exitCode` rather than `exit()`: over a pipe (which is how `device.exec` reads it, unlike
   // the CLI's inherited stdio) an immediate `exit()` can truncate a write that has not
   // flushed. Setting the code lets the process end once its streams have drained.

--- a/e2e/gateway-smoke.test.ts
+++ b/e2e/gateway-smoke.test.ts
@@ -1,0 +1,453 @@
+import { describe, expect, it } from "vitest";
+
+import { freeLoopbackPort, waitFor, withDaemon, type TestEnv } from "./helpers/index.js";
+
+/**
+ * ADR 0005's happy path, over real transports: a real gateway process, real worker processes
+ * dialling it over a real WebSocket, and a client reaching the fleet the way a user actually
+ * does -- the CLI on the gateway's own machine, and HTTP from anywhere else.
+ *
+ * Why this file exists at all. `src/daemon/gateway-fleet.e2e.test.ts` already proves lease
+ * routing and a real `device.exec` across two worker processes, but it drives them through the
+ * daemon's own `dispatch()` in-process. Everything between that dispatcher and a user was
+ * unproven for gateway mode: the CLI's own gateway/worker branch, the HTTP lease and exec
+ * routes against a gateway, SSE streaming of proxied output, and exit-code propagation. The one
+ * out-of-process lease that existed (`e2e/gateway-fleet.test.ts`) deliberately went straight to
+ * a worker's own socket, because fleet routing belonged to a later PR than the one that wrote
+ * it -- that PR has since landed, and nothing came back to close the gap.
+ *
+ * These are smoke tests. They prove the layers are wired to each other, not that the routing
+ * policy, the queue's ordering rules or the refusal lists are correct -- `src/gateway`'s own
+ * suites own that, and duplicating it here would buy nothing for a great deal of wall clock.
+ */
+
+interface WorkerView {
+  readonly id: string;
+  readonly label?: string;
+  readonly connection: "connected" | "disconnected" | "incompatible";
+  readonly catalog: readonly { readonly platform: string; readonly models: readonly string[] }[];
+}
+
+interface Grant {
+  readonly lease: {
+    readonly id: string;
+    readonly ttlDeadline: number;
+    readonly worker?: { readonly id: string; readonly label?: string };
+  };
+}
+
+interface WorkerSpec {
+  readonly label: string;
+  readonly models: readonly string[];
+  /** Seeded straight into the worker's config; used to pin a one-device worker for queueing. */
+  readonly limits?: Record<string, unknown>;
+}
+
+interface Fleet {
+  readonly gateway: TestEnv;
+  readonly workers: readonly TestEnv[];
+  readonly baseUrl: string;
+}
+
+/**
+ * A gateway plus its workers, all as separate daemons with their own `SIMLOCK_HOME` (and so
+ * their own instance identity), joined over a real uplink.
+ *
+ * Returns only once the gateway can actually *serve* each worker's models, not merely once the
+ * sockets are `connected`: a worker's catalog arrives on its own schedule after the uplink
+ * opens, and leasing before it lands fails for a reason that has nothing to do with what any of
+ * these tests are about.
+ */
+async function startFleet(specs: readonly WorkerSpec[], agentId: string): Promise<Fleet> {
+  const port = await freeLoopbackPort();
+  // `driver: "none"`: a gateway starts no drivers and warns about every worker-only key in its
+  // config (ADR 0005 §2), so it gets no fake-driver wiring and no capacity seeding.
+  const gateway = await withDaemon({
+    agentId,
+    configOverrides: { http: { enabled: true, host: "127.0.0.1", port }, mode: "gateway" },
+    driver: "none",
+  });
+
+  const minted = await gateway.cli(["token", "create", "--role", "worker"]);
+  expect(minted.code).toBe(0);
+  const { secret } = minted.json as { secret: string };
+
+  const workers: TestEnv[] = [];
+  for (const spec of specs) {
+    const worker = await withDaemon({
+      agentId,
+      configOverrides: {
+        gateway: { label: spec.label, token: secret, url: `ws://127.0.0.1:${port}` },
+        ...(spec.limits === undefined ? {} : { limits: spec.limits }),
+      },
+    });
+    await worker.driverScript.set({
+      android: { knownModels: [...spec.models], availableOsVersions: ["35"] },
+    });
+    workers.push(worker);
+  }
+
+  await waitFor(
+    async () => {
+      const listed = await gateway.cli(["worker", "list", "--json"]);
+      if (listed.code !== 0) return false;
+      const views = (listed.json as { workers: WorkerView[] }).workers;
+      if (views.length !== specs.length) return false;
+      return specs.every((spec) =>
+        views.some(
+          (view) =>
+            view.label === spec.label &&
+            view.connection === "connected" &&
+            spec.models.every((model) =>
+              view.catalog.some(
+                (entry) => entry.platform === "android" && entry.models.includes(model),
+              ),
+            ),
+        ),
+      );
+    },
+    { label: "every worker joined the gateway and its catalog arrived", timeout: 30_000 },
+  );
+
+  return { baseUrl: `http://127.0.0.1:${port}`, gateway, workers };
+}
+
+interface SseFrame {
+  readonly event: string;
+  readonly data: unknown;
+}
+
+/** Reads a finite SSE body, skipping keepalive comments -- the exec route ends the stream on
+ * its terminal `exit`/`error` event. Same shape as `device-exec.test.ts`'s own reader. */
+async function readSse(response: Response): Promise<SseFrame[]> {
+  const frames: SseFrame[] = [];
+  for (const raw of (await response.text()).split("\n\n")) {
+    if (raw.trim() === "" || raw.startsWith(":")) continue;
+    let event: string | undefined;
+    let data = "";
+    for (const line of raw.split("\n")) {
+      if (line.startsWith("event:")) event = line.slice(6).trim();
+      else if (line.startsWith("data:")) data += line.slice(5).trim();
+    }
+    if (event !== undefined) frames.push({ data: JSON.parse(data) as unknown, event });
+  }
+  return frames;
+}
+
+function chunksOf(frames: readonly SseFrame[], stream: "stdout" | "stderr"): string {
+  return frames
+    .filter((frame) => frame.event === "output")
+    .map((frame) => frame.data as { stream: string; chunk: string })
+    .filter((chunk) => chunk.stream === stream)
+    .map((chunk) => chunk.chunk)
+    .join("");
+}
+
+/** Mints an agent token on the gateway and returns the headers an HTTP client would send. */
+async function agentAuth(gateway: TestEnv): Promise<Record<string, string>> {
+  const created = await gateway.cli(["token", "create", "--role", "agent"]);
+  expect(created.code).toBe(0);
+  return {
+    authorization: `Bearer ${(created.json as { secret: string }).secret}`,
+    "content-type": "application/json",
+  };
+}
+
+/** A `queued` progress push at a given position, as `contention.test.ts` reads them on one
+ * machine -- ADR §10 requires a gateway to report the same states a worker does. */
+function isQueuedAt(event: unknown, position: number): boolean {
+  return (
+    typeof event === "object" &&
+    event !== null &&
+    (event as Record<string, unknown>).stage === "queued" &&
+    (event as Record<string, unknown>).queuePosition === position
+  );
+}
+
+describe("gateway smoke", () => {
+  it("leases and execs through a gateway from the CLI, with the tool's own exit code", async () => {
+    const { gateway, workers } = await startFleet(
+      [{ label: "worker-a", models: ["Pixel 8"] }],
+      "smoke-agent",
+    );
+
+    // 1. Leasing is identical against a gateway (docs/CLI.md, "Against a gateway") -- same
+    //    flags, same grant line, plus a `worker` block saying where it landed.
+    const leased = await gateway.cli(
+      ["lease", "--platform", "android", "--device", "Pixel 8", "--detach"],
+      { timeout: 30_000 },
+    );
+    expect(leased.code).toBe(0);
+    const grant = leased.json as Grant;
+    expect(grant.lease.worker?.label).toBe("worker-a");
+    // ADR §16: the gateway lease id names its worker. Asserted as a prefix rather than parsed,
+    // which is exactly what the docs tell a *client* not to do -- this is the fleet's own
+    // invariant, not a client reading it.
+    expect(grant.lease.id.startsWith(`${grant.lease.worker?.id ?? ""}.`)).toBe(true);
+
+    // 2. §27a: the worker sees the requester namespaced by the gateway, so a local `smoke-agent`
+    //    on that machine and this one cannot collide on its one-lease rule. This is the seam the
+    //    in-process test cannot see, because it never asks the worker for its own view.
+    const worker = workers[0];
+    // Thrown rather than optional-chained: a fleet with no worker means the harness is broken,
+    // and reading through `undefined` would surface that as a TypeError three lines later
+    // instead of as this sentence.
+    if (worker === undefined) throw new Error("expected the fleet to have a worker");
+    const workerStatus = await worker.cli(["status", "--json"], { timeout: 30_000 });
+    expect(workerStatus.code).toBe(0);
+    const workerLeases = (workerStatus.json as { leases: { requesterId: string }[] }).leases;
+    expect(workerLeases).toHaveLength(1);
+    expect(workerLeases[0]?.requesterId).toMatch(/^gw:[^:]+:smoke-agent$/);
+
+    // 3. The CLI branches on `status.get`'s `mode`: against a gateway `simlock adb` sends
+    //    `device.exec` instead of spawning locally, prints what streams back on the matching
+    //    stream, and exits with the tool's own code. Nothing else in the suite runs that branch.
+    //    `input: ""` closes the child's stdin, which models `simlock adb ... < /dev/null` and is
+    //    load-bearing here rather than tidiness: against a *worker* the CLI spawns the tool with
+    //    inherited stdio and never reads stdin, but against a gateway it must read stdin to EOF
+    //    before it can send the one `stdin` string `device.exec` carries (docs/CLI.md). The test
+    //    harness spawns with a pipe it never closes, so without this the CLI waits for an EOF
+    //    that never comes -- which is exactly what a real caller would see if it handed simlock
+    //    an open pipe it never closed.
+    const exec = await gateway.cli(
+      [
+        "adb",
+        "--lease",
+        grant.lease.id,
+        "devices",
+        "--fake-exec-stderr=a warning",
+        "--fake-exec-exit=3",
+      ],
+      { input: "", timeout: 30_000 },
+    );
+    expect(exec.code).toBe(3);
+    expect(exec.stderr).toContain("a warning");
+    // The *worker's* driver resolved the command -- its own device root is prepended, on a
+    // machine the CLI never talked to directly.
+    expect(JSON.parse(exec.stdout)).toEqual({
+      argv: ["/fake/android", "devices", "--fake-exec-stderr=a warning", "--fake-exec-exit=3"],
+      platform: "android",
+    });
+
+    const released = await gateway.cli(["release", grant.lease.id], { timeout: 30_000 });
+    expect(released.code).toBe(0);
+  });
+
+  it("leases and execs through a gateway over HTTP, streaming output and keeping a refusal's own status", async () => {
+    const { baseUrl, gateway } = await startFleet(
+      [{ label: "worker-a", models: ["Pixel 8"] }],
+      "smoke-agent",
+    );
+    const auth = await agentAuth(gateway);
+
+    await waitFor(
+      async () => {
+        try {
+          return (await fetch(`${baseUrl}/v1/healthz`)).ok;
+        } catch {
+          return false;
+        }
+      },
+      { label: "the gateway's HTTP port accepting connections" },
+    );
+
+    // 1. The same request resource a worker serves, answered by a gateway that owns no devices.
+    const created = await fetch(`${baseUrl}/v1/lease-requests`, {
+      body: JSON.stringify({ device: "Pixel 8", platform: "android" }),
+      headers: auth,
+      method: "POST",
+    });
+    expect(created.status).toBe(201);
+    const requestId = ((await created.json()) as { request: { id: string } }).request.id;
+
+    let leaseId = "";
+    await waitFor(
+      async () => {
+        const polled = await fetch(`${baseUrl}/v1/lease-requests/${requestId}?wait=10`, {
+          headers: auth,
+        });
+        const view = (await polled.json()) as {
+          request: { state: string; lease?: { id: string } };
+        };
+        leaseId = view.request.lease?.id ?? "";
+        return view.request.state === "granted";
+      },
+      { label: "the fleet granted the lease request", timeout: 30_000 },
+    );
+    expect(leaseId).not.toBe("");
+
+    // 2. A command that really runs: the gateway proxies it to the worker and relays the
+    //    worker's own chunks and exit code back down this SSE stream.
+    const streamed = await fetch(`${baseUrl}/v1/leases/${leaseId}/exec`, {
+      body: JSON.stringify({ args: ["devices", "--fake-exec-exit=5"], tool: "adb" }),
+      headers: auth,
+      method: "POST",
+    });
+    expect(streamed.status).toBe(200);
+    expect(streamed.headers.get("content-type")).toContain("text/event-stream");
+    const frames = await readSse(streamed);
+    expect(frames.at(-1)).toEqual({ data: { exitCode: 5 }, event: "exit" });
+    expect(JSON.parse(chunksOf(frames, "stdout"))).toMatchObject({ platform: "android" });
+
+    // 3. A **silent, slow** command: the one shape that isolates ADR §19a's `started` push end
+    //    to end. `http/app.ts` races the command settling against `started`, and a command that
+    //    merely succeeds reaches the same committed `200` either way -- just not until it
+    //    exits. So what `started` actually buys is timing, and the assertion has to be about
+    //    timing: the response head must arrive while the command is still running. Relaying it
+    //    is the gateway's own job (it holds no driver refusal list and cannot know a process
+    //    exists any other way), so this is the assertion that fails if that relay is lost.
+    //
+    //    Verified by mutation: neutering `FleetLeaseCoordinator#exec`'s `onStarted` relay
+    //    leaves every other assertion in this file green and fails only the deadline below.
+    //    Both weaker versions of this test -- a short silent command, and the refusal in 4 --
+    //    passed against that mutation, which is why neither of them is the one that guards it.
+    const slowStartedAt = Date.now();
+    const silent = await fetch(`${baseUrl}/v1/leases/${leaseId}/exec`, {
+      body: JSON.stringify({
+        args: ["devices", "--fake-exec-silent", "--fake-exec-sleep=4000"],
+        tool: "adb",
+      }),
+      headers: auth,
+      method: "POST",
+    });
+    const headHeadersMs = Date.now() - slowStartedAt;
+    expect(silent.status).toBe(200);
+    expect(silent.headers.get("content-type")).toContain("text/event-stream");
+    // Generously below the command's own 4s: the point is "well before it exits", not a precise
+    // latency budget, so this stays honest on a loaded machine while still failing outright if
+    // the route waits for the process to finish before answering.
+    expect(headHeadersMs).toBeLessThan(2_000);
+
+    const silentFrames = await readSse(silent);
+    expect(chunksOf(silentFrames, "stdout")).toBe("");
+    expect(silentFrames.at(-1)).toEqual({ data: { exitCode: 0 }, event: "exit" });
+
+    // 4. A refusal that happens *before* any process exists keeps its own status instead: the
+    //    route has not committed to a stream, so §19a′'s `PASSTHROUGH_REFUSED` arrives as a
+    //    real `422` rather than buried inside an already-committed `200`.
+    const refused = await fetch(`${baseUrl}/v1/leases/${leaseId}/exec`, {
+      body: JSON.stringify({ args: ["kill-server"], tool: "adb" }),
+      headers: auth,
+      method: "POST",
+    });
+    expect(refused.status).toBe(422);
+    expect(refused.headers.get("content-type")).toContain("application/json");
+    expect(((await refused.json()) as { error: { code: string } }).error.code).toBe(
+      "PASSTHROUGH_REFUSED",
+    );
+
+    await fetch(`${baseUrl}/v1/leases/${leaseId}`, { headers: auth, method: "DELETE" });
+  });
+  it("queues a fleet-wide FIFO behind a full worker, refuses --no-wait, and serves the waiter on release", async () => {
+    // One worker that can run exactly one device, so the fleet's whole capacity is one lease.
+    // ADR §10: the gateway keeps a single fleet-wide queue and reports the same codes and
+    // progress states a worker's own queue does -- which is what this asserts, over the real
+    // CLI, against a daemon that owns no devices at all.
+    const { gateway } = await startFleet(
+      [
+        {
+          label: "worker-a",
+          limits: { android: { maxDevices: 1, maxRunning: 1 }, maxRunning: 1 },
+          models: ["Pixel 8"],
+        },
+      ],
+      "smoke-agent",
+    );
+    const leaseArgs = ["lease", "--platform", "android", "--device", "Pixel 8"] as const;
+
+    const first = await gateway.cli([...leaseArgs, "--agent-id", "agent-a", "--detach"]);
+    expect(first.code).toBe(0);
+    const firstGrant = first.json as Grant;
+
+    // §14: one lease per requester is fleet-wide, not per machine.
+    const repeat = await gateway.cli([...leaseArgs, "--agent-id", "agent-a", "--detach"]);
+    expect(repeat.code).toBe(13);
+    expect(repeat.error).toMatchObject({ code: "REQUESTER_ALREADY_LEASED" });
+    expect(repeat.error?.message).toContain(firstGrant.lease.id);
+
+    // A second requester with nowhere to go is refused rather than queued.
+    const noWait = await gateway.cli([
+      ...leaseArgs,
+      "--agent-id",
+      "agent-b",
+      "--no-wait",
+      "--detach",
+    ]);
+    expect(noWait.code).toBe(11);
+    expect(noWait.error).toMatchObject({ code: "NO_CAPACITY" });
+
+    // A waiter queues, and says so with the same progress push a worker sends.
+    const waiter = gateway.cliBackground([...leaseArgs, "--agent-id", "agent-c"]);
+    await waitFor(() => waiter.progressEvents().some((event) => isQueuedAt(event, 1)), {
+      label: "agent-c queued at position 1 in the gateway's fleet queue",
+    });
+
+    // Releasing the only device in the fleet is what dispatches it.
+    expect((await gateway.cli(["release", firstGrant.lease.id])).code).toBe(0);
+    const served = JSON.parse(await waiter.firstStdoutLine(30_000)) as Grant;
+    expect(served.lease.worker?.label).toBe("worker-a");
+    expect(served.lease.id).not.toBe(firstGrant.lease.id);
+
+    waiter.kill("SIGTERM");
+    await waiter.waitForExit(15_000);
+  });
+
+  it("renews and releases a gateway-issued lease by the id the gateway handed out, and caps its own TTL", async () => {
+    // The gateway's own cap applies before anything is dispatched (§15), so it is the
+    // gateway's value that decides -- not the worker's, which is the 4h default here.
+    const { gateway } = await startFleet(
+      [{ label: "worker-a", models: ["Pixel 8"] }],
+      "smoke-agent",
+    );
+
+    const overCap = await gateway.cli([
+      "lease",
+      "--platform",
+      "android",
+      "--device",
+      "Pixel 8",
+      "--ttl",
+      "8h",
+      "--detach",
+    ]);
+    expect(overCap.code).toBe(2);
+    expect(overCap.error).toMatchObject({ code: "BAD_REQUEST" });
+
+    const leased = await gateway.cli([
+      "lease",
+      "--platform",
+      "android",
+      "--device",
+      "Pixel 8",
+      "--ttl",
+      "10m",
+      "--detach",
+    ]);
+    expect(leased.code).toBe(0);
+    const grant = leased.json as Grant;
+
+    // The id an operator reads back has to be the id every other verb accepts. Round 6 found a
+    // projection that broke exactly this for `status.get`, caught only by a unit test -- here it
+    // is over the socket, forwarded to the worker and back.
+    const listed = await gateway.cli(["status", "--json"]);
+    expect(listed.code).toBe(0);
+    const fleetLeases = (listed.json as { leases: { id: string }[] }).leases;
+    expect(fleetLeases.map((lease) => lease.id)).toContain(grant.lease.id);
+
+    const renewed = await gateway.cli(["lease", "renew", grant.lease.id]);
+    expect(renewed.code).toBe(0);
+    const renewedView = renewed.json as { id: string; ttlDeadline: number };
+    expect(renewedView.id).toBe(grant.lease.id);
+    expect(renewedView.ttlDeadline).toBeGreaterThanOrEqual(grant.lease.ttlDeadline);
+
+    expect((await gateway.cli(["release", grant.lease.id])).code).toBe(0);
+    // Released on the worker too, not merely forgotten by the gateway.
+    await waitFor(
+      async () => {
+        const after = await gateway.cli(["status", "--json"]);
+        return (after.json as { leases: unknown[] }).leases.length === 0;
+      },
+      { label: "the released lease is gone from the fleet's own view" },
+    );
+  });
+});

--- a/src/mcp/main.ts
+++ b/src/mcp/main.ts
@@ -185,7 +185,17 @@ function defaultEnvironment(
     // The renew timer's trigger: connects to a daemon that is already listening and never
     // launches one, so an operator's `simlock daemon stop` is not undone by an idle session
     // (ADR 0004 §2).
-    connectForRenew: () => connectToRunningDaemon({ ipc, principal: requesterId, socketPath }),
+    connectForRenew: () =>
+      connectToRunningDaemon({
+        ipc,
+        principal: requesterId,
+        // Resolved here rather than hoisted into a shared `const`, for the same reason
+        // `connect` resolves it inline above: `resolveDaemonSocketPath` throws for an over-long
+        // `SIMLOCK_HOME`, and a throw during construction escapes before the server can report
+        // it -- leaving a dead server and a raw stack trace on the stdio channel an MCP client
+        // is trying to speak protocol over.
+        socketPath: resolveDaemonSocketPath(dataDirectory),
+      }),
     createTransport: () => new StdioServerTransport(),
   };
 }


### PR DESCRIPTION
Stacked on #131. Four smoke tests for the seam nothing covered: a real gateway process, real worker processes on a real uplink, and a client reaching the fleet the way a user does.

## Why

`src/daemon/gateway-fleet.e2e.test.ts` already proves lease routing and a real `device.exec` across two worker processes — but through the daemon's own `dispatch()`, in-process. Everything between that dispatcher and a user was unproven for gateway mode: the CLI's gateway/worker branch, the HTTP lease and exec routes against a gateway, SSE streaming of proxied output, and exit-code propagation.

The one out-of-process lease that existed (`e2e/gateway-fleet.test.ts`) deliberately went straight to a worker's own socket, with a comment saying fleet routing belonged to a later PR than the one that wrote it. That PR has since landed and nothing came back to close the gap.

## The tests

1. **CLI through a gateway** — `simlock lease` gives a grant carrying its `worker` block and a worker-named id; the worker's own `status` shows §27a's namespaced requester (`gw:<instance>:<agent>`); `simlock adb` takes the gateway branch (`device.exec` rather than a local spawn), streams both streams, and exits with the tool's own code; `release`.
2. **HTTP through a gateway** — lease request to granted, exec streaming SSE with a real exit code, a silent long-running command answered while it still runs, and a pre-process refusal keeping its own `422 PASSTHROUGH_REFUSED` instead of a committed `200`.
3. **Fleet-wide FIFO** — `REQUESTER_ALREADY_LEASED` (13), `--no-wait` → `NO_CAPACITY` (11), a waiter reporting `queued` at position 1 and served on release.
4. **Renew/release** — an over-cap `--ttl` refused gateway-side (§15), and the gateway-issued id round-tripping through `status` and `lease renew`.

These are smoke tests: they prove the layers are wired to each other, not that the routing policy, queue ordering or refusal lists are correct. `src/gateway`'s own suites own that.

## Two new fake-driver flags, for one assertion

`--fake-exec-silent` and `--fake-exec-sleep=<ms>` exist together to pin ADR §19a's `started` push end to end.

What `started` buys a transport is **timing**, not status: `http/app.ts` races the command settling against `started`, so a command that merely succeeds reaches the same committed `200` either way — just not until it exits. Only a command that is both silent and slow separates them. Every existing fixture writes its argv and would let a first-chunk fallback pass identically.

That assertion took three attempts, and the first two are why the third is worth having. Billing the `422` refusal as "the only end-to-end test of `started`" was false — it passes with the gateway's relay ripped out, as does a short silent command. Neutering `FleetLeaseCoordinator#exec`'s `onStarted` now fails exactly one assertion: `expected 4049 to be less than 2000`, the response head arriving only after the command exited.

## One harness subtlety worth knowing

The CLI test passes `input: ""`, modelling `simlock adb ... < /dev/null`. That is load-bearing rather than tidiness: against a worker the CLI spawns the tool with inherited stdio and never reads stdin, but against a gateway it must read stdin to EOF before it can send the one `stdin` string `device.exec` carries. The e2e harness spawns with a pipe it never closes, so without this the CLI waits for an EOF that never comes — exactly what a real caller handing simlock an open pipe would see.

## Verification

- typecheck, e2e typecheck, lint, format — clean
- 1810 unit tests pass
- 4/4 smoke tests pass against the pushed code (136s)
- `device-exec` and `lease-environment-passthrough` re-run and unaffected by the fake-driver change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MA98m7ua7qvDFZjxFaww6Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01MA98m7ua7qvDFZjxFaww6Z)_