### PR TITLE
chore: ignore agent worktrees under .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .DS_Store
 .fallow/
 .claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
One line in `.gitignore`.

Subagents create git worktrees at `.claude/worktrees/agent-<id>/`, which show up as untracked directories in the repo root. They are transient checkouts of other branches and must never be committed.

`.gitignore` already ignores `.claude/settings.local.json`, so this keeps the same selective approach rather than ignoring `.claude/` wholesale — any project config added there stays trackable.

Independent of the ADR 0004/0005 stack (#121–#132) and based directly on `main`, so it can land whenever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MA98m7ua7qvDFZjxFaww6Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01MA98m7ua7qvDFZjxFaww6Z)_