### PR TITLE
fix(ios): write the download-lock separator as \0 instead of a raw NUL byte

### DIFF
--- a/src/drivers/ios/index.ts
+++ b/src/drivers/ios/index.ts
@@ -591,7 +591,7 @@ export class IosSimctlDriver implements Driver {
     args: readonly string[],
     requesterId: string | undefined,
   ): Promise<number> {
-    const key = args.join(" ");
+    const key = args.join("\0");
     const inFlight = this.#downloadLocks.get(key);
     if (inFlight !== undefined) {
       return inFlight;

--- a/src/source-hygiene.test.ts
+++ b/src/source-hygiene.test.ts
@@ -1,0 +1,60 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const NUL = 0x00;
+
+/**
+ * A raw NUL byte in a text file makes `grep` and `ripgrep` classify the whole file as
+ * binary and print `binary file matches` instead of the matching lines -- so the file
+ * stops being searchable for every human and agent working in this repo. The byte is
+ * almost always a `"\0"` escape that was written as the literal character instead.
+ *
+ * Enumerated from `git ls-files` rather than a directory walk so the check sees every
+ * tracked file in the repository (testing rule 4), not just the directories this test
+ * happened to name. Untracked and ignored files are out of scope: they are not part of
+ * what anyone clones or searches.
+ */
+describe("tracked files", () => {
+  const trackedFiles = execFileSync("git", ["ls-files", "-z"], {
+    cwd: REPO_ROOT,
+    encoding: "buffer",
+    maxBuffer: 32 * 1024 * 1024,
+  })
+    .toString("utf8")
+    .split("\0")
+    .filter((name) => name.length > 0)
+    // A submodule or a path deleted from the working tree is still listed by
+    // `git ls-files`; only regular files can be read.
+    .filter((name) => {
+      try {
+        return statSync(join(REPO_ROOT, name)).isFile();
+      } catch {
+        return false;
+      }
+    });
+
+  it("were enumerated from the git index", () => {
+    // Without this, an `execFileSync` that returned nothing would leave `it.each` with an
+    // empty list and the suite would pass while checking no file at all.
+    expect(trackedFiles.length).toBeGreaterThan(100);
+  });
+
+  it("contain no raw NUL byte, so grep and ripgrep can search them", () => {
+    const offenders = trackedFiles
+      .map((name) => ({ name, contents: readFileSync(join(REPO_ROOT, name)) }))
+      .filter(({ contents }) => contents.includes(NUL))
+      .map(({ name, contents }) => {
+        const offset = contents.indexOf(NUL);
+        const line = contents.subarray(0, offset).toString("utf8").split("\n").length;
+        return `${name}:${line} (byte ${offset})`;
+      });
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #141

`src/drivers/ios/index.ts:594` held a literal NUL character in the source text. That one byte made `grep` and `ripgrep` classify the whole 2011-line iOS driver as binary, so the file was invisible to a normal search. The `\0` escape produces the same runtime string, so the download-lock key is unchanged.

The guard test from triage comes with it, enumerating `git ls-files` so it covers every tracked file rather than one directory.

- **The source byte is gone.** `readFileSync("src/drivers/ios/index.ts").indexOf(0)` returns `-1`; it was `27650`.
- **The file is searchable again.** `rg -c advisor src/drivers/ios/index.ts` prints `2` instead of `binary file matches`.
- **Behaviour is unchanged.** iOS driver suite: 115 pass, 1 skipped.
- **The regression test fails for the right reason.** Reverting the one byte turns `tracked files > contain no raw NUL byte, so grep and ripgrep can search them` red with `src/drivers/ios/index.ts:594 (byte 27650)`.
- **`pnpm check`.** Typecheck, oxlint, oxfmt and the unit suite are clean. Two e2e files failed on a stray-daemon teardown under full-suite load and pass in isolation on this branch; the same files pass on `main` in isolation too.

*Written by an agent.*


---
_Generated by [Claude Code](https://claude.ai/code/session_018HHP7Th9NqWfhexmp4V9Pf)_