### PR TITLE
fix(lefthook): exclude docs/** from the format pre-commit job

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,6 +3,7 @@ pre-commit:
   commands:
     format:
       glob: "*.{ts,js,json,md,yml,yaml}"
+      exclude: "docs/**"
       run: pnpm exec oxfmt --check {staged_files}
       fail_text: "Run 'pnpm format' to fix formatting."
     lint:


### PR DESCRIPTION
## Summary
- The `format` pre-commit job's glob still matched `docs/**`, but `.oxfmtrc.json` ignores that path — so a docs-only staged commit left oxfmt with zero targets and it exited 2, rejecting the commit.
- Added `exclude: "docs/**"` to the `format` job to keep lefthook and oxfmt's ignore rules in sync.

Closes #126

## Test plan
- [x] Staged a docs-only change and ran `lefthook run pre-commit --command format`: job reports `(skip) no files for inspection`, exit 0.
- [x] Confirmed the `format` job still runs and passes on non-docs staged files.